### PR TITLE
test(api): cover ordinary REST resource contracts

### DIFF
--- a/garden/tests.py
+++ b/garden/tests.py
@@ -10,7 +10,71 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.test import TestCase
 
+from tests.api import RESTContractTestCase
+from tests.factories import make_garden_area, make_garden_bed
+
 from .models import GardenArea, GardenBed, GardenRow, GardenSquare
+
+
+class GardenRESTContractTests(RESTContractTestCase):
+    """Smoke tests for the garden REST resources."""
+
+    LIST_URLS = (
+        '/garden/areas/',
+        '/garden/beds/',
+        '/garden/rows/',
+        '/garden/squares/',
+    )
+
+    def setUp(self):
+        super().setUp()
+        self.area = make_garden_area()
+        self.bed = make_garden_bed(area=self.area)
+
+    def test_list_routes_require_authentication(self):
+        """Anonymous requests cannot list garden resources."""
+        self.assert_authentication_required(self.LIST_URLS)
+
+    def test_list_routes_return_lists(self):
+        """Authenticated garden collections use the common list contract."""
+        self.assert_list_contract(self.LIST_URLS)
+
+    def test_resources_round_trip(self):
+        """Each garden resource can be created and retrieved."""
+        area = self.assert_create_retrieve(
+            '/garden/areas/',
+            {
+                'name': 'Kitchen garden',
+                'size_x': 80,
+                'size_y': 60,
+            },
+        )
+        bed = self.assert_create_retrieve(
+            '/garden/beds/',
+            {
+                'area': area['pk'],
+                'name': 'North bed',
+                'placement_x': 2,
+                'placement_y': 3,
+                'size_x': 20,
+                'size_y': 10,
+            },
+        )
+        child_geometry = {
+            'bed': bed['pk'],
+            'placement_x': 1,
+            'placement_y': 1,
+            'size_x': 4,
+            'size_y': 1,
+        }
+        self.assert_create_retrieve(
+            '/garden/rows/',
+            {**child_geometry, 'name': 'Carrot row'},
+        )
+        self.assert_create_retrieve(
+            '/garden/squares/',
+            {**child_geometry, 'name': 'Square A1'},
+        )
 
 
 class GardenGeometryAPITests(TestCase):

--- a/plants/tests.py
+++ b/plants/tests.py
@@ -1,3 +1,62 @@
 """
 Tests for plants
 """
+from tests.api import RESTContractTestCase
+
+
+class PlantRESTContractTests(RESTContractTestCase):
+    """Smoke tests for plant taxonomy REST resources."""
+
+    LIST_URLS = (
+        '/plants/family/',
+        '/plants/plant/',
+        '/plants/variety/',
+    )
+
+    def test_list_routes_require_authentication(self):
+        """Anonymous requests cannot list plant resources."""
+        self.assert_authentication_required(self.LIST_URLS)
+
+    def test_list_routes_return_lists(self):
+        """Authenticated plant collections use the common list contract."""
+        self.assert_list_contract(self.LIST_URLS)
+
+    def test_resources_round_trip(self):
+        """Family, plant, and variety fields survive create and retrieve."""
+        family = self.assert_create_retrieve(
+            '/plants/family/',
+            {
+                'name': 'Apiaceae',
+                'notes': 'Carrot family',
+            },
+        )
+        plant = self.assert_create_retrieve(
+            '/plants/plant/',
+            {
+                'family': family['pk'],
+                'name': 'Carrot',
+                'notes': 'Root vegetable',
+                'spacing': 5,
+                'inter_row_spacing': 20,
+                'plants_per_square_foot': 16,
+                'germination_days_min': 7,
+                'germination_days_max': 21,
+                'maturity_days_min': 60,
+                'maturity_days_max': 80,
+            },
+        )
+        self.assert_create_retrieve(
+            '/plants/variety/',
+            {
+                'plant': plant['pk'],
+                'name': 'Nantes',
+                'notes': 'Early variety',
+                'spacing': 4,
+                'inter_row_spacing': 18,
+                'plants_per_square_foot': 16,
+                'germination_days_min': 7,
+                'germination_days_max': 18,
+                'maturity_days_min': 55,
+                'maturity_days_max': 70,
+            },
+        )

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -50,5 +50,5 @@ class SeedPacketAllViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-a
 
 router = routers.DefaultRouter()
 router.register(r'seeds', SeedsViewSet)
