### PR TITLE
test(plantings): correct concurrency status ordering

### DIFF
--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -493,5 +493,5 @@ class ConcurrentGerminationCapacityTests(TransactionTestCase):
                 range(2),
             ))
 
-        self.assertEqual(sorted(statuses), [400, 201])
+        self.assertEqual(sorted(statuses), [201, 400])
         self.assertEqual(self.cell_planting.specific_plants.count(), 1)


### PR DESCRIPTION
SQLite skipped this row-lock test, so its expected sorted statuses were not exercised until the PostgreSQL run. The implementation returned the intended one success and one capacity rejection; the assertion now reflects numeric sort order.

## Summary by Sourcery

Bug Fixes:
- Fix concurrency test assertion to expect success and capacity-rejection status codes in correct numeric order.