### PR TITLE
feat(frontend): add hash-based view routing

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v7
+     - name: Setup Node
+       uses: actions/setup-node@v7
+       with:
+         node-version: 24
+         cache: npm
      - name: Install modules
        run: npm ci
      - name: Run ESLint

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Tech stack
 Prerequisites
 - Git
 - Python 3.12+ (required by Django 6)
-- Node.js 18+ (required by esbuild) and npm
+- Node.js 22.22+ and npm (required by React Router)
 - Bash-compatible shell for `setup-venv.sh`
 
 Quick start (recommended)

--- a/frontend/js/garden.tsx
+++ b/frontend/js/garden.tsx
@@ -24,7 +24,7 @@ function haveSameItems<T>(previousItems: Array<T>, currentItems: Array<T>): bool
 }
 
 class GardenAreaDisplay extends React.Component<GardenAreaDisplayProps> {
-  canvasRef: React.RefObject<HTMLCanvasElement>
+  canvasRef: React.RefObject<HTMLCanvasElement | null>
   outlineWidth: number
 
   constructor(props: GardenAreaDisplayProps) {

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -4,7 +4,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { HashRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { HashRouter, Navigate, Route, Routes } from 'react-router'
 
 import { GPTopBar } from './menu.js'
 import { PlantsView } from './plants.js'

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -4,6 +4,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
+import { HashRouter, Navigate, Route, Routes } from 'react-router-dom'
 
 import { GPTopBar } from './menu.js'
 import { PlantsView } from './plants.js'
@@ -15,34 +16,22 @@ import { ApiErrorAlert } from './api_error_alert.js'
 import { queryClient } from './query.js'
 
 function FrontEndPage() {
-  const [selectedView, setSelectedView] = React.useState('gardens')
-
-  let view = <></>
-  if (selectedView === 'plants') {
-    view = <PlantsView />
-  } else if (selectedView === 'seeds-supplier') {
-    view = <SeedSuppliersTable />
-  } else if (selectedView === 'seeds-seed') {
-    view = <SeedTable />
-  } else if (selectedView === 'seeds-stock') {
-    view = <SeedStockTable />
-  } else if (selectedView === 'seedtrays-models') {
-    view = <SeedTrayModelsTable />
-  } else if (selectedView === 'seedtrays') {
-    view = <SeedTraysTable />
-  } else if (selectedView === 'planting-seedtrays') {
-    view = <SeedTrayPlantingTable />
-  } else if (selectedView === 'planting-gardensquare') {
-    view = <GardenSquarePlantingTable />
-  } else {
-    view = <GardenDisplay />
-  }
-
   return (
     <>
-      <GPTopBar setView={setSelectedView} />
+      <GPTopBar />
       <ApiErrorAlert />
-      {view}
+      <Routes>
+        <Route path="/gardens" element={<GardenDisplay />} />
+        <Route path="/plants" element={<PlantsView />} />
+        <Route path="/seeds/suppliers" element={<SeedSuppliersTable />} />
+        <Route path="/seeds" element={<SeedTable />} />
+        <Route path="/seeds/stock" element={<SeedStockTable />} />
+        <Route path="/seedtrays/models" element={<SeedTrayModelsTable />} />
+        <Route path="/seedtrays" element={<SeedTraysTable />} />
+        <Route path="/plantings/seedtrays" element={<SeedTrayPlantingTable />} />
+        <Route path="/plantings/garden-squares" element={<GardenSquarePlantingTable />} />
+        <Route path="*" element={<Navigate to="/gardens" replace />} />
+      </Routes>
     </>
   )
 }
@@ -55,7 +44,9 @@ function createFrontEnd(elementId: string) {
   const div = ReactDOM.createRoot(element)
   div.render(
     <QueryClientProvider client={queryClient}>
-      <FrontEndPage />
+      <HashRouter>
+        <FrontEndPage />
+      </HashRouter>
     </QueryClientProvider>
   )
 }

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -4,7 +4,7 @@ import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
 import { Nav, Navbar, NavDropdown } from 'react-bootstrap'
-import { NavLink, useLocation } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router'
 
 function GPTopBar() {
   const { pathname } = useLocation()

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -4,106 +4,56 @@ import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
 import { Nav, Navbar, NavDropdown } from 'react-bootstrap'
+import { NavLink, useLocation } from 'react-router-dom'
 
-interface GPTopBarProps {
-  setView: (view: string) => void
-}
+function GPTopBar() {
+  const { pathname } = useLocation()
+  const seedsActive = pathname === '/seeds' || pathname.startsWith('/seeds/')
+  const seedTraysActive = pathname === '/seedtrays' || pathname.startsWith('/seedtrays/')
+  const plantingActive = pathname === '/plantings' || pathname.startsWith('/plantings/')
 
-class GPTopBar extends React.Component<GPTopBarProps> {
-  constructor(props: GPTopBarProps) {
-    super(props)
-
-    this.setGardensView = this.setGardensView.bind(this)
-    this.setPlantsView = this.setPlantsView.bind(this)
-    this.setSeedsSupplierView = this.setSeedsSupplierView.bind(this)
-    this.setSeedsView = this.setSeedsView.bind(this)
-    this.setSeedsStockView = this.setSeedsStockView.bind(this)
-    this.setSeedTrayModelView = this.setSeedTrayModelView.bind(this)
-    this.setSeedTrayView = this.setSeedTrayView.bind(this)
-    this.setPlantingSeedTrayView = this.setPlantingSeedTrayView.bind(this)
-    this.setPlantingGardenSquareView = this.setPlantingGardenSquareView.bind(this)
-  }
-
-  setGardensView() {
-    this.props.setView('gardens')
-  }
-
-  setPlantsView() {
-    this.props.setView('plants')
-  }
-
-  setSeedsSupplierView() {
-    this.props.setView('seeds-supplier')
-  }
-
-  setSeedsView() {
-    this.props.setView('seeds-seed')
-  }
-
-  setSeedsStockView() {
-    this.props.setView('seeds-stock')
-  }
-
-  setPlantingSeedTrayView() {
-    this.props.setView('planting-seedtrays')
-  }
-
-  setPlantingGardenSquareView() {
-    this.props.setView('planting-gardensquare')
-  }
-
-  setSeedTrayModelView() {
-    this.props.setView('seedtrays-models')
-  }
-
-  setSeedTrayView() {
-    this.props.setView('seedtrays')
-  }
-
-  render() {
-    return (
-      <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
-        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-        <Navbar.Collapse id="responsive-navbar-nav">
-          <Nav>
-            <Nav.Link href="#gardens" onClick={this.setGardensView}>
-              Gardens
-            </Nav.Link>
-            <Nav.Link href="#plants" onClick={this.setPlantsView}>
-              Plants
-            </Nav.Link>
-            <NavDropdown title="Seeds">
-              <Nav.Link href="#seeds-supplier" onClick={this.setSeedsSupplierView}>
-                Suppliers
-              </Nav.Link>
-              <Nav.Link href="#seeds" onClick={this.setSeedsView}>
-                Seeds
-              </Nav.Link>
-              <Nav.Link href="#seeds-stock" onClick={this.setSeedsStockView}>
-                Stock
-              </Nav.Link>
-            </NavDropdown>
-            <NavDropdown title="Seed Trays">
-              <Nav.Link href="#seedtrays-models" onClick={this.setSeedTrayModelView}>
-                Seed Tray Models
-              </Nav.Link>
-              <Nav.Link href="#seedtrays" onClick={this.setSeedTrayView}>
-                Seed Trays
-              </Nav.Link>
-            </NavDropdown>
-            <NavDropdown title="Planting">
-              <Nav.Link href="#planting-seedtray" onClick={this.setPlantingSeedTrayView}>
-                Seed Trays
-              </Nav.Link>
-              <Nav.Link href="#planting-gardensquare" onClick={this.setPlantingGardenSquareView}>
-                Garden Squares
-              </Nav.Link>
-            </NavDropdown>
-          </Nav>
-        </Navbar.Collapse>
-      </Navbar>
-    )
-  }
+  return (
+    <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
+      <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+      <Navbar.Collapse id="responsive-navbar-nav">
+        <Nav>
+          <Nav.Link as={NavLink} to="/gardens">
+            Gardens
+          </Nav.Link>
+          <Nav.Link as={NavLink} to="/plants">
+            Plants
+          </Nav.Link>
+          <NavDropdown title="Seeds" active={seedsActive}>
+            <NavDropdown.Item as={NavLink} to="/seeds/suppliers">
+              Suppliers
+            </NavDropdown.Item>
+            <NavDropdown.Item as={NavLink} to="/seeds" end>
+              Seeds
+            </NavDropdown.Item>
+            <NavDropdown.Item as={NavLink} to="/seeds/stock">
+              Stock
+            </NavDropdown.Item>
+          </NavDropdown>
+          <NavDropdown title="Seed Trays" active={seedTraysActive}>
+            <NavDropdown.Item as={NavLink} to="/seedtrays/models">
+              Seed Tray Models
+            </NavDropdown.Item>
+            <NavDropdown.Item as={NavLink} to="/seedtrays" end>
+              Seed Trays
+            </NavDropdown.Item>
+          </NavDropdown>
+          <NavDropdown title="Planting" active={plantingActive}>
+            <NavDropdown.Item as={NavLink} to="/plantings/seedtrays">
+              Seed Trays
+            </NavDropdown.Item>
+            <NavDropdown.Item as={NavLink} to="/plantings/garden-squares">
+              Garden Squares
+            </NavDropdown.Item>
+          </NavDropdown>
+        </Nav>
+      </Navbar.Collapse>
+    </Navbar>
+  )
 }
 
 export { GPTopBar }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,24 +13,27 @@
         "esbuild": "^0.28.0",
         "esbuild-config": "^1.0.1",
         "js-cookie": "^3.0.5",
-        "react": "^18.3.1",
+        "react": "^19.2.8",
         "react-bootstrap": "^2.10.4",
         "react-datetime-picker": "^7.0.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.18.2",
+        "react-dom": "^19.2.8",
+        "react-router": "^8.3.0",
         "react-select": "^5.10.2",
         "typescript-eslint": "^8.50.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/js-cookie": "^3.0.6",
-        "@types/react": "^18.3.31",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "eslint": "^9.12.0",
         "eslint-plugin-react": "^7.37.1",
         "globals": "^17.0.0",
         "prettier": "^3.3.3",
         "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -934,6 +937,33 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -979,16 +1009,27 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
-      "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.1.tgz",
+      "integrity": "sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
       },
       "engines": {
         "node": ">= 12"
       },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
@@ -1047,9 +1088,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -1112,23 +1153,22 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -1140,9 +1180,9 @@
       }
     },
     "node_modules/@types/warning": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1491,6 +1531,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -1700,9 +1752,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1827,18 +1879,11 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3772,15 +3817,33 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/react-bootstrap": {
@@ -3815,9 +3878,9 @@
       }
     },
     "node_modules/react-calendar": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.0.tgz",
