### PR TITLE
fix(seedtrays): make nested cell parents authoritative

### DIFF
--- a/seedtrays/rest.py
+++ b/seedtrays/rest.py
@@ -1,8 +1,10 @@
 """
 Rest related classes for seed trays
 """
-from django.db import transaction
 from itertools import product
+
+from django.db import transaction
+from django.shortcuts import get_object_or_404
 from rest_framework import serializers, viewsets
 from rest_framework_nested import routers
 
@@ -17,6 +19,17 @@ class SeedTrayModelSerializer(serializers.ModelSerializer):
         model = SeedTrayModel
         fields = ['pk', 'identifier', 'description', 'height', 'x_size', 'y_size', 'x_cells', 'y_cells', 'cell_size_ml']
 
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        """Keep cell-grid dimensions stable after trays have been created."""
+        errors = {}
+        if self.instance is not None and self.instance.seedtray_set.exists():
+            for field in ('x_cells', 'y_cells'):
+                if field in data and data[field] != getattr(self.instance, field):
+                    errors[field] = 'Cannot change cell dimensions after trays have been created.'
+        if errors:
+            raise serializers.ValidationError(errors)
+        return data
+
 
 class SeedTraySerializer(serializers.ModelSerializer):
     """
@@ -25,6 +38,15 @@ class SeedTraySerializer(serializers.ModelSerializer):
     class Meta:
         model = SeedTray
         fields = ['pk', 'model', 'created', 'notes']
+
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        """A created tray keeps the model that defined its generated cell grid."""
+        if self.instance is not None and 'model' in data:
+            if data['model'].pk != self.instance.model_id:
+                raise serializers.ValidationError({
+                    'model': 'Cannot change the model of an existing tray.'
+                })
+        return data
 
     def create(self, validated_data):
         """
@@ -50,6 +72,37 @@ class SeedTrayCellSerializer(serializers.ModelSerializer):
     class Meta:
         model = SeedTrayCell
         fields = ['pk', 'tray', 'x_position', 'y_position']
+
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        """Keep a cell on its original tray and within that tray's grid."""
+        parent_tray = self.context.get('parent_tray')
+        tray = parent_tray or data.get('tray') or getattr(self.instance, 'tray', None)
+
+        if self.instance is not None and 'tray' in data:
+            if data['tray'].pk != self.instance.tray_id:
+                raise serializers.ValidationError({
+                    'tray': 'Cannot move an existing cell to another tray.'
+                })
+
+        if tray is None:
+            return data
+
+        x_position = data.get('x_position', getattr(self.instance, 'x_position', None))
+        y_position = data.get('y_position', getattr(self.instance, 'y_position', None))
+        errors = {}
+        if x_position is not None and x_position >= tray.model.x_cells:
+            errors['x_position'] = f'Must be less than {tray.model.x_cells}.'
+        if y_position is not None and y_position >= tray.model.y_cells:
+            errors['y_position'] = f'Must be less than {tray.model.y_cells}.'
+        if errors:
+            raise serializers.ValidationError(errors)
+        return data
+
+
+class NestedSeedTrayCellSerializer(SeedTrayCellSerializer):
+    """Cell serializer whose tray is supplied by the nested URL."""
+    class Meta(SeedTrayCellSerializer.Meta):
+        extra_kwargs = {'tray': {'read_only': True}}
 
 
 class SeedTrayModelsViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
@@ -81,10 +134,28 @@ class SeedTrayCellFilteredViewSet(viewsets.ModelViewSet):  # pylint: disable=too
     ViewSet of SeedTrayCells filtered by tray
     """
     queryset = SeedTrayCell.objects.all()
-    serializer_class = SeedTrayCellSerializer
+    serializer_class = NestedSeedTrayCellSerializer
+    _parent_tray = None
+
+    def get_parent_tray(self):
+        """Resolve and cache the tray identified by the nested URL."""
+        if self._parent_tray is None:
+            self._parent_tray = get_object_or_404(
+                SeedTray.objects.select_related('model'),
+                pk=self.kwargs['seedtray_pk'],
+            )
+        return self._parent_tray
 
     def get_queryset(self):
-        return self.queryset.filter(tray__pk=self.kwargs['seedtray_pk'])
+        return self.queryset.filter(tray=self.get_parent_tray())
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['parent_tray'] = self.get_parent_tray()
+        return context
+
+    def perform_create(self, serializer):
+        serializer.save(tray=self.get_parent_tray())
 
 
 router = routers.SimpleRouter()

--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -73,6 +73,29 @@ class SeedTrayCellIntegrityTests(TestCase):
         self.assertEqual(response.json(), {'x_position': ['Must be less than 2.']})
         self.assertFalse(SeedTrayCell.objects.exists())
 
+    def test_nested_update_rejects_positions_outside_url_tray(self):
+        """
+        Partial updates validate both coordinates without changing the existing cell.
+        """
+        cell = SeedTrayCell.objects.create(
+            tray=self.tray,
+            x_position=0,
+            y_position=0,
+        )
+
+        for field in ('x_position', 'y_position'):
+            with self.subTest(field=field):
+                response = self.client.patch(
+                    f'/seedtrays/seedtrays/{self.tray.pk}/cells/{cell.pk}/',
+                    data=json.dumps({field: 2}),
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.json(), {field: ['Must be less than 2.']})
+                cell.refresh_from_db()
+                self.assertEqual((cell.x_position, cell.y_position), (0, 0))
+
     def test_global_create_rejects_position_outside_payload_tray(self):
         """
         Non-nested cell writes enforce the same coordinate bounds.
