### PR TITLE
Add transactional specific plant moves

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -12,7 +12,8 @@ import {
   SeedTrayPlantingDetails,
   SpecificPlant,
   SpecificPlantCreate,
-  SpecificPlantLocationCreate
+  SpecificPlantLocationCreate,
+  SpecificPlantMove
 } from '../types/plantings'
 
 function getPlantingDirectSowGardenRows(): Promise<Array<GardenRowDirectPlanting>> {
@@ -93,6 +94,10 @@ function endSpecificPlantLocation(locationPk: number, ended?: string): Promise<R
   return csrfPatch(`/plantings/specificplantlocations/${locationPk}/`, ended ? { ended } : {})
 }
 
+function moveSpecificPlant(plantPk: number, data: SpecificPlantMove): Promise<Response> {
+  return csrfPost(`/plantings/specificplants/${plantPk}/move/`, data)
+}
+
 export {
   getPlantingDirectSowGardenRows,
   addPlantingDirectSowGardenRow,
@@ -111,5 +116,6 @@ export {
   getSpecificPlantsBySeedTray,
   addSpecificPlant,
   addSpecificPlantLocation,
-  endSpecificPlantLocation
+  endSpecificPlantLocation,
+  moveSpecificPlant
 }

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -6,7 +6,7 @@ import { localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDat
 import { getSeedTrayModels, getSeedTrays, getSeedTrayCells } from '../api/seedtrays'
 import { Button, Table } from 'react-bootstrap'
 import { SeedTrayPlanting, SpecificPlant, SpecificPlantLocation } from '../types/plantings'
-import { getPlantingSeedTray, getSpecificPlantsBySeedTray, addSpecificPlant, addSpecificPlantLocation, endSpecificPlantLocation } from '../api/plantings'
+import { getPlantingSeedTray, getSpecificPlantsBySeedTray, addSpecificPlant, moveSpecificPlant } from '../api/plantings'
 import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
 import { GardenSquare } from '../types/garden'
@@ -418,11 +418,7 @@ class SeedTrayDetails extends React.Component<SeedTrayDetailsProps, SeedTrayDeta
     const parsedMoveDate = parseLocalDatetimeInput(moveForm.date)
     if (!parsedMoveDate) return
     const moveIso = parsedMoveDate.toISOString()
-    if (moveForm.currentLocationPk) {
-      await endSpecificPlantLocation(moveForm.currentLocationPk, moveIso)
-    }
-    await addSpecificPlantLocation({
-      specific_plant: moveForm.plantPk,
+    await moveSpecificPlant(moveForm.plantPk, {
       location_type: moveForm.locationType,
       seed_tray_cell: moveForm.locationType === 'seed_tray_cell' ? moveForm.seedTrayCellPk : undefined,
       garden_square: moveForm.locationType === 'garden_square' ? moveForm.gardenSquarePk : undefined,

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -110,6 +110,14 @@ interface SpecificPlantLocationCreate {
   notes?: string
 }
 
+interface SpecificPlantMove {
+  location_type: 'seed_tray_cell' | 'garden_square'
+  seed_tray_cell?: number
+  garden_square?: number
+  started: string
+  notes?: string
+}
+
 interface SpecificPlant {
   pk: number
   cell_planting: number
@@ -139,5 +147,6 @@ export {
   SpecificPlant,
   SpecificPlantCreate,
   SpecificPlantLocation,
-  SpecificPlantLocationCreate
+  SpecificPlantLocationCreate,
+  SpecificPlantMove
 }

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -114,7 +114,7 @@ interface SpecificPlantMove {
   location_type: 'seed_tray_cell' | 'garden_square'
   seed_tray_cell?: number
   garden_square?: number
-  started: string
+  started?: string
   notes?: string
 }
 

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -1,8 +1,6 @@
 """
 Rest for Plantings
 """
-from functools import partial
-
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404
@@ -145,7 +143,12 @@ class SpecificPlantLocationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         # Delegate to the model's clean() as the single source of truth for FK/location_type consistency.
-        validate_specific_plant_location_for_instance(self.instance, data)
+        validate_specific_plant_location(
+            location_type=data.get('location_type', _FIELD_MISSING),
+            seed_tray_cell=data.get('seed_tray_cell', _FIELD_MISSING),
+            garden_square=data.get('garden_square', _FIELD_MISSING),
+            instance=self.instance,
+        )
         return data
 
 
@@ -161,7 +164,11 @@ class SpecificPlantMoveSerializer(serializers.ModelSerializer):
         }
 
     def validate(self, data):  # pylint: disable=arguments-renamed
-        validate_specific_plant_location_data(data)
+        validate_specific_plant_location(
+            location_type=data.get('location_type'),
+            seed_tray_cell=data.get('seed_tray_cell'),
+            garden_square=data.get('garden_square'),
+        )
         return data
 
 
@@ -197,37 +204,26 @@ class GardenSquareTransplantSerializer(serializers.ModelSerializer):
         fields = ['pk', 'transplanted', 'original_planting', 'quantity', 'location', 'removed', 'notes']
 
 
-def validate_specific_plant_location_for_instance(instance, data):
-    """
-    Validate location fields for a create or partial update.
-    """
-    if instance is None:
-        validate_specific_plant_location_data(data)
-        return
-
-    validate_specific_plant_location_fields({
-        'location_type': data.get('location_type', instance.location_type),
-        'seed_tray_cell': data.get('seed_tray_cell', instance.seed_tray_cell),
-        'garden_square': data.get('garden_square', instance.garden_square),
-    })
+_FIELD_MISSING = object()
 
 
-def validate_specific_plant_location_data(data):
+def validate_specific_plant_location(*, location_type=None, seed_tray_cell=None, garden_square=None, instance=None):
     """
-    Validate destination fields for a new SpecificPlantLocation.
+    Validate location fields, optionally defaulting omitted fields from an instance.
     """
-    validate_specific_plant_location_fields({
-        'location_type': data.get('location_type'),
-        'seed_tray_cell': data.get('seed_tray_cell'),
-        'garden_square': data.get('garden_square'),
-    })
+    if instance is not None:
+        if location_type is _FIELD_MISSING:
+            location_type = instance.location_type
+        if seed_tray_cell is _FIELD_MISSING:
+            seed_tray_cell = instance.seed_tray_cell
+        if garden_square is _FIELD_MISSING:
+            garden_square = instance.garden_square
 
-
-def validate_specific_plant_location_fields(fields):
-    """
-    Validate SpecificPlantLocation destination fields with model clean().
-    """
-    tmp = SpecificPlantLocation(**fields)
+    tmp = SpecificPlantLocation(
+        location_type=None if location_type is _FIELD_MISSING else location_type,
+        seed_tray_cell=None if seed_tray_cell is _FIELD_MISSING else seed_tray_cell,
+        garden_square=None if garden_square is _FIELD_MISSING else garden_square,
+    )
     try:
         tmp.clean()
     except DjangoValidationError as exc:
@@ -252,15 +248,29 @@ def get_single_active_location_for_update(plant):
     return None
 
 
-def move_specific_plant(plant_pk, move_data, check_permissions):
+def is_active_location_integrity_error(exc):
+    """
+    Return whether an integrity error came from the active-location constraint.
+    """
+    cause = getattr(exc, '__cause__', None)
+    diag = getattr(cause, 'diag', None)
+    if getattr(diag, 'constraint_name', None) == 'unique_active_location_per_plant':
+        return True
+
+    message = ' '.join(str(arg) for arg in exc.args)
+    names_constraint = 'unique_active_location_per_plant' in message
+    names_sqlite_column = 'plantings_specificplantlocation.specific_plant_id' in message
+    return names_constraint or names_sqlite_column
+
+
+def move_specific_plant(plant, move_data):
     """
     Move a plant by ending its active location and creating the new one atomically.
     """
     started = move_data.get('started') or timezone.now()
-    move_data['started'] = started
+    move_payload = {**move_data, 'started': started}
     with transaction.atomic():
-        plant = get_object_or_404(SpecificPlant.objects.select_for_update(), pk=plant_pk)
-        check_permissions(plant)
+        plant = get_object_or_404(SpecificPlant.objects.select_for_update(), pk=plant.pk)
         active_location = get_single_active_location_for_update(plant)
 
         if active_location:
@@ -270,9 +280,11 @@ def move_specific_plant(plant_pk, move_data, check_permissions):
         try:
             return SpecificPlantLocation.objects.create(
                 specific_plant=plant,
-                **move_data,
+                **move_payload,
             )
         except IntegrityError as exc:
+            if not is_active_location_integrity_error(exc):
+                raise
             raise serializers.ValidationError({
                 'specific_plant': 'Move must leave exactly one active location.'
             }) from exc
@@ -329,17 +341,17 @@ class SpecificPlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-a
     serializer_class = SpecificPlantSerializer
 
     @action(detail=True, methods=['post'])
-    def move(self, request, pk=None):
+    def move(self, request, pk=None):  # pylint: disable=unused-argument
         """
         Move a plant by ending its active location and creating the new one atomically.
         """
         serializer = SpecificPlantMoveSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
+        plant = self.get_object()
         location = move_specific_plant(
-            pk,
+            plant,
             dict(serializer.validated_data),
-            partial(self.check_object_permissions, request),
         )
         return Response(SpecificPlantLocationSerializer(location).data, status=status.HTTP_201_CREATED)
 

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -3,8 +3,11 @@ Rest for Plantings
 """
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from rest_framework import routers, serializers, viewsets
+from rest_framework import routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 
@@ -140,15 +143,20 @@ class SpecificPlantLocationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         # Delegate to the model's clean() as the single source of truth for FK/location_type consistency.
-        tmp = SpecificPlantLocation(
-            location_type=data.get('location_type', getattr(self.instance, 'location_type', None)),
-            seed_tray_cell=data.get('seed_tray_cell', getattr(self.instance, 'seed_tray_cell', None)),
-            garden_square=data.get('garden_square', getattr(self.instance, 'garden_square', None)),
-        )
-        try:
-            tmp.clean()
-        except DjangoValidationError as exc:
-            raise serializers.ValidationError(exc.message_dict) from exc
+        validate_specific_plant_location(data, self.instance)
+        return data
+
+
+class SpecificPlantMoveSerializer(serializers.ModelSerializer):
+    """
+    Serializer for moving a SpecificPlant to a new active location.
+    """
+    class Meta:
+        model = SpecificPlantLocation
+        fields = ['location_type', 'seed_tray_cell', 'garden_square', 'started', 'notes']
+
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        validate_specific_plant_location(data)
         return data
 
 
@@ -182,6 +190,21 @@ class GardenSquareTransplantSerializer(serializers.ModelSerializer):
     class Meta:
         model = GardenSquareTransplant
         fields = ['pk', 'transplanted', 'original_planting', 'quantity', 'location', 'removed', 'notes']
+
+
+def validate_specific_plant_location(data, instance=None):
+    """
+    Validate SpecificPlantLocation destination fields with model clean().
+    """
+    tmp = SpecificPlantLocation(
+        location_type=data.get('location_type', getattr(instance, 'location_type', None)),
+        seed_tray_cell=data.get('seed_tray_cell', getattr(instance, 'seed_tray_cell', None)),
+        garden_square=data.get('garden_square', getattr(instance, 'garden_square', None)),
+    )
+    try:
+        tmp.clean()
+    except DjangoValidationError as exc:
+        raise serializers.ValidationError(exc.message_dict) from exc
 
 
 class GardenRowDirectSowPlantingViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
@@ -233,6 +256,47 @@ class SpecificPlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-a
     """
     queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square')
     serializer_class = SpecificPlantSerializer
+
+    @action(detail=True, methods=['post'])
+    def move(self, request, pk=None):
+        """
+        Move a plant by ending its active location and creating the new one atomically.
+        """
+        serializer = SpecificPlantMoveSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        move_data = dict(serializer.validated_data)
+        started = move_data.get('started') or timezone.now()
+        move_data['started'] = started
+        with transaction.atomic():
+            plant = get_object_or_404(SpecificPlant.objects.select_for_update(), pk=pk)
+            self.check_object_permissions(request, plant)
+            active_locations = list(
+                SpecificPlantLocation.objects
+                .select_for_update()
+                .filter(specific_plant=plant, ended__isnull=True)
+            )
+
+            if len(active_locations) > 1:
+                raise serializers.ValidationError({
+                    'specific_plant': 'Plant has multiple active locations.'
+                })
+
+            if active_locations:
+                active_locations[0].ended = started
+                active_locations[0].save(update_fields=['ended'])
+
+            location = SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                **move_data,
+            )
+
+            if SpecificPlantLocation.objects.filter(specific_plant=plant, ended__isnull=True).count() != 1:
+                raise serializers.ValidationError({
+                    'specific_plant': 'Move must leave exactly one active location.'
+                })
+
+        return Response(SpecificPlantLocationSerializer(location).data, status=status.HTTP_201_CREATED)
 
 
 class SpecificPlantBySeedTrayViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -1,8 +1,10 @@
 """
 Rest for Plantings
 """
+from functools import partial
+
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import routers, serializers, status, viewsets
@@ -143,7 +145,7 @@ class SpecificPlantLocationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         # Delegate to the model's clean() as the single source of truth for FK/location_type consistency.
-        validate_specific_plant_location(data, self.instance)
+        validate_specific_plant_location_for_instance(self.instance, data)
         return data
 
 
@@ -154,9 +156,12 @@ class SpecificPlantMoveSerializer(serializers.ModelSerializer):
     class Meta:
         model = SpecificPlantLocation
         fields = ['location_type', 'seed_tray_cell', 'garden_square', 'started', 'notes']
+        extra_kwargs = {
+            'started': {'required': False},
+        }
 
     def validate(self, data):  # pylint: disable=arguments-renamed
-        validate_specific_plant_location(data)
+        validate_specific_plant_location_data(data)
         return data
 
 
@@ -192,19 +197,85 @@ class GardenSquareTransplantSerializer(serializers.ModelSerializer):
         fields = ['pk', 'transplanted', 'original_planting', 'quantity', 'location', 'removed', 'notes']
 
 
-def validate_specific_plant_location(data, instance=None):
+def validate_specific_plant_location_for_instance(instance, data):
+    """
+    Validate location fields for a create or partial update.
+    """
+    if instance is None:
+        validate_specific_plant_location_data(data)
+        return
+
+    validate_specific_plant_location_fields({
+        'location_type': data.get('location_type', instance.location_type),
+        'seed_tray_cell': data.get('seed_tray_cell', instance.seed_tray_cell),
+        'garden_square': data.get('garden_square', instance.garden_square),
+    })
+
+
+def validate_specific_plant_location_data(data):
+    """
+    Validate destination fields for a new SpecificPlantLocation.
+    """
+    validate_specific_plant_location_fields({
+        'location_type': data.get('location_type'),
+        'seed_tray_cell': data.get('seed_tray_cell'),
+        'garden_square': data.get('garden_square'),
+    })
+
+
+def validate_specific_plant_location_fields(fields):
     """
     Validate SpecificPlantLocation destination fields with model clean().
     """
-    tmp = SpecificPlantLocation(
-        location_type=data.get('location_type', getattr(instance, 'location_type', None)),
-        seed_tray_cell=data.get('seed_tray_cell', getattr(instance, 'seed_tray_cell', None)),
-        garden_square=data.get('garden_square', getattr(instance, 'garden_square', None)),
-    )
+    tmp = SpecificPlantLocation(**fields)
     try:
         tmp.clean()
     except DjangoValidationError as exc:
         raise serializers.ValidationError(exc.message_dict) from exc
+
+
+def get_single_active_location_for_update(plant):
+    """
+    Lock and return the current active location for a plant.
+    """
+    active_locations = list(
+        SpecificPlantLocation.objects
+        .select_for_update()
+        .filter(specific_plant=plant, ended__isnull=True)
+    )
+    if len(active_locations) > 1:
+        raise serializers.ValidationError({
+            'specific_plant': 'Plant has multiple active locations.'
+        })
+    if active_locations:
+        return active_locations[0]
+    return None
+
+
+def move_specific_plant(plant_pk, move_data, check_permissions):
+    """
+    Move a plant by ending its active location and creating the new one atomically.
+    """
+    started = move_data.get('started') or timezone.now()
+    move_data['started'] = started
+    with transaction.atomic():
+        plant = get_object_or_404(SpecificPlant.objects.select_for_update(), pk=plant_pk)
+        check_permissions(plant)
+        active_location = get_single_active_location_for_update(plant)
+
+        if active_location:
+            active_location.ended = started
+            active_location.save(update_fields=['ended'])
+
+        try:
+            return SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                **move_data,
+            )
+        except IntegrityError as exc:
+            raise serializers.ValidationError({
+                'specific_plant': 'Move must leave exactly one active location.'
+            }) from exc
 
 
 class GardenRowDirectSowPlantingViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
@@ -265,37 +336,11 @@ class SpecificPlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-a
         serializer = SpecificPlantMoveSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        move_data = dict(serializer.validated_data)
-        started = move_data.get('started') or timezone.now()
-        move_data['started'] = started
-        with transaction.atomic():
-            plant = get_object_or_404(SpecificPlant.objects.select_for_update(), pk=pk)
-            self.check_object_permissions(request, plant)
-            active_locations = list(
-                SpecificPlantLocation.objects
-                .select_for_update()
-                .filter(specific_plant=plant, ended__isnull=True)
-            )
-
-            if len(active_locations) > 1:
-                raise serializers.ValidationError({
-                    'specific_plant': 'Plant has multiple active locations.'
-                })
-
-            if active_locations:
-                active_locations[0].ended = started
-                active_locations[0].save(update_fields=['ended'])
-
-            location = SpecificPlantLocation.objects.create(
-                specific_plant=plant,
-                **move_data,
-            )
-
-            if SpecificPlantLocation.objects.filter(specific_plant=plant, ended__isnull=True).count() != 1:
-                raise serializers.ValidationError({
-                    'specific_plant': 'Move must leave exactly one active location.'
-                })
-
+        location = move_specific_plant(
+            pk,
+            dict(serializer.validated_data),
+            partial(self.check_object_permissions, request),
+        )
         return Response(SpecificPlantLocationSerializer(location).data, status=status.HTTP_201_CREATED)
 
 

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -1,3 +1,172 @@
 """
 Tests for plantings
 """
+import json
+from datetime import datetime, timezone as datetime_timezone
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from garden.models import GardenArea, GardenBed, GardenSquare
+from plants.models import Plant, PlantFamily, PlantVariety
+from seeds.models import SeedPacket, Seeds
+from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
+from supplies.models import Supplier
+from .models import SeedTrayCellPlanting, SeedTrayPlanting, SpecificPlant, SpecificPlantLocation
+
+
+class SpecificPlantMoveTests(TestCase):
+    """
+    Tests for moving a specific plant between tracked locations.
+    """
+
+    def setUp(self):
+        self.client.force_login(get_user_model().objects.create_user(username='tester'))
+        variety = PlantVariety.objects.create(
+            plant=Plant.objects.create(
+                family=PlantFamily.objects.create(name='Nightshade'),
+                name='Tomato',
+            ),
+            name='Roma',
+        )
+        packet = SeedPacket.objects.create(
+            seeds=Seeds.objects.create(
+                supplier=Supplier.objects.create(name='Test Supplier'),
+                plant_variety=variety,
+            ),
+        )
+        tray_model = SeedTrayModel.objects.create(
+            identifier='test-tray',
+            height=10,
+            x_size=20,
+            y_size=30,
+            x_cells=2,
+            y_cells=2,
+            cell_size_ml=40,
+        )
+        tray = SeedTray.objects.create(model=tray_model)
+        cell = SeedTrayCell.objects.create(tray=tray, x_position=0, y_position=0)
+        self.other_cell = SeedTrayCell.objects.create(
+            tray=SeedTray.objects.create(model=tray_model),
+            x_position=1,
+            y_position=1,
+        )
+        planting = SeedTrayPlanting.objects.create(
+            seeds_used=packet,
+            quantity=1,
+            seed_tray=tray,
+        )
+        cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=planting,
+            cell=cell,
+            quantity=1,
+        )
+        area = GardenArea.objects.create(name='Back garden', size_x=10, size_y=10)
+        bed = GardenBed.objects.create(
+            area=area,
+            name='Bed 1',
+            placement_x=0,
+            placement_y=0,
+            size_x=10,
+            size_y=10,
+        )
+        self.square = GardenSquare.objects.create(
+            bed=bed,
+            name='A1',
+            placement_x=0,
+            placement_y=0,
+            size_x=1,
+            size_y=1,
+        )
+        self.plant = SpecificPlant.objects.create(
+            cell_planting=cell_planting,
+            germinated=datetime(2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc),
+        )
+        self.active_location = SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=cell,
+            started=datetime(2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc),
+        )
+
+    def test_move_ends_current_location_and_creates_new_active_location(self):
+        """
+        Moving a plant is persisted as one ended location and one active location.
+        """
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2026-01-02T09:30:00Z',
+                'notes': 'Moved outside',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.active_location.refresh_from_db()
+        self.assertEqual(
+            self.active_location.ended,
+            datetime(2026, 1, 2, 9, 30, tzinfo=datetime_timezone.utc),
+        )
+        active_location = SpecificPlantLocation.objects.get(
+            specific_plant=self.plant,
+            ended__isnull=True,
+        )
+        self.assertEqual(active_location.location_type, SpecificPlantLocation.GARDEN_SQUARE)
+        self.assertEqual(active_location.garden_square, self.square)
+        self.assertEqual(active_location.notes, 'Moved outside')
+
+    def test_move_rolls_back_current_location_when_create_fails(self):
+        """
+        If the destination creation fails, the previous active location remains active.
+        """
+        self.client.raise_request_exception = False
+        with mock.patch('plantings.rest.SpecificPlantLocation.objects.create', side_effect=RuntimeError('create failed')):
+            response = self.client.post(
+                f'/plantings/specificplants/{self.plant.pk}/move/',
+                data=json.dumps({
+                    'location_type': SpecificPlantLocation.SEED_TRAY_CELL,
+                    'seed_tray_cell': self.other_cell.pk,
+                    'started': '2026-01-02T09:30:00Z',
+                }),
+                content_type='application/json',
+            )
+        self.client.raise_request_exception = True
+
+        self.assertEqual(response.status_code, 500)
+        self.active_location.refresh_from_db()
+        self.assertIsNone(self.active_location.ended)
+        active_locations = SpecificPlantLocation.objects.filter(
+            specific_plant=self.plant,
+            ended__isnull=True,
+        )
+        self.assertEqual(active_locations.count(), 1)
+        self.assertEqual(active_locations.get(), self.active_location)
+
+    def test_move_rejects_invalid_destination_without_ending_current_location(self):
+        """
+        Mismatched location fields are rejected before changing the active location.
+        """
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'seed_tray_cell': self.other_cell.pk,
+                'started': '2026-01-02T09:30:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.active_location.refresh_from_db()
+        self.assertIsNone(self.active_location.ended)
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                specific_plant=self.plant,
+                ended__isnull=True,
+            ).count(),
+            1,
+        )

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -2,11 +2,11 @@
 Tests for plantings
 """
 import json
-from datetime import datetime, timezone as datetime_timezone
+from datetime import datetime, timedelta, timezone as datetime_timezone
 from unittest import mock
 
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError
+from django.db import IntegrityError, connection
 from django.test import TestCase
 
 from garden.models import GardenArea, GardenBed, GardenSquare
@@ -91,6 +91,20 @@ class SpecificPlantMoveTests(TestCase):
             started=datetime(2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc),
         )
 
+    def _drop_active_location_index(self):
+        with connection.cursor() as cursor:
+            cursor.execute('DROP INDEX IF EXISTS unique_active_location_per_plant')
+        self.addCleanup(self._restore_active_location_index)
+
+    def _restore_active_location_index(self):
+        SpecificPlantLocation.objects.filter(specific_plant=self.plant, seed_tray_cell=self.other_cell).delete()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'CREATE UNIQUE INDEX IF NOT EXISTS "unique_active_location_per_plant" '
+                'ON "plantings_specificplantlocation" ("specific_plant_id") '
+                'WHERE "ended" IS NULL'
+            )
+
     def test_move_ends_current_location_and_creates_new_active_location(self):
         """
         Moving a plant is persisted as one ended location and one active location.