-      "integrity": "sha512-6wqaki3Us0DNDjZDr0DYIzhSFprNoy4FdPT9Pjy5aD2hJJVjtJwmdMT9VmrTUo949nlk35BOxehThxX62RkuRQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.1.tgz",
+      "integrity": "sha512-b8E61W7qk/He9XEbtbQBjnALPuGmxeglsotgZyAShqN1vHMzXWjl4g7WI5tRF93RE4Wbo0c0BKN3vTQhrBojpg==",
       "license": "MIT",
       "dependencies": {
         "@wojtekmaj/date-utils": "^2.0.2",
@@ -3864,9 +3927,9 @@
       }
     },
     "node_modules/react-date-picker": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-12.0.1.tgz",
-      "integrity": "sha512-VHXOIBt5/Bxa+ICMENjfWjGvllvXxd+lzGB2iH9fOc7+BfcetI/aI8MZuiIKofmNWq2oAdD+fg4MsZkKmOBjig==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-12.1.0.tgz",
+      "integrity": "sha512-ukbSL2FH9EJ4YdWegT0z6ptkvQqL65IaAdSO5YFEVN4zZDQ4bO8vlkZt9Q+hmKq64dkxznW6CJNskpD9W24Kbw==",
       "license": "MIT",
       "dependencies": {
         "@wojtekmaj/date-utils": "^2.0.2",
@@ -3875,7 +3938,7 @@
         "make-event-props": "^2.0.0",
         "react-calendar": "^6.0.0",
         "react-fit": "^3.0.0",
-        "update-input-width": "^1.4.0"
+        "update-input-width": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/react-date-picker?sponsor=1"
@@ -3922,16 +3985,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-fit": {
@@ -3968,41 +4030,24 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-select": {
@@ -4026,10 +4071,27 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-time-picker": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/react-time-picker/-/react-time-picker-8.0.2.tgz",
-      "integrity": "sha512-qT0MDiPy9rFM60QrNNfZ5F9nwDBW1E9DrBtslpM46UPP/RReaWDJrGlvHVH6CjtWHUeJi5sLk1vB+dzLS8ZvnA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-time-picker/-/react-time-picker-8.1.0.tgz",
+      "integrity": "sha512-tUNJ6EKOMOD5qEmqDdvY1DcxBn5hpAWh6AecC9KgPup1KjZlvUZ0Ttp+/VOqkrgBtQQdzD+DBqhoJwX6MYCSaQ==",
       "license": "MIT",
       "dependencies": {
         "@wojtekmaj/date-utils": "^2.0.2",
@@ -4038,7 +4100,7 @@
         "make-event-props": "^2.0.0",
         "react-clock": "^6.0.0",
         "react-fit": "^3.0.0",
-        "update-input-width": "^1.4.0"
+        "update-input-width": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/react-time-picker?sponsor=1"
@@ -4058,6 +4120,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -4195,12 +4258,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4211,12 +4272,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -4680,9 +4735,9 @@
       }
     },
     "node_modules/update-input-width": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.4.2.tgz",
