### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -1,4 +1,6 @@
 name: Run Check Code
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/sparlane/garden-planner/security/code-scanning/1](https://github.com/sparlane/garden-planner/security/code-scanning/1)

To fix the issue, we should explicitly define the minimal required permissions for this workflow/job. The best solution is to add a `permissions` block at the top level (applies to all jobs unless overridden) and set `contents: read`, since none of the steps require write access or special scopes (the workflow only checks out code, sets up dependencies, and runs checks). Update the `.github/workflows/checkcode.yml` file, inserting the following block after the workflow name (on a new line 2):

```yaml
permissions:
  contents: read
```

No additional imports, changes, or new methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add top-level permissions block to grant only contents: read for the checkcode workflow