@@ -148,7 +162,8 @@ class SpecificPlantMoveTests(TestCase):
         """
         If the destination creation violates the active-location invariant, the previous location remains active.
         """
-        with mock.patch('plantings.rest.SpecificPlantLocation.objects.create', side_effect=IntegrityError('create failed')):
+        error = IntegrityError('UNIQUE constraint failed: plantings_specificplantlocation.specific_plant_id')
+        with mock.patch('plantings.rest.SpecificPlantLocation.objects.create', side_effect=error):
             response = self.client.post(
                 f'/plantings/specificplants/{self.plant.pk}/move/',
                 data=json.dumps({
@@ -168,6 +183,37 @@ class SpecificPlantMoveTests(TestCase):
         )
         self.assertEqual(active_locations.count(), 1)
         self.assertEqual(active_locations.get(), self.active_location)
+
+    def test_move_without_active_location_creates_new_active_location(self):
+        """
+        A plant with no active location can still be moved to a new active location.
+        """
+        ended = datetime(2026, 1, 1, 12, 0, tzinfo=datetime_timezone.utc)
+        self.active_location.ended = ended
+        self.active_location.save(update_fields=['ended'])
+
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2026-01-02T09:30:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, ended)
+        active_location = SpecificPlantLocation.objects.get(
+            specific_plant=self.plant,
+            ended__isnull=True,
+        )
+        self.assertEqual(active_location.garden_square, self.square)
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(specific_plant=self.plant).count(),
+            2,
+        )
 
     def test_move_rejects_invalid_destination_without_ending_current_location(self):
         """
@@ -192,4 +238,43 @@ class SpecificPlantMoveTests(TestCase):
                 ended__isnull=True,
             ).count(),
             1,
+        )
+
+    def test_move_rejects_multiple_active_locations_without_ending_any_location(self):
+        """
+        A move is rejected when existing data already has multiple active locations.
+        """
+        self._drop_active_location_index()
+        second_active_location = SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=self.other_cell,
+            started=self.active_location.started + timedelta(hours=1),
+        )
+
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2026-01-02T09:30:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'specific_plant': 'Plant has multiple active locations.'},
+        )
+        self.active_location.refresh_from_db()
+        second_active_location.refresh_from_db()
+        self.assertIsNone(self.active_location.ended)
+        self.assertIsNone(second_active_location.ended)
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                specific_plant=self.plant,
+                ended__isnull=True,
+            ).count(),
+            2,
         )

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone as datetime_timezone
 from unittest import mock
 
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError
 from django.test import TestCase
 
 from garden.models import GardenArea, GardenBed, GardenSquare
@@ -119,12 +120,35 @@ class SpecificPlantMoveTests(TestCase):
         self.assertEqual(active_location.garden_square, self.square)
         self.assertEqual(active_location.notes, 'Moved outside')
 
-    def test_move_rolls_back_current_location_when_create_fails(self):
+    def test_move_without_started_defaults_to_current_time(self):
         """
