### PR TITLE
fix(plantings): support multigerm seedling counts

### DIFF
--- a/plantings/migrations/0015_audit_seed_allocation_capacity.py
+++ b/plantings/migrations/0015_audit_seed_allocation_capacity.py
@@ -1,5 +1,5 @@
 from django.db import migrations
-from django.db.models import Count, F, Sum
+from django.db.models import F, Sum
 
 
 def describe_rows(queryset, count):
@@ -10,16 +10,12 @@ def describe_rows(queryset, count):
 
 
 def audit_seed_allocation_capacity(apps, _schema_editor):
-    """Stop deployment when historical allocation totals exceed capacity."""
+    """Stop deployment when cell seed totals exceed their parent sowing."""
     planting_model = apps.get_model('plantings', 'SeedTrayPlanting')
-    cell_planting_model = apps.get_model('plantings', 'SeedTrayCellPlanting')
 
     over_allocated = planting_model.objects.annotate(
         allocated_quantity=Sum('cell_plantings__quantity', default=0),
     ).filter(allocated_quantity__gt=F('quantity'))
-    over_germinated = cell_planting_model.objects.annotate(
-        germinated_count=Count('specific_plants'),
-    ).filter(germinated_count__gt=F('quantity'))
 
     problems = []
     over_allocated_count = over_allocated.count()
@@ -28,13 +24,6 @@ def audit_seed_allocation_capacity(apps, _schema_editor):
             'over-allocated SeedTrayPlanting IDs: '
             f'{describe_rows(over_allocated, over_allocated_count)}'
         )
-    over_germinated_count = over_germinated.count()
-    if over_germinated_count:
-        problems.append(
-            'over-germinated SeedTrayCellPlanting IDs: '
-            f'{describe_rows(over_germinated, over_germinated_count)}'
-        )
-
     if problems:
         raise RuntimeError(
             'Seed allocation capacity audit failed. Repair these rows before '

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -134,32 +134,6 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
         if seed_tray_derived:
             data['seed_tray'] = seed_tray
 
-    def _validate_replacement_germination_capacity(
-        self,
-        replacements,
-        existing_cell_plantings=None,
-    ):
-        """Do not remove capacity already used by germinated plants."""
-        if self.instance is None:
-            return
-
-        replacement_quantities = {
-            self._get_cell(cell_planting).pk: self._get_cell_quantity(cell_planting)
-            for cell_planting in replacements
-        }
-        existing_cell_plantings = existing_cell_plantings or list(
-            self.instance.cell_plantings.all()
-        )
-        for existing in existing_cell_plantings:
-            germinated_count = existing.specific_plants.count()
-            if replacement_quantities.get(existing.cell_id, 0) < germinated_count:
-                raise serializers.ValidationError({
-                    'cell_plantings': [
-                        f'Cell {existing.cell_id} allocation cannot be less than '
-                        f'its germinated plant count ({germinated_count}).'
-                    ]
-                })
-
     @staticmethod
     def _validate_cells_belong_to_tray(cells, seed_tray):
         """Reject any cell outside the effective seed tray."""
@@ -176,8 +150,6 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
         """Keep retained or replacement cells on the effective seed tray."""
         cell_plantings = self._get_effective_cell_plantings(data)
         self._validate_cell_allocations(data, cell_plantings)
-        if 'cell_plantings' in data:
-            self._validate_replacement_germination_capacity(cell_plantings)
 
         return data
 
@@ -255,12 +227,6 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
                 validated_data,
                 effective_cell_plantings,
             )
-            if cell_data is not None:
-                self._validate_replacement_germination_capacity(
-                    cell_data,
-                    existing_cell_plantings,
-                )
-
             for attr, value in validated_data.items():
                 setattr(instance, attr, value)
             instance.save()
@@ -403,12 +369,6 @@ class SpecificPlantSerializer(serializers.ModelSerializer):
                         'This cell allocation no longer exists.'
                     ]
                 }) from exc
