### PR TITLE
feat(frontend): enforce strict TypeScript contracts

### DIFF
--- a/frontend/js/env.d.ts
+++ b/frontend/js/env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/frontend/js/garden.tsx
+++ b/frontend/js/garden.tsx
@@ -8,7 +8,7 @@ import { GardenArea, GardenBed, GardenSquare, GardenRow } from './types/garden'
 import { GardenSquarePlanting } from './types/plantings'
 import { getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares } from './api/garden'
 import { getPlantingGardenSquaresCurrent } from './api/plantings'
-import { SelectOption } from './types/others'
+import { NoProps, SelectOption } from './types/others'
 
 interface GardenAreaDisplayProps {
   area: GardenArea
@@ -149,9 +149,9 @@ interface GardenDisplayState {
   plantings: Array<GardenSquarePlanting>
 }
 
-class GardenDisplay extends React.Component<undefined, GardenDisplayState> {
+class GardenDisplay extends React.Component<NoProps, GardenDisplayState> {
   timer?: number
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -10,13 +10,14 @@ import { SeedStockTable, SeedSuppliersTable, SeedTable } from './seeds.js'
 import { GardenSquarePlantingTable, SeedTrayPlantingTable } from './planting.js'
 import { GardenDisplay } from './garden.js'
 import { SeedTrayModelsTable, SeedTraysTable } from './seedtrays.js'
+import { NoProps } from './types/others.js'
 
 interface FrontEndPageState {
   selectedView: string
 }
 
-class FrontEndPage extends React.Component<undefined, FrontEndPageState> {
-  constructor(props: undefined) {
+class FrontEndPage extends React.Component<NoProps, FrontEndPageState> {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {
@@ -63,8 +64,12 @@ class FrontEndPage extends React.Component<undefined, FrontEndPageState> {
 }
 
 function createFrontEnd(elementId: string) {
-  const div = ReactDOM.createRoot(document.getElementById(elementId))
+  const element = document.getElementById(elementId)
+  if (!element) {
+    throw new Error(`Cannot create frontend: element #${elementId} was not found`)
+  }
+  const div = ReactDOM.createRoot(element)
   div.render(<FrontEndPage />)
 }
 
-globalThis.createFrontEnd = createFrontEnd
+;(globalThis as Record<string, unknown>).createFrontEnd = createFrontEnd

--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -11,7 +11,7 @@ import { Seed, SeedPacket } from './types/seeds'
 import { GardenArea, GardenBed, GardenSquare } from './types/garden'
 import { GardenSquarePlanting, SeedTrayPlantingCreate, SeedTrayPlantingDetails } from './types/plantings'
 import { SeedTray, SeedTrayModel } from './types/seedtrays'
-import { SelectOption } from './types/others'
+import { NoProps, SelectOption } from './types/others'
 import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
 import { formatDate, formatDateRange } from './utils'
 import {
@@ -382,10 +382,10 @@ interface SeedTrayPlantingTableState {
   plantings: Array<SeedTrayPlantingDetails>
 }
 
-class SeedTrayPlantingTable extends React.Component<undefined, SeedTrayPlantingTableState> {
+class SeedTrayPlantingTable extends React.Component<NoProps, SeedTrayPlantingTableState> {
   timer?: number
 
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {
@@ -721,10 +721,10 @@ interface GardenSquarePlantingTableState {
   filterGardenBed?: string
 }
 
-class GardenSquarePlantingTable extends React.Component<undefined, GardenSquarePlantingTableState> {
+class GardenSquarePlantingTable extends React.Component<NoProps, GardenSquarePlantingTableState> {
   timer?: number
 
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {

--- a/frontend/js/plants.tsx
+++ b/frontend/js/plants.tsx
@@ -6,6 +6,7 @@ import { Table, Button } from 'react-bootstrap'
 
 import { Plant, PlantCreate, PlantFamily, PlantVariety, PlantVarietyCreate } from './types/plants'
 import { addPlant, addPlantFamily, addPlantVariety, getPlantFamilies, getPlants, getPlantVarieties } from './api/plants'
+import { NoProps } from './types/others'
 
 interface NewPlantFamilyRowProps {
   done: () => void
@@ -504,10 +505,10 @@ interface PlantsViewState {
   varieties: Array<PlantVariety>
 }
 
-class PlantsView extends React.Component<undefined, PlantsViewState> {
+class PlantsView extends React.Component<NoProps, PlantsViewState> {
   timer?: number
 
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {

--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -8,7 +8,7 @@ import Select from 'react-select'
 import { Supplier, SupplierCreate } from './types/suppliers'
 import { Seed, SeedCreate, SeedPacketCreate, SeedPacketDetails } from './types/seeds'
 import { PlantVariety } from './types/plants'
-import { SelectOption } from './types/others'
+import { NoProps, SelectOption } from './types/others'
 import { getPlantVarieties } from './api/plants'
 import { addSeed, addSeedPacket, emptySeedPacket, getSeedPacketsCurrent, getSeeds } from './api/seeds'
 import { addSupplier, getSuppliers } from './api/supplies'
@@ -113,10 +113,10 @@ interface SeedSuppliersTableState {
   suppliers: Array<Supplier>
 }
 
-class SeedSuppliersTable extends React.Component<undefined, SeedSuppliersTableState> {
+class SeedSuppliersTable extends React.Component<NoProps, SeedSuppliersTableState> {
   timer?: number
 
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {
@@ -355,9 +355,9 @@ interface SeedTableState {
   seeds: Array<Seed>
 }
 
-class SeedTable extends React.Component<undefined, SeedTableState> {
+class SeedTable extends React.Component<NoProps, SeedTableState> {
   timer?: number
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {
@@ -608,10 +608,10 @@ interface SeedStockTableState {
   seedPackets: Array<SeedPacketDetails>
 }
 
-class SeedStockTable extends React.Component<undefined, SeedStockTableState> {
+class SeedStockTable extends React.Component<NoProps, SeedStockTableState> {
   timer?: number
 
-  constructor(props: undefined) {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -576,7 +576,11 @@ class SeedTrayDetails extends React.Component<SeedTrayDetailsProps, SeedTrayDeta
 }
 
 function showSeedTrayDetails(elem: string, seedTrayPk: number) {
-  const root = ReactDOM.createRoot(document.getElementById(elem) as HTMLElement)
+  const element = document.getElementById(elem)
+  if (!element) {
+    throw new Error(`Cannot show seed tray details: element #${elem} was not found`)
+  }
+  const root = ReactDOM.createRoot(element)
   root.render(<SeedTrayDetails seedTrayPk={seedTrayPk} />)
 }
 

--- a/frontend/js/seedtrays.tsx
+++ b/frontend/js/seedtrays.tsx
@@ -8,6 +8,7 @@ import Select from 'react-select'
 import { SeedTrayModel, SeedTray, SeedTrayModelCreate, SeedTrayCreate } from './types/seedtrays'
 import { getSeedTrayModels, getSeedTrays, addSeedTrayModel, addSeedTray } from './api/seedtrays'
 import { formatDate } from './utils'
+import { NoProps } from './types/others'
 
 interface SeedTrayModelNewProps {
   done: () => void
@@ -76,8 +77,8 @@ interface SeedTrayModelsTableState {
   seedTrayModels: Array<SeedTrayModel>
 }
 
-class SeedTrayModelsTable extends React.Component<undefined, SeedTrayModelsTableState> {
-  constructor(props: undefined) {
+class SeedTrayModelsTable extends React.Component<NoProps, SeedTrayModelsTableState> {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {
@@ -192,8 +193,8 @@ interface SeedTraysTableState {
   seedTrayModels: { [key: number]: SeedTrayModel }
 }
 
-class SeedTraysTable extends React.Component<undefined, SeedTraysTableState> {
-  constructor(props: undefined) {
+class SeedTraysTable extends React.Component<NoProps, SeedTraysTableState> {
+  constructor(props: NoProps) {
     super(props)
 
     this.state = {

--- a/frontend/js/types/others.ts
+++ b/frontend/js/types/others.ts
@@ -3,4 +3,6 @@ type SelectOption = {
   label: string
 }
 
-export { SelectOption }
+type NoProps = Record<string, never>
+
+export { NoProps, SelectOption }

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -17,6 +17,7 @@ interface GardenSquareDirectPlantingCreate extends PlantingCreate {
 interface SeedTrayPlantingCreate extends PlantingCreate {
   seed_tray?: number
   location?: string
+  cell_plantings?: Array<{ cell: number; quantity: number }>
 }
 
 interface Planting {
@@ -66,16 +67,21 @@ interface SeedTrayPlantingDetails {
   cell_plantings?: Array<{ pk: number; cell: number; quantity: number }>
 }
 
+interface GardenSquarePlantingLocation extends Omit<GardenSquare, 'area' | 'bed'> {
+  area: string
+  bed: string
+}
+
 interface GardenSquarePlanting {
   specific_plant_pk?: number
   transplanting_pk?: number
   transplanted?: string
   planting_pk: number
-  plant: number
-  variety: number
+  plant: string
+  variety: string
   quantity: number
   planted: string
-  location: GardenSquare
+  location: GardenSquarePlantingLocation
   notes: string
   germination_date_early?: string
   germination_date_late?: string

--- a/frontend/js/types/seedtrays.ts
+++ b/frontend/js/types/seedtrays.ts
@@ -17,8 +17,10 @@ interface SeedTrayCreate {
   notes?: string
 }
 
-interface SeedTray extends SeedTrayCreate {
+interface SeedTray {
   pk: number
+  model: number
+  notes?: string
   created: string
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "frontend/main.js",
   "scripts": {
     "check": "eslint frontend/js/ && prettier -c frontend/js/",
+    "typecheck": "tsc --noEmit",
     "build-only": "esbuild $(esbuild-config)",
     "build": "esbuild $(esbuild-config) && cp -dpR dist/* frontend/static/",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
+  },
+  "include": ["frontend/js/**/*.ts", "frontend/js/**/*.tsx"]
+}


### PR DESCRIPTION
Transpilation and ESLint did not validate the frontend as a complete typed program. Add a strict no-emit compiler gate and align component, DOM, asset, and API declarations with the behavior already used at runtime.

## Summary by Sourcery

Introduce strict TypeScript type checking for the frontend and align existing components and types with the runtime behavior.

New Features:
- Add a TypeScript configuration enabling strict, no-emit compilation for the frontend codebase.
- Introduce a shared NoProps type for React components that do not accept props.

Bug Fixes:
- Validate DOM root elements before mounting React roots and throw descriptive errors when missing.
- Align planting and seed tray TypeScript types with actual runtime data shapes, including nested cell plantings and garden square planting locations.
- Correct global assignment typing for the createFrontEnd initializer to satisfy TypeScript.

Enhancements:
- Refine React component prop typings across frontend views to use explicit NoProps instead of undefined.
- Adjust SeedTray and related interfaces to more accurately represent model and notes fields in persisted data.

Build:
- Add a typecheck npm script that runs the TypeScript compiler in no-emit mode and wire it into the project tooling.