### PR TITLE
fix(plantings): enforce location chronology

### DIFF
--- a/plantings/models.py
+++ b/plantings/models.py
@@ -103,6 +103,7 @@ class SpecificPlantLocation(models.Model):
     notes = models.TextField(null=True, blank=True)
 
     def clean(self):
+        super().clean()
         if self.location_type == self.SEED_TRAY_CELL:
             if self.seed_tray_cell is None:
                 raise ValidationError({'seed_tray_cell': 'Required when location_type is seed_tray_cell.'})
@@ -113,6 +114,9 @@ class SpecificPlantLocation(models.Model):
                 raise ValidationError({'garden_square': 'Required when location_type is garden_square.'})
             if self.seed_tray_cell is not None:
                 raise ValidationError({'seed_tray_cell': 'Must be blank when location_type is garden_square.'})
+
+        if self.ended is not None and self.ended < self.started:
+            raise ValidationError({'ended': 'Must be on or after started.'})
 
     class Meta:
         constraints = [

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -3,6 +3,7 @@ Rest for Plantings
 """
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError, transaction
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import routers, serializers, status, viewsets
@@ -162,15 +163,72 @@ class SpecificPlantLocationSerializer(serializers.ModelSerializer):
         model = SpecificPlantLocation
         fields = ['pk', 'specific_plant', 'location_type', 'seed_tray_cell', 'garden_square', 'started', 'ended', 'notes']
 
+    def _get_effective_history_fields(self, data):
+        """Resolve the interval and plant represented by create or partial update data."""
+        specific_plant = data.get(
+            'specific_plant',
+            getattr(self.instance, 'specific_plant', None),
+        )
+        started = data.get(
+            'started',
+            getattr(self.instance, 'started', None),
+        )
+        if started is None:
+            started = timezone.now()
+            data['started'] = started
+        ended = data.get('ended', getattr(self.instance, 'ended', None))
+        return specific_plant, started, ended
+
+    def _validate_history(self, data, *, append_only):
+        """Validate this interval against the other locations for its plant."""
+        specific_plant, started, ended = self._get_effective_history_fields(data)
+        validate_location_history(
+            specific_plant=specific_plant,
+            started=started,
+            ended=ended,
+            exclude_pk=getattr(self.instance, 'pk', None),
+            append_only=append_only,
+        )
+
     def validate(self, data):  # pylint: disable=arguments-renamed
-        # Delegate to the model's clean() as the single source of truth for FK/location_type consistency.
+        if self.instance is not None and 'specific_plant' in data:
+            if data['specific_plant'].pk != self.instance.specific_plant_id:
+                raise serializers.ValidationError({
+                    'specific_plant': 'Cannot reassign an existing location.'
+                })
+
+        specific_plant, started, ended = self._get_effective_history_fields(data)
         validate_specific_plant_location(
             location_type=data.get('location_type', _FIELD_MISSING),
             seed_tray_cell=data.get('seed_tray_cell', _FIELD_MISSING),
             garden_square=data.get('garden_square', _FIELD_MISSING),
+            interval=(started, ended),
             instance=self.instance,
         )
+        validate_location_history(
+            specific_plant=specific_plant,
+            started=started,
+            ended=ended,
+            exclude_pk=getattr(self.instance, 'pk', None),
+            append_only=self.instance is None,
+        )
         return data
+
+    def create(self, validated_data):
+        with transaction.atomic():
+            SpecificPlant.objects.select_for_update().get(
+                pk=validated_data['specific_plant'].pk,
+            )
+            self._validate_history(validated_data, append_only=True)
+            return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        with transaction.atomic():
+            SpecificPlant.objects.select_for_update().get(pk=instance.specific_plant_id)
+            instance = SpecificPlantLocation.objects.select_for_update().get(pk=instance.pk)
+            self.instance = instance
+            self._validate_history(validated_data, append_only=False)
+            return super().update(instance, validated_data)
 
 
 class SpecificPlantMoveSerializer(serializers.ModelSerializer):
@@ -228,7 +286,14 @@ class GardenSquareTransplantSerializer(serializers.ModelSerializer):
 _FIELD_MISSING = object()
 
 
-def validate_specific_plant_location(*, location_type=None, seed_tray_cell=None, garden_square=None, instance=None):
+def validate_specific_plant_location(
+    *,
+    location_type=None,
+    seed_tray_cell=None,
+    garden_square=None,
+    interval=None,
+    instance=None,
+):
     """
     Validate location fields, optionally defaulting omitted fields from an instance.
     """
@@ -239,16 +304,56 @@ def validate_specific_plant_location(*, location_type=None, seed_tray_cell=None,
             seed_tray_cell = instance.seed_tray_cell
         if garden_square is _FIELD_MISSING:
             garden_square = instance.garden_square
+        if interval is None:
+            interval = (instance.started, instance.ended)
+
+    location_data = {
+        'location_type': None if location_type is _FIELD_MISSING else location_type,
+        'seed_tray_cell': None if seed_tray_cell is _FIELD_MISSING else seed_tray_cell,
+        'garden_square': None if garden_square is _FIELD_MISSING else garden_square,
+    }
+    if interval is not None:
+        location_data['started'], location_data['ended'] = interval
 
     tmp = SpecificPlantLocation(
-        location_type=None if location_type is _FIELD_MISSING else location_type,
-        seed_tray_cell=None if seed_tray_cell is _FIELD_MISSING else seed_tray_cell,
-        garden_square=None if garden_square is _FIELD_MISSING else garden_square,
+        **location_data,
     )
     try:
         tmp.clean()
     except DjangoValidationError as exc:
         raise serializers.ValidationError(exc.message_dict) from exc
+
+
+def validate_location_history(
+    *,
+    specific_plant,
+    started,
+    ended,
+    exclude_pk=None,
+    append_only=False,
+):
+    """Reject location intervals that overlap or insert before existing history."""
+    locations = SpecificPlantLocation.objects.filter(specific_plant=specific_plant)
+    if exclude_pk is not None:
+        locations = locations.exclude(pk=exclude_pk)
+
+    if append_only:
+        latest_location = locations.order_by('-started', '-pk').first()
+        if latest_location is None:
+            return
+        if latest_location.ended is None or started < latest_location.ended:
+            raise serializers.ValidationError({
+                'started': 'New locations must start at or after existing history ends.'
+            })
+        return
+
+    overlapping = locations.filter(Q(ended__isnull=True) | Q(ended__gt=started))
+    if ended is not None:
+        overlapping = overlapping.filter(started__lt=ended)
+    if overlapping.exists():
+        raise serializers.ValidationError({
+            'started': 'Location interval overlaps another location.'
+        })
 
 
 def get_single_active_location_for_update(plant):
@@ -295,8 +400,19 @@ def move_specific_plant(plant, move_data):
         active_location = get_single_active_location_for_update(plant)
 
         if active_location:
+            if started < active_location.started:
+                raise serializers.ValidationError({
+                    'started': 'Move cannot start before the active location.'
+                })
             active_location.ended = started
             active_location.save(update_fields=['ended'])
+        else:
+            validate_location_history(
+                specific_plant=plant,
+                started=started,
+                ended=None,
+                append_only=True,
+            )
 
         try:
             return SpecificPlantLocation.objects.create(
@@ -416,7 +532,14 @@ class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=to
             )
             self.check_object_permissions(request, location)
             if location.ended is None:
-                location.ended = timezone.now()
+                ended = timezone.now()
+                validate_specific_plant_location(
+                    location_type=location.location_type,
+                    seed_tray_cell=location.seed_tray_cell,
+                    garden_square=location.garden_square,
+                    interval=(location.started, ended),
+                )
+                location.ended = ended
                 location.save(update_fields=['ended'])
 
         return Response(self.get_serializer(location).data)

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -321,6 +321,91 @@ class SpecificPlantMoveTests(TestCase):
         )
         self.assertEqual(active_location.started, move_time)
 
+    def test_move_rejects_start_before_active_location(self):
+        """A move cannot give the active location a negative duration."""
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2025-12-31T08:00:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'started': 'Move cannot start before the active location.'},
+        )
+        self.active_location.refresh_from_db()
+        self.assertIsNone(self.active_location.ended)
+        self.assertEqual(self.plant.locations.count(), 1)
+
+    def test_move_at_active_start_allows_zero_duration_interval(self):
+        """A move at the current start is the documented inclusive boundary."""
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': self.active_location.started.isoformat(),
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, self.active_location.started)
+        new_location = self.plant.locations.get(ended__isnull=True)
+        self.assertEqual(new_location.started, self.active_location.started)
+
+    def test_move_without_active_location_rejects_history_insertion(self):
+        """Backdated moves cannot be inserted before the latest completed boundary."""
+        original_end = datetime(2026, 1, 2, 8, 0, tzinfo=datetime_timezone.utc)
+        self.active_location.ended = original_end
+        self.active_location.save(update_fields=['ended'])
+
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2026-01-01T12:00:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'started': 'New locations must start at or after existing history ends.'},
+        )
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, original_end)
+        self.assertEqual(self.plant.locations.count(), 1)
+
+    def test_move_without_active_location_allows_backdated_append(self):
+        """A historical move is valid when it appends after all existing history."""
+        original_end = datetime(2026, 1, 1, 12, 0, tzinfo=datetime_timezone.utc)
+        appended_start = original_end + timedelta(hours=1)
+        self.active_location.ended = original_end
+        self.active_location.save(update_fields=['ended'])
+
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': appended_start.isoformat(),
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        new_location = self.plant.locations.get(ended__isnull=True)
+        self.assertEqual(new_location.started, appended_start)
+
     def test_notes_only_patch_does_not_end_location(self):
         """Editing location metadata does not silently change lifecycle state."""
         response = self.client.patch(
@@ -372,6 +457,123 @@ class SpecificPlantMoveTests(TestCase):
         self.assertEqual(second_response.status_code, 200)
         self.active_location.refresh_from_db()
         self.assertEqual(self.active_location.ended, first_end)
+
+    def test_end_action_rejects_time_before_location_start(self):
+        """Explicit closure returns a field error rather than saving a reversed interval."""
+        end_time = self.active_location.started - timedelta(hours=1)
+        with mock.patch('plantings.rest.timezone.now', return_value=end_time):
+            response = self.client.post(
+                f'/plantings/specificplantlocations/{self.active_location.pk}/end/',
+                data=json.dumps({}),
+                content_type='application/json',
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'ended': ['Must be on or after started.']})
+        self.active_location.refresh_from_db()
+        self.assertIsNone(self.active_location.ended)
+
+    def test_location_create_rejects_end_before_start(self):
+        """Generic creation applies the same interval ordering rule."""
+        response = self.client.post(
+            '/plantings/specificplantlocations/',
+            data=json.dumps({
+                'specific_plant': self.plant.pk,
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2026-01-03T08:00:00Z',
+                'ended': '2026-01-02T08:00:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'ended': ['Must be on or after started.']})
+        self.assertEqual(self.plant.locations.count(), 1)
+
+    def test_location_patch_rejects_end_before_start(self):
+        """Generic partial updates cannot reverse an existing interval."""
+        response = self.client.patch(
+            f'/plantings/specificplantlocations/{self.active_location.pk}/',
+            data=json.dumps({'ended': '2025-12-31T08:00:00Z'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'ended': ['Must be on or after started.']})
+        self.active_location.refresh_from_db()
+        self.assertIsNone(self.active_location.ended)
+
+    def test_location_create_rejects_insertion_before_active_history(self):
+        """Generic creation follows the append-only history policy."""
+        response = self.client.post(
+            '/plantings/specificplantlocations/',
+            data=json.dumps({
+                'specific_plant': self.plant.pk,
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': '2025-12-30T08:00:00Z',
+                'ended': '2025-12-31T08:00:00Z',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'started': ['New locations must start at or after existing history ends.']},
+        )
+        self.assertEqual(self.plant.locations.count(), 1)
+
+    def test_location_create_allows_append_after_completed_history(self):
+        """Generic creation can append a new active interval after the latest end."""
+        original_end = datetime(2026, 1, 1, 12, 0, tzinfo=datetime_timezone.utc)
+        appended_start = original_end + timedelta(hours=1)
+        self.active_location.ended = original_end
+        self.active_location.save(update_fields=['ended'])
+
+        response = self.client.post(
+            '/plantings/specificplantlocations/',
+            data=json.dumps({
+                'specific_plant': self.plant.pk,
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': appended_start.isoformat(),
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        appended_location = self.plant.locations.get(ended__isnull=True)
+        self.assertEqual(appended_location.started, appended_start)
+
+    def test_location_patch_rejects_overlap_with_next_location(self):
+        """Editing a completed interval cannot extend it across the next location."""
+        move_start = datetime(2026, 1, 2, 8, 0, tzinfo=datetime_timezone.utc)
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            data=json.dumps({
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': self.square.pk,
+                'started': move_start.isoformat(),
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 201)
+
+        overlap_response = self.client.patch(
+            f'/plantings/specificplantlocations/{self.active_location.pk}/',
+            data=json.dumps({'ended': (move_start + timedelta(hours=1)).isoformat()}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(overlap_response.status_code, 400)
+        self.assertEqual(
+            overlap_response.json(),
+            {'started': ['Location interval overlaps another location.']},
+        )
+        self.active_location.refresh_from_db()
+        self.assertEqual(self.active_location.ended, move_start)
 
     def test_move_rolls_back_current_location_when_create_violates_invariant(self):
         """


### PR DESCRIPTION
Moves and generic location writes previously allowed reversed or overlapping intervals, making lifecycle history unreliable. Validate interval order under per-plant locks, accept boundary-equal moves, and permit backdated timestamps only when they append after completed history so concurrent API writes preserve an ordered timeline.

## Summary by Sourcery

Enforce chronological, non-overlapping location history for specific plants across moves, generic location CRUD, and end actions while preserving append-only semantics for backdated entries.

Bug Fixes:
- Prevent creating or updating specific plant locations with intervals where the end precedes the start or overlaps existing locations.
- Disallow moves that start before the current active location while still permitting zero-duration boundary moves at the current start time.
- Ensure backdated moves and generic location creations can only append after the latest completed history, rejecting insertion into existing history gaps.
- Validate explicit end actions against the location start time to avoid reversed intervals and maintain lifecycle integrity.
- Block reassignment of an existing location to a different specific plant via updates.

Enhancements:
- Centralize location interval and history validation in shared helpers used by serializers, move logic, and end actions, under per-plant locking for consistency.