### PR TITLE
test(api): cover planting REST contracts

### DIFF
--- a/plantings/test_rest.py
+++ b/plantings/test_rest.py
@@ -1,0 +1,214 @@
+"""Smoke tests for planting and specific-plant REST resources."""
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_garden_row,
+    make_garden_square,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+
+from .models import SpecificPlantLocation
+
+
+class PlantingRESTContractTests(RESTContractTestCase):
+    """Exercise the common contract for every planting REST registration."""
+    # pylint: disable=too-many-instance-attributes
+
+    def setUp(self):
+        super().setUp()
+        self.packet = make_seed_packet()
+        self.row = make_garden_row()
+        self.square = make_garden_square()
+        self.tray = make_seed_tray()
+        self.cell = make_seed_tray_cell(tray=self.tray)
+        self.tray_planting = make_seed_tray_planting(
+            seeds_used=self.packet,
+            quantity=4,
+            seed_tray=self.tray,
+        )
+        self.cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=self.tray_planting,
+            cell=self.cell,
+            quantity=4,
+        )
+        self.specific_plant = make_specific_plant(
+            cell_planting=self.cell_planting,
+        )
+        self.location = make_specific_plant_location(
+            specific_plant=self.specific_plant,
+        )
+
+    @property
+    def list_urls(self):
+        """Return every planting collection registered with the REST router."""
+        return (
+            '/plantings/directsowgardenrow/',
+            '/plantings/directsowgardensquare/',
+            '/plantings/seedtray/',
+            '/plantings/transplantedgardensquare/',
+            '/plantings/specificplants/',
+            '/plantings/specificplantlocations/',
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/',
+            f'/plantings/seedtray-data/{self.tray.pk}/specificplants/',
+            f'/plantings/specificplants/{self.specific_plant.pk}/locations/',
+        )
+
+    def test_list_routes_require_authentication(self):
+        """Anonymous requests cannot list planting resources."""
+        self.assert_authentication_required(self.list_urls)
+
+    def test_list_routes_return_lists(self):
+        """Authenticated planting collections use the common list contract."""
+        self.assert_list_contract(self.list_urls)
+
+    def test_aggregate_planting_resources_round_trip(self):
+        """Each aggregate planting representation survives create and retrieve."""
+        common_fields = {
+            'seeds_used': self.packet.pk,
+            'quantity': 3,
+            'removed': False,
+        }
+        self.assert_create_retrieve(
+            '/plantings/directsowgardenrow/',
+            {
+                **common_fields,
+                'location': self.row.pk,
+                'notes': 'Sown along the row',
+            },
+        )
+        self.assert_create_retrieve(
+            '/plantings/directsowgardensquare/',
+            {
+                **common_fields,
+                'location': self.square.pk,
+                'notes': 'Sown in a square',
+            },
+        )
+        tray_planting = self.assert_create_retrieve(
+            '/plantings/seedtray/',
+            {
+                **common_fields,
+                'seed_tray': self.tray.pk,
+                'location': 'Greenhouse bench',
+                'notes': 'Started under cover',
+                'cell_plantings': [{
+                    'cell': self.cell.pk,
+                    'quantity': 3,
+                }],
+            },
+            {
+                **common_fields,
+                'seed_tray': self.tray.pk,
+                'location': 'Greenhouse bench',
+                'notes': 'Started under cover',
+            },
+        )
+        self.assertEqual(
+            tray_planting['cell_plantings'],
+            [{
+                'pk': tray_planting['cell_plantings'][0]['pk'],
+                'cell': self.cell.pk,
+                'quantity': 3,
+            }],
+        )
+        self.assert_create_retrieve(
+            '/plantings/transplantedgardensquare/',
+            {
+                'original_planting': self.tray_planting.pk,
+                'quantity': 2,
+                'location': self.square.pk,
+                'removed': False,
+                'notes': 'Transplanted outside',
+            },
+        )
+
+    def test_specific_plant_and_location_resources_round_trip(self):
+        """Specific plants and location history survive create and retrieve."""
+        plant = self.assert_create_retrieve(
+            '/plantings/specificplants/',
+            {
+                'cell_planting': self.cell_planting.pk,
+                'germinated': '2026-04-01T08:00:00Z',
+                'notes': 'Second seedling',
+            },
+            {
+                'cell_planting': self.cell_planting.pk,
+                'notes': 'Second seedling',
+            },
+        )
+        self.assertEqual(len(plant['locations']), 1)
+        self.assertEqual(
+            plant['locations'][0]['location_type'],
+            SpecificPlantLocation.SEED_TRAY_CELL,
+        )
+        self.assertEqual(
+            plant['locations'][0]['seed_tray_cell'],
+            self.cell.pk,
+        )
+
+        unlocated_plant = make_specific_plant()
+        self.assert_create_retrieve(
+            '/plantings/specificplantlocations/',
+            {
+                'specific_plant': unlocated_plant.pk,
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'seed_tray_cell': None,
+                'garden_square': self.square.pk,
+                'started': '2026-04-02T09:30:00Z',
+                'ended': None,
+                'notes': 'Moved outside',
+            },
+        )
+
+    def test_filtered_routes_only_expose_parent_resources(self):
+        """Filtered collection and detail routes enforce their URL parent."""
+        other_tray = make_seed_tray()
+        other_cell = make_seed_tray_cell(tray=other_tray)
+        other_planting = make_seed_tray_planting(
+            seed_tray=other_tray,
+        )
+        other_cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=other_planting,
+            cell=other_cell,
+        )
+        other_plant = make_specific_plant(
+            cell_planting=other_cell_planting,
+        )
+        other_location = make_specific_plant_location(
+            specific_plant=other_plant,
+        )
+
+        route_cases = (
+            (
+                f'/plantings/seedtray-data/{self.tray.pk}/plantings/',
+                self.tray_planting.pk,
+                other_planting.pk,
+            ),
+            (
+                f'/plantings/seedtray-data/{self.tray.pk}/specificplants/',
+                self.specific_plant.pk,
+                other_plant.pk,
+            ),
+            (
+                f'/plantings/specificplants/{self.specific_plant.pk}/locations/',
+                self.location.pk,
+                other_location.pk,
+            ),
+        )
+        for url, expected_pk, excluded_pk in route_cases:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    {resource['pk'] for resource in response.data},
+                    {expected_pk},
+                )
+                response = self.client.get(f'{url}{expected_pk}/')
+                self.assertEqual(response.status_code, 200)
+                response = self.client.get(f'{url}{excluded_pk}/')
+                self.assertEqual(response.status_code, 404)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,6 +2,12 @@
 from itertools import count
 
 from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
