### PR TITLE
refactor(frontend): query garden and plant data

### DIFF
--- a/frontend/js/garden.tsx
+++ b/frontend/js/garden.tsx
@@ -3,12 +3,14 @@ import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
 import Select from 'react-select'
+import { useQuery } from '@tanstack/react-query'
 
-import { GardenArea, GardenBed, GardenSquare, GardenRow } from './types/garden'
+import { GardenArea, GardenBed, GardenSquare } from './types/garden'
 import { GardenSquarePlanting } from './types/plantings'
-import { getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares } from './api/garden'
+import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
 import { getPlantingGardenSquaresCurrent } from './api/plantings'
-import { NoProps, SelectOption } from './types/others'
+import { SelectOption } from './types/others'
+import { queryKeys } from './query'
 
 interface GardenAreaDisplayProps {
   area: GardenArea
@@ -140,116 +142,50 @@ class GardenAreaDisplay extends React.Component<GardenAreaDisplayProps> {
   }
 }
 
-interface GardenDisplayState {
-  selectedArea?: number
-  areas: Array<GardenArea>
-  beds: Array<GardenBed>
-  rows: Array<GardenRow>
-  squares: Array<GardenSquare>
-  plantings: Array<GardenSquarePlanting>
-}
+function GardenDisplay() {
+  const [selectedArea, setSelectedArea] = React.useState<number>()
+  const { data: areas = [] } = useQuery({
+    queryKey: queryKeys.garden.areas,
+    queryFn: ({ signal }) => getGardenAreas(signal)
+  })
+  const { data: beds = [] } = useQuery({
+    queryKey: queryKeys.garden.beds,
+    queryFn: ({ signal }) => getGardenBeds(signal)
+  })
+  const { data: squares = [] } = useQuery({
+    queryKey: queryKeys.garden.squares,
+    queryFn: ({ signal }) => getGardenSquares(signal)
+  })
+  const { data: plantings = [] } = useQuery({
+    queryKey: queryKeys.plantings.currentGardenSquares,
+    queryFn: ({ signal }) => getPlantingGardenSquaresCurrent(signal)
+  })
 
-class GardenDisplay extends React.Component<NoProps, GardenDisplayState> {
-  timer?: number
-  constructor(props: NoProps) {
-    super(props)
-
-    this.state = {
-      selectedArea: undefined,
-      areas: [],
-      beds: [],
-      rows: [],
-      squares: [],
-      plantings: []
-    }
-
-    this.updateSelectedGardenArea = this.updateSelectedGardenArea.bind(this)
-    this.updateGardenAreas = this.updateGardenAreas.bind(this)
-    this.updateGardenBeds = this.updateGardenBeds.bind(this)
-    this.updateGardenRows = this.updateGardenRows.bind(this)
-    this.updateGardenSquares = this.updateGardenSquares.bind(this)
-    this.updateGardenSquaresPlanting = this.updateGardenSquaresPlanting.bind(this)
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  updateSelectedGardenArea(selectedGardenArea: SelectOption | null) {
+  function updateSelectedGardenArea(selectedGardenArea: SelectOption | null) {
     const value = selectedGardenArea?.value
 
     if (value === undefined || value === null) {
-      this.setState({ selectedArea: undefined })
+      setSelectedArea(undefined)
     } else {
-      this.setState({ selectedArea: Number(value) })
+      setSelectedArea(Number(value))
     }
   }
 
-  updateGardenAreas(data: Array<GardenArea>) {
-    this.setState({
-      areas: data
-    })
-  }
-
-  updateGardenBeds(data: Array<GardenBed>) {
-    this.setState({
-      beds: data
-    })
-  }
-
-  updateGardenRows(data: Array<GardenRow>) {
-    this.setState({
-      rows: data
-    })
-  }
-
-  updateGardenSquares(data: Array<GardenSquare>) {
-    this.setState({
-      squares: data
-    })
-  }
-
-  updateGardenSquaresPlanting(plantings: Array<GardenSquarePlanting>) {
-    this.setState({
-      plantings
-    })
-  }
-
-  async updateData() {
-    this.updateGardenAreas(await getGardenAreas())
-    this.updateGardenBeds(await getGardenBeds())
-    this.updateGardenRows(await getGardenRows())
-    this.updateGardenSquares(await getGardenSquares())
-    this.updateGardenSquaresPlanting(await getPlantingGardenSquaresCurrent())
-  }
-
-  render() {
-    const areas = []
-    for (const idx in this.state.areas) {
-      const area = this.state.areas[idx]
-      areas.push({ value: area.pk, label: area.name })
+  const areaOptions = areas.map((area) => ({ value: area.pk, label: area.name }))
+  let areaView
+  if (selectedArea !== undefined) {
+    const area = areas.find((candidate) => candidate.pk === selectedArea)
+    if (area) {
+      areaView = <GardenAreaDisplay key={area.pk} area={area} gardenBeds={beds.filter((bed) => bed.area === area.pk)} squares={squares} plantings={plantings} />
     }
-    let areaView = undefined
-    if (this.state.selectedArea !== undefined) {
-      const area = this.state.areas.find((a) => a.pk === this.state.selectedArea)
-      if (area) {
-        const beds = this.state.beds.filter((b) => b.area === area?.pk)
-        areaView = <GardenAreaDisplay key={area?.pk} area={area} gardenBeds={beds} squares={this.state.squares} plantings={this.state.plantings} />
-      }
-    }
-    return (
-      <>
-        <Select onChange={this.updateSelectedGardenArea} options={areas} value={areas.find((o) => o.value === this.state.selectedArea)} />
-        <div>{areaView}</div>
-      </>
-    )
   }
+
+  return (
+    <>
+      <Select onChange={updateSelectedGardenArea} options={areaOptions} value={areaOptions.find((option) => option.value === selectedArea)} />
+      <div>{areaView}</div>
+    </>
+  )
 }
 
 export { GardenDisplay }

--- a/frontend/js/plants.tsx
+++ b/frontend/js/plants.tsx
@@ -3,13 +3,15 @@ import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
 import { Table, Button } from 'react-bootstrap'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { Plant, PlantCreate, PlantFamily, PlantVariety, PlantVarietyCreate } from './types/plants'
+import { Plant, PlantCreate, PlantFamily, PlantFamilyCreate, PlantVariety, PlantVarietyCreate } from './types/plants'
 import { addPlant, addPlantFamily, addPlantVariety, getPlantFamilies, getPlants, getPlantVarieties } from './api/plants'
-import { NoProps } from './types/others'
+import { queryKeys } from './query'
 
 interface NewPlantFamilyRowProps {
   done: () => void
+  createFamily: (data: PlantFamilyCreate) => Promise<void>
 }
 
 interface NewPlantFamilyRowState {
@@ -43,11 +45,12 @@ class NewPlantFamilyRow extends React.Component<NewPlantFamilyRowProps, NewPlant
     this.setState({ notes: value })
   }
 
-  add() {
-    addPlantFamily({
+  async add() {
+    await this.props.createFamily({
       name: this.state.name,
       notes: this.state.notes
-    }).then(this.props.done)
+    })
+    this.props.done()
   }
 
   render() {
@@ -111,6 +114,7 @@ class PlantFamilyRow extends React.Component<PlantFamilyRowProps> {
 
 interface NewPlantRowProps {
   done: () => void
+  createPlant: (data: PlantCreate) => Promise<void>
   familyName: string
   familyId: number
 }
@@ -186,7 +190,7 @@ class NewPlantRow extends React.Component<NewPlantRowProps, NewPlantRowState> {
     this.setState({ notes: value })
   }
 
-  add() {
+  async add() {
     const data: PlantCreate = {
       family: this.props.familyId,
       name: this.state.name,
@@ -201,7 +205,8 @@ class NewPlantRow extends React.Component<NewPlantRowProps, NewPlantRowState> {
     if (this.state.per_square_foot !== undefined) {
       data.plants_per_square_foot = this.state.per_square_foot
     }
-    addPlant(data).then(this.props.done)
+    await this.props.createPlant(data)
+    this.props.done()
   }
 
   render() {
@@ -271,6 +276,7 @@ class PlantRow extends React.Component<PlantRowProps> {
 
 interface NewPlantVarietyRowProps {
   done: () => void
+  createVariety: (data: PlantVarietyCreate) => Promise<void>
   familyName: string
   plantName: string
   plantId: number
@@ -403,7 +409,7 @@ class NewPlantVarietyRow extends React.Component<NewPlantVarietyRowProps, NewPla
     this.setState({ notes: value })
   }
 
-  add() {
+  async add() {
     const data: PlantVarietyCreate = {
       plant: this.props.plantId,
       name: this.state.name,
@@ -430,7 +436,8 @@ class NewPlantVarietyRow extends React.Component<NewPlantVarietyRowProps, NewPla
     if (this.state.maturity_days_max !== undefined) {
       data.maturity_days_max = this.state.maturity_days_max
     }
-    addPlantVariety(data).then(this.props.done)
+    await this.props.createVariety(data)
+    this.props.done()
   }
 
   render() {
@@ -496,163 +503,101 @@ class PlantVarietyRow extends React.Component<PlantVarietyRowProps> {
   }
 }
 
-interface PlantsViewState {
-  showFamilyAdd: boolean
-  showPlantAdd?: number
-  showVarietyAdd?: number
-  families: Array<PlantFamily>
-  plants: Array<Plant>
-  varieties: Array<PlantVariety>
-}
+function PlantsView() {
+  const queryClient = useQueryClient()
+  const [showFamilyAdd, setShowFamilyAdd] = React.useState(false)
+  const [showPlantAdd, setShowPlantAdd] = React.useState<number>()
+  const [showVarietyAdd, setShowVarietyAdd] = React.useState<number>()
+  const { data: families = [] } = useQuery({
+    queryKey: queryKeys.plants.families,
+    queryFn: ({ signal }) => getPlantFamilies(signal)
+  })
+  const { data: plants = [] } = useQuery({
+    queryKey: queryKeys.plants.plants,
+    queryFn: ({ signal }) => getPlants(signal)
+  })
+  const { data: varieties = [] } = useQuery({
+    queryKey: queryKeys.plants.varieties,
+    queryFn: ({ signal }) => getPlantVarieties(signal)
+  })
+  const familyMutation = useMutation({
+    mutationFn: addPlantFamily,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.plants.families })
+  })
+  const plantMutation = useMutation({
+    mutationFn: addPlant,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.plants.plants })
+  })
+  const varietyMutation = useMutation({
+    mutationFn: addPlantVariety,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.plants.varieties })
+  })
 
-class PlantsView extends React.Component<NoProps, PlantsViewState> {
-  timer?: number
+  async function createFamily(data: PlantFamilyCreate) {
+    await familyMutation.mutateAsync(data)
+  }
 
-  constructor(props: NoProps) {
-    super(props)
+  async function createPlant(data: PlantCreate) {
+    await plantMutation.mutateAsync(data)
+  }
 
-    this.state = {
-      showFamilyAdd: false,
-      showPlantAdd: undefined,
-      showVarietyAdd: undefined,
-      families: [],
-      plants: [],
-      varieties: []
+  async function createVariety(data: PlantVarietyCreate) {
+    await varietyMutation.mutateAsync(data)
+  }
+
+  const rows = []
+  if (showFamilyAdd) {
+    rows.push(<NewPlantFamilyRow createFamily={createFamily} done={() => setShowFamilyAdd(false)} key="family-add" />)
+  }
+  for (const familyData of families) {
+    rows.push(<PlantFamilyRow family={familyData} key={'family-' + familyData.pk} addNewPlant={setShowPlantAdd} />)
+    if (showPlantAdd === familyData.pk) {
+      rows.push(<NewPlantRow createPlant={createPlant} done={() => setShowPlantAdd(undefined)} familyId={familyData.pk} familyName={familyData.name} key="plant-add" />)
     }
-
-    this.showNewFamilyAdd = this.showNewFamilyAdd.bind(this)
-    this.hideNewFamilyAdd = this.hideNewFamilyAdd.bind(this)
-
-    this.showNewPlantAdd = this.showNewPlantAdd.bind(this)
-    this.hideNewPlantAdd = this.hideNewPlantAdd.bind(this)
-
-    this.showNewVarietyAdd = this.showNewVarietyAdd.bind(this)
-    this.hideNewVarietyAdd = this.hideNewVarietyAdd.bind(this)
-
-    this.updatePlantFamilyResponse = this.updatePlantFamilyResponse.bind(this)
-    this.updatePlantResponse = this.updatePlantResponse.bind(this)
-    this.updatePlantVarietiesResponse = this.updatePlantVarietiesResponse.bind(this)
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  showNewFamilyAdd() {
-    this.setState({
-      showFamilyAdd: true
-    })
-  }
-
-  hideNewFamilyAdd() {
-    this.setState({
-      showFamilyAdd: false
-    })
-  }
-
-  showNewPlantAdd(familyId: number) {
-    this.setState({
-      showPlantAdd: familyId
-    })
-  }
-
-  hideNewPlantAdd() {
-    this.setState({
-      showPlantAdd: undefined
-    })
-  }
-
-  showNewVarietyAdd(plantId: number) {
-    this.setState({
-      showVarietyAdd: plantId
-    })
-  }
-
-  hideNewVarietyAdd() {
-    this.setState({
-      showVarietyAdd: undefined
-    })
-  }
-
-  updatePlantFamilyResponse(data: Array<PlantFamily>) {
-    this.setState({
-      families: data
-    })
-  }
-
-  updatePlantResponse(data: Array<Plant>) {
-    this.setState({
-      plants: data
-    })
-  }
-
-  updatePlantVarietiesResponse(data: Array<PlantVariety>) {
-    this.setState({
-      varieties: data
-    })
-  }
-
-  async updateData() {
-    this.updatePlantFamilyResponse(await getPlantFamilies())
-    this.updatePlantVarietiesResponse(await getPlantVarieties())
-    this.updatePlantResponse(await getPlants())
-  }
-
-  render() {
-    const rows = []
-    if (this.state.showFamilyAdd) {
-      rows.push(<NewPlantFamilyRow done={this.hideNewFamilyAdd} key="family-add" />)
-    }
-    for (const f in this.state.families) {
-      const familyData = this.state.families[f]
-      rows.push(<PlantFamilyRow family={familyData} key={'family-' + familyData.pk} addNewPlant={this.showNewPlantAdd} />)
-      if (this.state.showPlantAdd === familyData.pk) {
-        rows.push(<NewPlantRow done={this.hideNewPlantAdd} familyId={familyData.pk} familyName={familyData.name} key="plant-add" />)
+    const familyPlants = plants.filter((plant) => plant.family === familyData.pk)
+    for (const plantData of familyPlants) {
+      rows.push(<PlantRow familyName={familyData.name} plant={plantData} key={'plant-' + plantData.pk} addNewPlantVariety={setShowVarietyAdd} />)
+      if (showVarietyAdd === plantData.pk) {
+        rows.push(
+          <NewPlantVarietyRow
+            createVariety={createVariety}
+            done={() => setShowVarietyAdd(undefined)}
+            plantId={plantData.pk}
+            familyName={familyData.name}
+            plantName={plantData.name}
+            key="variety-add"
+          />
+        )
       }
-      const plants = this.state.plants.filter((plant) => plant.family === familyData.pk)
-      for (const p in plants) {
-        const plantData = plants[p]
-        rows.push(<PlantRow familyName={familyData.name} plant={plantData} key={'plant-' + plantData.pk} addNewPlantVariety={this.showNewVarietyAdd} />)
-        if (this.state.showVarietyAdd === plantData.pk) {
-          rows.push(<NewPlantVarietyRow done={this.hideNewVarietyAdd} plantId={plantData.pk} familyName={familyData.name} plantName={plantData.name} key="variety-add" />)
-        }
-        const varieties = this.state.varieties.filter((variety) => variety.plant === plantData.pk)
-        for (const v in varieties) {
-          const varietyData = varieties[v]
-          rows.push(<PlantVarietyRow variety={varietyData} familyName={familyData.name} plantName={plantData.name} key={'variety-' + varietyData.pk} />)
-        }
+      const plantVarieties = varieties.filter((variety) => variety.plant === plantData.pk)
+      for (const varietyData of plantVarieties) {
+        rows.push(<PlantVarietyRow variety={varietyData} familyName={familyData.name} plantName={plantData.name} key={'variety-' + varietyData.pk} />)
       }
     }
-    return (
-      <Table>
-        <thead>
-          <tr>
-            <td>
-              Family{' '}
-              <a href="#" onClick={this.showNewFamilyAdd}>
-                +
-              </a>
-            </td>
-            <td>Plant</td>
-            <td>Variety</td>
-            <td>Spacing (mm)</td>
-            <td>Row Spacing (mm)</td>
-            <td>per sq/ft</td>
-            <td>Germination (days)</td>
-            <td>Maturity (days)</td>
-            <td>Notes</td>
-          </tr>
-        </thead>
-        <tbody>{rows}</tbody>
-      </Table>
-    )
   }
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <td>
+            Family{' '}
+            <a href="#" onClick={() => setShowFamilyAdd(true)}>
+              +
+            </a>
+          </td>
+          <td>Plant</td>
+          <td>Variety</td>
+          <td>Spacing (mm)</td>
+          <td>Row Spacing (mm)</td>
+          <td>per sq/ft</td>
+          <td>Germination (days)</td>
+          <td>Maturity (days)</td>
+          <td>Notes</td>
+        </tr>
+      </thead>
+      <tbody>{rows}</tbody>
+    </Table>
+  )
 }
 
 export { PlantsView }


### PR DESCRIPTION
Polling the garden and plant hierarchy wastes requests and can overlap slow responses. Read each resource through the shared cache, remove the unused garden-row fetch, and route plant metadata writes through mutations that revalidate before forms close.