### PR TITLE
fix(plantings): make location closure explicit

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -1,4 +1,4 @@
-import { fetchAsJson, csrfPost, csrfPatch } from '../utils'
+import { fetchAsJson, csrfPost } from '../utils'
 import {
   GardenRowDirectPlanting,
   GardenSquareDirectPlanting,
@@ -90,8 +90,8 @@ function addSpecificPlantLocation(data: SpecificPlantLocationCreate): Promise<Re
   return csrfPost('/plantings/specificplantlocations/', data)
 }
 
-function endSpecificPlantLocation(locationPk: number, ended?: string): Promise<Response> {
-  return csrfPatch(`/plantings/specificplantlocations/${locationPk}/`, ended ? { ended } : {})
+function endSpecificPlantLocation(locationPk: number): Promise<Response> {
+  return csrfPost(`/plantings/specificplantlocations/${locationPk}/end/`, {})
 }
 
 function moveSpecificPlant(plantPk: number, data: SpecificPlantMove): Promise<Response> {

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -400,17 +400,26 @@ class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=to
     """
     ViewSet of SpecificPlantLocation
 
-    PUT and DELETE are disabled: locations are append-only; use PATCH to set `ended`.
+    PUT and DELETE are disabled: PATCH edits fields and the end action closes a location.
     """
     queryset = SpecificPlantLocation.objects.select_related('seed_tray_cell', 'garden_square')
     serializer_class = SpecificPlantLocationSerializer
     http_method_names = ['get', 'post', 'patch', 'head', 'options']
 
-    def perform_update(self, serializer):
-        if 'ended' not in serializer.validated_data:
-            serializer.save(ended=timezone.now())
-        else:
-            serializer.save()
+    @action(detail=True, methods=['post'])
+    def end(self, request, pk=None):  # pylint: disable=unused-argument
+        """End an active location once without replacing an existing end time."""
+        with transaction.atomic():
+            location = get_object_or_404(
+                self.get_queryset().select_for_update(),
+                pk=pk,
+            )
+            self.check_object_permissions(request, location)
+            if location.ended is None:
+                location.ended = timezone.now()
+                location.save(update_fields=['ended'])
+
+        return Response(self.get_serializer(location).data)
 
 
 class SpecificPlantLocationByPlantViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -321,6 +321,58 @@ class SpecificPlantMoveTests(TestCase):
         )
         self.assertEqual(active_location.started, move_time)
 
+    def test_notes_only_patch_does_not_end_location(self):
+        """Editing location metadata does not silently change lifecycle state."""
+        response = self.client.patch(
+            f'/plantings/specificplantlocations/{self.active_location.pk}/',
+            data=json.dumps({'notes': 'Checked after rain'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.notes, 'Checked after rain')
+        self.assertIsNone(self.active_location.ended)
+
+    def test_empty_patch_preserves_existing_end_time(self):
+        """A no-op edit cannot replace a location's historical end timestamp."""
+        original_end = datetime(2026, 1, 1, 12, 0, tzinfo=datetime_timezone.utc)
+        self.active_location.ended = original_end
+        self.active_location.save(update_fields=['ended'])
+
+        response = self.client.patch(
+            f'/plantings/specificplantlocations/{self.active_location.pk}/',
+            data=json.dumps({}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, original_end)
+
+    def test_end_action_is_idempotent(self):
+        """Repeated explicit closes retain the timestamp from the first request."""
+        first_end = datetime(2026, 1, 1, 12, 0, tzinfo=datetime_timezone.utc)
+        later_end = first_end + timedelta(hours=1)
+
+        with mock.patch('plantings.rest.timezone.now', return_value=first_end):
+            first_response = self.client.post(
+                f'/plantings/specificplantlocations/{self.active_location.pk}/end/',
+                data=json.dumps({}),
+                content_type='application/json',
+            )
+        with mock.patch('plantings.rest.timezone.now', return_value=later_end):
+            second_response = self.client.post(
+                f'/plantings/specificplantlocations/{self.active_location.pk}/end/',
+                data=json.dumps({}),
+                content_type='application/json',
+            )
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, first_end)
+
     def test_move_rolls_back_current_location_when_create_violates_invariant(self):
         """
         If the destination creation violates the active-location invariant, the previous location remains active.


### PR DESCRIPTION
Generic PATCH requests previously treated omitted ended values as an instruction to close a location, so metadata edits and retries silently changed lifecycle history. Preserve ordinary PATCH semantics and route the frontend through an idempotent, row-locked end action that cannot replace an existing timestamp.

## Summary by Sourcery

Make specific plant location closure an explicit, idempotent end action instead of implicit PATCH behavior.

Bug Fixes:
- Ensure PATCH requests that only edit metadata or are empty no longer alter a location’s lifecycle or overwrite existing end timestamps.
- Prevent concurrent or repeated close operations from replacing an existing end time by row-locking and preserving the first closure.

Enhancements:
- Introduce a dedicated backend end action for specific plant locations and route the frontend through this endpoint for closing locations.

Tests:
- Add regression tests to confirm metadata-only and empty PATCH requests do not change end timestamps and that the explicit end action is idempotent.