### PR TITLE
feat(frontend): establish query data layer

### DIFF
--- a/frontend/js/api/garden.ts
+++ b/frontend/js/api/garden.ts
@@ -1,20 +1,20 @@
 import { GardenArea, GardenBed, GardenRow, GardenSquare } from '../types/garden'
 import { fetchAsJson } from '../utils'
 
-async function getGardenAreas(): Promise<Array<GardenArea>> {
-  return fetchAsJson<Array<GardenArea>>('/garden/areas/')
+async function getGardenAreas(signal?: AbortSignal): Promise<Array<GardenArea>> {
+  return fetchAsJson<Array<GardenArea>>('/garden/areas/', signal)
 }
 
-async function getGardenBeds(): Promise<Array<GardenBed>> {
-  return fetchAsJson<Array<GardenBed>>('/garden/beds/')
+async function getGardenBeds(signal?: AbortSignal): Promise<Array<GardenBed>> {
+  return fetchAsJson<Array<GardenBed>>('/garden/beds/', signal)
 }
 
-async function getGardenRows(): Promise<Array<GardenRow>> {
-  return fetchAsJson<Array<GardenRow>>('/garden/rows/')
+async function getGardenRows(signal?: AbortSignal): Promise<Array<GardenRow>> {
+  return fetchAsJson<Array<GardenRow>>('/garden/rows/', signal)
 }
 
-async function getGardenSquares(): Promise<Array<GardenSquare>> {
-  return fetchAsJson<Array<GardenSquare>>('/garden/squares/')
+async function getGardenSquares(signal?: AbortSignal): Promise<Array<GardenSquare>> {
+  return fetchAsJson<Array<GardenSquare>>('/garden/squares/', signal)
 }
 
 export { getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares }

--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -15,16 +15,16 @@ import {
   SpecificPlantMove
 } from '../types/plantings'
 
-function getPlantingDirectSowGardenRows(): Promise<Array<GardenRowDirectPlanting>> {
-  return fetchAsJson<Array<GardenRowDirectPlanting>>('/plantings/directsowgardenrow/')
+function getPlantingDirectSowGardenRows(signal?: AbortSignal): Promise<Array<GardenRowDirectPlanting>> {
+  return fetchAsJson<Array<GardenRowDirectPlanting>>('/plantings/directsowgardenrow/', signal)
 }
 
 function addPlantingDirectSowGardenRow(data: GardenRowDirectPlantingCreate) {
   return csrfPost('/plantings/directsowgardenrow/', data)
 }
 
-function getPlantingDirectSowGardenSquares(): Promise<Array<GardenSquareDirectPlanting>> {
-  return fetchAsJson<Array<GardenSquareDirectPlanting>>('/plantings/directsowgardensquare/')
+function getPlantingDirectSowGardenSquares(signal?: AbortSignal): Promise<Array<GardenSquareDirectPlanting>> {
+  return fetchAsJson<Array<GardenSquareDirectPlanting>>('/plantings/directsowgardensquare/', signal)
 }
 
 function addPlantingDirectSowGardenSquare(data: GardenSquareDirectPlantingCreate) {
@@ -37,12 +37,12 @@ function completePlantingDirectSowGardenSquare(plantingPk: number) {
   })
 }
 
-function getPlantingSeedTrays(): Promise<Array<SeedTrayPlanting>> {
-  return fetchAsJson<Array<SeedTrayPlanting>>('/plantings/seedtray/')
+function getPlantingSeedTrays(signal?: AbortSignal): Promise<Array<SeedTrayPlanting>> {
+  return fetchAsJson<Array<SeedTrayPlanting>>('/plantings/seedtray/', signal)
 }
 
-function getPlantingSeedTray(seedTrayPk: number): Promise<Array<SeedTrayPlanting>> {
-  return fetchAsJson<Array<SeedTrayPlanting>>(`/plantings/seedtray-data/${seedTrayPk}/plantings/`)
+function getPlantingSeedTray(seedTrayPk: number, signal?: AbortSignal): Promise<Array<SeedTrayPlanting>> {
+  return fetchAsJson<Array<SeedTrayPlanting>>(`/plantings/seedtray-data/${seedTrayPk}/plantings/`, signal)
 }
 
 function addPlantingSeedTray(data: SeedTrayPlantingCreate) {
@@ -55,8 +55,8 @@ function completePlantingSeedTray(plantingPk: number) {
   })
 }
 
-function getPlantingTransplantedGardenSquares(): Promise<Array<GardenSquareTransplanting>> {
-  return fetchAsJson<Array<GardenSquareTransplanting>>('/plantings/transplantedgardensquare/')
+function getPlantingTransplantedGardenSquares(signal?: AbortSignal): Promise<Array<GardenSquareTransplanting>> {
+  return fetchAsJson<Array<GardenSquareTransplanting>>('/plantings/transplantedgardensquare/', signal)
 }
 
 function completePlantingTransplantedGardenSquare(plantingPk: number) {
@@ -65,16 +65,16 @@ function completePlantingTransplantedGardenSquare(plantingPk: number) {
   })
 }
 
-function getPlantingSeedTrayCurrent(): Promise<Array<SeedTrayPlantingDetails>> {
-  return fetchAsJson<{ plantings: Array<SeedTrayPlantingDetails> }>('/plantings/seedtray/current/').then((data) => data.plantings)
+function getPlantingSeedTrayCurrent(signal?: AbortSignal): Promise<Array<SeedTrayPlantingDetails>> {
+  return fetchAsJson<{ plantings: Array<SeedTrayPlantingDetails> }>('/plantings/seedtray/current/', signal).then((data) => data.plantings)
 }
 
-function getPlantingGardenSquaresCurrent(): Promise<Array<GardenSquarePlanting>> {
-  return fetchAsJson<{ plantings: Array<GardenSquarePlanting> }>('/plantings/garden/squares/current/').then((data) => data.plantings)
+function getPlantingGardenSquaresCurrent(signal?: AbortSignal): Promise<Array<GardenSquarePlanting>> {
+  return fetchAsJson<{ plantings: Array<GardenSquarePlanting> }>('/plantings/garden/squares/current/', signal).then((data) => data.plantings)
 }
 
-function getSpecificPlantsBySeedTray(seedTrayPk: number): Promise<Array<SpecificPlant>> {
-  return fetchAsJson<Array<SpecificPlant>>(`/plantings/seedtray-data/${seedTrayPk}/specificplants/`)
+function getSpecificPlantsBySeedTray(seedTrayPk: number, signal?: AbortSignal): Promise<Array<SpecificPlant>> {
+  return fetchAsJson<Array<SpecificPlant>>(`/plantings/seedtray-data/${seedTrayPk}/specificplants/`, signal)
 }
 
 function addSpecificPlant(data: SpecificPlantCreate): Promise<SpecificPlant> {

--- a/frontend/js/api/plants.ts
+++ b/frontend/js/api/plants.ts
@@ -1,24 +1,24 @@
 import { fetchAsJson, csrfPost } from '../utils'
 import { PlantFamily, PlantVariety, Plant, PlantFamilyCreate, PlantCreate, PlantVarietyCreate } from '../types/plants'
 
-function getPlantFamilies(): Promise<Array<PlantFamily>> {
-  return fetchAsJson<Array<PlantFamily>>('/plants/family/')
+function getPlantFamilies(signal?: AbortSignal): Promise<Array<PlantFamily>> {
+  return fetchAsJson<Array<PlantFamily>>('/plants/family/', signal)
 }
 
 function addPlantFamily(data: PlantFamilyCreate) {
   return csrfPost('/plants/family/', data)
 }
 
-function getPlantVarieties(): Promise<Array<PlantVariety>> {
-  return fetchAsJson<Array<PlantVariety>>('/plants/variety/')
+function getPlantVarieties(signal?: AbortSignal): Promise<Array<PlantVariety>> {
+  return fetchAsJson<Array<PlantVariety>>('/plants/variety/', signal)
 }
 
 function addPlantVariety(data: PlantVarietyCreate) {
   return csrfPost('/plants/variety/', data)
 }
 
-function getPlants(): Promise<Array<Plant>> {
-  return fetchAsJson<Array<Plant>>('/plants/plant/')
+function getPlants(signal?: AbortSignal): Promise<Array<Plant>> {
+  return fetchAsJson<Array<Plant>>('/plants/plant/', signal)
 }
 
 function addPlant(data: PlantCreate) {

--- a/frontend/js/api/seeds.ts
+++ b/frontend/js/api/seeds.ts
@@ -1,24 +1,24 @@
 import { Seed, SeedCreate, SeedPacket, SeedPacketCreate, SeedPacketDetails } from '../types/seeds'
 import { csrfPost, fetchAsJson } from '../utils'
 
-function getSeeds(): Promise<Array<Seed>> {
-  return fetchAsJson<Array<Seed>>('/seeds/seeds/')
+function getSeeds(signal?: AbortSignal): Promise<Array<Seed>> {
+  return fetchAsJson<Array<Seed>>('/seeds/seeds/', signal)
 }
 
 function addSeed(seed: SeedCreate) {
   return csrfPost('/seeds/seeds/', seed)
 }
 
-function getSeedPackets(): Promise<Array<SeedPacket>> {
-  return fetchAsJson<Array<SeedPacket>>('/seeds/packets/')
+function getSeedPackets(signal?: AbortSignal): Promise<Array<SeedPacket>> {
+  return fetchAsJson<Array<SeedPacket>>('/seeds/packets/', signal)
 }
 
 function addSeedPacket(packet: SeedPacketCreate) {
   return csrfPost('/seeds/packets/', packet)
 }
 
-function getSeedPacketsCurrent(): Promise<Array<SeedPacketDetails>> {
-  return fetchAsJson<{ packets: Array<SeedPacketDetails> }>('/seeds/packets/current/').then((data) => data.packets)
+function getSeedPacketsCurrent(signal?: AbortSignal): Promise<Array<SeedPacketDetails>> {
+  return fetchAsJson<{ packets: Array<SeedPacketDetails> }>('/seeds/packets/current/', signal).then((data) => data.packets)
 }
 
 function emptySeedPacket(pk: number) {

--- a/frontend/js/api/seedtrays.ts
+++ b/frontend/js/api/seedtrays.ts
@@ -1,16 +1,16 @@
 import { SeedTray, SeedTrayCell, SeedTrayCreate, SeedTrayModel, SeedTrayModelCreate } from '../types/seedtrays'
 import { csrfPost, fetchAsJson } from '../utils'
 
-function getSeedTrayModels(): Promise<Array<SeedTrayModel>> {
-  return fetchAsJson<Array<SeedTrayModel>>('/seedtrays/seedtraymodels/')
+function getSeedTrayModels(signal?: AbortSignal): Promise<Array<SeedTrayModel>> {
+  return fetchAsJson<Array<SeedTrayModel>>('/seedtrays/seedtraymodels/', signal)
 }
 
 function addSeedTrayModel(model: SeedTrayModelCreate) {
   return csrfPost('/seedtrays/seedtraymodels/', model)
 }
 
-function getSeedTrays(): Promise<Array<SeedTray>> {
-  return fetchAsJson<Array<SeedTray>>('/seedtrays/seedtrays/')
+function getSeedTrays(signal?: AbortSignal): Promise<Array<SeedTray>> {
+  return fetchAsJson<Array<SeedTray>>('/seedtrays/seedtrays/', signal)
 }
 
 function addSeedTray(tray: SeedTrayCreate) {

--- a/frontend/js/api/supplies.ts
+++ b/frontend/js/api/supplies.ts
@@ -1,8 +1,8 @@
 import { Supplier, SupplierCreate } from '../types/suppliers'
 import { csrfPost, fetchAsJson } from '../utils'
 
-function getSuppliers(): Promise<Array<Supplier>> {
-  return fetchAsJson<Array<Supplier>>('/supplies/supplier/')
+function getSuppliers(signal?: AbortSignal): Promise<Array<Supplier>> {
+  return fetchAsJson<Array<Supplier>>('/supplies/supplier/', signal)
 }
 
 function addSupplier(supplier: SupplierCreate) {

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -3,6 +3,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
 
 import { GPTopBar } from './menu.js'
 import { PlantsView } from './plants.js'
@@ -11,6 +12,7 @@ import { GardenSquarePlantingTable, SeedTrayPlantingTable } from './planting.js'
 import { GardenDisplay } from './garden.js'
 import { SeedTrayModelsTable, SeedTraysTable } from './seedtrays.js'
 import { ApiErrorAlert } from './api_error_alert.js'
+import { queryClient } from './query.js'
 
 function FrontEndPage() {
   const [selectedView, setSelectedView] = React.useState('gardens')
@@ -51,7 +53,11 @@ function createFrontEnd(elementId: string) {
     throw new Error(`Cannot create frontend: element #${elementId} was not found`)
   }
   const div = ReactDOM.createRoot(element)
-  div.render(<FrontEndPage />)
+  div.render(
+    <QueryClientProvider client={queryClient}>
+      <FrontEndPage />
+    </QueryClientProvider>
+  )
 }
 
 ;(globalThis as Record<string, unknown>).createFrontEnd = createFrontEnd

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -1,0 +1,58 @@
+import { QueryClient } from '@tanstack/react-query'
+
+const queryKeys = {
+  garden: {
+    all: ['garden'] as const,
+    areas: ['garden', 'areas'] as const,
+    beds: ['garden', 'beds'] as const,
+    rows: ['garden', 'rows'] as const,
+    squares: ['garden', 'squares'] as const
+  },
+  plants: {
+    all: ['plants'] as const,
+    families: ['plants', 'families'] as const,
+    plants: ['plants', 'plants'] as const,
+    varieties: ['plants', 'varieties'] as const
+  },
+  suppliers: {
+    all: ['suppliers'] as const
+  },
+  seeds: {
+    all: ['seeds'] as const,
+    catalog: ['seeds', 'catalog'] as const,
+    packets: {
+      all: ['seeds', 'packets'] as const,
+      raw: ['seeds', 'packets', 'raw'] as const,
+      current: ['seeds', 'packets', 'current'] as const
+    }
+  },
+  seedTrays: {
+    all: ['seedTrays'] as const,
+    models: ['seedTrays', 'models'] as const,
+    trays: ['seedTrays', 'trays'] as const,
+    cells: (trayPk: number) => ['seedTrays', 'cells', trayPk] as const
+  },
+  plantings: {
+    all: ['plantings'] as const,
+    directGardenRows: ['plantings', 'directGardenRows'] as const,
+    directGardenSquares: ['plantings', 'directGardenSquares'] as const,
+    transplantedGardenSquares: ['plantings', 'transplantedGardenSquares'] as const,
+    seedTrays: ['plantings', 'seedTrays'] as const,
+    seedTray: (trayPk: number) => ['plantings', 'seedTrays', trayPk] as const,
+    currentSeedTrays: ['plantings', 'currentSeedTrays'] as const,
+    currentGardenSquares: ['plantings', 'currentGardenSquares'] as const,
+    specificPlants: (trayPk: number) => ['plantings', 'specificPlants', trayPk] as const
+  }
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      retry: false
+    }
+  }
+})
+
+export { queryClient, queryKeys }

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
 
 import { SeedTray, SeedTrayCell, SeedTrayModel } from '../types/seedtrays'
 import { localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime } from '../utils'
@@ -12,6 +13,7 @@ import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
 import { GardenSquare } from '../types/garden'
 import { getGardenSquares } from '../api/garden'
+import { queryClient } from '../query'
 
 interface SeedTrayDetailsProps {
   seedTrayPk: number
@@ -583,10 +585,10 @@ function showSeedTrayDetails(elem: string, seedTrayPk: number) {
   }
   const root = ReactDOM.createRoot(element)
   root.render(
-    <>
+    <QueryClientProvider client={queryClient}>
       <ApiErrorAlert />
       <SeedTrayDetails seedTrayPk={seedTrayPk} />
-    </>
+    </QueryClientProvider>
   )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "garden-planner",
       "version": "1.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.101.4",
         "bootstrap": "^5.3.3",
         "esbuild": "^0.28.0",
         "esbuild-config": "^1.0.1",
@@ -1051,6 +1052,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "",
   "description": "",
   "dependencies": {
+    "@tanstack/react-query": "^5.101.4",
     "bootstrap": "^5.3.3",
     "esbuild": "^0.28.0",
     "esbuild-config": "^1.0.1",


### PR DESCRIPTION
Manual fetch owners need a shared cache and cancellable request contract before individual views can migrate. Add TanStack Query, stable hierarchical keys, providers for both React roots, and optional abort signals on every GET helper.

## Summary by Sourcery

Introduce a shared query data layer for the frontend and wire it into both React roots.

New Features:
- Add a TanStack Query client and centralized hierarchical query keys for garden, plants, suppliers, seeds, seed trays, and plantings data.
- Wrap the main frontend and seed tray details React roots in a QueryClientProvider to enable query-based data fetching and caching.

Enhancements:
- Update existing GET API helpers to accept optional AbortSignal parameters for cancellable requests.

Build:
- Add @tanstack/react-query as a frontend dependency.