### PR TITLE
test(api): cover tray generation and suppliers

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -4,6 +4,6 @@ source venv/bin/activate
 
 pycodestyle --ignore=E501 */*.py
 
-pylint frontend/ garden/ plantings/ plants/ seeds/
+pylint frontend/ garden/ plantings/ plants/ seeds/ seedtrays/ supplies/
 
 deactivate

--- a/seedtrays/apps.py
+++ b/seedtrays/apps.py
@@ -1,6 +1,9 @@
+"""Django application configuration for seed trays."""
 from django.apps import AppConfig
 
 
 class SeedtraysConfig(AppConfig):
+    """Configure the seed-tray application."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "seedtrays"

--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -1,6 +1,7 @@
 """
 Tests for seed trays
 """
+# pylint: disable=duplicate-code
 import json
 
 from django.contrib.auth import get_user_model
@@ -46,6 +47,29 @@ class SeedTrayCellIntegrityTests(TestCase):
         self.assertRedirects(
             response,
             f'/accounts/login/?next=/seedtrays/seedtray/{self.tray.pk}/',
+        )
+
+    def test_create_tray_generates_complete_cell_grid(self):
+        """Creating a tray through the API generates every model cell once."""
+        response = self.client.post(
+            '/seedtrays/seedtrays/',
+            data=json.dumps({
+                'model': self.other_model.pk,
+                'notes': 'Propagation tray',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        tray = SeedTray.objects.get(pk=response.json()['pk'])
+        self.assertEqual(tray.notes, 'Propagation tray')
+        self.assertEqual(
+            set(tray.seedtraycell_set.values_list('x_position', 'y_position')),
+            {
+                (x_position, y_position)
+                for x_position in range(self.other_model.x_cells)
+                for y_position in range(self.other_model.y_cells)
+            },
         )
 
     def test_nested_create_uses_url_tray_instead_of_payload_tray(self):

--- a/seedtrays/views.py
+++ b/seedtrays/views.py
@@ -1,3 +1,4 @@
+"""HTML views for seed trays."""
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views import View
 from django.shortcuts import get_object_or_404, render
@@ -6,7 +7,10 @@ from .models import SeedTray
 
 
 class SeedTrayDetailView(LoginRequiredMixin, View):
+    """Render details for one seed tray."""
+
     def get(self, request, pk):
+        """Render the requested seed tray."""
         seed_tray = get_object_or_404(SeedTray, pk=pk)
         context = {
             'seed_tray': seed_tray

--- a/supplies/admin.py
+++ b/supplies/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
-# Register your models here.
+"""Django admin registrations for supplies."""

--- a/supplies/apps.py
+++ b/supplies/apps.py
@@ -1,6 +1,9 @@
+"""Django application configuration for supplies."""
 from django.apps import AppConfig
 
 
 class SuppliesConfig(AppConfig):
+    """Configure the supplies application."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "supplies"

--- a/supplies/models.py
+++ b/supplies/models.py
@@ -1,3 +1,4 @@
+"""Database models for garden supplies."""
 from django.db import models
 
 

--- a/supplies/tests.py
+++ b/supplies/tests.py
@@ -1,3 +1,43 @@
+"""
+Tests for supplies
+"""
+import json
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Supplier
+
+
+class SupplierAPITests(TestCase):
+    """Tests for the supplier REST resource."""
+
+    def setUp(self):
+        self.client.force_login(
+            get_user_model().objects.create_user(username='supplier-tester')
+        )
+
+    def test_create_and_retrieve_supplier(self):
+        """An authenticated supplier write round-trips through the API."""
+        response = self.client.post(
+            '/supplies/supplier/',
+            data=json.dumps({
+                'name': 'Local Seed Company',
+                'website': 'https://seeds.example.com',
+                'notes': 'Open-pollinated varieties',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        supplier = Supplier.objects.get(pk=response.json()['pk'])
+
+        response = self.client.get(f'/supplies/supplier/{supplier.pk}/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'pk': supplier.pk,
+            'name': 'Local Seed Company',
+            'website': 'https://seeds.example.com',
+            'notes': 'Open-pollinated varieties',
+        })

--- a/supplies/urls.py
+++ b/supplies/urls.py
@@ -5,7 +5,6 @@ URL Routing for supplies
 from django.urls import path, include
 
 from .rest import router
-from . import views
 
 urlpatterns = [
     path('', include(router.urls))


### PR DESCRIPTION
The remaining task 25 gaps need behavioral tripwires for automatic tray-cell creation and supplier serialization. Including both apps in pylint also ensures their test and API code stays within the project checks.

## Summary by Sourcery

Add tests and linting coverage for seed tray cell generation and supplier API, and align app modules with project tooling.

New Features:
- Add supplier API integration test covering create and retrieve operations.
- Add seed tray API test ensuring automatic generation of the full cell grid on tray creation.

Enhancements:
- Document seed tray HTML views, app configs, models, and admin modules with module and class docstrings.
- Exclude unused supplies views from URL configuration for a cleaner routing setup.

Build:
- Extend check-code script to run pylint on the seedtrays and supplies Django apps.

Tests:
- Introduce a dedicated test suite for the supplies app focused on supplier API behavior.
- Expand seed tray tests with coverage for automatic tray cell creation via the API.