### PR TITLE
feat(plantings): recover legacy transplant history

### DIFF
--- a/plantings/management/__init__.py
+++ b/plantings/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for planting data."""

--- a/plantings/management/commands/__init__.py
+++ b/plantings/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Planting management commands."""

--- a/plantings/management/commands/convert_legacy_transplant.py
+++ b/plantings/management/commands/convert_legacy_transplant.py
@@ -1,0 +1,288 @@
+"""Convert one legacy aggregate transplant into individual plant history."""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from plantings.models import (
+    GardenSquareTransplant,
+    SeedTrayCellPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
+
+
+class Command(BaseCommand):
+    """Preview or apply one explicit legacy-transplant conversion."""
+
+    help = (
+        'Convert one GardenSquareTransplant into individual SpecificPlant '
+        'location histories. The command is a dry run unless --apply is used.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('transplant_id', type=int)
+        parser.add_argument(
+            '--cell-planting',
+            type=int,
+            help='Source SeedTrayCellPlanting ID for newly recovered plants.',
+        )
+        parser.add_argument(
+            '--germinated-at',
+            help='Timezone-aware ISO-8601 germination time for new plants.',
+        )
+        parser.add_argument(
+            '--existing-plant',
+            action='append',
+            default=[],
+            type=int,
+            help=(
+                'SpecificPlant ID already included in the aggregate total. '
+                'Repeat for each existing plant.'
+            ),
+        )
+        parser.add_argument(
+            '--apply',
+            action='store_true',
+            dest='apply_changes',
+            help='Apply the conversion; without this flag, only preview it.',
+        )
+
+    def handle(self, *args, **options):
+        with transaction.atomic():
+            transplant = self._get_transplant(
+                options['transplant_id'],
+                for_update=options['apply_changes'],
+            )
+            self._describe_transplant(transplant)
+            self._validate_active(transplant)
+
+            if not options['cell_planting'] or not options['germinated_at']:
+                raise CommandError(
+                    'Choose --cell-planting and --germinated-at, then rerun '
+                    'the command. Add --apply only after reviewing the preview.'
+                )
+
+            cell_planting = self._get_cell_planting(
+                options['cell_planting'],
+                transplant,
+                for_update=options['apply_changes'],
+            )
+            germinated_at = self._parse_germinated_at(
+                options['germinated_at'],
+                transplant,
+            )
+            existing_plants = self._get_existing_plants(
+                options['existing_plant'],
+                transplant,
+                for_update=options['apply_changes'],
+            )
+            new_plant_count = self._describe_conversion(
+                transplant,
+                cell_planting,
+                germinated_at,
+                existing_plants,
+            )
+
+            if not options['apply_changes']:
+                self.stdout.write(self.style.WARNING(
+                    'Dry run only: no rows were changed. Rerun with --apply '
+                    'to perform this conversion.'
+                ))
+                return
+
+            self._apply_conversion(
+                transplant,
+                cell_planting,
+                germinated_at,
+                new_plant_count,
+            )
+            self.stdout.write(self.style.SUCCESS(
+                f'Converted and deleted GardenSquareTransplant '
+                f'#{options["transplant_id"]}.'
+            ))
+
+    @staticmethod
+    def _get_transplant(transplant_id, *, for_update):
+        queryset = GardenSquareTransplant.objects.select_related(
+            'original_planting__seeds_used__seeds__plant_variety__plant',
+            'location__bed__area',
+        )
+        if for_update:
+            queryset = queryset.select_for_update()
+        try:
+            return queryset.get(pk=transplant_id)
+        except GardenSquareTransplant.DoesNotExist as exc:
+            raise CommandError(
+                f'GardenSquareTransplant #{transplant_id} does not exist.'
+            ) from exc
+
+    def _describe_transplant(self, transplant):
+        planting = transplant.original_planting
+        variety = planting.seeds_used.seeds.plant_variety
+        square = transplant.location
+        self.stdout.write(f'Legacy transplant: #{transplant.pk}')
+        self.stdout.write(f'Plant: {variety.plant.name}')
+        self.stdout.write(f'Variety: {variety.name}')
+        self.stdout.write(f'Original planting: #{planting.pk}')
+        self.stdout.write(f'Target quantity: {transplant.quantity}')
+        self.stdout.write(f'Transplanted at: {transplant.transplanted.isoformat()}')
+        self.stdout.write(
+            f'Garden: {square.bed.area.name} / {square.bed.name} / {square.name} '
+            f'(square #{square.pk})'
+        )
+        self.stdout.write('Available source allocations:')
+        allocations = planting.cell_plantings.select_related(
+            'cell__tray__model',
+        ).order_by('pk')
+        if not allocations:
+            self.stdout.write('  none')
+        for allocation in allocations:
+            cell = allocation.cell
+            self.stdout.write(
+                f'  #{allocation.pk}: tray #{cell.tray_id} '
+                f'({cell.tray.model.identifier}), cell #{cell.pk} '
+                f'({cell.x_position}, {cell.y_position}), '
+                f'{allocation.quantity} sown, '
+                f'{allocation.specific_plants.count()} plants observed'
+            )
+
+    @staticmethod
+    def _validate_active(transplant):
+        if transplant.removed:
+            raise CommandError(
+                'Removed legacy transplants cannot be converted because no '
+                'truthful garden-location end time was recorded.'
+            )
+
+    @staticmethod
+    def _get_cell_planting(cell_planting_id, transplant, *, for_update):
+        queryset = SeedTrayCellPlanting.objects.select_related('cell__tray__model')
+        if for_update:
+            queryset = queryset.select_for_update()
+        try:
+            cell_planting = queryset.get(pk=cell_planting_id)
+        except SeedTrayCellPlanting.DoesNotExist as exc:
+            raise CommandError(
+                f'SeedTrayCellPlanting #{cell_planting_id} does not exist.'
+            ) from exc
+        if cell_planting.seed_tray_planting_id != transplant.original_planting_id:
+            raise CommandError(
+                f'SeedTrayCellPlanting #{cell_planting_id} does not belong to '
+                f'original planting #{transplant.original_planting_id}.'
+            )
+        return cell_planting
+
+    @staticmethod
+    def _parse_germinated_at(value, transplant):
+        germinated_at = parse_datetime(value)
+        if germinated_at is None or timezone.is_naive(germinated_at):
+            raise CommandError(
+                '--germinated-at must be a timezone-aware ISO-8601 datetime.'
+            )
+        planting = transplant.original_planting
+        if germinated_at < planting.planted:
+            raise CommandError(
+                '--germinated-at cannot be before the original sowing time.'
+            )
+        if germinated_at > transplant.transplanted:
+            raise CommandError(
+                '--germinated-at cannot be after the transplant time.'
+            )
+        return germinated_at
+
+    @staticmethod
+    def _get_existing_plants(plant_ids, transplant, *, for_update):
+        if len(plant_ids) != len(set(plant_ids)):
+            raise CommandError('--existing-plant IDs must be unique.')
+        if len(plant_ids) > transplant.quantity:
+            raise CommandError(
+                'Existing plant count cannot exceed the aggregate target quantity.'
+            )
+
+        queryset = SpecificPlant.objects.filter(pk__in=plant_ids)
+        if for_update:
+            queryset = queryset.select_for_update()
+        plants_by_id = {plant.pk: plant for plant in queryset}
+        missing_ids = sorted(set(plant_ids) - plants_by_id.keys())
+        if missing_ids:
+            raise CommandError(
+                f'SpecificPlant IDs do not exist: {missing_ids}.'
+            )
+
+        plants = [plants_by_id[plant_id] for plant_id in plant_ids]
+        for plant in plants:
+            if (
+                plant.cell_planting.seed_tray_planting_id
+                != transplant.original_planting_id
+            ):
+                raise CommandError(
+                    f'SpecificPlant #{plant.pk} does not belong to original '
+                    f'planting #{transplant.original_planting_id}.'
+                )
+            has_matching_history = plant.locations.filter(
+                location_type=SpecificPlantLocation.GARDEN_SQUARE,
+                garden_square_id=transplant.location_id,
+            ).exists()
+            if not has_matching_history:
+                raise CommandError(
+                    f'SpecificPlant #{plant.pk} has no garden history in '
+                    f'square #{transplant.location_id}.'
+                )
+        return plants
+
+    def _describe_conversion(
+        self,
+        transplant,
+        cell_planting,
+        germinated_at,
+        existing_plants,
+    ):
+        new_plant_count = transplant.quantity - len(existing_plants)
+        cell = cell_planting.cell
+        existing_ids = [plant.pk for plant in existing_plants]
+        self.stdout.write(
+            f'Source: allocation #{cell_planting.pk}, tray #{cell.tray_id}, '
+            f'cell #{cell.pk} ({cell.x_position}, {cell.y_position})'
+        )
+        self.stdout.write(f'Germinated at: {germinated_at.isoformat()}')
+        self.stdout.write(f'Existing plants in target: {existing_ids}')
+        self.stdout.write(f'New plants to create: {new_plant_count}')
+        self.stdout.write(
+            f'Legacy aggregate to delete after conversion: #{transplant.pk}'
+        )
+        return new_plant_count
+
+    @staticmethod
+    def _apply_conversion(
+        transplant,
+        cell_planting,
+        germinated_at,
+        new_plant_count,
+    ):
+        recovery_note = (
+            f'Recovered from legacy GardenSquareTransplant #{transplant.pk}.'
+        )
+        for _index in range(new_plant_count):
+            plant = SpecificPlant.objects.create(
+                cell_planting=cell_planting,
+                germinated=germinated_at,
+                notes=recovery_note,
+            )
+            SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+                seed_tray_cell=cell_planting.cell,
+                started=germinated_at,
+                ended=transplant.transplanted,
+                notes=recovery_note,
+            )
+            SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                location_type=SpecificPlantLocation.GARDEN_SQUARE,
+                garden_square=transplant.location,
+                started=transplant.transplanted,
+                notes=transplant.notes,
+            )
+        transplant.delete()

