### PR TITLE
refactor(plantings): harden quantity audit reporting

### DIFF
--- a/plantings/migrations/0014_constrain_positive_quantities.py
+++ b/plantings/migrations/0014_constrain_positive_quantities.py
@@ -12,9 +12,8 @@ QUANTITY_MODELS = (
 )
 
 
-def describe_rows(queryset):
+def describe_rows(queryset, count):
     """Return a bounded description of rows that failed the audit."""
-    count = queryset.count()
     row_ids = list(queryset.order_by('pk').values_list('pk', flat=True)[:20])
     suffix = '' if count <= len(row_ids) else f' (first 20 of {count})'
     return f'{row_ids}{suffix}'
@@ -26,8 +25,11 @@ def audit_positive_quantities(apps, _schema_editor):
     for model_name in QUANTITY_MODELS:
         model = apps.get_model('plantings', model_name)
         invalid_rows = model.objects.filter(quantity__lt=1)
-        if invalid_rows.count():
-            problems.append(f'{model_name} IDs: {describe_rows(invalid_rows)}')
+        invalid_count = invalid_rows.count()
+        if invalid_count:
+            problems.append(
+                f'{model_name} IDs: {describe_rows(invalid_rows, invalid_count)}'
+            )
 
     if problems:
         raise RuntimeError(

--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -102,20 +102,35 @@ class PlantingsDataMigrationTests(TestCase):
         valid_model = mock.MagicMock()
         valid_model.objects.filter.return_value = valid_rows
 
+        historical_models = dict.fromkeys(migration.QUANTITY_MODELS, valid_model)
+        historical_models['GardenRowDirectSowPlanting'] = invalid_model
         historical_apps = mock.MagicMock()
-        historical_apps.get_model.side_effect = [
-            invalid_model,
-            valid_model,
-            valid_model,
-            valid_model,
-            valid_model,
-        ]
+        historical_apps.get_model.side_effect = (
+            lambda _app, model_name: historical_models[model_name]
+        )
 
         with self.assertRaisesMessage(
             RuntimeError,
             'GardenRowDirectSowPlanting IDs: [7]',
         ):
             migration.audit_positive_quantities(historical_apps, None)
+
+        invalid_rows.count.assert_called_once_with()
+
+    def test_quantity_audit_describe_rows_truncates_with_total(self):
+        """Long audit reports show the first 20 IDs and the complete count."""
+        migration = import_module(
+            'plantings.migrations.0014_constrain_positive_quantities'
+        )
+        invalid_rows = mock.MagicMock()
+        first_ids = list(range(1, 21))
+        values = invalid_rows.order_by.return_value.values_list.return_value
+        values.__getitem__.return_value = first_ids
+
+        description = migration.describe_rows(invalid_rows, count=25)
+
+        self.assertEqual(description, f'{first_ids} (first 20 of 25)')
+        values.__getitem__.assert_called_once_with(slice(None, 20))
 
     def test_audit_reports_cross_tray_cell_planting(self):
         """The failure identifies a cell planting whose parent tray differs."""


### PR DESCRIPTION
Deployment audits may scan large tables, so avoid repeating the invalid-row count when formatting an error. Derive mocked historical models from the audited model list and pin the 20-ID truncation output so adding another quantity model cannot silently weaken or break the diagnostic tests.

## Summary by Sourcery

Refine quantity audit reporting to avoid redundant row counting while ensuring stable, bounded descriptions of invalid IDs in migration diagnostics.

Bug Fixes:
- Prevent repeated counting of invalid quantity rows during audit reporting by reusing the computed total.

Enhancements:
- Change the describe_rows helper to accept a precomputed total count and include it in a truncated list of IDs when applicable.
- Adjust historical model resolution in migration audits to be derived from the quantity model list for more robust diagnostics.

Tests:
- Update quantity audit tests to assert a single count call on invalid rows and add coverage for the truncated ID description including the total count.