### PR TITLE
test(plantings): cover exact cell allocation capacity

### DIFF
--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -260,6 +260,30 @@ class PositiveQuantityAPITests(TestCase):
         self.assertEqual(planting.quantity, 2)
         self.assertEqual(planting.cell_plantings.get().quantity, 1)
 
+    def test_exact_cell_allocation_is_allowed(self):
+        """Allocations may collectively use the planting's full capacity."""
+        response = self.client.post(
+            '/plantings/seedtray/',
+            data=json.dumps({
+                'seeds_used': self.packet.pk,
+                'quantity': 2,
+                'seed_tray': self.tray.pk,
+                'cell_plantings': [
+                    {'cell': self.cell.pk, 'quantity': 1},
+                    {'cell': self.other_cell.pk, 'quantity': 1},
+                ],
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        planting = SeedTrayPlanting.objects.get(pk=response.json()['pk'])
+        self.assertEqual(planting.quantity, 2)
+        self.assertEqual(
+            dict(planting.cell_plantings.values_list('cell_id', 'quantity')),
+            {self.cell.pk: 1, self.other_cell.pk: 1},
+        )
+
     def test_specific_plant_creation_stops_at_cell_capacity(self):
         """Only allocated seeds can become specific germinated plants."""
         cell_planting = SeedTrayCellPlanting.objects.create(


### PR DESCRIPTION
The partial-allocation test only established that totals below the parent are accepted. Exercising equality across two cells protects the inclusive boundary and verifies both allocations are persisted.

## Summary by Sourcery

Tests:
- Add a test verifying that multiple cell allocations can collectively use the full planting capacity and are persisted correctly.