--- a/plantings/migrations/0016_audit_transplant_ownership.py
+++ b/plantings/migrations/0016_audit_transplant_ownership.py
@@ -22,7 +22,10 @@ def audit_transplant_ownership(apps, _schema_editor):
         raise RuntimeError(
             'Transplant ownership audit failed. Repair aggregate '
             'GardenSquareTransplant rows that overlap individual garden '
-            'locations before retrying the migration. Conflicting '
+            'locations before retrying the migration. Inspect each row with '
+            '`python manage.py convert_legacy_transplant ID`, preview its '
+            'conversion with the requested source and history arguments, then '
+            'rerun with `--apply`. Conflicting '
             'GardenSquareTransplant IDs: '
             f'{describe_rows(conflicting_transplants)}'
         )

--- a/plantings/test_management_commands.py
+++ b/plantings/test_management_commands.py
@@ -1,0 +1,214 @@
+"""Tests for planting data-recovery management commands."""
+
+from datetime import datetime, timezone as datetime_timezone
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import IntegrityError
+from django.test import TestCase
+
+from tests.factories import (
+    make_garden_square,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+)
+from .models import (
+    GardenSquareTransplant,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
+
+
+class ConvertLegacyTransplantTests(TestCase):  # pylint: disable=too-many-instance-attributes
+    """Legacy aggregate conversion is explicit, inspectable, and atomic."""
+
+    def setUp(self):
+        self.planted_at = datetime(
+            2026, 1, 1, 8, 0, tzinfo=datetime_timezone.utc,
+        )
+        self.germinated_at = datetime(
+            2026, 1, 5, 8, 0, tzinfo=datetime_timezone.utc,
+        )
+        self.transplanted_at = datetime(
+            2026, 2, 1, 8, 0, tzinfo=datetime_timezone.utc,
+        )
+        self.cell = make_seed_tray_cell()
+        self.planting = make_seed_tray_planting(
+            seed_tray=self.cell.tray,
+            planted=self.planted_at,
+            quantity=2,
+        )
+        self.cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=self.planting,
+            cell=self.cell,
+            quantity=2,
+        )
+        self.square = make_garden_square()
+        self.transplant = GardenSquareTransplant.objects.create(
+            original_planting=self.planting,
+            transplanted=self.transplanted_at,
+            quantity=5,
+            location=self.square,
+            notes='Legacy transplant notes',
+        )
+
+    def _command_options(self, **overrides):
+        options = {
+            'cell_planting': self.cell_planting.pk,
+            'germinated_at': self.germinated_at.isoformat(),
+        }
+        options.update(overrides)
+        return options
+
+    def _make_existing_plant(self):
+        plant = make_specific_plant(cell_planting=self.cell_planting)
+        SpecificPlantLocation.objects.create(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=self.square,
+        )
+        return plant
+
+    def test_inspection_lists_labels_and_source_allocations(self):
+        """An incomplete invocation gives the operator actionable context."""
+        output = StringIO()
+
+        with self.assertRaisesMessage(CommandError, 'Choose --cell-planting'):
+            call_command(
+                'convert_legacy_transplant',
+                self.transplant.pk,
+                stdout=output,
+            )
+
+        details = output.getvalue()
+        variety = self.planting.seeds_used.seeds.plant_variety
+        self.assertIn(f'Plant: {variety.plant.name}', details)
+        self.assertIn(f'Variety: {variety.name}', details)
+        self.assertIn(self.square.bed.area.name, details)
+        self.assertIn(self.square.bed.name, details)
+        self.assertIn(self.square.name, details)
+        self.assertIn(f'#{self.cell_planting.pk}: tray', details)
+
+    def test_default_mode_previews_without_writing(self):
+        """Supplying a valid mapping remains non-mutating without --apply."""
+        output = StringIO()
+
+        call_command(
+            'convert_legacy_transplant',
+            self.transplant.pk,
+            stdout=output,
+            **self._command_options(),
+        )
+
+        self.assertIn('New plants to create: 5', output.getvalue())
+        self.assertIn('Dry run only', output.getvalue())
+        self.assertTrue(
+            GardenSquareTransplant.objects.filter(pk=self.transplant.pk).exists()
+        )
+        self.assertFalse(SpecificPlant.objects.exists())
+
+    def test_apply_uses_existing_plants_to_reach_total_target(self):
+        """Only the missing individuals are created before deleting the aggregate."""
+        existing_plants = [self._make_existing_plant() for _index in range(2)]
+        existing_location_ids = set(
+            SpecificPlantLocation.objects.values_list('pk', flat=True)
+        )
+
+        call_command(
+            'convert_legacy_transplant',
+            self.transplant.pk,
+            apply_changes=True,
+            existing_plant=[plant.pk for plant in existing_plants],
+            **self._command_options(),
+        )
+
+        self.assertFalse(
+            GardenSquareTransplant.objects.filter(pk=self.transplant.pk).exists()
+        )
+        self.assertEqual(SpecificPlant.objects.count(), 5)
+        self.assertEqual(
+            SpecificPlantLocation.objects.exclude(
+                pk__in=existing_location_ids,
+            ).count(),
+            6,
+        )
+        recovered_plants = SpecificPlant.objects.exclude(
+            pk__in=[plant.pk for plant in existing_plants],
+        )
+        for plant in recovered_plants:
+            self.assertEqual(plant.germinated, self.germinated_at)
+            locations = list(plant.locations.order_by('started'))
+            self.assertEqual(len(locations), 2)
+            self.assertEqual(locations[0].seed_tray_cell, self.cell)
+            self.assertEqual(locations[0].ended, self.transplanted_at)
+            self.assertEqual(locations[1].garden_square, self.square)
+            self.assertIsNone(locations[1].ended)
+            self.assertEqual(locations[1].notes, self.transplant.notes)
+
+    def test_invalid_source_allocation_leaves_everything_unchanged(self):
+        """A source from another sowing is rejected before any conversion."""
+        other_cell_planting = make_seed_tray_cell_planting()
+
+        with self.assertRaisesMessage(CommandError, 'does not belong'):
+            call_command(
+                'convert_legacy_transplant',
+                self.transplant.pk,
+                apply_changes=True,
+                **self._command_options(
+                    cell_planting=other_cell_planting.pk,
+                ),
+            )
+
+        self.assertTrue(
+            GardenSquareTransplant.objects.filter(pk=self.transplant.pk).exists()
+        )
+        self.assertFalse(SpecificPlant.objects.exists())
+
+    def test_existing_plant_requires_matching_square_history(self):
+        """Explicit overlap IDs cannot silently refer to another destination."""
+        plant = make_specific_plant(cell_planting=self.cell_planting)
+
+        with self.assertRaisesMessage(CommandError, 'has no garden history'):
+            call_command(
+                'convert_legacy_transplant',
+                self.transplant.pk,
+                existing_plant=[plant.pk],
+                **self._command_options(),
+            )
+
+    def test_removed_transplant_is_rejected(self):
+        """The command does not invent an end time for completed history."""
+        self.transplant.removed = True
+        self.transplant.save(update_fields=['removed'])
+
+        with self.assertRaisesMessage(CommandError, 'no truthful'):
+            call_command(
+                'convert_legacy_transplant',
+                self.transplant.pk,
+                **self._command_options(),
+            )
+
+    def test_apply_rolls_back_when_aggregate_delete_fails(self):
+        """No partial individual history survives a failed final deletion."""
+        with mock.patch.object(
+            GardenSquareTransplant,
+            'delete',
+            side_effect=IntegrityError('simulated delete failure'),
+        ):
+            with self.assertRaises(IntegrityError):
+                call_command(
+                    'convert_legacy_transplant',
+                    self.transplant.pk,
+                    apply_changes=True,
+                    **self._command_options(),
+                )
+
+        self.assertTrue(
+            GardenSquareTransplant.objects.filter(pk=self.transplant.pk).exists()
+        )
+        self.assertFalse(SpecificPlant.objects.exists())
+        self.assertFalse(SpecificPlantLocation.objects.exists())


### PR DESCRIPTION
Ambiguous aggregate transplants need operator-supplied source and overlap data before they can become individual plant histories. Provide a dry-run-first atomic command and point migration failures to it.

## Summary by Sourcery

Introduce an explicit management command to convert legacy aggregate garden-square transplants into individual plant histories with a dry-run-first, atomic workflow, and point the transplant ownership audit migration at this recovery path.

New Features:
- Add the convert_legacy_transplant management command to preview and apply recovery of legacy GardenSquareTransplant aggregates into SpecificPlant location histories.

Enhancements:
- Improve the transplant ownership audit migration error message to guide operators to the conversion command for resolving conflicting aggregate transplants.

Tests:
- Add unit tests for the convert_legacy_transplant management command covering inspection output, dry-run behavior, successful conversion, validation failures, and transactional rollback semantics.