### PR TITLE
ci(test): run Django suite on PostgreSQL

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -7,6 +7,25 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_DB: garden_tracker
+          POSTGRES_USER: garden_tracker
+          POSTGRES_PASSWORD: garden_tracker
+        options: >-
+          --health-cmd "pg_isready -U garden_tracker -d garden_tracker"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DB_HOST: 127.0.0.1
+      DB_NAME: garden_tracker
+      DB_USER: garden_tracker
+      DB_PASS: garden_tracker
     steps:
       - uses: actions/checkout@v7
       - name: Update apt database
@@ -19,9 +38,15 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: 3.13
+      - name: Configure CI settings
+        run:
+          cp gp/ci_settings.py gp/local_settings.py
       - name: Setup venv
         run:
           ./setup-venv.sh
+      - name: Test
+        run:
+          ./manage.py test
       - name: check-code
         run:
           ./check-code.sh

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -46,7 +46,7 @@ jobs:
           ./setup-venv.sh
       - name: Test
         run:
-          ./manage.py test
+          venv/bin/python manage.py test
       - name: check-code
         run:
           ./check-code.sh

--- a/gp/ci_settings.py
+++ b/gp/ci_settings.py
@@ -1,0 +1,18 @@
+"""Site-specific settings used by the continuous integration workflow."""
+import os
+
+
+DEBUG = False
+
+ALLOWED_HOSTS = ['testserver']
+CSRF_TRUSTED_ORIGINS = ['http://localhost']
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'HOST': os.environ['DB_HOST'],
+        'NAME': os.environ['DB_NAME'],
+        'USER': os.environ['DB_USER'],
+        'PASSWORD': os.environ['DB_PASS'],
+    },
+}


### PR DESCRIPTION
Pull requests currently lint without exercising backend behavior. An explicit PostgreSQL service and CI settings fragment make the full suite deterministic and ensure row-lock concurrency coverage runs instead of being skipped.

## Summary by Sourcery

Run the Django test suite against a PostgreSQL service in CI to exercise backend behavior deterministically.

CI:
- Add a PostgreSQL service and database environment variables to the checkcode GitHub Actions workflow.
- Introduce a CI-specific Django settings module and copy it into place before running tests.
- Run the Django test suite as part of the existing checkcode workflow.