### PR TITLE
ci: remove unused GDAL dependency

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -28,12 +28,6 @@ jobs:
       DB_PASS: garden_tracker
     steps:
       - uses: actions/checkout@v7
-      - name: Update apt database
-        run: |
-          sudo apt update
-      - name: Install apt depends
-        run: |
-          sudo apt install -y gdal-bin libgdal-dev
       - name: Setup python
         uses: actions/setup-python@v7
         with:

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-if grep -Eq 'django\.(contrib\.gis\.)?db\.backends\.(postgresql|postgis)' gp/local_settings.py
+if grep -Eq 'django\.db\.backends\.postgresql' gp/local_settings.py
 then
     [ -n "$DB_HOST" ] && sed -Ei "s|(['\"]HOST['\"]: ).*|\\1\"$DB_HOST\",|" gp/local_settings.py || true
     [ -n "$DB_USER" ] && sed -Ei "s|(['\"]USER['\"]: ).*|\\1\"$DB_USER\",|" gp/local_settings.py || true


### PR DESCRIPTION
The project has no GIS models or runtime dependencies, so installing GDAL only slows pull-request checks. Limit database setup substitutions to the supported PostgreSQL backend as part of retiring dormant PostGIS compatibility.

## Summary by Sourcery

Remove unused GIS-related dependencies from CI and narrow database setup to the standard PostgreSQL backend.

Build:
- Restrict setup-db.sh database configuration substitutions to Django's standard PostgreSQL backend, dropping dormant PostGIS compatibility.

CI:
- Stop installing GDAL system packages in the checkcode GitHub Actions workflow.