-            if cell_planting.specific_plants.count() >= cell_planting.quantity:
-                raise serializers.ValidationError({
-                    'cell_planting': [
-                        'Germination count cannot exceed this cell allocation.'
-                    ]
-                })
             validated_data['cell_planting'] = cell_planting
             plant = SpecificPlant.objects.create(**validated_data)
             SpecificPlantLocation.objects.create(

--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -139,10 +139,22 @@ class PlantingsDataMigrationTests(TestCase):  # pylint: disable=too-many-instanc
         values.__getitem__.assert_called_once_with(slice(None, 20))
 
     def test_capacity_audit_accepts_consistent_rows(self):
-        """Allocation and germination counts within capacity allow deployment."""
+        """Seed allocation totals within the parent sowing allow deployment."""
         migration = import_module(
             'plantings.migrations.0015_audit_seed_allocation_capacity'
         )
+
+        migration.audit_seed_allocation_capacity(django_apps, None)
+
+    def test_capacity_audit_accepts_multigerm_rows(self):
+        """Seedling counts may exceed a cell's sown seed quantity."""
+        migration = import_module(
+            'plantings.migrations.0015_audit_seed_allocation_capacity'
+        )
+        SpecificPlant.objects.bulk_create([
+            SpecificPlant(cell_planting=self.cell_planting),
+            SpecificPlant(cell_planting=self.cell_planting),
+        ])
 
         migration.audit_seed_allocation_capacity(django_apps, None)
 
@@ -186,25 +198,18 @@ class PlantingsDataMigrationTests(TestCase):  # pylint: disable=too-many-instanc
         ):
             self.transplant_audit(django_apps, None)
 
-    def test_capacity_audit_reports_parent_and_cell_row_ids(self):
-        """Deployment failures identify both kinds of capacity violation."""
+    def test_capacity_audit_reports_parent_row_ids(self):
+        """Deployment failures identify over-allocated parent sowings."""
         migration = import_module(
             'plantings.migrations.0015_audit_seed_allocation_capacity'
         )
         SeedTrayCellPlanting.objects.filter(pk=self.cell_planting.pk).update(
             quantity=2,
         )
-        SpecificPlant.objects.bulk_create([
-            SpecificPlant(cell_planting=self.cell_planting),
-            SpecificPlant(cell_planting=self.cell_planting),
-        ])
-
         with self.assertRaisesMessage(
             RuntimeError,
             'over-allocated SeedTrayPlanting IDs: '
-            f'[{self.cell_planting.seed_tray_planting_id}]; '
-            'over-germinated SeedTrayCellPlanting IDs: '
-            f'[{self.cell_planting.pk}]',
+            f'[{self.cell_planting.seed_tray_planting_id}]',
         ):
             migration.audit_seed_allocation_capacity(django_apps, None)
 

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -312,8 +312,8 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
             {self.cell.pk: 1, self.other_cell.pk: 1},
         )
 
-    def test_specific_plant_creation_stops_at_cell_capacity(self):
-        """Only allocated seeds can become specific germinated plants."""
+    def test_specific_plant_creation_can_exceed_sown_seed_quantity(self):
+        """A multigerm cluster can produce several specific plants."""
         cell_planting = SeedTrayCellPlanting.objects.create(
             seed_tray_planting=self.original_planting,
             cell=self.cell,
@@ -321,41 +321,7 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
         )
         payload = json.dumps({'cell_planting': cell_planting.pk})
 
-        first_response = self.client.post(
-            '/plantings/specificplants/',
-            data=payload,
-            content_type='application/json',
-        )
-        second_response = self.client.post(
-            '/plantings/specificplants/',
-            data=payload,
-            content_type='application/json',
-        )
-
-        self.assertEqual(first_response.status_code, 201)
-        self.assertEqual(second_response.status_code, 400)
-        self.assertEqual(
-            second_response.json(),
-            {
-                'cell_planting': [
-                    'Germination count cannot exceed this cell allocation.'
-                ],
-            },
-        )
-        self.assertEqual(cell_planting.specific_plants.count(), 1)
-
-    def test_specific_plant_creation_uses_full_larger_capacity(self):
-        """Every slot above one is usable, and the next germination is rejected."""
-        self.original_planting.quantity = 3
-        self.original_planting.save(update_fields=['quantity'])
-        cell_planting = SeedTrayCellPlanting.objects.create(
-            seed_tray_planting=self.original_planting,
-            cell=self.cell,
-            quantity=3,
-        )
-        payload = json.dumps({'cell_planting': cell_planting.pk})
-
-        for expected_count in range(1, 4):
+        for expected_count in range(1, 6):
             with self.subTest(expected_count=expected_count):
                 response = self.client.post(
                     '/plantings/specificplants/',
@@ -369,22 +335,7 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
                     expected_count,
                 )
 