+from plantings.models import (
+    SeedTrayCellPlanting,
+    SeedTrayPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
 from plants.models import Plant, PlantFamily, PlantVariety
 from seeds.models import SeedPacket, Seeds
 from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
@@ -39,10 +45,11 @@ def make_plant_family(**overrides):
 def make_plant(**overrides):
     """Create a plant with a family when one is not supplied."""
     values = {
-        'family': make_plant_family(),
         'name': _next_name('Plant'),
         'notes': 'Shared test plant',
     }
+    if 'family' not in overrides:
+        values['family'] = make_plant_family()
     values.update(overrides)
     return Plant.objects.create(**values)
 
@@ -50,10 +57,11 @@ def make_plant(**overrides):
 def make_plant_variety(**overrides):
     """Create a plant variety with a plant when one is not supplied."""
     values = {
-        'plant': make_plant(),
         'name': _next_name('Variety'),
         'notes': 'Shared test variety',
     }
+    if 'plant' not in overrides:
+        values['plant'] = make_plant()
     values.update(overrides)
     return PlantVariety.objects.create(**values)
 
@@ -61,12 +69,14 @@ def make_plant_variety(**overrides):
 def make_seeds(**overrides):
     """Create a seed product with its supplier and variety graph."""
     values = {
-        'supplier': make_supplier(),
-        'plant_variety': make_plant_variety(),
         'supplier_code': _next_name('CODE'),
         'url': 'https://supplier.example.com/seeds',
         'notes': 'Shared test seeds',
     }
+    if 'supplier' not in overrides:
+        values['supplier'] = make_supplier()
+    if 'plant_variety' not in overrides:
+        values['plant_variety'] = make_plant_variety()
     values.update(overrides)
     return Seeds.objects.create(**values)
 
@@ -74,9 +84,10 @@ def make_seeds(**overrides):
 def make_seed_packet(**overrides):
     """Create a seed packet and its seed product graph."""
     values = {
-        'seeds': make_seeds(),
         'notes': 'Shared test packet',
     }
+    if 'seeds' not in overrides:
+        values['seeds'] = make_seeds()
     values.update(overrides)
     return SeedPacket.objects.create(**values)
 
@@ -95,13 +106,14 @@ def make_garden_area(**overrides):
 def make_garden_bed(**overrides):
     """Create a garden bed and its area."""
     values = {
-        'area': make_garden_area(),
         'name': _next_name('Bed'),
         'placement_x': 0,
         'placement_y': 0,
         'size_x': 50,
         'size_y': 50,
     }
+    if 'area' not in overrides:
+        values['area'] = make_garden_area()
     values.update(overrides)
     return GardenBed.objects.create(**values)
 
@@ -109,13 +121,14 @@ def make_garden_bed(**overrides):
 def make_garden_row(**overrides):
     """Create a garden row and its parent geometry."""
     values = {
-        'bed': make_garden_bed(),
         'name': _next_name('Row'),
         'placement_x': 0,
         'placement_y': 0,
         'size_x': 10,
         'size_y': 1,
     }
+    if 'bed' not in overrides:
+        values['bed'] = make_garden_bed()
     values.update(overrides)
     return GardenRow.objects.create(**values)
 
@@ -123,13 +136,14 @@ def make_garden_row(**overrides):
 def make_garden_square(**overrides):
     """Create a garden square and its parent geometry."""
     values = {
-        'bed': make_garden_bed(),
         'name': _next_name('Square'),
         'placement_x': 0,
         'placement_y': 0,
         'size_x': 1,
         'size_y': 1,
     }
+    if 'bed' not in overrides:
+        values['bed'] = make_garden_bed()
     values.update(overrides)
     return GardenSquare.objects.create(**values)
 
@@ -153,9 +167,10 @@ def make_seed_tray_model(**overrides):
 def make_seed_tray(**overrides):
     """Create a seed tray without implicitly creating cells."""
     values = {
-        'model': make_seed_tray_model(),
         'notes': 'Shared test tray',
     }
+    if 'model' not in overrides:
+        values['model'] = make_seed_tray_model()
     values.update(overrides)
     return SeedTray.objects.create(**values)
 
@@ -163,9 +178,69 @@ def make_seed_tray(**overrides):
 def make_seed_tray_cell(**overrides):
     """Create a seed-tray cell and its parent tray."""
     values = {
-        'tray': make_seed_tray(),
         'x_position': 0,
         'y_position': 0,
     }
+    if 'tray' not in overrides:
+        values['tray'] = make_seed_tray()
     values.update(overrides)
     return SeedTrayCell.objects.create(**values)
+
+
+def make_seed_tray_planting(**overrides):
+    """Create a seed-tray planting and its related seed and tray graph."""
+    values = {
+        'quantity': 2,
+        'notes': 'Shared test tray planting',
+    }
+    if 'seeds_used' not in overrides:
+        values['seeds_used'] = make_seed_packet()
+    if 'seed_tray' not in overrides:
+        values['seed_tray'] = make_seed_tray()
+    values.update(overrides)
+    return SeedTrayPlanting.objects.create(**values)
+
+
+def make_seed_tray_cell_planting(**overrides):
+    """Create a cell allocation whose cell belongs to its planting's tray."""
+    values = dict(overrides)
+    cell = values.pop('cell', None)
+    planting = values.pop('seed_tray_planting', None)
+    if planting is None:
+        if cell is None:
+            cell = make_seed_tray_cell()
+        planting = make_seed_tray_planting(seed_tray=cell.tray)
+    elif cell is None:
+        cell = make_seed_tray_cell(tray=planting.seed_tray)
+    values = {
+        'seed_tray_planting': planting,
+        'cell': cell,
+        'quantity': 2,
+        **values,
+    }
+    return SeedTrayCellPlanting.objects.create(**values)
+
+
+def make_specific_plant(**overrides):
+    """Create a specific plant without implicitly adding location history."""
+    values = {
+        'notes': 'Shared test specific plant',
+    }
+    if 'cell_planting' not in overrides:
+        values['cell_planting'] = make_seed_tray_cell_planting()
+    values.update(overrides)
+    return SpecificPlant.objects.create(**values)
+
+
+def make_specific_plant_location(**overrides):
+    """Create a valid seed-tray location for a specific plant."""
+    values = dict(overrides)
+    plant = values.pop('specific_plant', None) or make_specific_plant()
+    defaults = {
+        'specific_plant': plant,
+        'location_type': SpecificPlantLocation.SEED_TRAY_CELL,
+        'seed_tray_cell': plant.cell_planting.cell,
+        'notes': 'Shared test location',
+    }
+    defaults.update(values)
+    return SpecificPlantLocation.objects.create(**defaults)


### PR DESCRIPTION
Planting serializers and parent-filtered routes carry the deepest model graph and are especially vulnerable to framework changes. Exercise every registration, round-trip each writable representation, and verify nested resources cannot escape their URL parent.

## Summary by Sourcery

Add REST contract coverage for planting and specific-plant APIs and extend test factories to build full planting graphs.

Bug Fixes:
- Ensure test factories only create related models when not explicitly provided, avoiding unintended overrides in tests.

Enhancements:
- Introduce factory helpers for seed-tray plantings, specific plants, and their locations to support richer test scenarios.

Tests:
- Add comprehensive REST contract tests for planting collections, including authentication, list contracts, create/retrieve round-trips, and nested resource filtering for seed trays and specific plants.