-        If the destination creation fails, the previous active location remains active.
+        Moves without an explicit start time use the backend current time.
         """
-        self.client.raise_request_exception = False
-        with mock.patch('plantings.rest.SpecificPlantLocation.objects.create', side_effect=RuntimeError('create failed')):
+        move_time = datetime(2026, 1, 2, 9, 30, tzinfo=datetime_timezone.utc)
+        with mock.patch('plantings.rest.timezone.now', return_value=move_time):
+            response = self.client.post(
+                f'/plantings/specificplants/{self.plant.pk}/move/',
+                data=json.dumps({
+                    'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                    'garden_square': self.square.pk,
+                }),
+                content_type='application/json',
+            )
+
+        self.assertEqual(response.status_code, 201)
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, move_time)
+        active_location = SpecificPlantLocation.objects.get(
+            specific_plant=self.plant,
+            ended__isnull=True,
+        )
+        self.assertEqual(active_location.started, move_time)
+
+    def test_move_rolls_back_current_location_when_create_violates_invariant(self):
+        """
+        If the destination creation violates the active-location invariant, the previous location remains active.
+        """
+        with mock.patch('plantings.rest.SpecificPlantLocation.objects.create', side_effect=IntegrityError('create failed')):
             response = self.client.post(
                 f'/plantings/specificplants/{self.plant.pk}/move/',
                 data=json.dumps({
@@ -134,9 +158,8 @@ class SpecificPlantMoveTests(TestCase):
                 }),
                 content_type='application/json',
             )
-        self.client.raise_request_exception = True
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 400)
         self.active_location.refresh_from_db()
         self.assertIsNone(self.active_location.ended)
         active_locations = SpecificPlantLocation.objects.filter(


### PR DESCRIPTION
## Summary by Sourcery

Introduce a transactional backend endpoint to move a specific plant between tracked locations while ensuring active-location invariants, and wire it through to the frontend move flow.

New Features:
- Add a dedicated SpecificPlant move REST action that atomically ends the current location and creates a new active location.
- Expose a frontend API and type for moving specific plants, and hook it into the seed tray details move UI.

Enhancements:
- Refactor SpecificPlantLocation validation into reusable helpers shared by standard serializers and the new move serializer.
- Ensure single-active-location enforcement for specific plants using row-level locking and invariant checks.

Tests:
- Add backend tests covering successful moves, default start times, transactional rollback on invariant violations, and validation of invalid destination data.