### PR TITLE
fix(plantings): enforce tray membership on updates

### DIFF
--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -36,6 +36,17 @@ class SeedTrayCellPlantingNestedSerializer(serializers.ModelSerializer):
         model = SeedTrayCellPlanting
         fields = ['pk', 'cell', 'quantity']
 
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        """Require complete entries because the parent replaces rather than patches them."""
+        missing_fields = {
+            field: 'This field is required.'
+            for field in ('cell', 'quantity')
+            if field not in data
+        }
+        if missing_fields:
+            raise serializers.ValidationError(missing_fields)
+        return data
+
 
 class SeedTrayPlantingSerializer(serializers.ModelSerializer):
     """
@@ -50,43 +61,53 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
             'seed_tray', 'location', 'removed', 'notes', 'cell_plantings',
         ]
 
-    def validate(self, data):  # pylint: disable=arguments-renamed
-        """Validate that all cell plantings belong to the same seed tray.
+    def _get_effective_cells(self, data):
+        """Return submitted replacement cells or the retained instance cells."""
+        if 'cell_plantings' in data:
+            return [cell_planting['cell'] for cell_planting in data['cell_plantings']]
+        if self.instance is not None:
+            return [
+                cell_planting.cell
+                for cell_planting in self.instance.cell_plantings.select_related('cell__tray')
+            ]
+        return []
 