@@ -89,6 +112,31 @@ class SeedTrayCellIntegrityTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {'y_position': ['Must be less than 2.']})
+
+    def test_global_create_rejects_negative_positions(self):
+        """
+        PositiveIntegerField validation enforces the lower coordinate bounds.
+        """
+        for field in ('x_position', 'y_position'):
+            with self.subTest(field=field):
+                payload = {
+                    'tray': self.tray.pk,
+                    'x_position': 0,
+                    'y_position': 0,
+                    field: -1,
+                }
+                response = self.client.post(
+                    '/seedtrays/seedtraycells/',
+                    data=json.dumps(payload),
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.json(),
+                    {field: ['Ensure this value is greater than or equal to 0.']},
+                )
+                self.assertFalse(SeedTrayCell.objects.exists())
 
     def test_existing_cell_cannot_be_moved_to_another_tray(self):
         """

--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -1,0 +1,135 @@
+"""
+Tests for seed trays
+"""
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from .models import SeedTray, SeedTrayCell, SeedTrayModel
+
+
+class SeedTrayCellIntegrityTests(TestCase):
+    """
+    Tests for stable tray grids and bounded cell membership.
+    """
+
+    def setUp(self):
+        self.client.force_login(get_user_model().objects.create_user(username='tray-tester'))
+        self.tray_model = SeedTrayModel.objects.create(
+            identifier='two-by-two',
+            height=10,
+            x_size=20,
+            y_size=20,
+            x_cells=2,
+            y_cells=2,
+            cell_size_ml=40,
+        )
+        self.other_model = SeedTrayModel.objects.create(
+            identifier='three-by-three',
+            height=10,
+            x_size=30,
+            y_size=30,
+            x_cells=3,
+            y_cells=3,
+            cell_size_ml=40,
+        )
+        self.tray = SeedTray.objects.create(model=self.tray_model)
+        self.other_tray = SeedTray.objects.create(model=self.other_model)
+
+    def test_nested_create_uses_url_tray_instead_of_payload_tray(self):
+        """
+        The nested resource parent is authoritative when the payload conflicts.
+        """
+        response = self.client.post(
+            f'/seedtrays/seedtrays/{self.tray.pk}/cells/',
+            data=json.dumps({
+                'tray': self.other_tray.pk,
+                'x_position': 0,
+                'y_position': 1,
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        cell = SeedTrayCell.objects.get(pk=response.json()['pk'])
+        self.assertEqual(cell.tray, self.tray)
+
+    def test_nested_create_rejects_position_outside_url_tray(self):
+        """
+        Bounds are checked against the URL tray, not a payload tray with a larger grid.
+        """
+        response = self.client.post(
+            f'/seedtrays/seedtrays/{self.tray.pk}/cells/',
+            data=json.dumps({
+                'tray': self.other_tray.pk,
+                'x_position': 2,
+                'y_position': 0,
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'x_position': ['Must be less than 2.']})
+        self.assertFalse(SeedTrayCell.objects.exists())
+
+    def test_global_create_rejects_position_outside_payload_tray(self):
+        """
+        Non-nested cell writes enforce the same coordinate bounds.
+        """
+        response = self.client.post(
+            '/seedtrays/seedtraycells/',
+            data=json.dumps({
+                'tray': self.tray.pk,
+                'x_position': 0,
+                'y_position': 2,
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'y_position': ['Must be less than 2.']})
+
+    def test_existing_cell_cannot_be_moved_to_another_tray(self):
+        """
+        Changing a cell's tray cannot invalidate plantings that refer to its identity.
+        """
+        cell = SeedTrayCell.objects.create(tray=self.tray, x_position=0, y_position=0)
+
+        response = self.client.patch(
+            f'/seedtrays/seedtraycells/{cell.pk}/',
+            data=json.dumps({'tray': self.other_tray.pk}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        cell.refresh_from_db()
+        self.assertEqual(cell.tray, self.tray)
+
+    def test_cell_dimensions_cannot_change_after_a_tray_exists(self):
+        """
+        Shrinking or reshaping a used model cannot strand existing cell coordinates.
+        """
+        response = self.client.patch(
+            f'/seedtrays/seedtraymodels/{self.tray_model.pk}/',
+            data=json.dumps({'x_cells': 1}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.tray_model.refresh_from_db()
+        self.assertEqual(self.tray_model.x_cells, 2)
+
+    def test_existing_tray_cannot_change_model(self):
+        """
+        A tray cannot swap to a model whose dimensions differ from its generated grid.
+        """
+        response = self.client.patch(
+            f'/seedtrays/seedtrays/{self.tray.pk}/',
+            data=json.dumps({'model': self.other_model.pk}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.tray.refresh_from_db()
+        self.assertEqual(self.tray.model, self.tray_model)


### PR DESCRIPTION
Nested cell creation previously trusted a payload tray that could disagree with the URL, and unchecked grid edits could leave coordinates outside their model. Bind nested writes to the resolved parent, validate cell bounds, and freeze grid-defining relationships once trays exist so later writes cannot create or expose inconsistent membership.

## Summary by Sourcery

Enforce consistent tray-cell relationships by making nested cell operations respect the URL parent tray and by preventing grid-defining changes on existing models and trays.

Bug Fixes:
- Ensure nested seed tray cell creation always uses the tray from the URL instead of any conflicting tray in the request payload.
- Validate seed tray cell coordinates against their tray’s model so cells cannot be created outside the defined grid.
- Disallow moving existing seed tray cells to a different tray, preserving referential integrity of plantings.

Enhancements:
- Prevent changes to a seed tray model’s cell dimensions once trays have been created from it, keeping tray grids stable.
- Prevent changing the model of an existing tray so its generated cell grid remains consistent with its defining model.
- Make nested cell serializers treat the tray as read-only and derive it from the resolved parent tray in the URL.

Tests:
- Add integration tests covering nested and global cell creation, coordinate bounds enforcement, tray immutability, and model dimension stability for seed trays.