### PR TITLE
data(plantings): constrain location chronology

### DIFF
--- a/plantings/migrations/0012_specificplantlocation_chronology.py
+++ b/plantings/migrations/0012_specificplantlocation_chronology.py
@@ -1,0 +1,87 @@
+from django.db import migrations, models
+from django.db.models import F, Q
+
+
+def find_location_overlaps(locations):
+    """Return bounded overlap pairs and the total overlap count."""
+    overlap_pairs = []
+    overlap_count = 0
+    current_plant_id = None
+    open_interval = None
+
+    for location in locations:
+        if location['specific_plant_id'] != current_plant_id:
+            current_plant_id = location['specific_plant_id']
+            open_interval = None
+
+        started = location['started']
+        ended = location['ended']
+        if ended is not None and ended <= started:
+            continue
+
+        if open_interval is not None:
+            open_end = open_interval['ended']
+            if open_end is None or started < open_end:
+                overlap_count += 1
+                if len(overlap_pairs) < 20:
+                    overlap_pairs.append((open_interval['pk'], location['pk']))
+                if open_end is None:
+                    continue
+                if ended is None or ended > open_end:
+                    open_interval = location
+                continue
+
+        open_interval = location
+
+    return overlap_pairs, overlap_count
+
+
+def audit_location_chronology(apps, _schema_editor):
+    """Stop deployment when existing location history violates chronology."""
+    location_model = apps.get_model('plantings', 'SpecificPlantLocation')
+    reversed_locations = location_model.objects.filter(ended__lt=F('started'))
+    reversed_count = reversed_locations.count()
+    reversed_ids = list(
+        reversed_locations.order_by('pk').values_list('pk', flat=True)[:20]
+    )
+
+    ordered_locations = (
+        location_model.objects
+        .exclude(ended__lt=F('started'))
+        .order_by('specific_plant_id', 'started', 'pk')
+        .values('pk', 'specific_plant_id', 'started', 'ended')
+        .iterator()
+    )
+    overlap_pairs, overlap_count = find_location_overlaps(ordered_locations)
+
+    problems = []
+    if reversed_count:
+        suffix = '' if reversed_count <= 20 else f' (first 20 of {reversed_count})'
+        problems.append(f'reversed location IDs: {reversed_ids}{suffix}')
+    if overlap_count:
+        suffix = '' if overlap_count <= 20 else f' (first 20 of {overlap_count})'
+        problems.append(f'overlapping location ID pairs: {overlap_pairs}{suffix}')
+
+    if problems:
+        raise RuntimeError(
+            'Location chronology audit failed. Repair these rows before retrying '
+            f'the migration: {"; ".join(problems)}'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plantings', '0011_audit_seed_tray_integrity'),
+    ]
+
+    operations = [
+        migrations.RunPython(audit_location_chronology, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name='specificplantlocation',
+            constraint=models.CheckConstraint(
+                condition=Q(ended__isnull=True) | Q(ended__gte=F('started')),
+                name='location_ended_not_before_started',
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -124,7 +124,11 @@ class SpecificPlantLocation(models.Model):
                 fields=['specific_plant'],
                 condition=models.Q(ended__isnull=True),
                 name='unique_active_location_per_plant',
-            )
+            ),
+            models.CheckConstraint(
+                condition=models.Q(ended__isnull=True) | models.Q(ended__gte=models.F('started')),
+                name='location_ended_not_before_started',
+            ),
         ]
 
     def __str__(self):

--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -1,21 +1,27 @@
 """
 Tests for plantings data migrations
 """
+from datetime import datetime, timezone as datetime_timezone
 from importlib import import_module
 
 from django.apps import apps as django_apps
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from plants.models import Plant, PlantFamily, PlantVariety
 from seeds.models import SeedPacket, Seeds
 from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
 from supplies.models import Supplier
-from .models import SeedTrayCellPlanting, SeedTrayPlanting
+from .models import (
+    SeedTrayCellPlanting,
+    SeedTrayPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
 
 
-class SeedTrayIntegrityAuditTests(TestCase):
+class PlantingsDataMigrationTests(TestCase):
     """
-    Tests for the deployment-time seed-tray integrity audit.
+    Tests for deployment-time planting integrity audits.
     """
 
     def setUp(self):
@@ -57,10 +63,15 @@ class SeedTrayIntegrityAuditTests(TestCase):
             cell=self.cell,
             quantity=1,
         )
+        self.plant = SpecificPlant.objects.create(cell_planting=self.cell_planting)
         migration = import_module(
             'plantings.migrations.0011_audit_seed_tray_integrity'
         )
         self.audit = migration.audit_seed_tray_integrity
+        chronology_migration = import_module(
+            'plantings.migrations.0012_specificplantlocation_chronology'
+        )
+        self.chronology_audit = chronology_migration.audit_location_chronology
 
     def test_audit_accepts_consistent_rows(self):
         """Valid parent membership and coordinates do not block deployment."""
