### PR TITLE
data(plantings): audit seed tray integrity

### DIFF
--- a/plantings/migrations/0011_audit_seed_tray_integrity.py
+++ b/plantings/migrations/0011_audit_seed_tray_integrity.py
@@ -1,0 +1,57 @@
+from django.db import migrations
+from django.db.models import F, Q
+
+
+def describe_rows(queryset):
+    """Return a bounded description of rows that failed the audit."""
+    count = queryset.count()
+    row_ids = list(queryset.order_by('pk').values_list('pk', flat=True)[:20])
+    suffix = '' if count <= len(row_ids) else f' (first 20 of {count})'
+    return f'{row_ids}{suffix}'
+
+
+def audit_seed_tray_integrity(apps, _schema_editor):
+    """Stop deployment when existing rows violate the new API invariants."""
+    cell_planting_model = apps.get_model('plantings', 'SeedTrayCellPlanting')
+    cell_model = apps.get_model('seedtrays', 'SeedTrayCell')
+
+    invalid_memberships = cell_planting_model.objects.filter(
+        Q(seed_tray_planting__seed_tray__isnull=True) |
+        ~Q(cell__tray_id=F('seed_tray_planting__seed_tray_id'))
+    )
+    invalid_cells = cell_model.objects.filter(
+        Q(x_position__lt=0) |
+        Q(y_position__lt=0) |
+        Q(x_position__gte=F('tray__model__x_cells')) |
+        Q(y_position__gte=F('tray__model__y_cells'))
+    )
+
+    problems = []
+    if invalid_memberships.exists():
+        problems.append(
+            'cross-tray SeedTrayCellPlanting IDs: '
+            f'{describe_rows(invalid_memberships)}'
+        )
+    if invalid_cells.exists():
+        problems.append(
+            'out-of-bounds SeedTrayCell IDs: '
+            f'{describe_rows(invalid_cells)}'
+        )
+
+    if problems:
+        raise RuntimeError(
+            'Seed-tray integrity audit failed. Repair these rows before retrying '
+            f'the migration: {"; ".join(problems)}'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plantings', '0010_datetimefield_germinated_started_ended'),
+        ('seedtrays', '0002_datetimefield_created'),
+    ]
+
+    operations = [
+        migrations.RunPython(audit_seed_tray_integrity, migrations.RunPython.noop),
+    ]

--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -1,0 +1,98 @@
+"""
+Tests for plantings data migrations
+"""
+from importlib import import_module
+
+from django.apps import apps as django_apps
+from django.test import TestCase
+
+from plants.models import Plant, PlantFamily, PlantVariety
+from seeds.models import SeedPacket, Seeds
+from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
+from supplies.models import Supplier
+from .models import SeedTrayCellPlanting, SeedTrayPlanting
+
+
+class SeedTrayIntegrityAuditTests(TestCase):
+    """
+    Tests for the deployment-time seed-tray integrity audit.
+    """
+
+    def setUp(self):
+        variety = PlantVariety.objects.create(
+            plant=Plant.objects.create(
+                family=PlantFamily.objects.create(name='Apiaceae'),
+                name='Carrot',
+            ),
+            name='Nantes',
+        )
+        packet = SeedPacket.objects.create(
+            seeds=Seeds.objects.create(
+                supplier=Supplier.objects.create(name='Audit Supplier'),
+                plant_variety=variety,
+            ),
+        )
+        self.tray_model = SeedTrayModel.objects.create(
+            identifier='audit-tray',
+            height=10,
+            x_size=20,
+            y_size=20,
+            x_cells=2,
+            y_cells=2,
+            cell_size_ml=40,
+        )
+        self.tray = SeedTray.objects.create(model=self.tray_model)
+        self.cell = SeedTrayCell.objects.create(
+            tray=self.tray,
+            x_position=0,
+            y_position=0,
+        )
+        planting = SeedTrayPlanting.objects.create(
+            seeds_used=packet,
+            quantity=1,
+            seed_tray=self.tray,
+        )
+        self.cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=planting,
+            cell=self.cell,
+            quantity=1,
+        )
+        migration = import_module(
+            'plantings.migrations.0011_audit_seed_tray_integrity'
+        )
+        self.audit = migration.audit_seed_tray_integrity
+
+    def test_audit_accepts_consistent_rows(self):
+        """Valid parent membership and coordinates do not block deployment."""
+        self.audit(django_apps, None)
+
+    def test_audit_reports_cross_tray_cell_planting(self):
+        """The failure identifies a cell planting whose parent tray differs."""
+        other_tray = SeedTray.objects.create(model=self.tray_model)
+        other_cell = SeedTrayCell.objects.create(
+            tray=other_tray,
+            x_position=0,
+            y_position=0,
+        )
+        self.cell_planting.cell = other_cell
+        self.cell_planting.save(update_fields=['cell'])
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            f'cross-tray SeedTrayCellPlanting IDs: [{self.cell_planting.pk}]',
+        ):
+            self.audit(django_apps, None)
+
+    def test_audit_reports_out_of_bounds_cell(self):
+        """The failure identifies a cell outside its tray model's grid."""
+        invalid_cell = SeedTrayCell.objects.create(
+            tray=self.tray,
+            x_position=self.tray_model.x_cells,
+            y_position=0,
+        )
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            f'out-of-bounds SeedTrayCell IDs: [{invalid_cell.pk}]',
+        ):
+            self.audit(django_apps, None)


### PR DESCRIPTION
Application validation cannot safely repair historical cross-tray relationships or out-of-bounds cells because lifecycle records may already depend on them. Fail deployment with bounded, actionable row IDs so operators can make an explicit repair before the stricter write contract takes effect.

## Summary by Sourcery

Add a deployment-time data migration to audit existing seed tray integrity and block deployment when violations are detected.

Enhancements:
- Introduce a migration that validates seed-tray cell memberships and coordinates against new integrity invariants, failing with actionable row IDs if issues exist.

Tests:
- Add migration tests that cover valid data, cross-tray cell plantings, and out-of-bounds seed tray cells for the new integrity audit.