-        response = self.client.post(
-            '/plantings/specificplants/',
-            data=payload,
-            content_type='application/json',
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.json(),
-            {
-                'cell_planting': [
-                    'Germination count cannot exceed this cell allocation.'
-                ],
-            },
-        )
-        self.assertEqual(cell_planting.specific_plants.count(), 3)
+        self.assertEqual(cell_planting.quantity, 1)
 
     def test_specific_plant_patch_allows_mutable_fields(self):
         """Notes can change without altering the plant's origin allocation."""
@@ -445,8 +396,8 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
         plant.refresh_from_db()
         self.assertEqual(plant.cell_planting, first_cell_planting)
 
-    def test_allocation_cannot_drop_below_germination_count(self):
-        """Replacement cannot remove capacity already used by plants."""
+    def test_allocation_can_drop_below_germination_count(self):
+        """Allocation quantity remains a seed count, not seedling capacity."""
         self.original_planting.quantity = 2
         self.original_planting.save(update_fields=['quantity'])
         cell_planting = SeedTrayCellPlanting.objects.create(
@@ -470,18 +421,10 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
             content_type='application/json',
         )
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.json(),
-            {
-                'cell_plantings': [
-                    f'Cell {self.cell.pk} allocation cannot be less than '
-                    'its germinated plant count (2).'
-                ],
-            },
-        )
+        self.assertEqual(response.status_code, 200)
         cell_planting.refresh_from_db()
-        self.assertEqual(cell_planting.quantity, 2)
+        self.assertEqual(cell_planting.quantity, 1)
+        self.assertEqual(cell_planting.specific_plants.count(), 2)
 
     def test_safe_allocation_reduction_preserves_germinated_plant(self):
         """A valid replacement updates the referenced row rather than deleting it."""
@@ -690,8 +633,8 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
 
 
 @skipUnlessDBFeature('has_select_for_update')
-class ConcurrentGerminationCapacityTests(TransactionTestCase):
-    """Real row locks serialize simultaneous final-capacity requests."""
+class ConcurrentGerminationTests(TransactionTestCase):
+    """Concurrent observations can record multiple multigerm seedlings."""
 
     def setUp(self):
         self.user = get_user_model().objects.create_user(username='concurrency-tester')
@@ -742,13 +685,13 @@ class ConcurrentGerminationCapacityTests(TransactionTestCase):
         close_old_connections()
         return response.status_code
 
-    def test_only_one_simultaneous_final_capacity_request_succeeds(self):
-        """The allocation lock prevents concurrent over-germination."""
+    def test_simultaneous_germination_requests_both_succeed(self):
+        """A seed count of one does not reject a second observed seedling."""
         with ThreadPoolExecutor(max_workers=2) as executor:
             statuses = list(executor.map(
                 lambda _index: self._record_germination(),
                 range(2),
             ))
 
-        self.assertEqual(sorted(statuses), [201, 400])
-        self.assertEqual(self.cell_planting.specific_plants.count(), 1)
+        self.assertEqual(statuses, [201, 201])
+        self.assertEqual(self.cell_planting.specific_plants.count(), 2)

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -107,6 +107,43 @@ class TransplantOwnershipCurrentViewTests(TestCase):
         self.assertEqual(garden_plantings[0]['specific_plant_pk'], plant.pk)
         self.assertEqual(garden_plantings[0]['transplanting_pk'], location.pk)
 
