### PR TITLE
feat(frontend): surface API failures

### DIFF
--- a/frontend/js/api/errors.ts
+++ b/frontend/js/api/errors.ts
@@ -1,0 +1,55 @@
+type ApiRequestMethod = 'GET' | 'POST' | 'PATCH'
+
+interface ApiErrorOptions {
+  method: ApiRequestMethod
+  url: string
+  status: number | null
+  statusText: string | null
+  body: unknown
+  cause?: unknown
+}
+
+class ApiError extends Error {
+  readonly method: ApiRequestMethod
+  readonly url: string
+  readonly status: number | null
+  readonly statusText: string | null
+  readonly body: unknown
+
+  constructor(message: string, options: ApiErrorOptions) {
+    super(message, { cause: options.cause })
+    this.name = 'ApiError'
+    this.method = options.method
+    this.url = options.url
+    this.status = options.status
+    this.statusText = options.statusText
+    this.body = options.body
+  }
+}
+
+type ApiErrorListener = () => void
+
+const listeners = new Set<ApiErrorListener>()
+let currentApiError: ApiError | null = null
+
+function reportApiError(error: ApiError): void {
+  currentApiError = error
+  listeners.forEach((listener) => listener())
+}
+
+function clearApiError(): void {
+  currentApiError = null
+  listeners.forEach((listener) => listener())
+}
+
+function subscribeToApiErrors(listener: ApiErrorListener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getCurrentApiError(): ApiError | null {
+  return currentApiError
+}
+
+export { ApiError, clearApiError, getCurrentApiError, reportApiError, subscribeToApiErrors }
+export type { ApiRequestMethod }

--- a/frontend/js/api_error_alert.tsx
+++ b/frontend/js/api_error_alert.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { Alert } from 'react-bootstrap'
+
+import { clearApiError, getCurrentApiError, subscribeToApiErrors } from './api/errors'
+
+const MAX_TEXT_DETAIL_LENGTH = 500
+
+function humanizeFieldName(field: string): string {
+  if (field === 'non_field_errors') {
+    return 'General'
+  }
+  return field.replaceAll('_', ' ')
+}
+
+function formatErrorBody(body: unknown, prefix?: string): Array<string> {
+  if (typeof body === 'string') {
+    let message = body.trim()
+    if (/^(<!doctype html|<html)/i.test(message)) {
+      message = 'The server returned an HTML error page.'
+    } else if (message.length > MAX_TEXT_DETAIL_LENGTH) {
+      message = `${message.slice(0, MAX_TEXT_DETAIL_LENGTH)}…`
+    }
+    return message ? [prefix ? `${prefix}: ${message}` : message] : []
+  }
+  if (Array.isArray(body)) {
+    return body.flatMap((value) => formatErrorBody(value, prefix))
+  }
+  if (typeof body === 'object' && body !== null) {
+    return Object.entries(body).flatMap(([field, value]) => {
+      const fieldName = humanizeFieldName(field)
+      return formatErrorBody(value, prefix ? `${prefix}.${fieldName}` : fieldName)
+    })
+  }
+  if (body === null || body === undefined) {
+    return []
+  }
+  return [prefix ? `${prefix}: ${String(body)}` : String(body)]
+}
+
+function ApiErrorAlert() {
+  const error = React.useSyncExternalStore(subscribeToApiErrors, getCurrentApiError, getCurrentApiError)
+
+  if (error === null) {
+    return null
+  }
+
+  const details = formatErrorBody(error.body)
+  return (
+    <Alert variant="danger" dismissible onClose={clearApiError}>
+      <Alert.Heading>Request failed</Alert.Heading>
+      <p className={details.length > 0 ? 'mb-2' : 'mb-0'}>{error.message}</p>
+      {details.length > 0 && (
+        <ul className="mb-0">
+          {details.map((detail, index) => (
+            <li key={`${index}-${detail}`}>{detail}</li>
+          ))}
+        </ul>
+      )}
+    </Alert>
+  )
+}
+
+export { ApiErrorAlert }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -10,57 +10,39 @@ import { SeedStockTable, SeedSuppliersTable, SeedTable } from './seeds.js'
 import { GardenSquarePlantingTable, SeedTrayPlantingTable } from './planting.js'
 import { GardenDisplay } from './garden.js'
 import { SeedTrayModelsTable, SeedTraysTable } from './seedtrays.js'
-import { NoProps } from './types/others.js'
+import { ApiErrorAlert } from './api_error_alert.js'
 
-interface FrontEndPageState {
-  selectedView: string
-}
+function FrontEndPage() {
+  const [selectedView, setSelectedView] = React.useState('gardens')
 
-class FrontEndPage extends React.Component<NoProps, FrontEndPageState> {
-  constructor(props: NoProps) {
-    super(props)
-
-    this.state = {
-      selectedView: 'gardens'
-    }
-
-    this.updateSelectedView = this.updateSelectedView.bind(this)
+  let view = <></>
+  if (selectedView === 'plants') {
+    view = <PlantsView />
+  } else if (selectedView === 'seeds-supplier') {
+    view = <SeedSuppliersTable />
+  } else if (selectedView === 'seeds-seed') {
+    view = <SeedTable />
+  } else if (selectedView === 'seeds-stock') {
+    view = <SeedStockTable />
+  } else if (selectedView === 'seedtrays-models') {
+    view = <SeedTrayModelsTable />
+  } else if (selectedView === 'seedtrays') {
+    view = <SeedTraysTable />
+  } else if (selectedView === 'planting-seedtrays') {
+    view = <SeedTrayPlantingTable />
+  } else if (selectedView === 'planting-gardensquare') {
+    view = <GardenSquarePlantingTable />
+  } else {
+    view = <GardenDisplay />
   }
 
-  updateSelectedView(view: string) {
-    this.setState({
-      selectedView: view
-    })
-  }
-
-  render() {
-    let view = <></>
-    if (this.state.selectedView === 'plants') {
-      view = <PlantsView />
-    } else if (this.state.selectedView === 'seeds-supplier') {
-      view = <SeedSuppliersTable />
-    } else if (this.state.selectedView === 'seeds-seed') {
-      view = <SeedTable />
-    } else if (this.state.selectedView === 'seeds-stock') {
-      view = <SeedStockTable />
-    } else if (this.state.selectedView === 'seedtrays-models') {
-      view = <SeedTrayModelsTable />
-    } else if (this.state.selectedView === 'seedtrays') {
-      view = <SeedTraysTable />
-    } else if (this.state.selectedView === 'planting-seedtrays') {
-      view = <SeedTrayPlantingTable />
-    } else if (this.state.selectedView === 'planting-gardensquare') {
-      view = <GardenSquarePlantingTable />
-    } else {
-      view = <GardenDisplay />
-    }
-    return (
-      <>
-        <GPTopBar setView={this.updateSelectedView} />
-        {view}
-      </>
-    )
-  }
+  return (
+    <>
+      <GPTopBar setView={setSelectedView} />
+      <ApiErrorAlert />
+      {view}
+    </>
+  )
 }
 
 function createFrontEnd(elementId: string) {

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -7,6 +7,7 @@ import { getSeedTrayModels, getSeedTrays, getSeedTrayCells } from '../api/seedtr
 import { Button, Table } from 'react-bootstrap'
 import { SeedTrayPlanting, SpecificPlant, SpecificPlantLocation } from '../types/plantings'
 import { getPlantingSeedTray, getSpecificPlantsBySeedTray, addSpecificPlant, moveSpecificPlant } from '../api/plantings'
+import { ApiErrorAlert } from '../api_error_alert'
 import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
 import { GardenSquare } from '../types/garden'
@@ -581,7 +582,12 @@ function showSeedTrayDetails(elem: string, seedTrayPk: number) {
     throw new Error(`Cannot show seed tray details: element #${elem} was not found`)
   }
   const root = ReactDOM.createRoot(element)
-  root.render(<SeedTrayDetails seedTrayPk={seedTrayPk} />)
+  root.render(
+    <>
+      <ApiErrorAlert />
+      <SeedTrayDetails seedTrayPk={seedTrayPk} />
+    </>
+  )
 }
 
 ;(globalThis as Record<string, unknown>).showSeedTrayDetails = showSeedTrayDetails

--- a/frontend/js/utils.tsx
+++ b/frontend/js/utils.tsx
@@ -1,5 +1,7 @@
 import Cookies from 'js-cookie'
 
+import { ApiError, reportApiError, type ApiRequestMethod } from './api/errors'
+
 const LOGIN_PATH = '/accounts/login/'
 const NOT_AUTHENTICATED_DETAIL = 'Authentication credentials were not provided.'
 
@@ -40,30 +42,108 @@ async function isAuthenticationFailure(response: Response): Promise<boolean> {
   }
 }
 
-function redirectToLogin(url: string, response: Response): never {
+function redirectToLogin(method: ApiRequestMethod, url: string, response: Response): never {
   const next = `${window.location.pathname}${window.location.search}${window.location.hash}`
   window.location.assign(`${LOGIN_PATH}?next=${encodeURIComponent(next)}`)
-  throw new Error(`Authentication required while fetching ${url}; redirecting to login (${responseStatus(response)})`)
+  throw new Error(`Authentication required for ${method} ${url}; redirecting to login (${responseStatus(response)})`)
 }
 
-function csrfPost(url: string, data: object): Promise<Response> {
-  return fetch(url, {
-    method: 'POST',
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError'
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error)
+}
+
+function raiseApiError(error: ApiError): never {
+  reportApiError(error)
+  throw error
+}
+
+function raiseNetworkError(method: ApiRequestMethod, url: string, cause: unknown): never {
+  raiseApiError(
+    new ApiError(`${method} ${url} failed before receiving a response: ${errorMessage(cause)}`, {
+      method,
+      url,
+      status: null,
+      statusText: null,
+      body: null,
+      cause
+    })
+  )
+}
+
+async function fetchResponse(method: ApiRequestMethod, url: string, init: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init)
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+    raiseNetworkError(method, url, error)
+  }
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const body = await response.text()
+  if (!body) {
+    return null
+  }
+  try {
+    return JSON.parse(body) as unknown
+  } catch {
+    return body
+  }
+}
+
+async function raiseResponseError(method: ApiRequestMethod, url: string, response: Response, message: string): Promise<never> {
+  let body: unknown = null
+  try {
+    body = await parseResponseBody(response)
+  } catch (error) {
+    body = `The response body could not be read: ${errorMessage(error)}`
+  }
+  raiseApiError(
+    new ApiError(message, {
+      method,
+      url,
+      status: response.status,
+      statusText: response.statusText || null,
+      body
+    })
+  )
+}
+
+async function checkResponse(method: ApiRequestMethod, url: string, response: Response): Promise<void> {
+  if (await isAuthenticationFailure(response)) {
+    redirectToLogin(method, url, response)
+  }
+  if (!response.ok) {
+    await raiseResponseError(method, url, response, `${method} ${url} failed: ${responseStatus(response)}`)
+  }
+}
+
+async function csrfRequest(method: 'POST' | 'PATCH', url: string, data: object): Promise<Response> {
+  const response = await fetchResponse(method, url, {
+    method,
     headers: {
       'Content-Type': 'application/json',
       'X-CSRFToken': Cookies.get('csrftoken') || ''
     },
     body: JSON.stringify(data)
-  }).then((response) => {
-    if (!response.ok) {
-      throw new Error(`Failed to post data to ${url} ${response.status}: ${response.statusText}`)
-    }
-    return response
   })
+  await checkResponse(method, url, response)
+  return response
+}
+
+function csrfPost(url: string, data: object): Promise<Response> {
+  return csrfRequest('POST', url, data)
 }
 
 async function fetchAsJson<T = unknown>(url: string, signal?: AbortSignal): Promise<T> {
-  const response = await fetch(url, {
+  const method = 'GET'
+  const response = await fetchResponse(method, url, {
     method: 'GET',
     headers: {
       Accept: 'application/json'
@@ -71,39 +151,46 @@ async function fetchAsJson<T = unknown>(url: string, signal?: AbortSignal): Prom
     signal
   })
 
-  if (await isAuthenticationFailure(response)) {
-    redirectToLogin(url, response)
-  }
-  if (!response.ok) {
-    throw new Error(`Failed to fetch JSON from ${url}: ${responseStatus(response)}`)
-  }
+  await checkResponse(method, url, response)
   if (!isJsonResponse(response)) {
     const contentType = response.headers.get('Content-Type') || 'no Content-Type'
-    throw new Error(`Failed to fetch JSON from ${url}: expected JSON but received ${contentType} (${responseStatus(response)})`)
+    await raiseResponseError(method, url, response, `${method} ${url} failed: expected JSON but received ${contentType} (${responseStatus(response)})`)
+  }
+
+  let body: string
+  try {
+    body = await response.text()
+  } catch (error) {
+    raiseApiError(
+      new ApiError(`${method} ${url} failed while reading JSON (${responseStatus(response)}): ${errorMessage(error)}`, {
+        method,
+        url,
+        status: response.status,
+        statusText: response.statusText || null,
+        body: null,
+        cause: error
+      })
+    )
   }
 
   try {
-    return (await response.json()) as T
+    return JSON.parse(body) as T
   } catch (error) {
-    const detail = error instanceof Error ? `: ${error.message}` : ''
-    throw new Error(`Failed to parse JSON from ${url} (${responseStatus(response)})${detail}`)
+    raiseApiError(
+      new ApiError(`${method} ${url} returned malformed JSON (${responseStatus(response)}): ${errorMessage(error)}`, {
+        method,
+        url,
+        status: response.status,
+        statusText: response.statusText || null,
+        body,
+        cause: error
+      })
+    )
   }
 }
 
 function csrfPatch(url: string, data: object): Promise<Response> {
-  return fetch(url, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-CSRFToken': Cookies.get('csrftoken') || ''
-    },
-    body: JSON.stringify(data)
-  }).then((response) => {
-    if (!response.ok) {
-      throw new Error(`Failed to patch data to ${url} ${response.status}: ${response.statusText}`)
-    }
-    return response
-  })
+  return csrfRequest('PATCH', url, data)
 }
 
 function localDatetimeInputValue(date: Date = new Date()): string {
@@ -133,4 +220,4 @@ function formatDateRange(start: string | null | undefined, end: string | null | 
   return `${formatDate(start ?? '')} - ${formatDate(end ?? '')}`
 }
 
-export { csrfPost, csrfPatch, fetchAsJson, localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime, formatDateRange }
+export { ApiError, csrfPost, csrfPatch, fetchAsJson, localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime, formatDateRange }


### PR DESCRIPTION
Frontend request errors currently reject promises without giving users actionable feedback. Preserve parsed response details in a typed ApiError and publish failures to dismissible alerts in both React entry points, while retaining authentication redirects and abort semantics.

## Summary by Sourcery

Surface API request failures to users via a shared error reporting mechanism and alert UI while preserving existing authentication and abort behavior.

New Features:
- Introduce a shared ApiError type and error reporting utilities for API requests, including capturing response metadata and bodies.
- Add a reusable ApiErrorAlert React component that displays dismissible alerts for the latest API failure in main and seed tray detail entry points.

Enhancements:
- Refactor fetch and CSRF helpers to centralize error handling, parse response bodies, and standardize error messages for network and response failures.
- Convert the main FrontEndPage React entry point from a class component to a functional component using hooks, and export ApiError from the utilities module for broader use.