### PR TITLE
fix(plantings): make individual transplants authoritative

### DIFF
--- a/plantings/migrations/0016_audit_transplant_ownership.py
+++ b/plantings/migrations/0016_audit_transplant_ownership.py
@@ -1,0 +1,42 @@
+from django.db import migrations
+
+
+def describe_rows(queryset):
+    """Return a bounded description of conflicting aggregate rows."""
+    count = queryset.count()
+    row_ids = list(queryset.order_by('pk').values_list('pk', flat=True)[:20])
+    suffix = '' if count <= len(row_ids) else f' (first 20 of {count})'
+    return f'{row_ids}{suffix}'
+
+
+def audit_transplant_ownership(apps, _schema_editor):
+    """Reject plantings represented by aggregate and individual transplants."""
+    transplant_model = apps.get_model('plantings', 'GardenSquareTransplant')
+    conflicting_transplants = transplant_model.objects.filter(
+        original_planting__cell_plantings__specific_plants__locations__location_type=(
+            'garden_square'
+        ),
+    ).distinct()
+
+    if conflicting_transplants.exists():
+        raise RuntimeError(
+            'Transplant ownership audit failed. Repair aggregate '
+            'GardenSquareTransplant rows that overlap individual garden '
+            'locations before retrying the migration. Conflicting '
+            'GardenSquareTransplant IDs: '
+            f'{describe_rows(conflicting_transplants)}'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plantings', '0015_audit_seed_allocation_capacity'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            audit_transplant_ownership,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -167,7 +167,9 @@ class SpecificPlantLocation(models.Model):
 
 class GardenSquareTransplant(models.Model):
     """
-    Transplant from a seedtray into a garden square
+    Legacy aggregate transplant from a seed tray into a garden square.
+
+    New transplant workflows use SpecificPlantLocation as their source of truth.
     """
     original_planting = models.ForeignKey(SeedTrayPlanting, on_delete=models.PROTECT)
     transplanted = models.DateTimeField(default=timezone.now)

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -629,9 +629,11 @@ class SeedTrayPlantingViewSeedTraySet(
         return self.queryset.filter(seed_tray__pk=self.kwargs['seed_tray_pk'])
 
 
-class GardenSquareTransplantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenSquareTransplantViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
     """
-    ViewSet of GardenSquareTransplant
+    Read-only access to legacy aggregate transplant records.
+
+    New transplant workflows move individual SpecificPlant records instead.
     """
     queryset = GardenSquareTransplant.objects.all()
     serializer_class = GardenSquareTransplantSerializer

--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -12,7 +12,9 @@ from plants.models import Plant, PlantFamily, PlantVariety
 from seeds.models import SeedPacket, Seeds
 from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
 from supplies.models import Supplier
+from tests.factories import make_garden_square
 from .models import (
+    GardenSquareTransplant,
     SeedTrayCellPlanting,
     SeedTrayPlanting,
     SpecificPlant,
@@ -20,7 +22,7 @@ from .models import (
 )
 
 
-class PlantingsDataMigrationTests(TestCase):
+class PlantingsDataMigrationTests(TestCase):  # pylint: disable=too-many-instance-attributes
     """
     Tests for deployment-time planting integrity audits.
     """
@@ -73,6 +75,10 @@ class PlantingsDataMigrationTests(TestCase):
             'plantings.migrations.0012_specificplantlocation_chronology'
         )
         self.chronology_audit = chronology_migration.audit_location_chronology
+        transplant_migration = import_module(
+            'plantings.migrations.0016_audit_transplant_ownership'
+        )
+        self.transplant_audit = transplant_migration.audit_transplant_ownership
 
     def test_audit_accepts_consistent_rows(self):
         """Valid parent membership and coordinates do not block deployment."""
@@ -139,6 +145,46 @@ class PlantingsDataMigrationTests(TestCase):
         )
 
         migration.audit_seed_allocation_capacity(django_apps, None)
+
+    def test_transplant_audit_accepts_separate_representations(self):
+        """Aggregate and individual transplants may belong to different plantings."""
+        square = make_garden_square()
+        legacy_planting = SeedTrayPlanting.objects.create(
+            seeds_used=self.cell_planting.seed_tray_planting.seeds_used,
+            quantity=1,
+        )
+        GardenSquareTransplant.objects.create(
+            original_planting=legacy_planting,
+            quantity=1,
+            location=square,
+        )
+        SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=square,
+        )
+
+        self.transplant_audit(django_apps, None)
+
+    def test_transplant_audit_reports_conflicting_aggregate_rows(self):
+        """Deployment failures identify aggregate rows with individual overlap."""
+        square = make_garden_square()
+        transplant = GardenSquareTransplant.objects.create(
+            original_planting=self.cell_planting.seed_tray_planting,
+            quantity=1,
+            location=square,
+        )
+        SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=square,
+        )
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            f'Conflicting GardenSquareTransplant IDs: [{transplant.pk}]',
+        ):
+            self.transplant_audit(django_apps, None)
 
     def test_capacity_audit_reports_parent_and_cell_row_ids(self):
         """Deployment failures identify both kinds of capacity violation."""

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -107,18 +107,10 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
                 SeedTrayPlanting,
                 {'seeds_used': self.packet.pk, 'seed_tray': self.tray.pk},
             ),