-router.register(r'packets', SeedPacketCurrentViewSet)
 router.register(r'packets/all', SeedPacketAllViewSet, 'AllSeedPackets')
+router.register(r'packets', SeedPacketCurrentViewSet)

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -1,3 +1,151 @@
 """
 Tests related to seeds
 """
+from plantings.models import (
+    GardenSquareDirectSowPlanting,
+    GardenSquareTransplant,
+    SeedTrayPlanting,
+)
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_garden_square,
+    make_seed_packet,
+    make_seed_tray,
+)
+
+
+class SeedRESTContractTests(RESTContractTestCase):
+    """Smoke tests for seed-product and packet REST resources."""
+
+    LIST_URLS = (
+        '/seeds/seeds/',
+        '/seeds/packets/',
+        '/seeds/packets/all/',
+    )
+
+    def setUp(self):
+        super().setUp()
+        self.packet = make_seed_packet()
+
+    def test_list_routes_require_authentication(self):
+        """Anonymous requests cannot list seed resources."""
+        self.assert_authentication_required(self.LIST_URLS)
+
+    def test_list_routes_return_lists(self):
+        """Authenticated seed collections use the common list contract."""
+        self.assert_list_contract(self.LIST_URLS)
+
+    def test_resources_round_trip(self):
+        """Seed products and packets survive create and retrieve."""
+        seeds = self.assert_create_retrieve(
+            '/seeds/seeds/',
+            {
+                'supplier': self.packet.seeds.supplier_id,
+                'plant_variety': self.packet.seeds.plant_variety_id,
+                'supplier_code': 'CARROT-01',
+                'url': 'https://seeds.example.com/carrot',
+                'notes': 'Pelleted seed',
+            },
+        )
+        self.assert_create_retrieve(
+            '/seeds/packets/',
+            {
+                'seeds': seeds['pk'],
+                'purchase_date': '2026-03-01',
+                'sow_by': '2028-03-01',
+                'empty': False,
+                'notes': 'Opened packet',
+            },
+        )
+
+    def test_current_and_all_packet_routes_apply_empty_filter(self):
+        """The current route omits empty packets while the all route retains them."""
+        empty_packet = make_seed_packet(empty=True)
+
+        current_response = self.client.get('/seeds/packets/')
+        all_response = self.client.get('/seeds/packets/all/')
+
+        self.assertEqual(current_response.status_code, 200)
+        self.assertEqual(all_response.status_code, 200)
+        self.assertEqual(
+            {packet['pk'] for packet in current_response.data},
+            {self.packet.pk},
+        )
+        self.assertEqual(
+            {packet['pk'] for packet in all_response.data},
+            {self.packet.pk, empty_packet.pk},
+        )
+
+    def test_current_packet_summary_coalesces_usage_without_fan_out(self):
+        """Packet summaries total each planting path independently."""
+        used_packet = make_seed_packet(notes='Partially used packet')
+        empty_packet = make_seed_packet(empty=True, notes='Fully used packet')
+        tray = make_seed_tray()
+        square = make_garden_square()
+
+        first_tray_planting = SeedTrayPlanting.objects.create(
+            seeds_used=used_packet,
+            quantity=4,
+            seed_tray=tray,
+        )
+        second_tray_planting = SeedTrayPlanting.objects.create(
+            seeds_used=used_packet,
+            quantity=6,
+            seed_tray=tray,
+        )
+        for quantity in (3, 5):
+            GardenSquareDirectSowPlanting.objects.create(
+                seeds_used=used_packet,
+                quantity=quantity,
+                location=square,
+            )
+        GardenSquareTransplant.objects.create(
+            original_planting=first_tray_planting,
+            quantity=1,
+            location=square,
+        )
+        GardenSquareTransplant.objects.create(
+            original_planting=second_tray_planting,
+            quantity=2,
+            location=square,
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.get('/seeds/packets/current/')
+
+        self.assertEqual(response.status_code, 200)
+        packets = {
+            packet['pk']: packet
+            for packet in response.json()['packets']
+        }
+        self.assertNotIn(empty_packet.pk, packets)
+        self.assertEqual(
+            {
+                key: packets[self.packet.pk][key]
+                for key in (
+                    'seeds_planted_trays',
+                    'seeds_planted_direct',
+                    'transplanted_count',
+                )
+            },
+            {
+                'seeds_planted_trays': 0,
+                'seeds_planted_direct': 0,
+                'transplanted_count': 0,
+            },
+        )
+        self.assertEqual(
+            {
+                key: packets[used_packet.pk][key]
+                for key in (
+                    'seeds_planted_trays',
+                    'seeds_planted_direct',
+                    'transplanted_count',
+                )
+            },
+            {
+                'seeds_planted_trays': 10,
+                'seeds_planted_direct': 8,
+                'transplanted_count': 3,
+            },
+        )

--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -7,7 +7,100 @@ import json
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from tests.api import RESTContractTestCase
+from tests.factories import make_seed_tray, make_seed_tray_cell
+
 from .models import SeedTray, SeedTrayCell, SeedTrayModel
+
+
+class SeedTrayRESTContractTests(RESTContractTestCase):
+    """Smoke tests for seed-tray REST resources."""
+
+    def setUp(self):
+        super().setUp()
+        self.tray = make_seed_tray()
+        self.other_tray = make_seed_tray()
+
+    @property
+    def list_urls(self):
+        """Return global and nested seed-tray collection routes."""
+        return (
+            '/seedtrays/seedtraymodels/',
+            '/seedtrays/seedtrays/',
+            '/seedtrays/seedtraycells/',
+            f'/seedtrays/seedtrays/{self.tray.pk}/cells/',
+        )
+
+    def test_list_routes_require_authentication(self):
+        """Anonymous requests cannot list seed-tray resources."""
+        self.assert_authentication_required(self.list_urls)
+
+    def test_list_routes_return_lists(self):
+        """Authenticated seed-tray collections use the common list contract."""
+        self.assert_list_contract(self.list_urls)
+
+    def test_resources_round_trip(self):
+        """Tray models, trays, and global cells survive create and retrieve."""
+        tray_model = self.assert_create_retrieve(
+            '/seedtrays/seedtraymodels/',
+            {
+                'identifier': 'propagation-6',
+                'description': 'Six-cell propagation tray',
+                'height': 6,
+                'x_size': 30,
+                'y_size': 20,
+                'x_cells': 3,
+                'y_cells': 2,
+                'cell_size_ml': 45,
+            },
+        )
+        tray = self.assert_create_retrieve(
+            '/seedtrays/seedtrays/',
+            {
+                'model': tray_model['pk'],
+                'notes': 'Spring sowing',
+            },
+        )
+        cell = SeedTrayCell.objects.get(
+            tray_id=tray['pk'],
+            x_position=2,
+            y_position=1,
+        )
+        response = self.client.get(f'/seedtrays/seedtraycells/{cell.pk}/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {
+            'pk': cell.pk,
+            'tray': tray['pk'],
+            'x_position': 2,
+            'y_position': 1,
+        })
+
+        self.assert_create_retrieve(
+            '/seedtrays/seedtraycells/',
+            {
+                'tray': self.tray.pk,
+                'x_position': 1,
+                'y_position': 1,
+            },
+        )
+
+    def test_nested_cell_routes_are_scoped_to_url_tray(self):
+        """Nested list and detail routes cannot expose another tray's cells."""
+        own_cell = make_seed_tray_cell(tray=self.tray)
+        other_cell = make_seed_tray_cell(tray=self.other_tray)
+        nested_url = f'/seedtrays/seedtrays/{self.tray.pk}/cells/'
+
+        response = self.client.get(nested_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {cell['pk'] for cell in response.data},
+            {own_cell.pk},
+        )
+        response = self.client.get(f'{nested_url}{own_cell.pk}/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(f'{nested_url}{other_cell.pk}/')
+        self.assertEqual(response.status_code, 404)
 
 
 class SeedTrayCellIntegrityTests(TestCase):

--- a/supplies/tests.py
+++ b/supplies/tests.py
@@ -1,43 +1,29 @@
 """
 Tests for supplies
 """
-import json
-
-from django.contrib.auth import get_user_model
-from django.test import TestCase
-
-from .models import Supplier
+from tests.api import RESTContractTestCase
 
 
-class SupplierAPITests(TestCase):
+class SupplierAPITests(RESTContractTestCase):
     """Tests for the supplier REST resource."""
 
-    def setUp(self):
-        self.client.force_login(
-            get_user_model().objects.create_user(username='supplier-tester')
-        )
+    LIST_URLS = ('/supplies/supplier/',)
 
-    def test_create_and_retrieve_supplier(self):
+    def test_list_route_requires_authentication(self):
+        """Anonymous requests cannot list suppliers."""
+        self.assert_authentication_required(self.LIST_URLS)
+
+    def test_list_route_returns_a_list(self):
+        """Authenticated supplier collections use the common list contract."""
+        self.assert_list_contract(self.LIST_URLS)
+
+    def test_supplier_round_trip(self):
         """An authenticated supplier write round-trips through the API."""
-        response = self.client.post(
+        self.assert_create_retrieve(
             '/supplies/supplier/',
-            data=json.dumps({
+            {
                 'name': 'Local Seed Company',
                 'website': 'https://seeds.example.com',
                 'notes': 'Open-pollinated varieties',
-            }),
-            content_type='application/json',
+            },
         )
-
-        self.assertEqual(response.status_code, 201)
-        supplier = Supplier.objects.get(pk=response.json()['pk'])
-
-        response = self.client.get(f'/supplies/supplier/{supplier.pk}/')
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {
-            'pk': supplier.pk,
-            'name': 'Local Seed Company',
-            'website': 'https://seeds.example.com',
-            'notes': 'Open-pollinated varieties',
-        })

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test support for the garden tracker project."""

--- a/tests/api.py
+++ b/tests/api.py
@@ -1,0 +1,46 @@
+"""Helpers for exercising the common REST resource contract."""
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+
+class RESTContractTestCase(APITestCase):
+    """Base class for authenticated REST contract tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(
+            username=f'{self.__class__.__name__}-user',
+        )
+        self.client.force_authenticate(self.user)
+
+    def assert_authentication_required(self, urls):
+        """Assert every list route rejects an anonymous request."""
+        self.client.force_authenticate(user=None)
+        try:
+            for url in urls:
+                with self.subTest(url=url):
+                    response = self.client.get(url)
+                    self.assertEqual(response.status_code, 403)
+        finally:
+            self.client.force_authenticate(self.user)
+
+    def assert_list_contract(self, urls):
+        """Assert every authenticated list route returns an unpaginated list."""
+        for url in urls:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertIsInstance(response.data, list)
+
+    def assert_create_retrieve(self, url, payload, expected_fields=None):
+        """Create a resource and verify its fields through the detail route."""
+        response = self.client.post(url, payload, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        created_pk = response.data['pk']
+
+        response = self.client.get(f'{url}{created_pk}/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['pk'], created_pk)
+        for field, expected in (expected_fields or payload).items():
+            self.assertEqual(response.data[field], expected)
+        return response.data

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,171 @@
+"""Small dependency-free model builders shared by API tests."""
+from itertools import count
+
+from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
+from plants.models import Plant, PlantFamily, PlantVariety
+from seeds.models import SeedPacket, Seeds
+from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
+from supplies.models import Supplier
+
+
+_SEQUENCE = count(1)
+
+
+def _next_name(prefix):
+    return f'{prefix} {next(_SEQUENCE)}'
+
+
+def make_supplier(**overrides):
+    """Create a supplier with valid defaults."""
+    values = {
+        'name': _next_name('Supplier'),
+        'website': 'https://supplier.example.com',
+        'notes': 'Shared test supplier',
+    }
+    values.update(overrides)
+    return Supplier.objects.create(**values)
+
+
+def make_plant_family(**overrides):
+    """Create a plant family with valid defaults."""
+    values = {
+        'name': _next_name('Family'),
+        'notes': 'Shared test family',
+    }
+    values.update(overrides)
+    return PlantFamily.objects.create(**values)
+
+
+def make_plant(**overrides):
+    """Create a plant with a family when one is not supplied."""
+    values = {
+        'family': make_plant_family(),
+        'name': _next_name('Plant'),
+        'notes': 'Shared test plant',
+    }
+    values.update(overrides)
+    return Plant.objects.create(**values)
+
+
+def make_plant_variety(**overrides):
+    """Create a plant variety with a plant when one is not supplied."""
+    values = {
+        'plant': make_plant(),
+        'name': _next_name('Variety'),
+        'notes': 'Shared test variety',
+    }
+    values.update(overrides)
+    return PlantVariety.objects.create(**values)
+
+
+def make_seeds(**overrides):
+    """Create a seed product with its supplier and variety graph."""
+    values = {
+        'supplier': make_supplier(),
+        'plant_variety': make_plant_variety(),
+        'supplier_code': _next_name('CODE'),
+        'url': 'https://supplier.example.com/seeds',
+        'notes': 'Shared test seeds',
+    }
+    values.update(overrides)
+    return Seeds.objects.create(**values)
+
+
+def make_seed_packet(**overrides):
+    """Create a seed packet and its seed product graph."""
+    values = {
+        'seeds': make_seeds(),
+        'notes': 'Shared test packet',
+    }
+    values.update(overrides)
+    return SeedPacket.objects.create(**values)
+
+
+def make_garden_area(**overrides):
+    """Create a garden area with drawable dimensions."""
+    values = {
+        'name': _next_name('Area'),
+        'size_x': 100,
+        'size_y': 100,
+    }
+    values.update(overrides)
+    return GardenArea.objects.create(**values)
+
+
+def make_garden_bed(**overrides):
+    """Create a garden bed and its area."""
+    values = {
+        'area': make_garden_area(),
+        'name': _next_name('Bed'),
+        'placement_x': 0,
+        'placement_y': 0,
+        'size_x': 50,
+        'size_y': 50,
+    }
+    values.update(overrides)
+    return GardenBed.objects.create(**values)
+
+
+def make_garden_row(**overrides):
+    """Create a garden row and its parent geometry."""
+    values = {
+        'bed': make_garden_bed(),
+        'name': _next_name('Row'),
+        'placement_x': 0,
+        'placement_y': 0,
+        'size_x': 10,
+        'size_y': 1,
+    }
+    values.update(overrides)
+    return GardenRow.objects.create(**values)
+
+
+def make_garden_square(**overrides):
+    """Create a garden square and its parent geometry."""
+    values = {
+        'bed': make_garden_bed(),
+        'name': _next_name('Square'),
+        'placement_x': 0,
+        'placement_y': 0,
+        'size_x': 1,
+        'size_y': 1,
+    }
+    values.update(overrides)
+    return GardenSquare.objects.create(**values)
+
+
+def make_seed_tray_model(**overrides):
+    """Create a seed-tray model with a two-by-two grid."""
+    values = {
+        'identifier': _next_name('Tray model'),
+        'description': 'Shared test tray model',
+        'height': 10,
+        'x_size': 20,
+        'y_size': 20,
+        'x_cells': 2,
+        'y_cells': 2,
+        'cell_size_ml': 40,
+    }
+    values.update(overrides)
+    return SeedTrayModel.objects.create(**values)
+
+
+def make_seed_tray(**overrides):
+    """Create a seed tray without implicitly creating cells."""
+    values = {
+        'model': make_seed_tray_model(),
+        'notes': 'Shared test tray',
+    }
+    values.update(overrides)
+    return SeedTray.objects.create(**values)
+
+
+def make_seed_tray_cell(**overrides):
+    """Create a seed-tray cell and its parent tray."""
+    values = {
+        'tray': make_seed_tray(),
+        'x_position': 0,
+        'y_position': 0,
+    }
+    values.update(overrides)
+    return SeedTrayCell.objects.create(**values)


### PR DESCRIPTION
Dependency upgrades can otherwise break authentication, list responses, or serializer round trips without a focused signal. Shared builders keep the related model graph readable, while the route-order fix makes the declared all-packets endpoint reachable for its contract tests.

## Summary by Sourcery

Add shared REST API contract helpers and apply them across seed, seed tray, garden, plant, and supplier resources while fixing packet route registration so all-packets tests can run.

Bug Fixes:
- Make the seed packet router registration order expose the all-packets endpoint as intended.

Enhancements:
- Introduce shared RESTContractTestCase and model factory helpers for building consistent API test data.

Tests:
- Add REST contract smoke tests for seed products and packets, including current/all packet filtering and packet usage summaries.
- Add REST contract smoke tests for seed tray models, trays, cells, and nested cell routes with tray scoping.
- Add REST contract smoke tests for garden areas, beds, rows, and squares, covering create/retrieve flows.
- Add REST contract smoke tests for plant taxonomy (family, plant, variety) covering list and round-trip behavior.
- Refactor supplier API tests to use the shared REST contract base class and helpers.