### PR TITLE
fix(deploy): harden WSGI startup

### DIFF
--- a/gp/settings.py
+++ b/gp/settings.py
@@ -123,7 +123,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = "static/"
-STATIC_ROOT = "static/"
+STATIC_ROOT = BASE_DIR / "static"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/start-wsgi.sh
+++ b/start-wsgi.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
+cd "$(dirname "$0")"
+
+: "${UWSGI_SOCKET:=127.0.0.1:8080}"
+: "${UWSGI_PROCESSES:=4}"
+
 source venv/bin/activate
 
 ./manage.py migrate
-uwsgi --socket 127.0.0.1:8080 -w gp.wsgi -M -p 10 --vacuum
+exec uwsgi \
+	--socket "$UWSGI_SOCKET" \
+	-w gp.wsgi \
+	-M \
+	-p "$UWSGI_PROCESSES" \
+	--vacuum \
+	--die-on-term \
+	--need-app


### PR DESCRIPTION
Static collection and application startup depended on the caller's working directory, while uWSGI's socket and oversized worker pool were fixed in the script. Anchor deployment paths to the repository, expose the operational settings as environment overrides, and make the supervised process fail and terminate cleanly.

## Summary by Sourcery

Harden the WSGI deployment startup by anchoring paths to the repository, parameterizing uWSGI runtime settings, and ensuring supervised termination behavior.

Enhancements:
- Set STATIC_ROOT to a BASE_DIR-relative path to ensure consistent static asset collection across environments.

Deployment:
- Anchor static file collection and WSGI startup to the repository base directory instead of the caller's working directory.
- Expose uWSGI socket address and worker process count as environment-configurable settings.
- Adjust uWSGI invocation to run as the main process and terminate cleanly when the supervisor stops it.