### PR TITLE
Include the plant name with the variety when showing seed stock

### DIFF
--- a/frontend/js/seeds.js
+++ b/frontend/js/seeds.js
@@ -548,13 +548,10 @@ class SeedPacketRow extends React.Component {
   }
 
   render() {
-    const seed = this.props.seeds.find((s) => s.pk === this.props.seedPacket.seeds)
-    const supplier = this.props.suppliers.find((s) => s.pk == seed.supplier)
-    const variety = this.props.varieties.find((v) => v.pk === seed.plant_variety)
     return (
       <tr>
         <td>
-          {variety.name} from {supplier.name}
+          {this.props.seedPacket.plant}, {this.props.seedPacket.variety} from {this.props.seedPacket.supplier}
         </td>
         <td>{this.props.seedPacket.purchase_date}</td>
         <td>{this.props.seedPacket.sow_by}</td>
@@ -567,9 +564,6 @@ class SeedPacketRow extends React.Component {
   }
 }
 SeedPacketRow.propTypes = {
-  suppliers: PropTypes.array.isRequired,
-  varieties: PropTypes.array.isRequired,
-  seeds: PropTypes.array.isRequired,
   seedPacket: PropTypes.object.isRequired
 }
 
@@ -637,7 +631,7 @@ class SeedStockTable extends React.Component {
 
   updateSeedPacketList(data) {
     this.setState({
-      seedPackets: data
+      seedPackets: data['packets']
     })
   }
 
@@ -645,7 +639,7 @@ class SeedStockTable extends React.Component {
     await $.getJSON('/seeds/supplier/', this.updateSupplierList)
     await $.getJSON('/plants/variety/', this.updateVarietiesList)
     await $.getJSON('/seeds/seeds/', this.updateSeedList)
-    await $.getJSON('/seeds/packets/', this.updateSeedPacketList)
+    await $.getJSON('/seeds/packets/current/', this.updateSeedPacketList)
   }
 
   render() {
@@ -655,7 +649,7 @@ class SeedStockTable extends React.Component {
     }
     for (const s in this.state.seedPackets) {
       const seedPacketData = this.state.seedPackets[s]
-      rows.push(<SeedPacketRow key={seedPacketData.pk} suppliers={this.state.suppliers} varieties={this.state.varieties} seeds={this.state.seeds} seedPacket={seedPacketData} />)
+      rows.push(<SeedPacketRow key={seedPacketData.pk} seedPacket={seedPacketData} />)
     }
     return (
       <Table>

--- a/seeds/urls.py
+++ b/seeds/urls.py
@@ -9,5 +9,6 @@ from . import views
 
 urlpatterns = [
     path('packets/empty/', views.packets_empty, name='empty_packet'),
+    path('packets/current/', views.packets_current, name='current_packet'),
     path('', include(router.urls))
 ]

--- a/seeds/views.py
+++ b/seeds/views.py
@@ -3,10 +3,30 @@ Views for seeds
 """
 
 
-from django.http import HttpResponse, HttpResponseNotAllowed
+from django.http import HttpResponse, HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import get_object_or_404
 
 from .models import SeedPacket
+
+
+def packets_current(request):
+    """
+    List the seed packets that are not empty
+    """
+    packets = SeedPacket.objects.select_related('seeds', 'seeds__plant_variety', 'seeds__plant_variety__plant', 'seeds__supplier').filter(empty=False).order_by('seeds__plant_variety__plant__name', 'seeds__plant_variety__name')
+    packet_data = [
+        {
+            'pk': packet.pk,
+            'plant': packet.seeds.plant_variety.plant.name,
+            'variety': packet.seeds.plant_variety.name,
+            'supplier': packet.seeds.supplier.name,
+            'purchase_date': packet.purchase_date.isoformat() if packet.purchase_date else None,
+            'sow_by': packet.sow_by.isoformat() if packet.sow_by else None,
+            'notes': packet.notes
+        }
+        for packet in packets
+    ]
+    return JsonResponse({'packets': packet_data})
 
 
 def packets_empty(request):


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated endpoint for current seed stock and streamline the React table to use the enriched packet data directly

New Features:
- Add a new API endpoint to list non-empty seed packets with plant name, variety, supplier, dates, and notes

Enhancements:
- Update frontend to fetch data from the new packets/current endpoint and map the response to state
- Simplify SeedPacketRow component to display plant and variety directly and drop redundant supplier, variety, and seed props