@@ -83,6 +94,48 @@ class SeedTrayIntegrityAuditTests(TestCase):
         ):
             self.audit(django_apps, None)
 
+    def test_chronology_audit_accepts_adjacent_intervals(self):
+        """Intervals that meet at a boundary pass the deployment audit."""
+        boundary = datetime(2026, 1, 2, 8, 0, tzinfo=datetime_timezone.utc)
+        SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=self.cell,
+            started=datetime(2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc),
+            ended=boundary,
+        )
+        SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=self.cell,
+            started=boundary,
+        )
+
+        self.chronology_audit(django_apps, None)
+
+    def test_chronology_audit_reports_overlapping_intervals(self):
+        """The deployment failure identifies both rows in an overlap."""
+        first_location = SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=self.cell,
+            started=datetime(2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc),
+            ended=datetime(2026, 1, 3, 8, 0, tzinfo=datetime_timezone.utc),
+        )
+        second_location = SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=self.cell,
+            started=datetime(2026, 1, 2, 8, 0, tzinfo=datetime_timezone.utc),
+            ended=datetime(2026, 1, 4, 8, 0, tzinfo=datetime_timezone.utc),
+        )
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            f'overlapping location ID pairs: [({first_location.pk}, {second_location.pk})]',
+        ):
+            self.chronology_audit(django_apps, None)
+
     def test_audit_reports_out_of_bounds_cell(self):
         """The failure identifies a cell outside its tray model's grid."""
         invalid_cell = SeedTrayCell.objects.create(
@@ -96,3 +149,25 @@ class SeedTrayIntegrityAuditTests(TestCase):
             f'out-of-bounds SeedTrayCell IDs: [{invalid_cell.pk}]',
         ):
             self.audit(django_apps, None)
+
+
+class LocationChronologyAuditHelperTests(SimpleTestCase):
+    """Tests for detecting historical overlaps before adding the constraint."""
+
+    def test_overlap_scan_allows_boundaries_and_zero_duration_intervals(self):
+        """Only intervals with shared duration are reported as overlapping."""
+        migration = import_module(
+            'plantings.migrations.0012_specificplantlocation_chronology'
+        )
+        locations = [
+            {'pk': 1, 'specific_plant_id': 1, 'started': 1, 'ended': 3},
+            {'pk': 2, 'specific_plant_id': 1, 'started': 2, 'ended': 4},
+            {'pk': 3, 'specific_plant_id': 1, 'started': 4, 'ended': None},
+            {'pk': 4, 'specific_plant_id': 2, 'started': 1, 'ended': 1},
+            {'pk': 5, 'specific_plant_id': 2, 'started': 1, 'ended': None},
+        ]
+
+        pairs, count = migration.find_location_overlaps(locations)
+
+        self.assertEqual(pairs, [(1, 2)])
+        self.assertEqual(count, 1)

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone as datetime_timezone
 from unittest import mock
 
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError, connection
+from django.db import IntegrityError, connection, transaction
 from django.test import TestCase
 
 from garden.models import GardenArea, GardenBed, GardenSquare
@@ -180,7 +180,7 @@ class SeedTrayPlantingMembershipTests(TestCase):
         self.assertFalse(self.planting.cell_plantings.exists())
 
 
-class SpecificPlantMoveTests(TestCase):
+class SpecificPlantMoveTests(TestCase):  # pylint: disable=too-many-public-methods
     """
     Tests for moving a specific plant between tracked locations.
     """
@@ -574,6 +574,18 @@ class SpecificPlantMoveTests(TestCase):
         )
         self.active_location.refresh_from_db()
         self.assertEqual(self.active_location.ended, move_start)
+
+    def test_database_rejects_end_before_start(self):
+        """The database protects chronology outside serializer-controlled writes."""
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                SpecificPlantLocation.objects.create(
+                    specific_plant=self.plant,
+                    location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+                    seed_tray_cell=self.other_cell,
+                    started=datetime(2026, 1, 2, 8, 0, tzinfo=datetime_timezone.utc),
+                    ended=datetime(2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc),
+                )
 
     def test_move_rolls_back_current_location_when_create_violates_invariant(self):
         """


### PR DESCRIPTION
Serializer checks cannot protect direct database writes, while adding a check blindly would make deployments fail without identifying historical corruption. Audit reversed and overlapping intervals with actionable row IDs first, then enforce ended-at-or-after-started at the database layer.

## Summary by Sourcery

Audit existing specific plant location history for reversed and overlapping intervals before enforcing a database chronology constraint.

New Features:
- Add a deployment-time audit migration that reports reversed and overlapping specific plant location intervals with actionable row IDs.

Enhancements:
- Add a database check constraint ensuring a specific plant location cannot end before it starts, protecting writes outside serializers.
- Extend planting migration tests to cover location chronology audits and helper overlap detection logic.

Tests:
- Add tests validating the chronology audit migration behavior for adjacent and overlapping intervals, including helper overlap scanning logic.
- Add tests confirming the database rejects specific plant locations where the end timestamp precedes the start timestamp.