### PR TITLE
fix(plantings): normalize cell membership errors

### DIFF
--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -166,10 +166,10 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
         for cell in cells:
             if cell.tray_id != seed_tray.pk:
                 raise serializers.ValidationError({
-                    'cell_plantings': (
+                    'cell_plantings': [
                         f'Cell {cell.pk} belongs to tray {cell.tray_id}, '
                         f'not tray {seed_tray.pk}.'
-                    )
+                    ]
                 })
 
     def validate(self, data):  # pylint: disable=arguments-renamed


### PR DESCRIPTION
Allocation validation should expose one stable field-error shape regardless of which invariant fails or whether validation runs before or during save. Returning a list prevents clients from special-casing cross-tray membership failures.

## Summary by Sourcery

Bug Fixes:
- Ensure cell tray membership validation always returns a list of error messages under the cell_plantings field instead of a single string.