### PR TITLE
fix(plantings): report protected planting deletes

### DIFF
--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -589,7 +589,25 @@ class GardenSquareDirectSowPlantingViewSet(viewsets.ModelViewSet):  # pylint: di
     serializer_class = GardenSquareDirectSowSerializer
 
 
-class SeedTrayPlantingViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class ProtectedSeedTrayPlantingDestroyMixin:  # pylint: disable=too-few-public-methods
+    """Return a domain error when dependent records protect a planting."""
+
+    def perform_destroy(self, instance):
+        """Delete a planting unless protected dependents still refer to it."""
+        try:
+            instance.delete()
+        except ProtectedError as exc:
+            raise serializers.ValidationError({
+                'detail': [
+                    'Cannot delete a seed tray planting while dependent records exist.'
+                ]
+            }) from exc
+
+
+class SeedTrayPlantingViewSet(
+    ProtectedSeedTrayPlantingDestroyMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SeedTrayPlanting
     """
@@ -597,7 +615,10 @@ class SeedTrayPlantingViewSet(viewsets.ModelViewSet):  # pylint: disable=too-man
     serializer_class = SeedTrayPlantingSerializer
 
 
-class SeedTrayPlantingViewSeedTraySet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedTrayPlantingViewSeedTraySet(
+    ProtectedSeedTrayPlantingDestroyMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SeedTrayPlanting filtered by SeedTray
     """

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -371,6 +371,32 @@ class PositiveQuantityAPITests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertTrue(SeedTrayCellPlanting.objects.filter(pk=cell_planting.pk).exists())
 
+    def test_parent_delete_with_germination_returns_domain_error(self):
+        """Protected germination data produces a client error rather than a 500."""
+        cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.original_planting,
+            cell=self.cell,
+            quantity=1,
+        )
+        SpecificPlant.objects.create(cell_planting=cell_planting)
+
+        response = self.client.delete(
+            f'/plantings/seedtray/{self.original_planting.pk}/',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': [
+                    'Cannot delete a seed tray planting while dependent records exist.'
+                ],
+            },
+        )
+        self.assertTrue(
+            SeedTrayPlanting.objects.filter(pk=self.original_planting.pk).exists()
+        )
+
     def test_database_rejects_non_positive_quantities(self):
         """Direct writes cannot bypass the minimum-one quantity invariant."""
         planting_rows = [


### PR DESCRIPTION
Deleting a seed tray planting with germinated dependents previously surfaced Django ProtectedError as a server failure. Translating it into a client-visible domain error explains why the data must be retained and keeps both planting routes consistent.

## Summary by Sourcery

Handle protected seed tray plantings as client-visible domain errors instead of server failures when deletions are blocked by dependent records.

Bug Fixes:
- Translate Django ProtectedError on seed tray planting deletion into a 400 validation error with an explanatory message when dependent germination records exist.

Enhancements:
- Introduce a reusable destroy mixin for seed tray planting viewsets to consistently apply protected-deletion handling across related endpoints.

Tests:
- Add tests verifying that deleting a seed tray planting with germination dependents returns a domain error response and leaves the planting intact.