### PR TITLE
build(frontend): align React and TypeScript dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,19 +12,23 @@
         "esbuild": "^0.28.0",
         "esbuild-config": "^1.0.1",
         "js-cookie": "^3.0.5",
+        "react": "^18.3.1",
         "react-bootstrap": "^2.10.4",
         "react-datetime-picker": "^7.0.1",
+        "react-dom": "^18.3.1",
         "react-select": "^5.10.2",
         "typescript-eslint": "^8.50.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/js-cookie": "^3.0.6",
-        "@types/react-dom": "^19.2.3",
+        "@types/react": "^18.3.31",
+        "@types/react-dom": "^18.3.7",
         "eslint": "^9.12.0",
         "eslint-plugin-react": "^7.37.1",
         "globals": "^17.0.0",
-        "prettier": "^3.3.3"
+        "prettier": "^3.3.3",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1080,22 +1084,23 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
-      "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.2.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -3729,7 +3734,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3879,7 +3884,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4114,7 +4119,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -4527,7 +4531,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -20,18 +20,22 @@
     "esbuild": "^0.28.0",
     "esbuild-config": "^1.0.1",
     "js-cookie": "^3.0.5",
+    "react": "^18.3.1",
     "react-bootstrap": "^2.10.4",
     "react-datetime-picker": "^7.0.1",
+    "react-dom": "^18.3.1",
     "react-select": "^5.10.2",
     "typescript-eslint": "^8.50.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",
     "@types/js-cookie": "^3.0.6",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "eslint": "^9.12.0",
     "eslint-plugin-react": "^7.37.1",
     "globals": "^17.0.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
The frontend imports React directly and now needs a stable compiler contract. Declare the React 18 runtime, matching type packages, and TypeScript explicitly so clean installs do not depend on transitive versions.

## Summary by Sourcery

Align frontend build with React 18 and explicit TypeScript tooling versions.

Build:
- Declare React and React DOM 18 runtime dependencies in the frontend package manifest.
- Align React type definitions with React 18 and update React DOM types accordingly.
- Add an explicit TypeScript dev dependency to stabilize the compiler toolchain.