### PR TITLE
fix(plantings): cap cell allocations at planted quantity

### DIFF
--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -62,16 +62,29 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
             'seed_tray', 'location', 'removed', 'notes', 'cell_plantings',
         ]
 
-    def _get_effective_cells(self, data):
-        """Return submitted replacement cells or the retained instance cells."""
+    def _get_effective_cell_plantings(self, data):
+        """Return submitted replacements or the retained cell plantings."""
         if 'cell_plantings' in data:
-            return [cell_planting['cell'] for cell_planting in data['cell_plantings']]
+            return data['cell_plantings']
         if self.instance is not None:
-            return [
-                cell_planting.cell
-                for cell_planting in self.instance.cell_plantings.select_related('cell__tray')
-            ]
+            return list(
+                self.instance.cell_plantings.select_related('cell__tray')
+            )
         return []
+
+    @staticmethod
+    def _get_cell(cell_planting):
+        """Return the cell from submitted data or an existing model instance."""
+        if isinstance(cell_planting, dict):
+            return cell_planting['cell']
+        return cell_planting.cell
+
+    @staticmethod
+    def _get_cell_quantity(cell_planting):
+        """Return quantity from submitted data or an existing model instance."""
+        if isinstance(cell_planting, dict):
+            return cell_planting['quantity']
+        return cell_planting.quantity
 
     def _get_effective_seed_tray(self, data, cells):
         """Return the effective tray and whether it was derived from a cell."""
@@ -97,7 +110,21 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """Keep retained or replacement cells on the effective seed tray."""
-        cells = self._get_effective_cells(data)
+        cell_plantings = self._get_effective_cell_plantings(data)
+        quantity = data.get('quantity', getattr(self.instance, 'quantity', None))
+        allocated_quantity = sum(
+            self._get_cell_quantity(cell_planting)
+            for cell_planting in cell_plantings
+        )
+        if quantity is not None and allocated_quantity > quantity:
+            raise serializers.ValidationError({
+                'cell_plantings': 'Cell allocation total cannot exceed planting quantity.'
+            })
+
+        cells = [
+            self._get_cell(cell_planting)
+            for cell_planting in cell_plantings
+        ]
         if not cells:
             return data
 

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -155,6 +155,73 @@ class PositiveQuantityAPITests(TestCase):
                     },
                 )
 
+    def test_create_rejects_cell_allocation_above_parent_quantity(self):
+        """Cell allocations cannot account for more seeds than were planted."""
+        response = self.client.post(
+            '/plantings/seedtray/',
+            data=json.dumps({
+                'seeds_used': self.packet.pk,
+                'quantity': 1,
+                'seed_tray': self.tray.pk,
+                'cell_plantings': [{
+                    'cell': self.cell.pk,
+                    'quantity': 2,
+                }],
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'cell_plantings': [
+                    'Cell allocation total cannot exceed planting quantity.'
+                ],
+            },
+        )
+
+    def test_update_rejects_parent_quantity_below_retained_allocation(self):
+        """Reducing a parent cannot strand a larger retained allocation."""
+        self.original_planting.quantity = 2
+        self.original_planting.save(update_fields=['quantity'])
+        SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.original_planting,
+            cell=self.cell,
+            quantity=2,
+        )
+
+        response = self.client.patch(
+            f'/plantings/seedtray/{self.original_planting.pk}/',
+            data=json.dumps({'quantity': 1}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.original_planting.refresh_from_db()
+        self.assertEqual(self.original_planting.quantity, 2)
+
+    def test_partial_cell_allocation_is_allowed(self):
+        """A planting may leave some seeds unassigned to individual cells."""
+        response = self.client.post(
+            '/plantings/seedtray/',
+            data=json.dumps({
+                'seeds_used': self.packet.pk,
+                'quantity': 2,
+                'seed_tray': self.tray.pk,
+                'cell_plantings': [{
+                    'cell': self.cell.pk,
+                    'quantity': 1,
+                }],
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        planting = SeedTrayPlanting.objects.get(pk=response.json()['pk'])
+        self.assertEqual(planting.quantity, 2)
+        self.assertEqual(planting.cell_plantings.get().quantity, 1)
+
     def test_database_rejects_non_positive_quantities(self):
         """Direct writes cannot bypass the minimum-one quantity invariant."""
         planting_rows = [


### PR DESCRIPTION
Nested cell rows could account for more seeds than their parent planting, making tray occupancy and stock-derived metrics disagree. Validate submitted and retained allocation totals while still allowing intentionally unassigned seeds.

## Summary by Sourcery

Enforce that total cell allocations for a seed tray planting cannot exceed the planting quantity while still allowing partially allocated plantings.

Bug Fixes:
- Prevent creating seed tray plantings where summed cell allocations exceed the parent planting quantity.
- Prevent updating a planting quantity to a value lower than the already retained cell allocation quantity.

Tests:
- Add API tests covering over-allocation rejection, retained over-allocation on updates, and allowed partial cell allocation scenarios.