### PR TITLE
fix(config): fail closed on unset deployment database

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Table of contents
 - Tech stack
 - Prerequisites
 - Quick start (recommended)
-- PostgreSQL setup
+- Production deploy (PostgreSQL)
 - Development notes
 - API endpoints (important)
 - Project layout (high level)
@@ -104,15 +104,23 @@ Quick start (recommended)
    ```
    Open http://127.0.0.1:8000
 
-PostgreSQL setup
-- Install and initialise PostgreSQL before running the project setup.
-- Copy the deployment template before running `setup-venv.sh`; the setup script preserves an existing `gp/local_settings.py`:
+Production deploy (PostgreSQL)
+
+Install and initialise PostgreSQL, then copy the deployment template before running `setup-venv.sh`; the setup script preserves an existing `gp/local_settings.py`:
+
   ```bash
   cp gp/local_settings.postgresql.py.template gp/local_settings.py
   chmod 600 gp/local_settings.py
   ```
-- Set `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` in `gp/local_settings.py`. Configure the four database placeholders directly, or provide `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` in the deployment environment.
-- Run `./setup-venv.sh`. It substitutes any provided database variables and applies migrations to the configured PostgreSQL database.
+
+Before setup:
+
+- Set `ALLOWED_HOSTS` to every hostname that serves the site.
+- Set `CSRF_TRUSTED_ORIGINS` to every public origin, including its scheme.
+- Fill in all four database values directly, or provide `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` in the deployment environment.
+- For HTTPS behind a trusted reverse proxy, review and enable the commented proxy and secure-cookie settings.
+
+Run `./setup-venv.sh`; it substitutes any provided database variables and applies migrations to the configured PostgreSQL database.
 
 Development notes
 - Python dependencies are defined by `requirements.txt`. Recreate a stale local `venv` before setup when it contains older or untracked dependency versions.

--- a/gp/local_settings.postgresql.py.template
+++ b/gp/local_settings.postgresql.py.template
@@ -18,16 +18,17 @@ TIME_ZONE = "UTC"
 # Database
 # https://docs.djangoproject.com/en/stable/ref/settings/#databases
 #
-# Replace these placeholders directly or set DB_HOST, DB_NAME, DB_USER, and
-# DB_PASS before running setup-venv.sh.
+# REQUIRED: fill in every value below directly, or set DB_HOST, DB_NAME,
+# DB_USER, and DB_PASS before running setup-venv.sh. Empty values make an
+# incomplete database configuration fail instead of using placeholder names.
 
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "HOST": "POSTGRES_SERVER",
-        "NAME": "POSTGRES_DBNAME",
-        "USER": "POSTGRES_USER",
-        "PASSWORD": "POSTGRES_PASSWORD",
+        "HOST": "",
+        "NAME": "",
+        "USER": "",
+        "PASSWORD": "",
         "OPTIONS": {
             "pool": True,
         },


### PR DESCRIPTION
Empty deployment database settings expose incomplete configuration immediately instead of attempting to resolve literal placeholder hosts. Document the required production edits so deployers configure host and CSRF protections before setup.

## Summary by Sourcery

Documentation:
- Retitle and expand the PostgreSQL section of the README into a production deployment guide with explicit steps for configuring ALLOWED_HOSTS, CSRF_TRUSTED_ORIGINS, database credentials, and secure proxy settings before setup.