-            (
-                '/plantings/transplantedgardensquare/',
-                GardenSquareTransplant,
-                {
-                    'original_planting': self.original_planting.pk,
-                    'location': self.square.pk,
-                },
-            ),
         ]
 
     def test_create_rejects_non_positive_parent_quantities(self):
-        """Every aggregate planting endpoint requires at least one item."""
+        """Every writable aggregate planting endpoint requires at least one item."""
         for quantity in (0, -1):
             for url, model, payload in self._quantity_endpoints():
                 with self.subTest(quantity=quantity, model=model.__name__):

--- a/plantings/test_rest.py
+++ b/plantings/test_rest.py
@@ -12,7 +12,7 @@ from tests.factories import (
     make_specific_plant_location,
 )
 
-from .models import SpecificPlantLocation
+from .models import GardenSquareTransplant, SpecificPlantLocation
 
 
 class PlantingRESTContractTests(RESTContractTestCase):
@@ -66,8 +66,8 @@ class PlantingRESTContractTests(RESTContractTestCase):
         """Authenticated planting collections use the common list contract."""
         self.assert_list_contract(self.list_urls)
 
-    def test_aggregate_planting_resources_round_trip(self):
-        """Each aggregate planting representation survives create and retrieve."""
+    def test_writable_planting_resources_round_trip(self):
+        """Each current aggregate planting resource survives create and retrieve."""
         common_fields = {
             'seeds_used': self.packet.pk,
             'quantity': 3,
@@ -116,16 +116,45 @@ class PlantingRESTContractTests(RESTContractTestCase):
                 'quantity': 3,
             }],
         )
