### PR TITLE
test(plantings): cover deleted allocation race

### DIFF
--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -6,6 +6,7 @@ import json
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, close_old_connections, transaction
 from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+from rest_framework import serializers
 from rest_framework.test import APIClient
 
 from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
@@ -21,6 +22,7 @@ from .models import (
     SeedTrayPlanting,
     SpecificPlant,
 )
+from .rest import SpecificPlantSerializer
 
 
 class PositiveQuantityAPITests(TestCase):
@@ -579,6 +581,31 @@ class PositiveQuantityAPITests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertTrue(SeedTrayCellPlanting.objects.filter(pk=cell_planting.pk).exists())
+
+    def test_specific_plant_creation_rejects_deleted_validated_allocation(self):
+        """A deleted allocation is reported when it disappears after validation."""
+        cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.original_planting,
+            cell=self.cell,
+            quantity=1,
+        )
+        stale_id = cell_planting.pk
+        serializer = SpecificPlantSerializer(data={
+            'cell_planting': stale_id,
+        })
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        SeedTrayCellPlanting.objects.filter(pk=stale_id).delete()
+
+        with self.assertRaises(serializers.ValidationError) as context:
+            serializer.save()
+
+        self.assertEqual(
+            context.exception.detail,
+            {'cell_planting': ['This cell allocation no longer exists.']},
+        )
+        self.assertFalse(
+            SpecificPlant.objects.filter(cell_planting_id=stale_id).exists()
+        )
 
     def test_parent_delete_with_germination_returns_domain_error(self):
         """Protected germination data produces a client error rather than a 500."""


### PR DESCRIPTION
A request with an already-missing ID is rejected during ordinary DRF validation and cannot exercise the save-time race handler. This serializer-level test removes a previously validated allocation before save and verifies the custom error prevents plant creation.

## Summary by Sourcery

Tests:
- Add a test verifying that SpecificPlantSerializer raises a validation error and does not create a plant when the referenced cell allocation is removed after validation.