### PR TITLE
fix(seedtrays): require login for detail view

### DIFF
--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -37,6 +37,17 @@ class SeedTrayCellIntegrityTests(TestCase):
         self.tray = SeedTray.objects.create(model=self.tray_model)
         self.other_tray = SeedTray.objects.create(model=self.other_model)
 
+    def test_detail_view_requires_login(self):
+        """Anonymous visitors cannot discover seed tray detail pages."""
+        self.client.logout()
+
+        response = self.client.get(f'/seedtrays/seedtray/{self.tray.pk}/')
+
+        self.assertRedirects(
+            response,
+            f'/accounts/login/?next=/seedtrays/seedtray/{self.tray.pk}/',
+        )
+
     def test_nested_create_uses_url_tray_instead_of_payload_tray(self):
         """
         The nested resource parent is authoritative when the payload conflicts.

--- a/seedtrays/views.py
+++ b/seedtrays/views.py
@@ -1,10 +1,11 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views import View
 from django.shortcuts import get_object_or_404, render
 
 from .models import SeedTray
 
 
-class SeedTrayDetailView(View):
+class SeedTrayDetailView(LoginRequiredMixin, View):
     def get(self, request, pk):
         seed_tray = get_object_or_404(SeedTray, pk=pk)
         context = {


### PR DESCRIPTION
The REST calls were authenticated but the HTML shell exposed valid tray IDs to anonymous visitors. Protecting the route makes the current single-user deployment boundary consistent across HTML and API surfaces.

## Summary by Sourcery

Require authentication for seed tray detail pages to prevent anonymous access to tray information.

Bug Fixes:
- Protect the seed tray detail HTML view with login requirements to align with existing authenticated REST API behavior.

Tests:
- Add a test ensuring the seed tray detail view redirects anonymous users to the login page.