### PR TITLE
data(plantings): audit seed allocation capacity

### DIFF
--- a/plantings/migrations/0015_audit_seed_allocation_capacity.py
+++ b/plantings/migrations/0015_audit_seed_allocation_capacity.py
@@ -1,0 +1,56 @@
+from django.db import migrations
+from django.db.models import Count, F, Sum
+
+
+def describe_rows(queryset, count):
+    """Return a bounded description of rows that failed the audit."""
+    row_ids = list(queryset.order_by('pk').values_list('pk', flat=True)[:20])
+    suffix = '' if count <= len(row_ids) else f' (first 20 of {count})'
+    return f'{row_ids}{suffix}'
+
+
+def audit_seed_allocation_capacity(apps, _schema_editor):
+    """Stop deployment when historical allocation totals exceed capacity."""
+    planting_model = apps.get_model('plantings', 'SeedTrayPlanting')
+    cell_planting_model = apps.get_model('plantings', 'SeedTrayCellPlanting')
+
+    over_allocated = planting_model.objects.annotate(
+        allocated_quantity=Sum('cell_plantings__quantity', default=0),
+    ).filter(allocated_quantity__gt=F('quantity'))
+    over_germinated = cell_planting_model.objects.annotate(
+        germinated_count=Count('specific_plants'),
+    ).filter(germinated_count__gt=F('quantity'))
+
+    problems = []
+    over_allocated_count = over_allocated.count()
+    if over_allocated_count:
+        problems.append(
+            'over-allocated SeedTrayPlanting IDs: '
+            f'{describe_rows(over_allocated, over_allocated_count)}'
+        )
+    over_germinated_count = over_germinated.count()
+    if over_germinated_count:
+        problems.append(
+            'over-germinated SeedTrayCellPlanting IDs: '
+            f'{describe_rows(over_germinated, over_germinated_count)}'
+        )
+
+    if problems:
+        raise RuntimeError(
+            'Seed allocation capacity audit failed. Repair these rows before '
+            f'retrying the migration: {"; ".join(problems)}'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plantings', '0014_constrain_positive_quantities'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            audit_seed_allocation_capacity,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -132,6 +132,36 @@ class PlantingsDataMigrationTests(TestCase):
         self.assertEqual(description, f'{first_ids} (first 20 of 25)')
         values.__getitem__.assert_called_once_with(slice(None, 20))
 
+    def test_capacity_audit_accepts_consistent_rows(self):
+        """Allocation and germination counts within capacity allow deployment."""
+        migration = import_module(
+            'plantings.migrations.0015_audit_seed_allocation_capacity'
+        )
+
+        migration.audit_seed_allocation_capacity(django_apps, None)
+
+    def test_capacity_audit_reports_parent_and_cell_row_ids(self):
+        """Deployment failures identify both kinds of capacity violation."""
+        migration = import_module(
+            'plantings.migrations.0015_audit_seed_allocation_capacity'
+        )
+        SeedTrayCellPlanting.objects.filter(pk=self.cell_planting.pk).update(
+            quantity=2,
+        )
+        SpecificPlant.objects.bulk_create([
+            SpecificPlant(cell_planting=self.cell_planting),
+            SpecificPlant(cell_planting=self.cell_planting),
+        ])
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            'over-allocated SeedTrayPlanting IDs: '
+            f'[{self.cell_planting.seed_tray_planting_id}]; '
+            'over-germinated SeedTrayCellPlanting IDs: '
+            f'[{self.cell_planting.pk}]',
+        ):
+            migration.audit_seed_allocation_capacity(django_apps, None)
+
     def test_audit_reports_cross_tray_cell_planting(self):
         """The failure identifies a cell planting whose parent tray differs."""
         other_tray = SeedTray.objects.create(model=self.tray_model)


### PR DESCRIPTION
Application enforcement cannot repair historical rows that already over-allocate a parent planting or over-germinate a cell. Failing the migration with bounded record IDs makes operators correct those records before relying on the new capacity invariant.

## Summary by Sourcery

Add a data-migration audit that blocks deployment when historical seed tray plantings exceed allocation or germination capacity, and surface clear IDs for offending rows.

Bug Fixes:
- Detect and prevent deployments where SeedTrayPlanting allocations exceed their recorded quantity or SeedTrayCellPlanting germinations exceed their cell capacity.

Tests:
- Extend migration tests to cover successful capacity audits and verify that failures report both over-allocated plantings and over-germinated cell plantings with their IDs.