### PR TITLE
fix(frontend): show multigerm counts clearly

### DIFF
--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -269,7 +269,8 @@ class SeedTrayPlantingRow extends React.Component<SeedTrayPlantingRowProps> {
           {this.props.planting.plant} - {this.props.planting.variety}
         </td>
         <td>
-          {this.props.planting.quantity} (<span title="Number that have germinated">Germinated: {this.props.planting.germinated_count}</span>,{' '}
+          <span title="Number of seeds or seed clusters sown">Sown: {this.props.planting.quantity}</span> (
+          <span title="Number of individual plants that have germinated">Germinated: {this.props.planting.germinated_count}</span>,{' '}
           <span title="Number that have been transplanted to a garden square">Transplanted: {this.props.planting.transplanted_count}</span>)
         </td>
         <td>{formatDate(this.props.planting.planted)}</td>
@@ -371,7 +372,7 @@ function SeedTrayPlantingTable() {
               +
             </a>
           </td>
-          <td>Quantity</td>
+          <td>Seeds / clusters sown</td>
           <td>Date</td>
           <td>Seed Tray</td>
           <td>Location</td>

--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -504,7 +504,7 @@ class SeedPacketRow extends React.Component<SeedPacketRowProps> {
         <td>{this.props.seedPacket.sow_by}</td>
         <td>{this.props.seedPacket.seeds_planted_direct}</td>
         <td>
-          {this.props.seedPacket.transplanted_count}/{this.props.seedPacket.seeds_planted_trays}
+          {this.props.seedPacket.transplanted_count} plants / {this.props.seedPacket.seeds_planted_trays} sown
         </td>
         <td>{this.props.seedPacket.notes}</td>
         <td>
@@ -566,7 +566,7 @@ function SeedStockTable() {
           <td>Purchase Date</td>
           <td>Sow By</td>
           <td>Direct Planted</td>
-          <td>Transplanted/Seed Tray</td>
+          <td>Transplanted plants / seeds or clusters sown in trays</td>
           <td>Notes</td>
           <td>
             <a href="#" onClick={() => setShowSeedPacketAdd(true)}>

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -126,8 +126,8 @@ const SeedTrayCellView: React.FC<SeedTrayCellViewProps> = ({
   return (
     <td style={{ textAlign: 'center', minWidth: 70, verticalAlign: 'top' }}>
       <div>{cell?.pk ?? ''}</div>
-      <div style={{ fontWeight: 'bold' }}>{cell ? total || 0 : ''}</div>
-      {cell && totalGerminated > 0 && <div style={{ color: 'green', fontSize: '0.85em' }}>{totalGerminated} germinated</div>}
+      {cell && <div style={{ fontWeight: 'bold' }}>{total || 0} sown</div>}
+      {cell && <div style={{ color: 'green', fontSize: '0.85em' }}>{totalGerminated} germinated</div>}
       {plants.map((plant) => {
         const loc = currentLocation(plant)
         const sortedLocations = [...plant.locations].sort((a, b) => new Date(a.started).getTime() - new Date(b.started).getTime())
@@ -154,21 +154,17 @@ const SeedTrayCellView: React.FC<SeedTrayCellViewProps> = ({
         )
       })}
       {cell &&
-        entries.map((entry) => {
-          const germinated = germinatedByCellPlanting[entry.cellPlantingPk] ?? 0
-          if (germinated >= entry.quantity) return null
-          return (
-            <Button
-              key={entry.cellPlantingPk}
-              size="sm"
-              variant={germinatingCellPlantingPk === entry.cellPlantingPk ? 'success' : 'outline-success'}
-              style={{ fontSize: '0.75em', padding: '1px 4px', marginTop: 4 }}
-              onClick={() => onToggleGermination(entry.cellPlantingPk)}
-            >
-              + Germination{entries.length > 1 ? ` (#${entry.cellPlantingPk})` : ''}
-            </Button>
-          )
-        })}
+        entries.map((entry) => (
+          <Button
+            key={entry.cellPlantingPk}
+            size="sm"
+            variant={germinatingCellPlantingPk === entry.cellPlantingPk ? 'success' : 'outline-success'}
+            style={{ fontSize: '0.75em', padding: '1px 4px', marginTop: 4 }}
+            onClick={() => onToggleGermination(entry.cellPlantingPk)}
+          >
+            + Germination{entries.length > 1 ? ` (#${entry.cellPlantingPk})` : ''}
+          </Button>
+        ))}
     </td>
   )
 }
@@ -491,7 +487,7 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
           <tr>
             <th>Planting ID</th>
             <th>Planted On</th>
-            <th>Quantity</th>
+            <th>Seeds / clusters sown</th>
             <th>Seeds Used</th>
             <th>Notes</th>
             <th>Removed</th>
@@ -504,7 +500,7 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
               <tr key={planting.pk}>
                 <td>{planting.pk}</td>
                 <td>{formatDate(planting.planted)}</td>
-                <td>{planting.quantity}</td>
+                <td>{planting.quantity} sown</td>
                 <td>
                   {packet?.plant} - {packet?.variety}
                 </td>


### PR DESCRIPTION
Operators need to distinguish seeds or clusters sown from individual plants observed. Keep germination available beyond the sowing quantity and label each count by its domain meaning.

## Summary by Sourcery

Clarify seed tray UI so operators can distinguish sown seeds/clusters from germinated plants and track germination beyond the original sowing quantity.

Enhancements:
- Label cell totals explicitly as seeds or clusters sown and always show germination counts for each cell.
- Update planting and seed tray tables to describe quantities as seeds/clusters sown versus individual plants germinated or transplanted.
- Improve seed stock views to display transplanted plants separately from seeds or clusters sown in trays.