### PR TITLE
Add tests plantings

### DIFF
--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -369,6 +369,36 @@ class PositiveQuantityAPITests(TestCase):
         )
         self.assertEqual(cell_planting.specific_plants.count(), 3)
 
+    def test_specific_plant_patch_allows_mutable_fields(self):
+        """Notes can change without altering the plant's origin allocation."""
+        cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.original_planting,
+            cell=self.cell,
+            quantity=1,
+        )
+        create_response = self.client.post(
+            '/plantings/specificplants/',
+            data=json.dumps({
+                'cell_planting': cell_planting.pk,
+                'notes': 'Initial notes',
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(create_response.status_code, 201)
+        plant = SpecificPlant.objects.get(pk=create_response.json()['pk'])
+
+        response = self.client.patch(
+            f'/plantings/specificplants/{plant.pk}/',
+            data=json.dumps({'notes': 'Updated notes'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['notes'], 'Updated notes')
+        plant.refresh_from_db()
+        self.assertEqual(plant.notes, 'Updated notes')
+        self.assertEqual(plant.cell_planting, cell_planting)
+
     def test_specific_plant_cannot_be_reassigned(self):
         """Changing a plant's origin cannot bypass another cell's capacity."""
         first_cell_planting = SeedTrayCellPlanting.objects.create(

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -327,6 +327,48 @@ class PositiveQuantityAPITests(TestCase):
         )
         self.assertEqual(cell_planting.specific_plants.count(), 1)
 
+    def test_specific_plant_creation_uses_full_larger_capacity(self):
+        """Every slot above one is usable, and the next germination is rejected."""
+        self.original_planting.quantity = 3
+        self.original_planting.save(update_fields=['quantity'])
+        cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.original_planting,
+            cell=self.cell,
+            quantity=3,
+        )
+        payload = json.dumps({'cell_planting': cell_planting.pk})
+
+        for expected_count in range(1, 4):
+            with self.subTest(expected_count=expected_count):
+                response = self.client.post(
+                    '/plantings/specificplants/',
+                    data=payload,
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 201)
+                self.assertEqual(
+                    cell_planting.specific_plants.count(),
+                    expected_count,
+                )
+
+        response = self.client.post(
+            '/plantings/specificplants/',
+            data=payload,
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'cell_planting': [
+                    'Germination count cannot exceed this cell allocation.'
+                ],
+            },
+        )
+        self.assertEqual(cell_planting.specific_plants.count(), 3)
+
     def test_specific_plant_cannot_be_reassigned(self):
         """Changing a plant's origin cannot bypass another cell's capacity."""
         first_cell_planting = SeedTrayCellPlanting.objects.create(


### PR DESCRIPTION
## Summary by Sourcery

Extend test coverage for specific plant creation and updates in seed tray cell allocations.

Tests:
- Add test ensuring specific plants can be created up to a larger cell capacity and further germinations are rejected with an error.
- Add test verifying PATCH updates to specific plants allow mutable fields like notes without changing their originating cell allocation.