### PR TITLE
test(plantings): let transactions restore dropped index

### DIFF
--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -257,16 +257,6 @@ class SpecificPlantMoveTests(TestCase):  # pylint: disable=too-many-public-metho
     def _drop_active_location_index(self):
         with connection.cursor() as cursor:
             cursor.execute('DROP INDEX IF EXISTS unique_active_location_per_plant')
-        self.addCleanup(self._restore_active_location_index)
-
-    def _restore_active_location_index(self):
-        SpecificPlantLocation.objects.filter(specific_plant=self.plant, seed_tray_cell=self.other_cell).delete()
-        with connection.cursor() as cursor:
-            cursor.execute(
-                'CREATE UNIQUE INDEX IF NOT EXISTS "unique_active_location_per_plant" '
-                'ON "plantings_specificplantlocation" ("specific_plant_id") '
-                'WHERE "ended" IS NULL'
-            )
 
     def test_move_ends_current_location_and_creates_new_active_location(self):
         """


### PR DESCRIPTION
The corruption test recreated a partial index before PostgreSQL had cleared deferred foreign-key trigger events, causing teardown to fail. Django already rolls back the test-scoped index drop and corrupt row together, so the manual cleanup was both redundant and non-portable.

## Summary by Sourcery

Tests:
- Remove manual restoration of the unique_active_location_per_plant index from tests and depend on Django’s transactional test behavior for cleanup.