### PR TITLE
ci(frontend): run TypeScript type checking

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -15,3 +15,5 @@ jobs:
        run: npm ci
      - name: Run ESLint
        run: npm run check
+     - name: Run TypeScript type checking
+       run: npm run typecheck


### PR DESCRIPTION
Pull requests currently lint and format the frontend but do not verify its compile-time contracts. Run the strict no-emit compiler after clean dependency installation so type drift blocks CI.

## Summary by Sourcery

CI:
- Extend the frontend ESLint GitHub Actions workflow to run `npm run typecheck` after linting.