### PR TITLE
fix(plantings): lock location without nullable joins

### DIFF
--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -694,7 +694,7 @@ class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=to
         """End an active location once without replacing an existing end time."""
         with transaction.atomic():
             location = get_object_or_404(
-                self.get_queryset().select_for_update(),
+                SpecificPlantLocation.objects.select_for_update(),
                 pk=pk,
             )
             self.check_object_permissions(request, location)


### PR DESCRIPTION
PostgreSQL rejects FOR UPDATE when the queryset includes nullable outer joins to both location targets. Locking the SpecificPlantLocation row directly preserves end-action serialization without attempting to lock optional related rows.

## Summary by Sourcery

Bug Fixes:
- Prevent PostgreSQL errors when applying FOR UPDATE on querysets with nullable outer joins by selecting for update on SpecificPlantLocation directly.