### PR TITLE
feat(workspaces): add deployment profile foundation

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -4,6 +4,6 @@ source venv/bin/activate
 
 pycodestyle --ignore=E501 */*.py
 
-pylint frontend/ garden/ plantings/ plants/ seeds/ seedtrays/ supplies/
+pylint frontend/ garden/ plantings/ plants/ seeds/ seedtrays/ supplies/ workspaces/
 
 deactivate

--- a/gp/settings.py
+++ b/gp/settings.py
@@ -41,6 +41,7 @@ if not SECRET_KEY:
 # Application definition
 
 INSTALLED_APPS = [
+    "workspaces",
     "plants",
     "seeds",
     "garden",
@@ -131,6 +132,10 @@ STATIC_ROOT = BASE_DIR / "static"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGIN_REDIRECT_URL = "/"
+
+# The initial deployment deliberately exposes one shared workspace to every
+# authenticated user. Tests may create other workspaces to verify isolation.
+CURRENT_WORKSPACE_ID = globals().get("CURRENT_WORKSPACE_ID", 1)
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (

--- a/gp/urls.py
+++ b/gp/urls.py
@@ -21,6 +21,7 @@ from django.urls import path, include
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("accounts/", include('django.contrib.auth.urls')),
+    path("settings/", include('workspaces.urls')),
     path("", include('frontend.urls')),
     path("plants/", include('plants.urls')),
     path("garden/", include('garden.urls')),

--- a/workspaces/__init__.py
+++ b/workspaces/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace ownership and deployment profile support."""

--- a/workspaces/admin.py
+++ b/workspaces/admin.py
@@ -12,7 +12,8 @@ class WorkspaceAdmin(admin.ModelAdmin):
     list_display = ('name', 'mode', 'currency_code', 'timezone', 'updated')
 
     def has_add_permission(self, request):
-        return not Workspace.objects.exists() and super().has_add_permission(request)
+        """Keep workspace provisioning outside concurrent admin requests."""
+        return False
 
     def has_delete_permission(self, request, obj=None):
         return False

--- a/workspaces/admin.py
+++ b/workspaces/admin.py
@@ -1,0 +1,18 @@
+"""Admin support for the deployment workspace."""
+
+from django.contrib import admin
+
+from .models import Workspace
+
+
+@admin.register(Workspace)
+class WorkspaceAdmin(admin.ModelAdmin):
+    """Allow the one deployment workspace to be configured safely."""
+
+    list_display = ('name', 'mode', 'currency_code', 'timezone', 'updated')
+
+    def has_add_permission(self, request):
+        return not Workspace.objects.exists() and super().has_add_permission(request)
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/workspaces/apps.py
+++ b/workspaces/apps.py
@@ -1,0 +1,10 @@
+"""Django application configuration for workspaces."""
+
+from django.apps import AppConfig
+
+
+class WorkspacesConfig(AppConfig):
+    """Configure the workspace application."""
+
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'workspaces'

--- a/workspaces/current.py
+++ b/workspaces/current.py
@@ -1,0 +1,17 @@
+"""Resolve the deployment's configured workspace."""
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from .models import Workspace
+
+
+def get_current_workspace():
+    """Return the single workspace configured for this deployment."""
+    workspace_id = settings.CURRENT_WORKSPACE_ID
+    try:
+        return Workspace.objects.get(pk=workspace_id)
+    except Workspace.DoesNotExist as exc:
+        raise ImproperlyConfigured(
+            f'CURRENT_WORKSPACE_ID={workspace_id} does not identify a workspace.'
+        ) from exc

--- a/workspaces/migrations/0001_initial.py
+++ b/workspaces/migrations/0001_initial.py
@@ -1,0 +1,53 @@
+# Generated manually for the workspace ownership boundary.
+
+import decimal
+
+import django.core.validators
+from django.db import migrations, models
+
+import workspaces.models
+
+
+def create_default_workspace(apps, _schema_editor):
+    """Create the compatibility workspace used by existing installations."""
+    workspace_model = apps.get_model('workspaces', 'Workspace')
+    workspace_model.objects.create(
+        pk=1,
+        name='My Garden',
+        mode='garden',
+        currency_code='USD',
+        default_tax_rate=decimal.Decimal('0'),
+        timezone='UTC',
+        measurement_system='metric',
+    )
+
+
+def remove_default_workspace(apps, _schema_editor):
+    """Remove only the compatibility workspace on migration reversal."""
+    workspace_model = apps.get_model('workspaces', 'Workspace')
+    workspace_model.objects.filter(pk=1).delete()
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Workspace',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+                ('mode', models.CharField(choices=[('garden', 'Garden'), ('nursery', 'Nursery')], default='garden', max_length=16)),
+                ('currency_code', models.CharField(default='USD', max_length=3, validators=[django.core.validators.RegexValidator(message='Enter a three-letter uppercase ISO 4217 currency code.', regex='^[A-Z]{3}$')])),
+                ('default_tax_rate', models.DecimalField(decimal_places=4, default=decimal.Decimal('0'), help_text='Default tax percentage from 0 through 100.', max_digits=7, validators=[django.core.validators.MinValueValidator(decimal.Decimal('0')), django.core.validators.MaxValueValidator(decimal.Decimal('100'))])),
+                ('timezone', models.CharField(default='UTC', max_length=64, validators=[workspaces.models.validate_iana_timezone])),
+                ('measurement_system', models.CharField(choices=[('metric', 'Metric'), ('imperial', 'Imperial')], default='metric', max_length=16)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.RunPython(create_default_workspace, remove_default_workspace),
+    ]

--- a/workspaces/migrations/0001_initial.py
+++ b/workspaces/migrations/0001_initial.py
@@ -11,8 +11,12 @@ import workspaces.models
 def create_default_workspace(apps, _schema_editor):
     """Create the compatibility workspace used by existing installations."""
     workspace_model = apps.get_model('workspaces', 'Workspace')
+    # This is the first row in a newly-created table, so supported databases
+    # allocate ID 1 while also advancing their sequence. Do not pass an
+    # explicit primary key: PostgreSQL would otherwise reuse 1 on the next
+    # insert. Runtime selection remains independently configurable through
+    # CURRENT_WORKSPACE_ID.
     workspace_model.objects.create(
-        pk=1,
         name='My Garden',
         mode='garden',
         currency_code='USD',

--- a/workspaces/migrations/__init__.py
+++ b/workspaces/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace database migrations."""

--- a/workspaces/models.py
+++ b/workspaces/models.py
@@ -1,0 +1,74 @@
+"""Workspace ownership and deployment profile models."""
+
+from decimal import Decimal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from django.core.exceptions import ValidationError
+from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
+from django.db import models
+
+
+def validate_iana_timezone(value):
+    """Require a timezone name understood by the system IANA database."""
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValidationError('Enter a valid IANA timezone name.') from exc
+
+
+class Workspace(models.Model):
+    """The ownership and configuration root for one deployment."""
+
+    class Mode(models.TextChoices):
+        """Supported product profiles."""
+
+        GARDEN = 'garden', 'Garden'
+        NURSERY = 'nursery', 'Nursery'
+
+    class MeasurementSystem(models.TextChoices):
+        """Supported display measurement systems."""
+
+        METRIC = 'metric', 'Metric'
+        IMPERIAL = 'imperial', 'Imperial'
+
+    name = models.CharField(max_length=255)
+    mode = models.CharField(
+        max_length=16,
+        choices=Mode.choices,
+        default=Mode.GARDEN,
+    )
+    currency_code = models.CharField(
+        max_length=3,
+        default='USD',
+        validators=[
+            RegexValidator(
+                regex=r'^[A-Z]{3}$',
+                message='Enter a three-letter uppercase ISO 4217 currency code.',
+            ),
+        ],
+    )
+    default_tax_rate = models.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        default=Decimal('0'),
+        validators=[
+            MinValueValidator(Decimal('0')),
+            MaxValueValidator(Decimal('100')),
+        ],
+        help_text='Default tax percentage from 0 through 100.',
+    )
+    timezone = models.CharField(
+        max_length=64,
+        default='UTC',
+        validators=[validate_iana_timezone],
+    )
+    measurement_system = models.CharField(
+        max_length=16,
+        choices=MeasurementSystem.choices,
+        default=MeasurementSystem.METRIC,
+    )
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name

--- a/workspaces/rest.py
+++ b/workspaces/rest.py
@@ -1,0 +1,36 @@
+"""Singleton REST interface for workspace settings."""
+
+from rest_framework import generics, serializers
+
+from .current import get_current_workspace
+from .models import Workspace
+
+
+class WorkspaceSerializer(serializers.ModelSerializer):
+    """Serialize the editable profile for the current workspace."""
+
+    class Meta:
+        model = Workspace
+        fields = [
+            'name',
+            'mode',
+            'currency_code',
+            'default_tax_rate',
+            'timezone',
+            'measurement_system',
+            'created',
+            'updated',
+        ]
+        read_only_fields = ['created', 'updated']
+
+
+class CurrentWorkspaceView(generics.RetrieveUpdateAPIView):
+    """Retrieve or partially update the deployment workspace."""
+
+    serializer_class = WorkspaceSerializer
+    http_method_names = ['get', 'patch', 'head', 'options']
+
+    def get_object(self):
+        workspace = get_current_workspace()
+        self.check_object_permissions(self.request, workspace)
+        return workspace

--- a/workspaces/tests.py
+++ b/workspaces/tests.py
@@ -4,11 +4,13 @@
 
 from decimal import Decimal
 
+from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from rest_framework.test import APITestCase
 
+from .admin import WorkspaceAdmin
 from .current import get_current_workspace
 from .models import Workspace
 
@@ -31,6 +33,16 @@ class CurrentWorkspaceTests(TestCase):
             'CURRENT_WORKSPACE_ID=9999 does not identify a workspace.',
         ):
             get_current_workspace()
+
+
+class WorkspaceAdminTests(TestCase):
+    """Admin cannot provision additional workspace rows."""
+
+    def test_admin_never_provisions_additional_workspaces(self):
+        """Concurrent admin requests cannot race to create workspace rows."""
+        workspace_admin = WorkspaceAdmin(Workspace, AdminSite())
+
+        self.assertFalse(workspace_admin.has_add_permission(request=None))
 
 
 class WorkspaceEndpointTests(APITestCase):

--- a/workspaces/tests.py
+++ b/workspaces/tests.py
@@ -1,0 +1,120 @@
+"""Tests for workspace configuration and selection."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, override_settings
+from rest_framework.test import APITestCase
+
+from .current import get_current_workspace
+from .models import Workspace
+
+
+class CurrentWorkspaceTests(TestCase):
+    """The configured ID selects one workspace deterministically."""
+
+    def test_selects_configured_workspace_when_another_exists(self):
+        """Other rows do not change the configured deployment workspace."""
+        current = Workspace.objects.get(pk=1)
+        Workspace.objects.create(name='Other workspace')
+
+        self.assertEqual(get_current_workspace(), current)
+
+    @override_settings(CURRENT_WORKSPACE_ID=9999)
+    def test_missing_configured_workspace_fails_clearly(self):
+        """A stale configured ID fails instead of leaking another workspace."""
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+            'CURRENT_WORKSPACE_ID=9999 does not identify a workspace.',
+        ):
+            get_current_workspace()
+
+
+class WorkspaceEndpointTests(APITestCase):
+    """The singleton endpoint exposes and edits only profile settings."""
+
+    url = '/settings/workspace/'
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='workspace-user')
+        self.client.force_authenticate(self.user)
+
+    def test_authentication_is_required(self):
+        """Anonymous callers cannot read deployment profile settings."""
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_returns_neutral_defaults_without_an_id(self):
+        """The profile response uses neutral migration defaults and hides IDs."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('pk', response.data)
+        self.assertNotIn('id', response.data)
+        self.assertEqual(response.data['name'], 'My Garden')
+        self.assertEqual(response.data['mode'], 'garden')
+        self.assertEqual(response.data['currency_code'], 'USD')
+        self.assertEqual(response.data['default_tax_rate'], '0.0000')
+        self.assertEqual(response.data['timezone'], 'UTC')
+        self.assertEqual(response.data['measurement_system'], 'metric')
+
+    def test_patch_updates_editable_settings(self):
+        """Authenticated users share the ability to update the profile."""
+        response = self.client.patch(
+            self.url,
+            {
+                'name': 'Propagation House',
+                'mode': 'nursery',
+                'currency_code': 'NZD',
+                'default_tax_rate': '15.0000',
+                'timezone': 'Pacific/Auckland',
+                'measurement_system': 'metric',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        workspace = Workspace.objects.get(pk=1)
+        self.assertEqual(workspace.name, 'Propagation House')
+        self.assertEqual(workspace.mode, Workspace.Mode.NURSERY)
+        self.assertEqual(workspace.currency_code, 'NZD')
+        self.assertEqual(workspace.default_tax_rate, Decimal('15'))
+        self.assertEqual(workspace.timezone, 'Pacific/Auckland')
+
+    def test_patch_validates_profile_fields(self):
+        """Invalid profile values receive field-specific errors."""
+        response = self.client.patch(
+            self.url,
+            {
+                'mode': 'retail',
+                'currency_code': 'nzd',
+                'default_tax_rate': '101',
+                'timezone': 'Middle/Earth',
+                'measurement_system': 'mixed',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            set(response.data),
+            {
+                'mode',
+                'currency_code',
+                'default_tax_rate',
+                'timezone',
+                'measurement_system',
+            },
+        )
+
+    def test_put_post_and_delete_are_not_supported(self):
+        """The singleton resource supports partial updates only."""
+        for method in ('put', 'post', 'delete'):
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(self.url, {}, format='json')
+                self.assertEqual(response.status_code, 405)

--- a/workspaces/urls.py
+++ b/workspaces/urls.py
@@ -1,0 +1,10 @@
+"""URL routing for workspace settings."""
+
+from django.urls import path
+
+from .rest import CurrentWorkspaceView
+
+
+urlpatterns = [
+    path('workspace/', CurrentWorkspaceView.as_view(), name='current-workspace'),
+]


### PR DESCRIPTION
Authenticated users need one deterministic configuration root before domain records can be isolated. Add the workspace model, singleton resolver and settings endpoint with safe neutral defaults.

## Summary by Sourcery

Introduce a workspace ownership and deployment profile foundation with a single configured deployment workspace and authenticated settings endpoint.

New Features:
- Add a Workspace model and initial migration establishing a single deployment-wide workspace with neutral default profile settings.
- Expose a singleton REST endpoint at /settings/workspace/ for authenticated users to read and partially update the deployment profile without leaking identifiers.
- Provide a resolver that deterministically selects the configured current workspace from settings, failing clearly if misconfigured.

Enhancements:
- Register the Workspace model in the Django admin with guarded add/delete permissions to maintain a single safe deployment workspace boundary.
- Wire the workspaces app into the Django project settings, URLs, and code-style checks.

Tests:
- Add unit and API tests covering current workspace resolution, authentication requirements, default profile responses, field validation, and allowed HTTP methods for the workspace settings endpoint.