### PR TITLE
build(frontend): allow bundler install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "globals": "^17.0.0",
     "prettier": "^3.3.3",
     "typescript": "^6.0.3"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "esbuild-config@1.0.1": true
   }
 }


### PR DESCRIPTION
Clean npm installs now block unlisted dependency lifecycle scripts, leaving esbuild and esbuild-config without their generated executables. Explicitly allow only those two pinned bundler packages so the production build remains reproducible.