### PR TITLE
fix(setup): secure secret key bootstrap

### DIFF
--- a/gp/settings.py
+++ b/gp/settings.py
@@ -10,9 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
-import os
 from datetime import timedelta
 from pathlib import Path
+
+from django.core.exceptions import ImproperlyConfigured
 
 # Import other settings
 from gp.local_settings import *
@@ -21,8 +22,21 @@ from gp.local_settings import *
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-with open(os.path.join(BASE_DIR, 'gp', 'secretkey.txt')) as f:
-    SECRET_KEY = f.read().strip()
+SECRET_KEY_PATH = BASE_DIR / "gp" / "secretkey.txt"
+
+try:
+    SECRET_KEY = SECRET_KEY_PATH.read_text(encoding="utf-8").strip()
+except OSError as error:
+    raise ImproperlyConfigured(
+        f"Unable to read Django secret key from {SECRET_KEY_PATH}. "
+        "Run setup-venv.sh or provide a readable key file."
+    ) from error
+
+if not SECRET_KEY:
+    raise ImproperlyConfigured(
+        f"Django secret key file {SECRET_KEY_PATH} is empty. "
+        "Populate it with a securely generated key before starting the application."
+    )
 
 # Application definition
 

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,7 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 [ ! -z "$DB_HOST" ] && sed -i "s|'HOST': .*|'HOST': '$DB_HOST',|" gp/local_settings.py || true
 [ ! -z "$DB_USER" ] && sed -i "s|'USER': .*|'USER': '$DB_USER',|" gp/local_settings.py || true
 [ ! -z "$DB_NAME" ] && sed -i "s|'NAME': .*|'NAME': '$DB_NAME',|" gp/local_settings.py || true
 [ ! -z "$DB_PASS" ] && sed -i "s|'PASSWORD': .*|'PASSWORD': '$DB_PASS',|" gp/local_settings.py || true
-

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 python3 -m venv venv
 
@@ -18,20 +18,28 @@ echo ""
 # Create the local settings file from the template
 if [ ! -f gp/local_settings.py ]
 then
-	cp gp/local_settings.py.template gp/local_settings.py
+	(
+		umask 077
+		cp gp/local_settings.py.template gp/local_settings.py
+	)
 	echo ""
 	echo "Create gp/local_settings.py from template"
 	echo "You should check this reflects your required settings"
         echo "At a minimum you will need to set your database parameters"
 fi
+chmod 600 gp/local_settings.py
 
 ./setup-db.sh
 
 if [ ! -f gp/secretkey.txt ]
 then
-	python -c 'import random; result = "".join([random.choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)") for i in range(50)]); print(result)' > gp/secretkey.txt
+	(
+		umask 077
+		python -c 'import sys; from django.core.management.utils import get_random_secret_key; open(sys.argv[1], "x", encoding="utf-8").write(get_random_secret_key() + "\n")' gp/secretkey.txt
+	)
 	echo ""
 	echo "Created new secretkey.txt in gp/secretkey.txt"
 fi
+chmod 600 gp/secretkey.txt
 
 ./manage.py collectstatic --no-input


### PR DESCRIPTION
The bootstrap generated signing keys with a non-cryptographic PRNG, left configuration files world-readable, and traced expanded database credentials. Generate keys with Django's secure helper, enforce owner-only permissions without rotating existing keys, and fail clearly when the key file cannot supply a value.

## Summary by Sourcery

Secure Django secret key handling and tighten setup scripts for configuration and credentials.

New Features:
- Add explicit configuration error handling when the Django secret key file is unreadable or empty.

Enhancements:
- Generate Django secret keys using Django's secure helper instead of a non-cryptographic random source.
- Ensure local settings and secret key files are created with owner-only permissions and enforce restrictive file modes after setup.
- Reduce verbosity of setup scripts by removing shell xtrace while keeping error-on-fail behavior.