-        self.assert_create_retrieve(
-            '/plantings/transplantedgardensquare/',
-            {
-                'original_planting': self.tray_planting.pk,
-                'quantity': 2,
-                'location': self.square.pk,
-                'removed': False,
-                'notes': 'Transplanted outside',
-            },
+
+    def test_legacy_transplants_are_read_only(self):
+        """The REST API exposes legacy transplants without accepting mutations."""
+        transplant = GardenSquareTransplant.objects.create(
+            original_planting=self.tray_planting,
+            quantity=2,
+            location=self.square,
+            notes='Transplanted outside',
         )
+
+        response = self.client.get(
+            f'/plantings/transplantedgardensquare/{transplant.pk}/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['pk'], transplant.pk)
+
+        collection_url = '/plantings/transplantedgardensquare/'
+        mutation_cases = (
+            ('post', collection_url, {
+                'original_planting': self.tray_planting.pk,
+                'quantity': 1,
+                'location': self.square.pk,
+            }),
+            ('put', f'{collection_url}{transplant.pk}/', {
+                'original_planting': self.tray_planting.pk,
+                'quantity': 1,
+                'location': self.square.pk,
+            }),
+            ('patch', f'{collection_url}{transplant.pk}/', {'notes': 'Changed'}),
+            ('delete', f'{collection_url}{transplant.pk}/', None),
+        )
+        for method, url, data in mutation_cases:
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(url, data, format='json')
+                self.assertEqual(response.status_code, 405)
+
+        transplant.refresh_from_db()
+        self.assertEqual(transplant.quantity, 2)
+        self.assertEqual(transplant.notes, 'Transplanted outside')
 
     def test_specific_plant_and_location_resources_round_trip(self):
         """Specific plants and location history survive create and retrieve."""

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -14,6 +14,15 @@ from plants.models import Plant, PlantFamily, PlantVariety
 from seeds.models import SeedPacket, Seeds
 from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
 from supplies.models import Supplier
+from tests.factories import (
+    make_garden_square,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+)
 from .models import (
     GardenSquareDirectSowPlanting,
     GardenSquareTransplant,
@@ -22,6 +31,95 @@ from .models import (
     SpecificPlant,
     SpecificPlantLocation,
 )
+
+
+class TransplantOwnershipCurrentViewTests(TestCase):
+    """Current summaries prefer individual plants over legacy aggregates."""
+
+    def setUp(self):
+        self.client.force_login(
+            get_user_model().objects.create_user(username='ownership-tester')
+        )
+        self.square = make_garden_square()
+        self.tray = make_seed_tray()
+        self.cell = make_seed_tray_cell(tray=self.tray)
+        self.planting = make_seed_tray_planting(
+            seeds_used=make_seed_packet(),
+            quantity=3,
+            seed_tray=self.tray,
+        )
+
+    def _make_legacy_transplant(self):
+        return GardenSquareTransplant.objects.create(
+            original_planting=self.planting,
+            quantity=2,
+            location=self.square,
+        )
+
+    def _make_specific_garden_plant(self):
+        cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=self.planting,
+            cell=self.cell,
+            quantity=1,
+        )
+        plant = make_specific_plant(cell_planting=cell_planting)
+        location = SpecificPlantLocation.objects.create(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=self.square,
+        )
+        return plant, location
+
+    def test_legacy_aggregate_contributes_to_current_summaries(self):
+        """Aggregate-only history remains visible and counted."""
+        transplant = self._make_legacy_transplant()
+
+        response = self.client.get('/plantings/seedtray/current/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()['plantings'][0]['transplanted_count'],
+            transplant.quantity,
+        )
+
+        response = self.client.get('/plantings/garden/squares/current/')
+        self.assertEqual(response.status_code, 200)
+        garden_plantings = response.json()['plantings']
+        self.assertEqual(len(garden_plantings), 1)
+        self.assertEqual(garden_plantings[0]['transplanting_pk'], transplant.pk)
+        self.assertEqual(garden_plantings[0]['quantity'], transplant.quantity)
+
+    def test_individual_representation_wins_over_aggregate(self):
+        """Defensive reads never add or display both representations."""
+        self._make_legacy_transplant()
+        plant, location = self._make_specific_garden_plant()
+
+        response = self.client.get('/plantings/seedtray/current/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()['plantings'][0]['transplanted_count'],
+            1,
+        )
+
+        response = self.client.get('/plantings/garden/squares/current/')
+        self.assertEqual(response.status_code, 200)
+        garden_plantings = response.json()['plantings']
+        self.assertEqual(len(garden_plantings), 1)
+        self.assertEqual(garden_plantings[0]['specific_plant_pk'], plant.pk)
+        self.assertEqual(garden_plantings[0]['transplanting_pk'], location.pk)
+
+    def test_legacy_aggregate_can_still_be_completed(self):
+        """The compatibility action can retire a legacy aggregate row."""
+        transplant = self._make_legacy_transplant()
+
+        response = self.client.post(
+            '/plantings/garden/squares/transplant/complete/',
+            data=json.dumps({'planting': transplant.pk}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 204)
+        transplant.refresh_from_db()
+        self.assertTrue(transplant.removed)
 
 
 class SeedTrayPlantingMembershipTests(TestCase):

--- a/plantings/views.py
+++ b/plantings/views.py
@@ -5,7 +5,7 @@ Planting views
 import datetime
 
 from django.contrib.auth.decorators import login_required
-from django.db.models import Count, Sum
+from django.db.models import Count, Exists, OuterRef, Sum
 from django.http import HttpResponseNotAllowed, JsonResponse, HttpResponse
 from django.shortcuts import get_object_or_404
 
@@ -49,7 +49,10 @@ def seedtray_current(request):
     )
     planting_data = []
     for planting in plantings:
-        transplanted_count = transplanted_counts.get(planting.pk, 0) + garden_square_location_counts.get(planting.pk, 0)
+        if planting.pk in garden_square_location_counts:
+            transplanted_count = garden_square_location_counts[planting.pk]
+        else:
+            transplanted_count = transplanted_counts.get(planting.pk, 0)
         germinated_count = germinated_counts.get(planting.pk, 0)
         variety = planting.seeds_used.seeds.plant_variety
         germination_min, germination_max, _, _ = _get_variety_days(variety)
@@ -136,9 +139,19 @@ def gardensquare_current(request):
             'maturity_date_early': _add_nullable_days(planting.planted, maturity_min),
             'maturity_date_late': _add_nullable_days(planting.planted, maturity_max)
         })
+    specific_garden_locations = SpecificPlantLocation.objects.filter(
+        location_type=SpecificPlantLocation.GARDEN_SQUARE,
+        specific_plant__cell_planting__seed_tray_planting_id=OuterRef(
+            'original_planting_id'
+        ),
+    )
     transplantings = (
         GardenSquareTransplant.objects
         .filter(removed=False)
+        .annotate(
+            has_specific_representation=Exists(specific_garden_locations),
+        )
+        .filter(has_specific_representation=False)
         .select_related('original_planting__seeds_used__seeds__plant_variety__plant', 'location__bed__area')
     )
     for transplanting in transplantings:


### PR DESCRIPTION
Prevent new aggregate transplant writes while preserving legacy reads and completion. Defensive summary precedence and a deployment audit keep aggregate history from double-counting individual plant locations.

## Summary by Sourcery

Make individual SpecificPlant-based transplants the authoritative representation while preserving legacy aggregate transplant visibility and compatibility.

Bug Fixes:
- Prevent double-counting transplants in current seed tray and garden square summaries when both aggregate and individual representations exist.

Enhancements:
- Exclude aggregate GardenSquareTransplant rows from current garden square summaries when an equivalent individual SpecificPlant representation exists.
- Treat GardenSquareTransplant REST endpoints as read-only legacy resources and document the legacy status in models and views.
- Add a deployment-time audit to detect GardenSquareTransplant rows that conflict with individual garden locations.

Tests:
- Add view, REST, and migration tests to cover transplant ownership precedence, read-only legacy behavior, and the new transplant ownership audit.