+    def test_seed_tray_summary_counts_distinct_multigerm_plants(self):
+        """Repeated garden history does not inflate observed plant totals."""
+        self.planting.quantity = 2
+        self.planting.save(update_fields=['quantity'])
+        cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=self.planting,
+            cell=self.cell,
+            quantity=2,
+        )
+        plants = [
+            make_specific_plant(cell_planting=cell_planting)
+            for _index in range(5)
+        ]
+        for plant in plants:
+            SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                location_type=SpecificPlantLocation.GARDEN_SQUARE,
+                garden_square=self.square,
+                started=datetime(2026, 1, 1, tzinfo=datetime_timezone.utc),
+                ended=datetime(2026, 1, 2, tzinfo=datetime_timezone.utc),
+            )
+        SpecificPlantLocation.objects.create(
+            specific_plant=plants[0],
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=self.square,
+            started=datetime(2026, 1, 3, tzinfo=datetime_timezone.utc),
+        )
+        self._make_legacy_transplant()
+
+        response = self.client.get('/plantings/seedtray/current/')
+
+        self.assertEqual(response.status_code, 200)
+        summary = response.json()['plantings'][0]
+        self.assertEqual(summary['quantity'], 2)
+        self.assertEqual(summary['germinated_count'], 5)
+        self.assertEqual(summary['transplanted_count'], 5)
+
     def test_legacy_aggregate_can_still_be_completed(self):
         """The compatibility action can retire a legacy aggregate row."""
         transplant = self._make_legacy_transplant()

--- a/plantings/views.py
+++ b/plantings/views.py
@@ -31,7 +31,7 @@ def seedtray_current(request):
             specific_plant__cell_planting__seed_tray_planting__in=plantings,
         )
         .values_list('specific_plant__cell_planting__seed_tray_planting_id')
-        .annotate(total=Count('id'))
+        .annotate(total=Count('specific_plant_id', distinct=True))
     )
     germinated_counts = dict(
         SpecificPlant.objects

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -4,13 +4,17 @@ Tests related to seeds
 from plantings.models import (
     GardenSquareDirectSowPlanting,
     GardenSquareTransplant,
+    SeedTrayCellPlanting,
     SeedTrayPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
 )
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_garden_square,
     make_seed_packet,
     make_seed_tray,
+    make_seed_tray_cell,
 )
 
 
@@ -149,3 +153,50 @@ class SeedRESTContractTests(RESTContractTestCase):
                 'transplanted_count': 3,
             },
         )
+
+    def test_current_packet_summary_separates_multigerm_plants_from_seeds(self):
+        """Two sown clusters can yield five transplanted individual plants."""
+        packet = make_seed_packet(notes='Multigerm packet')
+        tray = make_seed_tray()
+        cell = make_seed_tray_cell(tray=tray)
+        square = make_garden_square()
+        planting = SeedTrayPlanting.objects.create(
+            seeds_used=packet,
+            quantity=2,
+            seed_tray=tray,
+        )
+        cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=planting,
+            cell=cell,
+            quantity=2,
+        )
+        plants = SpecificPlant.objects.bulk_create([
+            SpecificPlant(cell_planting=cell_planting)
+            for _index in range(5)
+        ])
+        SpecificPlantLocation.objects.bulk_create([
+            SpecificPlantLocation(
+                specific_plant=plant,
+                location_type=SpecificPlantLocation.GARDEN_SQUARE,
+                garden_square=square,
+            )
+            for plant in plants
+        ])
+        legacy = GardenSquareTransplant.objects.create(
+            original_planting=planting,
+            quantity=5,
+            location=square,
+        )
+        self.client.force_login(self.user)
+
+        for delete_legacy in (False, True):
+            with self.subTest(legacy_present=not delete_legacy):
+                if delete_legacy:
+                    legacy.delete()
+                response = self.client.get('/seeds/packets/current/')
+                summary = next(
+                    item for item in response.json()['packets']
+                    if item['pk'] == packet.pk
+                )
+                self.assertEqual(summary['seeds_planted_trays'], 2)
+                self.assertEqual(summary['transplanted_count'], 5)