-      "integrity": "sha512-/p0XLhrQQQ4bMWD7bL9duYObwYCO1qGr8R19xcMmoMSmXuQ7/1//veUnCObQ7/iW6E2pGS6rFkS4TfH4ur7e/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-2.0.0.tgz",
+      "integrity": "sha512-Ri49Yv+QEwaf/nZEKxuOeD+M65NE+WLau4rGyHTUBCNKNN+jtKT36vUpOugt0lIrEb8l9ZkEgY+Sg+I+zO/3PA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/wojtekmaj/update-input-width?sponsor=1"
@@ -4709,6 +4764,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/warning": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-bootstrap": "^2.10.4",
         "react-datetime-picker": "^7.0.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^7.18.2",
         "react-select": "^5.10.2",
         "typescript-eslint": "^8.50.1"
       },
@@ -1825,6 +1826,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3953,6 +3967,44 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-select": {
       "version": "5.10.2",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
@@ -4159,6 +4211,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-bootstrap": "^2.10.4",
     "react-datetime-picker": "^7.0.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.18.2",
     "react-select": "^5.10.2",
     "typescript-eslint": "^8.50.1"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "https://github.com/sparlane/garden-planner.git"
   },
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "author": "",
   "license": "",
   "description": "",
@@ -22,19 +25,19 @@
     "esbuild": "^0.28.0",
     "esbuild-config": "^1.0.1",
     "js-cookie": "^3.0.5",