-        For partial updates the `seed_tray` may not be present in `data`,
-        so it is derived from the existing instance or from cells.
-        """
-        cell_plantings = data.get('cell_plantings', [])
-        if not cell_plantings:
-            return data
+    def _get_effective_seed_tray(self, data, cells):
+        """Return the effective tray and whether it was derived from a cell."""
+        if 'seed_tray' in data:
+            return data['seed_tray'], False
 
-        # 1. Determine effective seed_tray: payload → instance → first cell
-        seed_tray = data.get('seed_tray') or getattr(self.instance, 'seed_tray', None)
+        seed_tray = getattr(self.instance, 'seed_tray', None)
+        if seed_tray is None and cells:
+            return cells[0].tray, True
+        return seed_tray, False
 
-        if not seed_tray:
-            first_cell_entry = cell_plantings[0]
-            first_cell = first_cell_entry.get('cell')
-            if not first_cell:
-                raise serializers.ValidationError({
-                    'cell_plantings': 'Cannot derive seed_tray from empty cell entry'
-                })
-            seed_tray = first_cell.tray
-
-        # 2. Validate all cells belong to the determined tray
-        for cp in cell_plantings:
-            cell = cp.get('cell')
-            if not cell:
-                raise serializers.ValidationError({'cell_plantings': 'Invalid cell entry'})
-            if cell.tray_id != seed_tray.id:
+    @staticmethod
+    def _validate_cells_belong_to_tray(cells, seed_tray):
+        """Reject any cell outside the effective seed tray."""
+        for cell in cells:
+            if cell.tray_id != seed_tray.pk:
                 raise serializers.ValidationError({
                     'cell_plantings': (
-                        f'Cell {cell.pk} belongs to tray {cell.tray.pk}, '
-                        f'not tray {seed_tray.pk}'
+                        f'Cell {cell.pk} belongs to tray {cell.tray_id}, '
+                        f'not tray {seed_tray.pk}.'
                     )
                 })
 
-        # 3. Set derived seed_tray in data if not already present
-        if not data.get('seed_tray'):
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        """Keep retained or replacement cells on the effective seed tray."""
+        cells = self._get_effective_cells(data)
+        if not cells:
+            return data
+
+        seed_tray, seed_tray_derived = self._get_effective_seed_tray(data, cells)
+        if seed_tray is None:
+            raise serializers.ValidationError({
+                'seed_tray': 'A planting with cell plantings must have a seed tray.'
+            })
+
+        self._validate_cells_belong_to_tray(cells, seed_tray)
+        if seed_tray_derived:
             data['seed_tray'] = seed_tray
 
         return data

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -24,6 +24,162 @@ from .models import (
 )
 
 
+class SeedTrayPlantingMembershipTests(TestCase):
+    """
+    Tests for keeping a seed tray planting's cells on its parent tray.
+    """
+
+    def setUp(self):
+        self.client.force_login(get_user_model().objects.create_user(username='planting-tester'))
+        variety = PlantVariety.objects.create(
+            plant=Plant.objects.create(
+                family=PlantFamily.objects.create(name='Brassicaceae'),
+                name='Broccoli',
+            ),
+            name='Calabrese',
+        )
+        self.packet = SeedPacket.objects.create(
+            seeds=Seeds.objects.create(
+                supplier=Supplier.objects.create(name='Membership Supplier'),
+                plant_variety=variety,
+            ),
+        )
+        tray_model = SeedTrayModel.objects.create(
+            identifier='membership-tray',
+            height=10,
+            x_size=20,
+            y_size=30,
+            x_cells=2,
+            y_cells=2,
+            cell_size_ml=40,
+        )
+        self.first_tray = SeedTray.objects.create(model=tray_model)
+        self.first_cell = SeedTrayCell.objects.create(
+            tray=self.first_tray,
+            x_position=0,
+            y_position=0,
+        )
+        self.second_tray = SeedTray.objects.create(model=tray_model)
+        self.second_cell = SeedTrayCell.objects.create(
+            tray=self.second_tray,
+            x_position=0,
+            y_position=0,
+        )
+        self.planting = SeedTrayPlanting.objects.create(
+            seeds_used=self.packet,
+            quantity=1,
+            seed_tray=self.first_tray,
+        )
+        self.cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.planting,
+            cell=self.first_cell,
+            quantity=1,
+        )
+
+    def _patch_planting(self, data):
+        return self.client.patch(
+            f'/plantings/seedtray/{self.planting.pk}/',
+            data=json.dumps(data),
+            content_type='application/json',
+        )
+
+    def test_changing_tray_without_replacing_cells_is_rejected(self):
+        """
+        Retained child rows prevent a partial update from changing their parent tray.
+        """
+        response = self._patch_planting({'seed_tray': self.second_tray.pk})
+
+        self.assertEqual(response.status_code, 400)
+        self.planting.refresh_from_db()
+        self.cell_planting.refresh_from_db()
+        self.assertEqual(self.planting.seed_tray, self.first_tray)
+        self.assertEqual(self.cell_planting.cell, self.first_cell)
+
+    def test_changing_tray_with_valid_replacement_cells_succeeds(self):
+        """
+        A complete replacement can move a planting when every new cell is valid.
+        """
+        response = self._patch_planting({
+            'seed_tray': self.second_tray.pk,
+            'cell_plantings': [{'cell': self.second_cell.pk, 'quantity': 1}],
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.planting.refresh_from_db()
+        self.assertEqual(self.planting.seed_tray, self.second_tray)
+        replacement = self.planting.cell_plantings.get()
+        self.assertEqual(replacement.cell, self.second_cell)
+
+    def test_invalid_replacement_leaves_planting_unchanged(self):
+        """
+        Membership validation happens before either the parent or children are saved.
+        """
+        response = self._patch_planting({
+            'seed_tray': self.second_tray.pk,
+            'cell_plantings': [{'cell': self.first_cell.pk, 'quantity': 1}],
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.planting.refresh_from_db()
+        self.cell_planting.refresh_from_db()
+        self.assertEqual(self.planting.seed_tray, self.first_tray)
+        self.assertEqual(self.cell_planting.cell, self.first_cell)
+
+    def test_replacing_only_cells_with_another_trays_cell_is_rejected(self):
+        """
+        A replacement without seed_tray is checked against the retained parent tray.
+        """
+        response = self._patch_planting({
+            'cell_plantings': [{'cell': self.second_cell.pk, 'quantity': 1}],
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.planting.refresh_from_db()
+        self.cell_planting.refresh_from_db()
+        self.assertEqual(self.planting.seed_tray, self.first_tray)
+        self.assertEqual(self.cell_planting.cell, self.first_cell)
+
+    def test_partial_replacement_requires_a_cell(self):
+        """Malformed replacement entries return 400 instead of raising a KeyError."""
+        response = self._patch_planting({
+            'cell_plantings': [{'quantity': 1}],
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'cell_plantings': [{'cell': ['This field is required.']}]},
+        )
+        self.assertEqual(self.planting.cell_plantings.get(), self.cell_planting)
+
+    def test_partial_replacement_requires_a_quantity(self):
+        """Every replacement entry is complete even when its parent request is partial."""
+        response = self._patch_planting({
+            'cell_plantings': [{'cell': self.first_cell.pk}],
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'cell_plantings': [{'quantity': ['This field is required.']}]},
+        )
+        self.assertEqual(self.planting.cell_plantings.get(), self.cell_planting)
+
+    def test_explicitly_clearing_cells_allows_changing_tray(self):
+        """
+        An empty replacement list removes the old tray membership intentionally.
+        """
+        response = self._patch_planting({
+            'seed_tray': self.second_tray.pk,
+            'cell_plantings': [],
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.planting.refresh_from_db()
+        self.assertEqual(self.planting.seed_tray, self.second_tray)
+        self.assertFalse(self.planting.cell_plantings.exists())
+
+
 class SpecificPlantMoveTests(TestCase):
     """
     Tests for moving a specific plant between tracked locations.


### PR DESCRIPTION
Partial updates previously skipped membership validation when cell_plantings was omitted, allowing the parent tray to diverge from retained cells. Validate the effective child set on every write while preserving explicit replacement and clear semantics so only consistent updates are persisted.

## Summary by Sourcery

Enforce consistent seed tray membership for seed tray plantings on all writes, including partial updates, and add coverage to ensure invalid tray changes are rejected.

Bug Fixes:
- Prevent partial seed tray planting updates from changing the parent tray while implicitly retaining child cell plantings that belong to a different tray.
- Ensure a planting with cell plantings always has a valid seed tray and that all associated cells belong to that tray before persisting changes.

Tests:
- Add integration tests covering tray changes with retained cells, valid and invalid cell replacements, and explicit clearing of cell plantings during updates.