### PR TITLE
feat(frontend): route garden and tray details

### DIFF
--- a/frontend/js/garden.tsx
+++ b/frontend/js/garden.tsx
@@ -4,6 +4,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import Select from 'react-select'
 import { useQuery } from '@tanstack/react-query'
+import { useNavigate, useParams } from 'react-router'
 
 import { GardenArea, GardenBed, GardenSquare } from './types/garden'
 import { GardenSquarePlanting } from './types/plantings'
@@ -143,8 +144,10 @@ class GardenAreaDisplay extends React.Component<GardenAreaDisplayProps> {
 }
 
 function GardenDisplay() {
-  const [selectedArea, setSelectedArea] = React.useState<number>()
-  const { data: areas = [] } = useQuery({
+  const navigate = useNavigate()
+  const { areaId } = useParams()
+  const selectedArea = areaId === undefined ? undefined : Number(areaId)
+  const { data: areas = [], isPending: areasPending } = useQuery({
     queryKey: queryKeys.garden.areas,
     queryFn: ({ signal }) => getGardenAreas(signal)
   })
@@ -165,18 +168,20 @@ function GardenDisplay() {
     const value = selectedGardenArea?.value
 
     if (value === undefined || value === null) {
-      setSelectedArea(undefined)
+      navigate('/gardens')
     } else {
-      setSelectedArea(Number(value))
+      navigate(`/gardens/${Number(value)}`)
     }
   }
 
   const areaOptions = areas.map((area) => ({ value: area.pk, label: area.name }))
   let areaView
-  if (selectedArea !== undefined) {
+  if (areaId !== undefined) {
     const area = areas.find((candidate) => candidate.pk === selectedArea)
     if (area) {
       areaView = <GardenAreaDisplay key={area.pk} area={area} gardenBeds={beds.filter((bed) => bed.area === area.pk)} squares={squares} plantings={plantings} />
+    } else if (!areasPending) {
+      areaView = <div>Garden area not found.</div>
     }
   }
 

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -4,7 +4,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { HashRouter, Navigate, Route, Routes } from 'react-router'
+import { HashRouter, Navigate, Route, Routes, useParams } from 'react-router'
 
 import { GPTopBar } from './menu.js'
 import { PlantsView } from './plants.js'
@@ -14,6 +14,18 @@ import { GardenDisplay } from './garden.js'
 import { SeedTrayModelsTable, SeedTraysTable } from './seedtrays.js'
 import { ApiErrorAlert } from './api_error_alert.js'
 import { queryClient } from './query.js'
+import { SeedTrayDetails } from './seedtray/seedtray_details.js'
+
+function SeedTrayDetailsRoute() {
+  const { trayId } = useParams()
+  const seedTrayPk = Number(trayId)
+
+  if (!trayId || !Number.isInteger(seedTrayPk) || seedTrayPk <= 0) {
+    return <div>Seed tray not found.</div>
+  }
+
+  return <SeedTrayDetails seedTrayPk={seedTrayPk} />
+}
 
 function FrontEndPage() {
   return (
@@ -22,12 +34,14 @@ function FrontEndPage() {
       <ApiErrorAlert />
       <Routes>
         <Route path="/gardens" element={<GardenDisplay />} />
+        <Route path="/gardens/:areaId" element={<GardenDisplay />} />
         <Route path="/plants" element={<PlantsView />} />
         <Route path="/seeds/suppliers" element={<SeedSuppliersTable />} />
         <Route path="/seeds" element={<SeedTable />} />
         <Route path="/seeds/stock" element={<SeedStockTable />} />
         <Route path="/seedtrays/models" element={<SeedTrayModelsTable />} />
         <Route path="/seedtrays" element={<SeedTraysTable />} />
+        <Route path="/seedtrays/:trayId" element={<SeedTrayDetailsRoute />} />
         <Route path="/plantings/seedtrays" element={<SeedTrayPlantingTable />} />
         <Route path="/plantings/garden-squares" element={<GardenSquarePlantingTable />} />
         <Route path="*" element={<Navigate to="/gardens" replace />} />

--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Table, Button } from 'react-bootstrap'
 import Select from 'react-select'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router'
 
 import { Supplier } from './types/suppliers'
 import { PlantVariety } from './types/plants'
@@ -278,9 +279,9 @@ class SeedTrayPlantingRow extends React.Component<SeedTrayPlantingRowProps> {
         <td>{this.props.planting.notes}</td>
         <td>
           {this.props.planting.seed_tray && (
-            <a className="btn btn-primary" href={`/seedtrays/seedtray/${this.props.planting.seed_tray}/`}>
+            <Link className="btn btn-primary" to={`/seedtrays/${this.props.planting.seed_tray}`}>
               Manage Plants
-            </a>
+            </Link>
           )}
           <Button onClick={this.empty}>Empty</Button>
         </td>

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -469,8 +469,12 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     return square ? square.name : `Square #${location.garden_square}`
   }
 
-  if (isLoading || !seedTray) {
+  if (isLoading) {
     return <div>Loading...</div>
+  }
+
+  if (!seedTray) {
+    return <div>Seed tray not found.</div>
   }
 
   return (
@@ -577,3 +581,5 @@ function showSeedTrayDetails(elem: string, seedTrayPk: number) {
 }
 
 ;(globalThis as Record<string, unknown>).showSeedTrayDetails = showSeedTrayDetails
+
+export { SeedTrayDetails }

--- a/frontend/js/seedtrays.tsx
+++ b/frontend/js/seedtrays.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Table } from 'react-bootstrap'
 import Select from 'react-select'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router'
 
 import { SeedTrayModel, SeedTrayModelCreate, SeedTrayCreate } from './types/seedtrays'
 import { getSeedTrayModels, getSeedTrays, addSeedTrayModel, addSeedTray } from './api/seedtrays'
@@ -216,7 +217,7 @@ function SeedTraysTable() {
         {seedTrays.map((tray) => (
           <tr key={tray.pk}>
             <td>
-              <a href={`/seedtrays/seedtray/${tray.pk}/`}>{tray.pk}</a>
+              <Link to={`/seedtrays/${tray.pk}`}>{tray.pk}</Link>
             </td>
             <td>{tray.model && seedTrayModelsMap[tray.model]?.identifier}</td>
             <td>{formatDate(tray.created)}</td>


### PR DESCRIPTION
Garden selection and tray management still escaped the URL-driven navigation model. Store garden identity in route parameters, reuse the tray detail view inside the main shell, and keep internal links within browser history while reporting missing resources clearly.

## Summary by Sourcery

Integrate garden areas and seed tray details into the router-based navigation, making them addressable via URL parameters and improving missing-resource handling.

New Features:
- Add route parameter support for garden areas so individual gardens are directly addressable via /gardens/:areaId.
- Expose seed tray detail pages within the main frontend shell via a new /seedtrays/:trayId route.

Bug Fixes:
- Display clear fallback messages when requested garden areas or seed trays are not found instead of failing silently.

Enhancements:
- Align internal navigation for garden selection and seed tray management with React Router, replacing raw anchors with Link components to keep navigation within SPA history.
- Refine seed tray detail loading states by separating loading from not-found cases for clearer user feedback.