-    "react": "^18.3.1",
+    "react": "^19.2.8",
     "react-bootstrap": "^2.10.4",
     "react-datetime-picker": "^7.0.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.2",
+    "react-dom": "^19.2.8",
+    "react-router": "^8.3.0",
     "react-select": "^5.10.2",
     "typescript-eslint": "^8.50.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",
     "@types/js-cookie": "^3.0.6",
-    "@types/react": "^18.3.31",
-    "@types/react-dom": "^18.3.7",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "eslint": "^9.12.0",
     "eslint-plugin-react": "^7.37.1",
     "globals": "^17.0.0",


### PR DESCRIPTION
The frontend's selectedView state prevents deep links and browser history. Route every existing menu screen through React Router and derive navigation styling from the current URL while leaving Django API paths untouched.

## Summary by Sourcery

Replace local view state with hash-based React Router navigation for the frontend menu to support deep linking and URL-driven routing.

New Features:
- Introduce hash-based routing with React Router for all frontend views, mapping menu entries to URL paths.
- Add URL-driven active state handling for Seeds, Seed Trays, and Planting dropdowns in the navigation bar.

Enhancements:
- Refactor the top navigation bar into a route-aware component that no longer depends on a parent-selectedView prop.

Build:
- Add react-router-dom as a frontend dependency for client-side routing.