### PR TITLE
test(plantings): reject duplicate cell allocations

### DIFF
--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -219,6 +219,29 @@ class PositiveQuantityAPITests(TestCase):
         )
         self.assertEqual(SeedTrayPlanting.objects.count(), original_count)
 
+    def test_update_rejects_duplicate_cell_allocations(self):
+        """One request cannot allocate the same tray cell more than once."""
+        self.original_planting.quantity = 2
+        self.original_planting.save(update_fields=['quantity'])
+
+        response = self.client.patch(
+            f'/plantings/seedtray/{self.original_planting.pk}/',
+            data=json.dumps({
+                'cell_plantings': [
+                    {'cell': self.cell.pk, 'quantity': 1},
+                    {'cell': self.cell.pk, 'quantity': 1},
+                ],
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'cell_plantings': ['Each cell may only be allocated once.']},
+        )
+        self.assertFalse(self.original_planting.cell_plantings.exists())
+
     def test_update_rejects_parent_quantity_below_retained_allocation(self):
         """Reducing a parent cannot strand a larger retained allocation."""
         self.original_planting.quantity = 2


### PR DESCRIPTION
The database uniqueness constraint cannot provide a clear response for duplicate cells submitted in one nested replacement. This API regression test protects the serializer-level domain error and confirms the failed update creates no allocation rows.

## Summary by Sourcery

Add test coverage ensuring seed tray planting updates reject duplicate cell allocations in a single request and leave no allocation rows created on failure.

Tests:
- Add regression test verifying API returns a domain error when duplicate tray cells are allocated in one update request.
- Confirm failed duplicate cell allocation update does not persist any cell planting records.