### PR TITLE
refactor(garden): reuse geometry audit counts

### DIFF
--- a/garden/migrations/0004_constrain_garden_geometry.py
+++ b/garden/migrations/0004_constrain_garden_geometry.py
@@ -11,9 +11,8 @@ GEOMETRY_MODELS = (
 )
 
 
-def describe_rows(queryset):
+def describe_rows(queryset, count):
     """Return a bounded description of rows that failed the audit."""
-    count = queryset.count()
     row_ids = list(queryset.order_by('pk').values_list('pk', flat=True)[:20])
     suffix = '' if count <= len(row_ids) else f' (first 20 of {count})'
     return f'{row_ids}{suffix}'
@@ -27,19 +26,22 @@ def audit_garden_geometry(apps, _schema_editor):
         invalid_sizes = model.objects.filter(
             models.Q(size_x__lt=1) | models.Q(size_y__lt=1)
         )
-        if invalid_sizes.count():
+        invalid_size_count = invalid_sizes.count()
+        if invalid_size_count:
             problems.append(
-                f'{model_name} size IDs: {describe_rows(invalid_sizes)}'
+                f'{model_name} size IDs: '
+                f'{describe_rows(invalid_sizes, invalid_size_count)}'
             )
 
         if has_placement:
             invalid_placements = model.objects.filter(
                 models.Q(placement_x__lt=0) | models.Q(placement_y__lt=0)
             )
-            if invalid_placements.count():
+            invalid_placement_count = invalid_placements.count()
+            if invalid_placement_count:
                 problems.append(
                     f'{model_name} placement IDs: '
-                    f'{describe_rows(invalid_placements)}'
+                    f'{describe_rows(invalid_placements, invalid_placement_count)}'
                 )
 
     if problems:

--- a/garden/tests.py
+++ b/garden/tests.py
@@ -202,26 +202,38 @@ class GardenGeometryAPITests(TestCase):
     def test_geometry_audit_reports_model_field_and_row_ids(self):
         """Deployment failures identify invalid geometry precisely."""
         migration = import_module('garden.migrations.0004_constrain_garden_geometry')
-        invalid_rows = mock.MagicMock()
-        invalid_rows.count.return_value = 1
-        values = invalid_rows.order_by.return_value.values_list.return_value
-        values.__getitem__.return_value = [9]
+        invalid_sizes = mock.MagicMock()
+        invalid_sizes.count.return_value = 1
+        size_values = invalid_sizes.order_by.return_value.values_list.return_value
+        size_values.__getitem__.return_value = [9]
+
+        invalid_placements = mock.MagicMock()
+        invalid_placements.count.return_value = 1
+        placement_values = (
+            invalid_placements.order_by.return_value.values_list.return_value
+        )
+        placement_values.__getitem__.return_value = [10]
 
         empty_rows = mock.MagicMock()
         empty_rows.count.return_value = 0
 
-        def model_returning(rows):
+        def model_returning(*rows):
             historical_model = mock.MagicMock()
-            historical_model.objects.filter.return_value = rows
+            historical_model.objects.filter.side_effect = rows
             return historical_model
 
         historical_apps = mock.MagicMock()
         historical_apps.get_model.side_effect = [
-            model_returning(invalid_rows),
-            model_returning(empty_rows),
-            model_returning(empty_rows),
-            model_returning(empty_rows),
+            model_returning(invalid_sizes),
+            model_returning(empty_rows, invalid_placements),
+            model_returning(empty_rows, empty_rows),
+            model_returning(empty_rows, empty_rows),
         ]
 
-        with self.assertRaisesMessage(RuntimeError, 'GardenArea size IDs: [9]'):
+        with self.assertRaises(RuntimeError) as raised:
             migration.audit_garden_geometry(historical_apps, None)
+
+        self.assertIn('GardenArea size IDs: [9]', str(raised.exception))
+        self.assertIn('GardenBed placement IDs: [10]', str(raised.exception))
+        invalid_sizes.count.assert_called_once_with()
+        invalid_placements.count.assert_called_once_with()


### PR DESCRIPTION
Deployment audits can scan large geometry tables, and formatting an invalid-row diagnostic should not repeat the count query that already established the failure. Pass each size or placement count into the formatter and test both paths so future changes preserve the single-query behavior.

## Summary by Sourcery

Optimize garden geometry audit to reuse precomputed invalid row counts when formatting diagnostic messages.

Bug Fixes:
- Ensure geometry audit uses the same count queried for invalid sizes and placements instead of re-counting when formatting diagnostics.

Enhancements:
- Refine geometry audit error reporting to include both invalid size and placement IDs in a single RuntimeError message.

Tests:
- Extend geometry audit tests to cover both invalid size and placement diagnostics and assert single count invocations for each path.