### PR TITLE
refactor(frontend): query trays and plantings

### DIFF
--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -4,14 +4,15 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import { Table, Button } from 'react-bootstrap'
 import Select from 'react-select'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { Supplier } from './types/suppliers'
 import { PlantVariety } from './types/plants'
 import { Seed, SeedPacket } from './types/seeds'
-import { GardenArea, GardenBed, GardenSquare } from './types/garden'
-import { GardenSquarePlanting, SeedTrayPlantingCreate, SeedTrayPlantingDetails } from './types/plantings'
+import { GardenBed, GardenSquare } from './types/garden'
+import { GardenSquareDirectPlantingCreate, GardenSquarePlanting, SeedTrayPlantingCreate, SeedTrayPlantingDetails } from './types/plantings'
 import { SeedTray, SeedTrayModel } from './types/seedtrays'
-import { NoProps, SelectOption } from './types/others'
+import { SelectOption } from './types/others'
 import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
 import { formatDate, formatDateRange } from './utils'
 import {
@@ -29,6 +30,7 @@ import { getSeedPackets, getSeeds } from './api/seeds'
 import { getSeedTrayModels, getSeedTrays, getSeedTrayCells } from './api/seedtrays'
 import { SeedTrayCell } from './types/seedtrays'
 import { getSuppliers } from './api/supplies'
+import { queryKeys } from './query'
 
 interface SeedTrayCellGridProps {
   cells: Array<SeedTrayCell>
@@ -99,237 +101,153 @@ interface NewSeedTrayPlantingRowProps {
   seedTrays: Array<SeedTray>
   seedTrayModels: { [key: number]: SeedTrayModel }
   done: () => void
+  createPlanting: (data: SeedTrayPlantingCreate) => Promise<void>
 }
 
-interface NewSeedTrayPlantingRowState {
-  seedPacket?: number
-  quantity: number
-  seedTray?: number
-  location?: string
-  notes?: string
-  seedTrayCells: Array<SeedTrayCell>
-  cellQuantities: { [cellPk: number]: number }
-  showCellGrid: boolean
-  error?: string
-}
+function NewSeedTrayPlantingRow({ suppliers, varieties, seeds, seedPackets, seedTrays, seedTrayModels, done, createPlanting }: NewSeedTrayPlantingRowProps) {
+  const [seedPacket, setSeedPacket] = React.useState<number>()
+  const [quantity, setQuantity] = React.useState(1)
+  const [seedTray, setSeedTray] = React.useState<number>()
+  const [location, setLocation] = React.useState<string>()
+  const [notes, setNotes] = React.useState<string>()
+  const [cellQuantities, setCellQuantities] = React.useState<Record<number, number>>({})
+  const [error, setError] = React.useState<string>()
+  const { data: seedTrayCells = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.cells(seedTray ?? 0),
+    queryFn: ({ signal }) => getSeedTrayCells(seedTray as number, signal),
+    enabled: Boolean(seedTray)
+  })
 
-class NewSeedTrayPlantingRow extends React.Component<NewSeedTrayPlantingRowProps, NewSeedTrayPlantingRowState> {
-  private trayAbortController: AbortController | null = null
-
-  componentWillUnmount() {
-    this.abortTrayRequest()
-  }
-
-  constructor(props: NewSeedTrayPlantingRowProps) {
-    super(props)
-
-    this.state = {
-      seedPacket: undefined,
-      quantity: 1,
-      seedTray: undefined,
-      location: undefined,
-      notes: undefined,
-      seedTrayCells: [],
-      cellQuantities: {},
-      showCellGrid: false,
-      error: undefined
-    }
-
-    this.updateSeedPacket = this.updateSeedPacket.bind(this)
-    this.updateQuantity = this.updateQuantity.bind(this)
-    this.updateLocation = this.updateLocation.bind(this)
-    this.updateNotes = this.updateNotes.bind(this)
-    this.updateSeedTray = this.updateSeedTray.bind(this)
-    this.updateCellQuantity = this.updateCellQuantity.bind(this)
-
-    this.add = this.add.bind(this)
-  }
-
-  private abortTrayRequest() {
-    if (this.trayAbortController) {
-      this.trayAbortController.abort()
-      this.trayAbortController = null
-    }
-  }
-
-  private loadTrayCells(trayPk: number) {
-    this.abortTrayRequest()
-    this.trayAbortController = new AbortController()
-    const { signal } = this.trayAbortController
-
-    getSeedTrayCells(trayPk, signal)
-      .then((cells) => {
-        // only update state if this request wasn't aborted
-        if (!signal.aborted) {
-          this.setState({ seedTrayCells: cells, showCellGrid: true })
-        }
-      })
-      .catch((err) => {
-        // ignore abort errors
-        if (err.name !== 'AbortError') {
-          console.error('Error fetching seed tray cells:', err)
-        }
-      })
-  }
-
-  updateSeedPacket(event: React.ChangeEvent<HTMLSelectElement>) {
+  function updateSeedPacket(event: React.ChangeEvent<HTMLSelectElement>) {
     const { value } = event.target
 
     if (value === '' || value === undefined || value === null) {
-      this.setState({ seedPacket: undefined })
+      setSeedPacket(undefined)
       return
     }
-    this.setState({ seedPacket: Number(value) })
+    setSeedPacket(Number(value))
   }
 
-  updateQuantity(event: React.ChangeEvent<HTMLInputElement>) {
+  function updateQuantity(event: React.ChangeEvent<HTMLInputElement>) {
     const { value } = event.target
 
     if (value === '' || value === undefined || value === null) {
-      this.setState({ quantity: 0 })
+      setQuantity(0)
       return
     }
-    this.setState({ quantity: Number(value) })
+    setQuantity(Number(value))
   }
 
-  updateLocation(event: React.ChangeEvent<HTMLInputElement>) {
-    const { value } = event.target
-
-    this.setState({ location: value })
-  }
-
-  updateNotes(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    const { value } = event.target
-
-    this.setState({ notes: value })
-  }
-
-  updateSeedTray(selectedSeedTray: SelectOption | null) {
+  function updateSeedTray(selectedSeedTray: SelectOption | null) {
     const value = selectedSeedTray?.value
-    this.setState({ seedTrayCells: [], cellQuantities: {}, showCellGrid: false })
-    this.abortTrayRequest()
+    setCellQuantities({})
+    setSeedTray(value === undefined || value === null ? undefined : Number(value))
+  }
 
-    if (value === undefined || value === null) {
-      this.setState({ seedTray: undefined })
+  function updateCellQuantity(cellPk: number, qty: number) {
+    setCellQuantities((currentQuantities) => {
+      const updated = { ...currentQuantities }
+      if (qty > 0) {
+        updated[cellPk] = qty
+      } else {
+        delete updated[cellPk]
+      }
+      return updated
+    })
+  }
+
+  async function add() {
+    if (seedPacket === undefined) {
       return
     }
 
-    const trayPk = Number(value)
-    this.setState({ seedTray: trayPk })
-    this.loadTrayCells(trayPk)
-  }
-
-  updateCellQuantity(cellPk: number, qty: number) {
-    const updated = { ...this.state.cellQuantities }
-    if (qty > 0) {
-      updated[cellPk] = qty
-    } else {
-      delete updated[cellPk]
-    }
-    this.setState({ cellQuantities: updated })
-  }
-
-  add() {
-    if (this.state.seedPacket === undefined) {
-      return
-    }
-
-    const cellPlantings = Object.entries(this.state.cellQuantities).map(([cellPk, qty]) => ({
+    const cellPlantings = Object.entries(cellQuantities).map(([cellPk, qty]) => ({
       cell: Number(cellPk),
       quantity: qty
     }))
 
     // Validate per-cell total doesn't exceed overall quantity
-    const cellTotal = Object.values(this.state.cellQuantities).reduce((sum, qty) => sum + qty, 0)
-    if (cellTotal > this.state.quantity) {
-      this.setState({ error: `Cell total (${cellTotal}) exceeds planting quantity (${this.state.quantity})` })
+    const cellTotal = Object.values(cellQuantities).reduce((sum, qty) => sum + qty, 0)
+    if (cellTotal > quantity) {
+      setError(`Cell total (${cellTotal}) exceeds planting quantity (${quantity})`)
       return
     }
 
-    this.setState({ error: undefined })
+    setError(undefined)
 
     const data: SeedTrayPlantingCreate = {
-      seeds_used: this.state.seedPacket,
-      quantity: this.state.quantity,
-      location: this.state.location,
-      seed_tray: this.state.seedTray,
-      notes: this.state.notes
+      seeds_used: seedPacket,
+      quantity,
+      location,
+      seed_tray: seedTray,
+      notes
     }
     if (cellPlantings.length > 0) {
       data.cell_plantings = cellPlantings
     }
-    addPlantingSeedTray(data).then(this.props.done)
+    await createPlanting(data)
+    done()
   }
 
-  render() {
-    const seedPackets = [<option key="blank"></option>]
-    for (const sp in this.props.seedPackets) {
-      const seedPacketData = this.props.seedPackets[sp]
-      const seeds = this.props.seeds.find((s) => s.pk === seedPacketData.seeds)
-      const supplier = this.props.suppliers.find((s) => s.pk === seeds?.supplier)
-      const variety = this.props.varieties.find((v) => v.pk === seeds?.plant_variety)
-      seedPackets.push(
-        <option key={seedPacketData.pk} value={seedPacketData.pk}>
-          {variety?.name} from {supplier?.name} (Sow By: {seedPacketData.sow_by})
-        </option>
-      )
-    }
-    const seedTrays = []
-    for (const seedTrayData of this.props.seedTrays) {
-      seedTrays.push({ value: seedTrayData.pk, label: `${seedTrayData.pk} (${this.props.seedTrayModels[seedTrayData.model]?.description})` })
-    }
-
-    return (
-      <>
-        {this.state.error && (
-          <tr>
-            <td colSpan={7} style={{ padding: '8px', backgroundColor: '#f8d7da', color: '#721c24', border: '1px solid #f5c6cb' }}>
-              <strong>Error:</strong> {this.state.error}
-            </td>
-          </tr>
-        )}
-        <tr>
-          <td>
-            <select onChange={this.updateSeedPacket}>{seedPackets}</select>
-          </td>
-          <td>
-            <input type="number" defaultValue={this.state.quantity} onChange={this.updateQuantity} />
-          </td>
-          <td></td>
-          <td>
-            <Select onChange={this.updateSeedTray} options={seedTrays} value={seedTrays.find((o) => o.value === this.state.seedTray)} />
-          </td>
-          <td>
-            <input type="text" onChange={this.updateLocation} />
-          </td>
-          <td>
-            <textarea onChange={this.updateNotes} />
-          </td>
-          <td>
-            <Button onClick={this.add}>Add</Button>
-            <Button onClick={this.props.done}>Cancel</Button>
-          </td>
-        </tr>
-        {this.state.showCellGrid && this.state.seedTrayCells.length > 0 && (
-          <tr>
-            <td colSpan={7} style={{ padding: '16px' }}>
-              <div style={{ marginBottom: '8px', fontWeight: 'bold' }}>Select cells and quantities:</div>
-              <SeedTrayCellGrid
-                cells={this.state.seedTrayCells}
-                cellQuantities={this.state.cellQuantities}
-                quantity={this.state.quantity}
-                onUpdateCellQuantity={this.updateCellQuantity}
-              />
-            </td>
-          </tr>
-        )}
-      </>
+  const packetOptions = [<option key="blank"></option>]
+  for (const seedPacketData of seedPackets) {
+    const seedData = seeds.find((candidate) => candidate.pk === seedPacketData.seeds)
+    const supplier = suppliers.find((candidate) => candidate.pk === seedData?.supplier)
+    const variety = varieties.find((candidate) => candidate.pk === seedData?.plant_variety)
+    packetOptions.push(
+      <option key={seedPacketData.pk} value={seedPacketData.pk}>
+        {variety?.name} from {supplier?.name} (Sow By: {seedPacketData.sow_by})
+      </option>
     )
   }
+  const trayOptions = seedTrays.map((tray) => ({ value: tray.pk, label: `${tray.pk} (${seedTrayModels[tray.model]?.description})` }))
+
+  return (
+    <>
+      {error && (
+        <tr>
+          <td colSpan={7} style={{ padding: '8px', backgroundColor: '#f8d7da', color: '#721c24', border: '1px solid #f5c6cb' }}>
+            <strong>Error:</strong> {error}
+          </td>
+        </tr>
+      )}
+      <tr>
+        <td>
+          <select onChange={updateSeedPacket}>{packetOptions}</select>
+        </td>
+        <td>
+          <input type="number" defaultValue={quantity} onChange={updateQuantity} />
+        </td>
+        <td></td>
+        <td>
+          <Select onChange={updateSeedTray} options={trayOptions} value={trayOptions.find((option) => option.value === seedTray)} />
+        </td>
+        <td>
+          <input type="text" onChange={(event) => setLocation(event.target.value)} />
+        </td>
+        <td>
+          <textarea onChange={(event) => setNotes(event.target.value)} />
+        </td>
+        <td>
+          <Button onClick={add}>Add</Button>
+          <Button onClick={done}>Cancel</Button>
+        </td>
+      </tr>
+      {seedTray !== undefined && seedTrayCells.length > 0 && (
+        <tr>
+          <td colSpan={7} style={{ padding: '16px' }}>
+            <div style={{ marginBottom: '8px', fontWeight: 'bold' }}>Select cells and quantities:</div>
+            <SeedTrayCellGrid cells={seedTrayCells} cellQuantities={cellQuantities} quantity={quantity} onUpdateCellQuantity={updateCellQuantity} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
 }
 
 interface SeedTrayPlantingRowProps {
   planting: SeedTrayPlantingDetails
+  completePlanting: (plantingPk: number) => Promise<void>
 }
 
 class SeedTrayPlantingRow extends React.Component<SeedTrayPlantingRowProps> {
@@ -339,8 +257,8 @@ class SeedTrayPlantingRow extends React.Component<SeedTrayPlantingRowProps> {
     this.empty = this.empty.bind(this)
   }
 
-  empty() {
-    completePlantingSeedTray(this.props.planting.pk)
+  async empty() {
+    await this.props.completePlanting(this.props.planting.pk)
   }
 
   render() {
@@ -371,166 +289,98 @@ class SeedTrayPlantingRow extends React.Component<SeedTrayPlantingRowProps> {
   }
 }
 
-interface SeedTrayPlantingTableState {
-  showPlantingAdd: boolean
-  suppliers: Array<Supplier>
-  varieties: Array<PlantVariety>
-  seeds: Array<Seed>
-  seedPackets: Array<SeedPacket>
-  seedTrays: Array<SeedTray>
-  seedTrayModels: { [key: number]: SeedTrayModel }
-  plantings: Array<SeedTrayPlantingDetails>
-}
+function SeedTrayPlantingTable() {
+  const queryClient = useQueryClient()
+  const [showPlantingAdd, setShowPlantingAdd] = React.useState(false)
+  const { data: suppliers = [] } = useQuery({
+    queryKey: queryKeys.suppliers.all,
+    queryFn: ({ signal }) => getSuppliers(signal)
+  })
+  const { data: varieties = [] } = useQuery({
+    queryKey: queryKeys.plants.varieties,
+    queryFn: ({ signal }) => getPlantVarieties(signal)
+  })
+  const { data: seeds = [] } = useQuery({
+    queryKey: queryKeys.seeds.catalog,
+    queryFn: ({ signal }) => getSeeds(signal)
+  })
+  const { data: seedPackets = [] } = useQuery({
+    queryKey: queryKeys.seeds.packets.raw,
+    queryFn: ({ signal }) => getSeedPackets(signal)
+  })
+  const { data: plantings = [] } = useQuery({
+    queryKey: queryKeys.plantings.currentSeedTrays,
+    queryFn: ({ signal }) => getPlantingSeedTrayCurrent(signal)
+  })
+  const { data: seedTrays = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.trays,
+    queryFn: ({ signal }) => getSeedTrays(signal)
+  })
+  const { data: seedTrayModelList = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.models,
+    queryFn: ({ signal }) => getSeedTrayModels(signal)
+  })
+  const createMutation = useMutation({
+    mutationFn: addPlantingSeedTray,
+    onSuccess: () => Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.plantings.all }), queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })])
+  })
+  const completeMutation = useMutation({
+    mutationFn: completePlantingSeedTray,
+    onSuccess: () => Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.plantings.all }), queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })])
+  })
+  const seedTrayModels = seedTrayModelList.reduce<Record<number, SeedTrayModel>>((models, model) => {
+    models[model.pk] = model
+    return models
+  }, {})
 
-class SeedTrayPlantingTable extends React.Component<NoProps, SeedTrayPlantingTableState> {
-  timer?: number
-
-  constructor(props: NoProps) {
-    super(props)
-
-    this.state = {
-      showPlantingAdd: false,
-      suppliers: [],
-      varieties: [],
-      seeds: [],
-      seedPackets: [],
-      seedTrays: [],
-      seedTrayModels: {},
-      plantings: []
-    }
-
-    this.showNewPlantingAdd = this.showNewPlantingAdd.bind(this)
-    this.hideNewPlantingAdd = this.hideNewPlantingAdd.bind(this)
-
-    this.updateData = this.updateData.bind(this)
-    this.updateSupplierList = this.updateSupplierList.bind(this)
-    this.updateVarietiesList = this.updateVarietiesList.bind(this)
-    this.updateSeedList = this.updateSeedList.bind(this)
-    this.updateSeedPacketList = this.updateSeedPacketList.bind(this)
-    this.updatePlantingList = this.updatePlantingList.bind(this)
-    this.updateSeedTrays = this.updateSeedTrays.bind(this)
-    this.updateSeedTrayModels = this.updateSeedTrayModels.bind(this)
+  async function createPlanting(data: SeedTrayPlantingCreate) {
+    await createMutation.mutateAsync(data)
   }
 
-  showNewPlantingAdd() {
-    this.setState({
-      showPlantingAdd: true
-    })
+  async function completePlanting(plantingPk: number) {
+    await completeMutation.mutateAsync(plantingPk)
   }
 
-  hideNewPlantingAdd() {
-    this.setState({
-      showPlantingAdd: false
-    })
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  updateSupplierList(data: Array<Supplier>) {
-    this.setState({
-      suppliers: data
-    })
-  }
-
-  updateVarietiesList(data: Array<PlantVariety>) {
-    this.setState({
-      varieties: data
-    })
-  }
-
-  updateSeedList(data: Array<Seed>) {
-    this.setState({
-      seeds: data
-    })
-  }
-
-  updateSeedPacketList(data: Array<SeedPacket>) {
-    this.setState({
-      seedPackets: data
-    })
-  }
-
-  updatePlantingList(plantings: Array<SeedTrayPlantingDetails>) {
-    this.setState({
-      plantings
-    })
-  }
-
-  updateSeedTrays(data: Array<SeedTray>) {
-    this.setState({
-      seedTrays: data
-    })
-  }
-
-  updateSeedTrayModels(data: Array<SeedTrayModel>) {
-    this.setState({
-      seedTrayModels: data.reduce((acc: { [key: number]: SeedTrayModel }, model: SeedTrayModel) => {
-        acc[model.pk] = model
-        return acc
-      }, {})
-    })
-  }
-
-  async updateData() {
-    this.updateSupplierList(await getSuppliers())
-    this.updateVarietiesList(await getPlantVarieties())
-    this.updateSeedList(await getSeeds())
-    this.updateSeedPacketList(await getSeedPackets())
-    this.updatePlantingList(await getPlantingSeedTrayCurrent())
-    this.updateSeedTrays(await getSeedTrays())
-    this.updateSeedTrayModels(await getSeedTrayModels())
-  }
-
-  render() {
-    const rows = []
-    if (this.state.showPlantingAdd) {
-      rows.push(
-        <NewSeedTrayPlantingRow
-          key="new"
-          seedPackets={this.state.seedPackets}
-          seeds={this.state.seeds}
-          suppliers={this.state.suppliers}
-          varieties={this.state.varieties}
-          seedTrays={this.state.seedTrays}
-          seedTrayModels={this.state.seedTrayModels}
-          done={this.hideNewPlantingAdd}
-        />
-      )
-    }
-    for (const p in this.state.plantings) {
-      const plantingData = this.state.plantings[p]
-      rows.push(<SeedTrayPlantingRow key={plantingData.pk} planting={plantingData} />)
-    }
-    return (
-      <Table>
-        <thead>
-          <tr>
-            <td>
-              Plant{' '}
-              <a href="#" onClick={this.showNewPlantingAdd}>
-                +
-              </a>
-            </td>
-            <td>Quantity</td>
-            <td>Date</td>
-            <td>Seed Tray</td>
-            <td>Location</td>
-            <td>Expected Germination</td>
-            <td>Notes</td>
-          </tr>
-        </thead>
-        <tbody>{rows}</tbody>
-      </Table>
+  const rows = []
+  if (showPlantingAdd) {
+    rows.push(
+      <NewSeedTrayPlantingRow
+        key="new"
+        seedPackets={seedPackets}
+        seeds={seeds}
+        suppliers={suppliers}
+        varieties={varieties}
+        seedTrays={seedTrays}
+        seedTrayModels={seedTrayModels}
+        createPlanting={createPlanting}
+        done={() => setShowPlantingAdd(false)}
+      />
     )
   }
+  for (const planting of plantings) {
+    rows.push(<SeedTrayPlantingRow key={planting.pk} planting={planting} completePlanting={completePlanting} />)
+  }
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <td>
+            Plant{' '}
+            <a href="#" onClick={() => setShowPlantingAdd(true)}>
+              +
+            </a>
+          </td>
+          <td>Quantity</td>
+          <td>Date</td>
+          <td>Seed Tray</td>
+          <td>Location</td>
+          <td>Expected Germination</td>
+          <td>Notes</td>
+        </tr>
+      </thead>
+      <tbody>{rows}</tbody>
+    </Table>
+  )
 }
 
 interface NewGardenSquarePlantingRowProps {
@@ -541,6 +391,7 @@ interface NewGardenSquarePlantingRowProps {
   gardenBeds: Array<GardenBed>
   gardenSquares: Array<GardenSquare>
   done: () => void
+  createPlanting: (data: GardenSquareDirectPlantingCreate) => Promise<void>
 }
 
 interface NewGardenSquarePlantingRowState {
@@ -603,17 +454,18 @@ class NewGardenSquarePlantingRow extends React.Component<NewGardenSquarePlanting
     this.setState({ notes: value })
   }
 
-  add() {
+  async add() {
     if (this.state.seedPacket === undefined || this.state.location === undefined) {
       return
     }
-    const data = {
+    const data: GardenSquareDirectPlantingCreate = {
       seeds_used: this.state.seedPacket,
       quantity: this.state.quantity,
       location: this.state.location,
       notes: this.state.notes
     }
-    addPlantingDirectSowGardenSquare(data).then(this.props.done)
+    await this.props.createPlanting(data)
+    this.props.done()
   }
 
   render() {
@@ -660,6 +512,7 @@ class NewGardenSquarePlantingRow extends React.Component<NewGardenSquarePlanting
 
 interface GardenSquarePlantingRowProps {
   planting: GardenSquarePlanting
+  completePlanting: (planting: GardenSquarePlanting) => Promise<void>
 }
 
 class GardenSquarePlantingRow extends React.Component<GardenSquarePlantingRowProps> {
@@ -669,14 +522,8 @@ class GardenSquarePlantingRow extends React.Component<GardenSquarePlantingRowPro
     this.empty = this.empty.bind(this)
   }
 
-  empty() {
-    if (this.props.planting.specific_plant_pk && this.props.planting.transplanting_pk) {
-      endSpecificPlantLocation(this.props.planting.transplanting_pk)
-    } else if (this.props.planting.transplanted && this.props.planting.transplanting_pk) {
-      completePlantingTransplantedGardenSquare(this.props.planting.transplanting_pk)
-    } else {
-      completePlantingDirectSowGardenSquare(this.props.planting.planting_pk)
-    }
+  async empty() {
+    await this.props.completePlanting(this.props.planting)
   }
 
   render() {
@@ -707,237 +554,179 @@ class GardenSquarePlantingRow extends React.Component<GardenSquarePlantingRowPro
   }
 }
 
-interface GardenSquarePlantingTableState {
-  showPlantingAdd: boolean
-  suppliers: Array<Supplier>
-  varieties: Array<PlantVariety>
-  seeds: Array<Seed>
-  seedPackets: Array<SeedPacket>
-  plantings: Array<GardenSquarePlanting>
-  gardenSquares: Array<GardenSquare>
-  gardenBeds: Array<GardenBed>
-  gardenAreas: Array<GardenArea>
-  filterGardenArea?: number
-  filterGardenBed?: string
-}
+function GardenSquarePlantingTable() {
+  const queryClient = useQueryClient()
+  const [showPlantingAdd, setShowPlantingAdd] = React.useState(false)
+  const [filterGardenArea, setFilterGardenArea] = React.useState<number>()
+  const [filterGardenBed, setFilterGardenBed] = React.useState<string>()
+  const { data: suppliers = [] } = useQuery({
+    queryKey: queryKeys.suppliers.all,
+    queryFn: ({ signal }) => getSuppliers(signal)
+  })
+  const { data: varieties = [] } = useQuery({
+    queryKey: queryKeys.plants.varieties,
+    queryFn: ({ signal }) => getPlantVarieties(signal)
+  })
+  const { data: seeds = [] } = useQuery({
+    queryKey: queryKeys.seeds.catalog,
+    queryFn: ({ signal }) => getSeeds(signal)
+  })
+  const { data: seedPackets = [] } = useQuery({
+    queryKey: queryKeys.seeds.packets.raw,
+    queryFn: ({ signal }) => getSeedPackets(signal)
+  })
+  const { data: plantings = [] } = useQuery({
+    queryKey: queryKeys.plantings.currentGardenSquares,
+    queryFn: ({ signal }) => getPlantingGardenSquaresCurrent(signal)
+  })
+  const { data: gardenAreas = [] } = useQuery({
+    queryKey: queryKeys.garden.areas,
+    queryFn: ({ signal }) => getGardenAreas(signal)
+  })
+  const { data: gardenSquares = [] } = useQuery({
+    queryKey: queryKeys.garden.squares,
+    queryFn: ({ signal }) => getGardenSquares(signal)
+  })
+  const { data: gardenBeds = [] } = useQuery({
+    queryKey: queryKeys.garden.beds,
+    queryFn: ({ signal }) => getGardenBeds(signal)
+  })
+  const invalidatePlantingsAndPackets = () =>
+    Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.plantings.all }), queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })])
+  const createMutation = useMutation({
+    mutationFn: addPlantingDirectSowGardenSquare,
+    onSuccess: invalidatePlantingsAndPackets
+  })
+  const completeDirectMutation = useMutation({
+    mutationFn: completePlantingDirectSowGardenSquare,
+    onSuccess: invalidatePlantingsAndPackets
+  })
+  const completeTransplantMutation = useMutation({
+    mutationFn: completePlantingTransplantedGardenSquare,
+    onSuccess: invalidatePlantingsAndPackets
+  })
+  const endLocationMutation = useMutation({
+    mutationFn: endSpecificPlantLocation,
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.currentGardenSquares }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.specificPlantsAll })
+      ])
+  })
 
-class GardenSquarePlantingTable extends React.Component<NoProps, GardenSquarePlantingTableState> {
-  timer?: number
-
-  constructor(props: NoProps) {
-    super(props)
-
-    this.state = {
-      showPlantingAdd: false,
-      suppliers: [],
-      varieties: [],
-      seeds: [],
-      seedPackets: [],
-      plantings: [],
-      gardenSquares: [],
-      gardenBeds: [],
-      gardenAreas: [],
-      filterGardenArea: undefined,
-      filterGardenBed: undefined
-    }
-
-    this.showNewPlantingAdd = this.showNewPlantingAdd.bind(this)
-    this.hideNewPlantingAdd = this.hideNewPlantingAdd.bind(this)
-
-    this.updateData = this.updateData.bind(this)
-    this.updateSupplierList = this.updateSupplierList.bind(this)
-    this.updateVarietiesList = this.updateVarietiesList.bind(this)
-    this.updateSeedList = this.updateSeedList.bind(this)
-    this.updateSeedPacketList = this.updateSeedPacketList.bind(this)
-    this.updatePlantingList = this.updatePlantingList.bind(this)
-    this.updateGardenSquares = this.updateGardenSquares.bind(this)
-    this.updateGardenBeds = this.updateGardenBeds.bind(this)
-    this.updateGardenAreas = this.updateGardenAreas.bind(this)
-    this.updateGardenAreaFilter = this.updateGardenAreaFilter.bind(this)
-    this.updateGardenBedFilter = this.updateGardenBedFilter.bind(this)
-  }
-
-  showNewPlantingAdd() {
-    this.setState({
-      showPlantingAdd: true
-    })
-  }
-
-  hideNewPlantingAdd() {
-    this.setState({
-      showPlantingAdd: false
-    })
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  updateSupplierList(data: Array<Supplier>) {
-    this.setState({
-      suppliers: data
-    })
-  }
-
-  updateVarietiesList(data: Array<PlantVariety>) {
-    this.setState({
-      varieties: data
-    })
-  }
-
-  updateSeedList(data: Array<Seed>) {
-    this.setState({
-      seeds: data
-    })
-  }
-
-  updateSeedPacketList(data: Array<SeedPacket>) {
-    this.setState({
-      seedPackets: data
-    })
-  }
-
-  updatePlantingList(plantings: Array<GardenSquarePlanting>) {
-    this.setState({
-      plantings
-    })
-  }
-
-  updateGardenSquares(data: Array<GardenSquare>) {
-    this.setState({
-      gardenSquares: data
-    })
-  }
-
-  updateGardenBeds(data: Array<GardenBed>) {
-    this.setState({
-      gardenBeds: data
-    })
-  }
-
-  updateGardenAreas(data: Array<GardenArea>) {
-    this.setState({
-      gardenAreas: data
-    })
-  }
-
-  updateGardenAreaFilter(event: React.ChangeEvent<HTMLSelectElement>) {
+  function updateGardenAreaFilter(event: React.ChangeEvent<HTMLSelectElement>) {
     const { value } = event.target
     if (value === 'all') {
-      this.setState({ filterGardenArea: undefined })
+      setFilterGardenArea(undefined)
       return
     }
-    this.setState({ filterGardenArea: Number(value) })
+    setFilterGardenArea(Number(value))
   }
 
-  updateGardenBedFilter(event: React.ChangeEvent<HTMLSelectElement>) {
+  function updateGardenBedFilter(event: React.ChangeEvent<HTMLSelectElement>) {
     const { value } = event.target
     if (value === 'all') {
-      this.setState({ filterGardenBed: undefined })
+      setFilterGardenBed(undefined)
       return
     }
-    this.setState({ filterGardenBed: value })
+    setFilterGardenBed(value)
   }
 
-  async updateData() {
-    this.updateSupplierList(await getSuppliers())
-    this.updateVarietiesList(await getPlantVarieties())
-    this.updateSeedList(await getSeeds())
-    this.updateSeedPacketList(await getSeedPackets())
-    this.updatePlantingList(await getPlantingGardenSquaresCurrent())
-    this.updateGardenAreas(await getGardenAreas())
-    this.updateGardenSquares(await getGardenSquares())
-    this.updateGardenBeds(await getGardenBeds())
+  async function createPlanting(data: GardenSquareDirectPlantingCreate) {
+    await createMutation.mutateAsync(data)
   }
 
-  render() {
-    const areas = this.state.gardenAreas.map((area) => (
-      <option value={area.pk} key={area.pk}>
-        {area.name}
+  async function completePlanting(planting: GardenSquarePlanting) {
+    if (planting.specific_plant_pk && planting.transplanting_pk) {
+      await endLocationMutation.mutateAsync(planting.transplanting_pk)
+    } else if (planting.transplanted && planting.transplanting_pk) {
+      await completeTransplantMutation.mutateAsync(planting.transplanting_pk)
+    } else {
+      await completeDirectMutation.mutateAsync(planting.planting_pk)
+    }
+  }
+
+  const areas = gardenAreas.map((area) => (
+    <option value={area.pk} key={area.pk}>
+      {area.name}
+    </option>
+  ))
+  const beds = gardenBeds
+    .filter((bed) => filterGardenArea && bed.area === filterGardenArea)
+    .map((bed) => (
+      <option value={bed.name} key={bed.name}>
+        {bed.name}
       </option>
     ))
-    const beds = this.state.gardenBeds
-      .filter((bed) => this.state.filterGardenArea && bed.area === this.state.filterGardenArea)
-      .map((bed) => (
-        <option value={bed.name} key={bed.name}>
-          {bed.name}
-        </option>
-      ))
-    areas.unshift(
-      <option key="all" value="all">
-        All Areas
-      </option>
-    )
-    beds.unshift(
-      <option key="all" value="all">
-        All Beds
-      </option>
-    )
-    const rows = []
-    if (this.state.showPlantingAdd) {
-      rows.push(
-        <NewGardenSquarePlantingRow
-          key="new"
-          seedPackets={this.state.seedPackets}
-          seeds={this.state.seeds}
-          suppliers={this.state.suppliers}
-          varieties={this.state.varieties}
-          gardenSquares={this.state.gardenSquares}
-          gardenBeds={this.state.gardenBeds}
-          done={this.hideNewPlantingAdd}
-        />
-      )
-    }
-    for (const p in this.state.plantings) {
-      const plantingData = this.state.plantings[p]
-      if (
-        !this.state.filterGardenArea ||
-        (this.state.gardenAreas.find((area) => area.pk === this.state.filterGardenArea)?.name === plantingData.location.area &&
-          (!this.state.filterGardenBed || this.state.filterGardenBed === plantingData.location.bed))
-      ) {
-        rows.push(<GardenSquarePlantingRow key={plantingData.transplanting_pk ? 't' + plantingData.transplanting_pk : plantingData.planting_pk} planting={plantingData} />)
-      }
-    }
-    return (
-      <Table>
-        <thead>
-          <tr key="header">
-            <td>
-              Plant{' '}
-              <a href="#" onClick={this.showNewPlantingAdd}>
-                +
-              </a>
-            </td>
-            <td>Quantity</td>
-            <td>Date</td>
-            <td>Location</td>
-            <td>Expected Germination</td>
-            <td>Expected Maturity</td>
-            <td>Notes</td>
-          </tr>
-          <tr key="filters">
-            <td></td>
-            <td></td>
-            <td></td>
-            <td>
-              <select onChange={this.updateGardenAreaFilter}>{areas}</select>
-              <select onChange={this.updateGardenBedFilter}>{beds}</select>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>
-          </tr>
-        </thead>
-        <tbody>{rows}</tbody>
-      </Table>
+  areas.unshift(
+    <option key="all" value="all">
+      All Areas
+    </option>
+  )
+  beds.unshift(
+    <option key="all" value="all">
+      All Beds
+    </option>
+  )
+  const rows = []
+  if (showPlantingAdd) {
+    rows.push(
+      <NewGardenSquarePlantingRow
+        key="new"
+        seedPackets={seedPackets}
+        seeds={seeds}
+        suppliers={suppliers}
+        varieties={varieties}
+        gardenSquares={gardenSquares}
+        gardenBeds={gardenBeds}
+        createPlanting={createPlanting}
+        done={() => setShowPlantingAdd(false)}
+      />
     )
   }
+  for (const planting of plantings) {
+    if (
+      !filterGardenArea ||
+      (gardenAreas.find((area) => area.pk === filterGardenArea)?.name === planting.location.area && (!filterGardenBed || filterGardenBed === planting.location.bed))
+    ) {
+      rows.push(
+        <GardenSquarePlantingRow key={planting.transplanting_pk ? 't' + planting.transplanting_pk : planting.planting_pk} planting={planting} completePlanting={completePlanting} />
+      )
+    }
+  }
+  return (
+    <Table>
+      <thead>
+        <tr key="header">
+          <td>
+            Plant{' '}
+            <a href="#" onClick={() => setShowPlantingAdd(true)}>
+              +
+            </a>
+          </td>
+          <td>Quantity</td>
+          <td>Date</td>
+          <td>Location</td>
+          <td>Expected Germination</td>
+          <td>Expected Maturity</td>
+          <td>Notes</td>
+        </tr>
+        <tr key="filters">
+          <td></td>
+          <td></td>
+          <td></td>
+          <td>
+            <select onChange={updateGardenAreaFilter}>{areas}</select>
+            <select onChange={updateGardenBedFilter}>{beds}</select>
+          </td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+      </thead>
+      <tbody>{rows}</tbody>
+    </Table>
+  )
 }
 
 export { SeedTrayPlantingTable, GardenSquarePlantingTable, SeedTrayPlantingRow }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -41,6 +41,7 @@ const queryKeys = {
     seedTray: (trayPk: number) => ['plantings', 'seedTrays', trayPk] as const,
     currentSeedTrays: ['plantings', 'currentSeedTrays'] as const,
     currentGardenSquares: ['plantings', 'currentGardenSquares'] as const,
+    specificPlantsAll: ['plantings', 'specificPlants'] as const,
     specificPlants: (trayPk: number) => ['plantings', 'specificPlants', trayPk] as const
   }
 }

--- a/frontend/js/seedtrays.tsx
+++ b/frontend/js/seedtrays.tsx
@@ -4,14 +4,16 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import { Table } from 'react-bootstrap'
 import Select from 'react-select'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { SeedTrayModel, SeedTray, SeedTrayModelCreate, SeedTrayCreate } from './types/seedtrays'
+import { SeedTrayModel, SeedTrayModelCreate, SeedTrayCreate } from './types/seedtrays'
 import { getSeedTrayModels, getSeedTrays, addSeedTrayModel, addSeedTray } from './api/seedtrays'
 import { formatDate } from './utils'
-import { NoProps } from './types/others'
+import { queryKeys } from './query'
 
 interface SeedTrayModelNewProps {
   done: () => void
+  createModel: (data: SeedTrayModelCreate) => Promise<void>
 }
 
 class SeedTrayModelNew extends React.Component<SeedTrayModelNewProps, SeedTrayModelCreate> {
@@ -38,8 +40,9 @@ class SeedTrayModelNew extends React.Component<SeedTrayModelNewProps, SeedTrayMo
     this.setState({ [field]: parseInt(event.target.value, 10) || 0 } as Pick<SeedTrayModelCreate, typeof field>)
   }
 
-  private createSeedTrayModel = () => {
-    addSeedTrayModel(this.state).then((response) => response.ok && this.props.done())
+  private createSeedTrayModel = async () => {
+    await this.props.createModel(this.state)
+    this.props.done()
   }
 
   render() {
@@ -72,72 +75,57 @@ class SeedTrayModelNew extends React.Component<SeedTrayModelNewProps, SeedTrayMo
   }
 }
 
-interface SeedTrayModelsTableState {
-  showAddRow: boolean
-  seedTrayModels: Array<SeedTrayModel>
-}
+function SeedTrayModelsTable() {
+  const queryClient = useQueryClient()
+  const [showAddRow, setShowAddRow] = React.useState(false)
+  const { data: seedTrayModels = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.models,
+    queryFn: ({ signal }) => getSeedTrayModels(signal)
+  })
+  const modelMutation = useMutation({
+    mutationFn: addSeedTrayModel,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.seedTrays.models })
+  })
 
-class SeedTrayModelsTable extends React.Component<NoProps, SeedTrayModelsTableState> {
-  constructor(props: NoProps) {
-    super(props)
-
-    this.state = {
-      showAddRow: false,
-      seedTrayModels: []
-    }
+  async function createModel(data: SeedTrayModelCreate) {
+    await modelMutation.mutateAsync(data)
   }
 
-  componentDidMount() {
-    this.fetchSeedTrayModels()
-  }
-
-  private hideAddRow = () => {
-    this.setState({ showAddRow: false })
-    this.fetchSeedTrayModels()
-  }
-
-  private showAddRow = () => this.setState({ showAddRow: true })
-
-  private fetchSeedTrayModels = async () => {
-    this.setState({ seedTrayModels: await getSeedTrayModels() })
-  }
-
-  render() {
-    return (
-      <Table>
-        <thead>
-          <tr>
-            <th>
-              ID<button onClick={this.showAddRow}>+</button>
-            </th>
-            <th>Name</th>
-            <th>Description</th>
-            <th>Size mm (cells)</th>
-            <th>Cell Size (ml)</th>
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>
+            ID<button onClick={() => setShowAddRow(true)}>+</button>
+          </th>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Size mm (cells)</th>
+          <th>Cell Size (ml)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {showAddRow && <SeedTrayModelNew key="add" createModel={createModel} done={() => setShowAddRow(false)} />}
+        {seedTrayModels.map((model) => (
+          <tr key={model.pk}>
+            <td>{model.pk}</td>
+            <td>{model.identifier}</td>
+            <td>{model.description}</td>
+            <td>
+              {model.x_size}x{model.y_size}x{model.height} ({model.x_cells}x{model.y_cells})
+            </td>
+            <td>{model.cell_size_ml}</td>
           </tr>
-        </thead>
-        <tbody>
-          {this.state.showAddRow && <SeedTrayModelNew key="add" done={this.hideAddRow} />}
-          {this.state.seedTrayModels.map((model) => (
-            <tr key={model.pk}>
-              <td>{model.pk}</td>
-              <td>{model.identifier}</td>
-              <td>{model.description}</td>
-              <td>
-                {model.x_size}x{model.y_size}x{model.height} ({model.x_cells}x{model.y_cells})
-              </td>
-              <td>{model.cell_size_ml}</td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-    )
-  }
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
 interface SeedTrayAddProps {
   done: () => void
   models: Array<SeedTrayModel>
+  createTray: (data: SeedTrayCreate) => Promise<void>
 }
 
 class SeedTrayAdd extends React.Component<SeedTrayAddProps, SeedTrayCreate> {
@@ -158,11 +146,12 @@ class SeedTrayAdd extends React.Component<SeedTrayAddProps, SeedTrayCreate> {
     this.setState({ notes: event.target.value })
   }
 
-  private createSeedTray = () => {
+  private createSeedTray = async () => {
     if (!this.state.model) {
       return
     }
-    addSeedTray(this.state).then((response) => response.ok && this.props.done())
+    await this.props.createTray(this.state)
+    this.props.done()
   }
 
   render() {
@@ -186,76 +175,57 @@ class SeedTrayAdd extends React.Component<SeedTrayAddProps, SeedTrayCreate> {
   }
 }
 
-interface SeedTraysTableState {
-  showAddRow: boolean
-  seedTrays: Array<SeedTray>
-  seedTrayModelList: Array<SeedTrayModel>
-  seedTrayModels: { [key: number]: SeedTrayModel }
-}
+function SeedTraysTable() {
+  const queryClient = useQueryClient()
+  const [showAddRow, setShowAddRow] = React.useState(false)
+  const { data: seedTrays = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.trays,
+    queryFn: ({ signal }) => getSeedTrays(signal)
+  })
+  const { data: seedTrayModels = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.models,
+    queryFn: ({ signal }) => getSeedTrayModels(signal)
+  })
+  const trayMutation = useMutation({
+    mutationFn: addSeedTray,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.seedTrays.trays })
+  })
+  const seedTrayModelsMap = seedTrayModels.reduce<Record<number, SeedTrayModel>>((models, model) => {
+    models[model.pk] = model
+    return models
+  }, {})
 
-class SeedTraysTable extends React.Component<NoProps, SeedTraysTableState> {
-  constructor(props: NoProps) {
-    super(props)
-
-    this.state = {
-      showAddRow: false,
-      seedTrays: [],
-      seedTrayModelList: [],
-      seedTrayModels: {}
-    }
+  async function createTray(data: SeedTrayCreate) {
+    await trayMutation.mutateAsync(data)
   }
 
-  componentDidMount() {
-    this.fetchSeedTrays()
-  }
-
-  private showAddRow = () => this.setState({ showAddRow: true })
-
-  private hideAddRow = () => {
-    this.setState({ showAddRow: false })
-    this.fetchSeedTrays()
-  }
-
-  private fetchSeedTrays = async () => {
-    const [seedTraysData, seedTrayModelsData] = (await Promise.all([getSeedTrays(), getSeedTrayModels()])) as [Array<SeedTray>, Array<SeedTrayModel>]
-
-    const seedTrayModelsMap: { [key: number]: SeedTrayModel } = seedTrayModelsData.reduce((acc: { [key: number]: SeedTrayModel }, model: SeedTrayModel) => {
-      acc[model.pk] = model
-      return acc
-    }, {})
-
-    this.setState({ seedTrays: seedTraysData, seedTrayModels: seedTrayModelsMap, seedTrayModelList: seedTrayModelsData })
-  }
-
-  render() {
-    return (
-      <Table>
-        <thead>
-          <tr>
-            <th>
-              ID<button onClick={this.showAddRow}>+</button>
-            </th>
-            <th>Model</th>
-            <th>Created</th>
-            <th>Notes</th>
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>
+            ID<button onClick={() => setShowAddRow(true)}>+</button>
+          </th>
+          <th>Model</th>
+          <th>Created</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {showAddRow && <SeedTrayAdd key="add" createTray={createTray} done={() => setShowAddRow(false)} models={seedTrayModels} />}
+        {seedTrays.map((tray) => (
+          <tr key={tray.pk}>
+            <td>
+              <a href={`/seedtrays/seedtray/${tray.pk}/`}>{tray.pk}</a>
+            </td>
+            <td>{tray.model && seedTrayModelsMap[tray.model]?.identifier}</td>
+            <td>{formatDate(tray.created)}</td>
+            <td>{tray.notes}</td>
           </tr>
-        </thead>
-        <tbody>
-          {this.state.showAddRow && <SeedTrayAdd key="add" done={this.hideAddRow} models={this.state.seedTrayModelList} />}
-          {this.state.seedTrays.map((tray) => (
-            <tr key={tray.pk}>
-              <td>
-                <a href={`/seedtrays/seedtray/${tray.pk}/`}>{tray.pk}</a>
-              </td>
-              <td>{tray.model && this.state.seedTrayModels[tray.model]?.identifier}</td>
-              <td>{formatDate(tray.created)}</td>
-              <td>{tray.notes}</td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-    )
-  }
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
 export { SeedTrayModelsTable, SeedTraysTable }


### PR DESCRIPTION
Seed-tray metadata and planting summaries need cache-driven refreshes instead of mount fetches and polling. Move their writes into mutation owners, invalidate planting and packet families after lifecycle changes, and replace manual tray-cell cancellation with an enabled parameterized query.

## Summary by Sourcery

Refactor planting and seed tray frontend components to use React Query-driven data fetching and mutations, consolidating lifecycle actions and cache invalidation for trays, garden squares, and related plantings.

New Features:
- Introduce React Query-based parameterized loading of seed tray cells when a tray is selected.
- Add support for creating direct garden square plantings via a mutation callback passed into the planting row components.

Bug Fixes:
- Prevent stale or over-fetched seed tray and garden square planting data by relying on cache invalidation rather than interval-based polling.

Enhancements:
- Replace polling and manual data reloads in planting and seed tray tables with React Query hooks for suppliers, seeds, packets, trays, models, and plantings.
- Move creation and completion of seed tray and garden square plantings into mutation handlers that invalidate planting and seed packet query families.
- Simplify garden square filter management by storing filter state locally and driving rendering directly from query results.
- Update seed tray model and tray creation flows to use mutations that refresh the corresponding query caches instead of refetching in component lifecycle methods.
- Unify handling of specific plant location endings and transplanted/direct sow completion through a single completion callback in garden square planting rows.
- Convert the new seed tray planting row from a class component with manual abort handling to a functional component that leverages an enabled React Query for tray cells.