--- a/seeds/views.py
+++ b/seeds/views.py
@@ -3,13 +3,19 @@ Views for seeds
 """
 
 from django.contrib.auth.decorators import login_required
-from django.db.models import IntegerField, OuterRef, Subquery, Sum, Value
+from django.db.models import Count, IntegerField, OuterRef, Subquery, Sum, Value
 from django.db.models.functions import Coalesce
 from django.http import HttpResponse, HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import get_object_or_404
 
 from gp.utils import get_request_data
-from plantings.models import SeedTrayPlanting, GardenSquareDirectSowPlanting, GardenSquareTransplant
+from plantings.models import (
+    GardenSquareDirectSowPlanting,
+    GardenSquareTransplant,
+    SeedTrayPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
 
 from .models import SeedPacket
 
@@ -32,22 +38,62 @@ def coalesced_sum(model, lookup):
     return Coalesce(Subquery(subq, output_field=IntegerField()), Value(0))
 
 
+def get_transplanted_counts(packet_ids):
+    """Count distinct plants per packet, with legacy fallback per sowing."""
+    individual_counts = {
+        planting_id: (packet_id, count)
+        for planting_id, packet_id, count in (
+            SpecificPlant.objects
+            .filter(
+                cell_planting__seed_tray_planting__seeds_used_id__in=packet_ids,
+                locations__location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            )
+            .values_list(
+                'cell_planting__seed_tray_planting_id',
+                'cell_planting__seed_tray_planting__seeds_used_id',
+            )
+            .annotate(total=Count('pk', distinct=True))
+        )
+    }
+    legacy_counts = {
+        planting_id: (packet_id, count)
+        for planting_id, packet_id, count in (
+            GardenSquareTransplant.objects
+            .filter(original_planting__seeds_used_id__in=packet_ids)
+            .values_list(
+                'original_planting_id',
+                'original_planting__seeds_used_id',
+            )
+            .annotate(total=Sum('quantity'))
+        )
+    }
+
+    transplanted_counts = dict.fromkeys(packet_ids, 0)
+    for planting_id in individual_counts.keys() | legacy_counts.keys():
+        if planting_id in individual_counts:
+            packet_id, count = individual_counts[planting_id]
+        else:
+            packet_id, count = legacy_counts[planting_id]
+        transplanted_counts[packet_id] += count
+    return transplanted_counts
+
+
 @login_required
 def packets_current(request):
     """
     List the seed packets that are not empty
     """
-    packets = (
+    packets = list(
         SeedPacket.objects
         .select_related('seeds', 'seeds__plant_variety', 'seeds__plant_variety__plant', 'seeds__supplier')
         .filter(empty=False)
         .annotate(
             seeds_planted_trays=coalesced_sum(SeedTrayPlanting, 'seeds_used'),
             seeds_planted_direct=coalesced_sum(GardenSquareDirectSowPlanting, 'seeds_used'),
-            transplanted_count=coalesced_sum(GardenSquareTransplant, 'original_planting__seeds_used'),
         )
         .order_by('seeds__plant_variety__plant__name', 'seeds__plant_variety__name')
     )
+    transplanted_counts = get_transplanted_counts([packet.pk for packet in packets])
     packet_data = [
         {
             'pk': packet.pk,
@@ -59,7 +105,7 @@ def packets_current(request):
             'notes': packet.notes,
             'seeds_planted_trays': packet.seeds_planted_trays,
             'seeds_planted_direct': packet.seeds_planted_direct,
-            'transplanted_count': packet.transplanted_count,
+            'transplanted_count': transplanted_counts[packet.pk],
         }
         for packet in packets
     ]


### PR DESCRIPTION
Seed quantities describe sown seeds or clusters, so they cannot cap observed seedlings. Keep allocation accounting intact while making individual plants authoritative in tray and packet transplant summaries.

## Summary by Sourcery

Allow multigerm seedlings to exceed sown seed allocation while making individual plants authoritative for tray and packet transplant summaries.

Bug Fixes:
- Correct transplanted counts for seed packets and seed tray summaries to be based on distinct specific plants instead of seed quantities or repeated history.
- Relax capacity validation so observed germination is no longer incorrectly capped by cell seed allocations, including under concurrent requests.

Enhancements:
- Treat seed quantities as sowing allocations only, decoupled from observed seedling capacity across tray and packet summaries.
- Refine deployment audit to focus solely on over-allocated seed tray sowing quantities rather than germination counts.
- Ensure legacy aggregate transplant rows coexist correctly with individual plant records when summarizing current usage.

Tests:
- Update and extend planting, seeds, concurrency, and migration tests to cover multigerm behavior, new counting rules, and the relaxed capacity constraints.