### PR TITLE
feat(models): establish workspace ownership

### DIFF
--- a/garden/migrations/0005_workspace_ownership.py
+++ b/garden/migrations/0005_workspace_ownership.py
@@ -1,0 +1,58 @@
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+from django.db.models import F
+
+
+OWNED_MODELS = ('GardenArea', 'GardenBed', 'GardenRow', 'GardenSquare')
+
+
+def backfill_and_audit_workspace(apps, _schema_editor):
+    """Backfill ownership and reject inconsistent garden parentage."""
+    for model_name in OWNED_MODELS:
+        apps.get_model('garden', model_name).objects.update(workspace_id=1)
+
+    relationships = (
+        ('GardenBed', 'area__workspace_id'),
+        ('GardenRow', 'bed__workspace_id'),
+        ('GardenSquare', 'bed__workspace_id'),
+    )
+    for model_name, parent_workspace in relationships:
+        invalid = apps.get_model('garden', model_name).objects.exclude(
+            workspace_id=F(parent_workspace),
+        )
+        if invalid.exists():
+            raise RuntimeError(
+                'Garden workspace audit failed. Repair cross-workspace area, '
+                'bed, row, or square relationships before retrying the migration.'
+            )
+
+
+def add_workspace(model_name):
+    return migrations.AddField(
+        model_name=model_name,
+        name='workspace',
+        field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+    )
+
+
+def require_workspace(model_name):
+    return migrations.AlterField(
+        model_name=model_name,
+        name='workspace',
+        field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('garden', '0004_constrain_garden_geometry'),
+        ('workspaces', '0001_initial'),
+    ]
+
+    operations = [
+        *(add_workspace(name.lower()) for name in OWNED_MODELS),
+        migrations.RunPython(backfill_and_audit_workspace, migrations.RunPython.noop),
+        *(require_workspace(name.lower()) for name in OWNED_MODELS),
+    ]

--- a/garden/models.py
+++ b/garden/models.py
@@ -5,8 +5,10 @@ Garden models
 from django.core.validators import MinValueValidator
 from django.db import models
 
+from workspaces.models import WorkspaceOwnedModel
 
-class GardenArea(models.Model):
+
+class GardenArea(WorkspaceOwnedModel):
     """
     An Area of garden
     """
@@ -26,7 +28,7 @@ class GardenArea(models.Model):
         return self.name
 
 
-class GardenBed(models.Model):
+class GardenBed(WorkspaceOwnedModel):
     """
     A Garden bed
     """
@@ -53,7 +55,7 @@ class GardenBed(models.Model):
         return self.name
 
 
-class GardenRow(models.Model):
+class GardenRow(WorkspaceOwnedModel):
     """
     A Row in a garden bed
     """
@@ -80,7 +82,7 @@ class GardenRow(models.Model):
         return f'{self.name} ({self.size_x},{self.size_y}) @ ({self.placement_x},{self.placement_y}) in {self.bed}'
 
 
-class GardenSquare(models.Model):
+class GardenSquare(WorkspaceOwnedModel):
     """
     A square in a garden bed
     """

--- a/plantings/migrations/0017_workspace_ownership.py
+++ b/plantings/migrations/0017_workspace_ownership.py
@@ -1,0 +1,85 @@
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+from django.db.models import F, Q
+
+
+OWNED_MODELS = (
+    'GardenRowDirectSowPlanting',
+    'GardenSquareDirectSowPlanting',
+    'GardenSquareTransplant',
+    'SeedTrayPlanting',
+    'SpecificPlant',
+)
+
+
+def backfill_and_audit_workspace(apps, _schema_editor):
+    """Backfill ownership and reject inconsistent cultivation parentage."""
+    for model_name in OWNED_MODELS:
+        apps.get_model('plantings', model_name).objects.update(workspace_id=1)
+
+    relationships = (
+        ('GardenRowDirectSowPlanting', 'seeds_used__workspace_id'),
+        ('GardenRowDirectSowPlanting', 'location__workspace_id'),
+        ('GardenSquareDirectSowPlanting', 'seeds_used__workspace_id'),
+        ('GardenSquareDirectSowPlanting', 'location__workspace_id'),
+        ('GardenSquareTransplant', 'original_planting__workspace_id'),
+        ('GardenSquareTransplant', 'location__workspace_id'),
+        ('SpecificPlant', 'cell_planting__seed_tray_planting__workspace_id'),
+    )
+    for model_name, parent_workspace in relationships:
+        invalid = apps.get_model('plantings', model_name).objects.exclude(
+            workspace_id=F(parent_workspace),
+        )
+        if invalid.exists():
+            raise RuntimeError(
+                'Planting workspace audit failed. Repair cross-workspace seed, '
+                'location, tray, or planting relationships before retrying.'
+            )
+
+    tray_planting = apps.get_model('plantings', 'SeedTrayPlanting')
+    invalid_tray_plantings = tray_planting.objects.filter(
+        ~Q(workspace_id=F('seeds_used__workspace_id')) |
+        (
+            Q(seed_tray__isnull=False) &
+            ~Q(workspace_id=F('seed_tray__workspace_id'))
+        ),
+    )
+    if invalid_tray_plantings.exists():
+        raise RuntimeError(
+            'Planting workspace audit failed. Repair cross-workspace seed packet '
+            'or seed tray relationships before retrying.'
+        )
+
+
+def add_workspace(model_name):
+    return migrations.AddField(
+        model_name=model_name,
+        name='workspace',
+        field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+    )
+
+
+def require_workspace(model_name):
+    return migrations.AlterField(
+        model_name=model_name,
+        name='workspace',
+        field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('garden', '0005_workspace_ownership'),
+        ('plantings', '0016_audit_transplant_ownership'),
+        ('seeds', '0004_workspace_ownership'),
+        ('seedtrays', '0003_workspace_ownership'),
+        ('workspaces', '0001_initial'),
+    ]
+
+    operations = [
+        *(add_workspace(name.lower()) for name in OWNED_MODELS),
+        migrations.RunPython(backfill_and_audit_workspace, migrations.RunPython.noop),
+        *(require_workspace(name.lower()) for name in OWNED_MODELS),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -9,9 +9,10 @@ from django.utils import timezone
 from seeds.models import SeedPacket
 from seedtrays.models import SeedTray, SeedTrayCell
 from garden.models import GardenRow, GardenSquare
+from workspaces.models import WorkspaceOwnedModel
 
 
-class Planting(models.Model):
+class Planting(WorkspaceOwnedModel):
     """
     An abstract class for planting of seeds
     """
@@ -98,7 +99,7 @@ class SeedTrayCellPlanting(models.Model):
         return f'{self.quantity} in {self.cell} for planting {self.seed_tray_planting.pk}'
 
 
-class SpecificPlant(models.Model):
+class SpecificPlant(WorkspaceOwnedModel):
     """
     A specific individual plant that has germinated from a seed tray cell.
     Created when germination is observed for a particular cell planting.
@@ -165,7 +166,7 @@ class SpecificPlantLocation(models.Model):
         return f'Plant {self.specific_plant_id} @ {loc} from {self.started}'
 
 
-class GardenSquareTransplant(models.Model):
+class GardenSquareTransplant(WorkspaceOwnedModel):
     """
     Legacy aggregate transplant from a seed tray into a garden square.
 

--- a/plants/migrations/0002_workspace_ownership.py
+++ b/plants/migrations/0002_workspace_ownership.py
@@ -1,0 +1,53 @@
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+from django.db.models import F
+
+
+OWNED_MODELS = ('PlantFamily', 'Plant', 'PlantVariety')
+
+
+def backfill_and_audit_workspace(apps, _schema_editor):
+    """Backfill ownership and reject inconsistent catalog parentage."""
+    for model_name in OWNED_MODELS:
+        apps.get_model('plants', model_name).objects.update(workspace_id=1)
+
+    plant_model = apps.get_model('plants', 'Plant')
+    variety_model = apps.get_model('plants', 'PlantVariety')
+    invalid_plants = plant_model.objects.exclude(workspace_id=F('family__workspace_id'))
+    invalid_varieties = variety_model.objects.exclude(workspace_id=F('plant__workspace_id'))
+    if invalid_plants.exists() or invalid_varieties.exists():
+        raise RuntimeError(
+            'Plant workspace audit failed. Repair cross-workspace family, plant, '
+            'or variety relationships before retrying the migration.'
+        )
+
+
+def add_workspace(model_name):
+    return migrations.AddField(
+        model_name=model_name,
+        name='workspace',
+        field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+    )
+
+
+def require_workspace(model_name):
+    return migrations.AlterField(
+        model_name=model_name,
+        name='workspace',
+        field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plants', '0001_initial'),
+        ('workspaces', '0001_initial'),
+    ]
+
+    operations = [
+        *(add_workspace(name.lower()) for name in OWNED_MODELS),
+        migrations.RunPython(backfill_and_audit_workspace, migrations.RunPython.noop),
+        *(require_workspace(name.lower()) for name in OWNED_MODELS),
+    ]

--- a/plants/models.py
+++ b/plants/models.py
@@ -3,8 +3,10 @@ Models for plants
 """
 from django.db import models
 
+from workspaces.models import WorkspaceOwnedModel
 
-class PlantFamily(models.Model):
+
+class PlantFamily(WorkspaceOwnedModel):
     """
     Plant Family
     """
@@ -15,7 +17,7 @@ class PlantFamily(models.Model):
         return self.name
 
 
-class Plant(models.Model):
+class Plant(WorkspaceOwnedModel):
     """
     A Plant
     """
@@ -34,7 +36,7 @@ class Plant(models.Model):
         return self.name
 
 
-class PlantVariety(models.Model):
+class PlantVariety(WorkspaceOwnedModel):
     """
     A Specific Variety of a Plant
     """

--- a/seeds/migrations/0004_workspace_ownership.py
+++ b/seeds/migrations/0004_workspace_ownership.py
@@ -1,0 +1,60 @@
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+from django.db.models import F
+
+
+def backfill_and_audit_workspace(apps, _schema_editor):
+    """Backfill ownership and reject inconsistent seed catalog parentage."""
+    seeds_model = apps.get_model('seeds', 'Seeds')
+    packet_model = apps.get_model('seeds', 'SeedPacket')
+    seeds_model.objects.update(workspace_id=1)
+    packet_model.objects.update(workspace_id=1)
+
+    invalid_seeds = seeds_model.objects.exclude(
+        workspace_id=F('supplier__workspace_id'),
+    ) | seeds_model.objects.exclude(
+        workspace_id=F('plant_variety__workspace_id'),
+    )
+    invalid_packets = packet_model.objects.exclude(
+        workspace_id=F('seeds__workspace_id'),
+    )
+    if invalid_seeds.exists() or invalid_packets.exists():
+        raise RuntimeError(
+            'Seed workspace audit failed. Repair cross-workspace supplier, '
+            'variety, seed, or packet relationships before retrying the migration.'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plants', '0002_workspace_ownership'),
+        ('seeds', '0003_alter_seeds_supplier_delete_supplier'),
+        ('supplies', '0002_supplier_workspace'),
+        ('workspaces', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='seedpacket',
+            name='workspace',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.AddField(
+            model_name='seeds',
+            name='workspace',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.RunPython(backfill_and_audit_workspace, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='seedpacket',
+            name='workspace',
+            field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.AlterField(
+            model_name='seeds',
+            name='workspace',
+            field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+    ]

--- a/seeds/models.py
+++ b/seeds/models.py
@@ -5,9 +5,10 @@ from django.db import models
 
 from plants.models import PlantVariety
 from supplies.models import Supplier
+from workspaces.models import WorkspaceOwnedModel
 
 
-class Seeds(models.Model):
+class Seeds(WorkspaceOwnedModel):
     """
     Seeds for a specific plant
     """
@@ -21,7 +22,7 @@ class Seeds(models.Model):
         return f"{self.plant_variety} from {self.supplier} ({self.supplier_code})"
 
 
-class SeedPacket(models.Model):
+class SeedPacket(WorkspaceOwnedModel):
     """
     Specific packet/store of seeds
     """

--- a/seedtrays/migrations/0003_workspace_ownership.py
+++ b/seedtrays/migrations/0003_workspace_ownership.py
@@ -1,0 +1,58 @@
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+from django.db.models import F
+
+
+def backfill_and_audit_workspace(apps, _schema_editor):
+    """Backfill tray ownership and reject mismatched tray models."""
+    tray_model = apps.get_model('seedtrays', 'SeedTrayModel')
+    tray = apps.get_model('seedtrays', 'SeedTray')
+    tray_model.objects.update(workspace_id=1)
+    tray.objects.update(workspace_id=1)
+    if tray.objects.exclude(workspace_id=F('model__workspace_id')).exists():
+        raise RuntimeError(
+            'Seed tray workspace audit failed. Repair trays whose model belongs '
+            'to another workspace before retrying the migration.'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seedtrays', '0002_datetimefield_created'),
+        ('workspaces', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='seedtray',
+            name='workspace',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.AddField(
+            model_name='seedtraymodel',
+            name='workspace',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.RunPython(backfill_and_audit_workspace, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='seedtray',
+            name='workspace',
+            field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.AlterField(
+            model_name='seedtraymodel',
+            name='workspace',
+            field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.AlterField(
+            model_name='seedtraymodel',
+            name='identifier',
+            field=models.CharField(max_length=256),
+        ),
+        migrations.AddConstraint(
+            model_name='seedtraymodel',
+            constraint=models.UniqueConstraint(fields=('workspace', 'identifier'), name='unique_tray_model_identifier_workspace'),
+        ),
+    ]

--- a/seedtrays/models.py
+++ b/seedtrays/models.py
@@ -3,12 +3,14 @@ Models for seed trays
 """
 from django.db import models
 
+from workspaces.models import WorkspaceOwnedModel
 
-class SeedTrayModel(models.Model):
+
+class SeedTrayModel(WorkspaceOwnedModel):
     """
     A seed tray model used for starting seeds
     """
-    identifier = models.CharField(max_length=256, unique=True)
+    identifier = models.CharField(max_length=256)
     description = models.TextField(null=True, blank=True)
 
     # Dimensions of the tray itself
@@ -23,8 +25,16 @@ class SeedTrayModel(models.Model):
     def __str__(self):
         return self.identifier
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['workspace', 'identifier'],
+                name='unique_tray_model_identifier_workspace',
+            ),
+        ]
 
-class SeedTray(models.Model):
+
+class SeedTray(WorkspaceOwnedModel):
     """
     A specific seed tray
     """

--- a/supplies/migrations/0002_supplier_workspace.py
+++ b/supplies/migrations/0002_supplier_workspace.py
@@ -1,0 +1,29 @@
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+
+
+def backfill_workspace(apps, _schema_editor):
+    apps.get_model('supplies', 'Supplier').objects.update(workspace_id=1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('supplies', '0001_initial'),
+        ('workspaces', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='supplier',
+            name='workspace',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+        migrations.RunPython(backfill_workspace, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='supplier',
+            name='workspace',
+            field=models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace'),
+        ),
+    ]

--- a/supplies/models.py
+++ b/supplies/models.py
@@ -1,8 +1,10 @@
 """Database models for garden supplies."""
 from django.db import models
 
+from workspaces.models import WorkspaceOwnedModel
 
-class Supplier(models.Model):
+
+class Supplier(WorkspaceOwnedModel):
     """
     A seed supplier
     """

--- a/workspaces/current.py
+++ b/workspaces/current.py
@@ -1,17 +1,5 @@
-"""Resolve the deployment's configured workspace."""
+"""Compatibility import for the current workspace resolver."""
 
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from .models import get_current_workspace
 
-from .models import Workspace
-
-
-def get_current_workspace():
-    """Return the single workspace configured for this deployment."""
-    workspace_id = settings.CURRENT_WORKSPACE_ID
-    try:
-        return Workspace.objects.get(pk=workspace_id)
-    except Workspace.DoesNotExist as exc:
-        raise ImproperlyConfigured(
-            f'CURRENT_WORKSPACE_ID={workspace_id} does not identify a workspace.'
-        ) from exc
+__all__ = ['get_current_workspace']

--- a/workspaces/models.py
+++ b/workspaces/models.py
@@ -3,7 +3,8 @@
 from decimal import Decimal
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from django.core.exceptions import ValidationError
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 
@@ -72,3 +73,34 @@ class Workspace(models.Model):
 
     def __str__(self):
         return self.name
+
+
+def get_default_workspace_id():
+    """Return the configured workspace ID for direct ORM-created records."""
+    return get_current_workspace().pk
+
+
+def get_current_workspace():
+    """Return the single workspace configured for this deployment."""
+    workspace_id = settings.CURRENT_WORKSPACE_ID
+    try:
+        return Workspace.objects.get(pk=workspace_id)
+    except Workspace.DoesNotExist as exc:
+        raise ImproperlyConfigured(
+            f'CURRENT_WORKSPACE_ID={workspace_id} does not identify a workspace.'
+        ) from exc
+
+
+class WorkspaceOwnedModel(models.Model):
+    """Abstract base for independently addressable workspace data."""
+
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.PROTECT,
+        default=get_default_workspace_id,
+        editable=False,
+        related_name='+',
+    )
+
+    class Meta:
+        abstract = True

--- a/workspaces/tests.py
+++ b/workspaces/tests.py
@@ -7,8 +7,11 @@ from decimal import Decimal
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
+from django.db import IntegrityError, transaction
 from django.test import TestCase, override_settings
 from rest_framework.test import APITestCase
+from seedtrays.models import SeedTrayModel
+from supplies.models import Supplier
 
 from .admin import WorkspaceAdmin
 from .current import get_current_workspace
@@ -43,6 +46,35 @@ class WorkspaceAdminTests(TestCase):
         workspace_admin = WorkspaceAdmin(Workspace, AdminSite())
 
         self.assertFalse(workspace_admin.has_add_permission(request=None))
+
+
+class WorkspaceOwnershipModelTests(TestCase):
+    """Domain models receive a required workspace ownership root."""
+
+    def test_direct_orm_creates_default_to_current_workspace(self):
+        """Legacy and maintenance code receives the configured workspace."""
+        supplier = Supplier.objects.create(name='Defaulted supplier')
+
+        self.assertEqual(supplier.workspace, get_current_workspace())
+
+    def test_tray_model_identifier_is_unique_within_workspace(self):
+        """Identifiers can repeat across workspaces but not within one."""
+        current = get_current_workspace()
+        other = Workspace.objects.create(name='Other workspace')
+        values = {
+            'identifier': 'Shared identifier',
+            'height': 10,
+            'x_size': 20,
+            'y_size': 20,
+            'x_cells': 2,
+            'y_cells': 2,
+            'cell_size_ml': 40,
+        }
+        SeedTrayModel.objects.create(workspace=current, **values)
+        SeedTrayModel.objects.create(workspace=other, **values)
+
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            SeedTrayModel.objects.create(workspace=current, **values)
 
 
 class WorkspaceEndpointTests(APITestCase):


### PR DESCRIPTION
Future inventory and nursery records need an unambiguous ownership root. Backfill existing domain data, audit parent relationships, require workspace keys, and scope tray-model uniqueness to each workspace.

## Summary by Sourcery

Introduce workspace ownership as a required root for core domain data and audit existing records for consistent parentage across the garden, plants, seeds, supplies, seedtrays, and plantings apps.

New Features:
- Add a WorkspaceOwnedModel abstract base class that attaches domain records to a workspace and defaults ORM-created objects to the deployment’s current workspace.
- Enforce per-workspace uniqueness of seed tray model identifiers via a workspace-scoped unique constraint.

Enhancements:
- Centralize current workspace resolution in the workspaces models module and provide a compatibility shim for existing imports.

Tests:
- Add tests verifying default workspace assignment for directly created domain objects and per-workspace uniqueness of seed tray model identifiers.
- Extend workspace tests to cover integrity errors when tray model identifiers conflict within the same workspace.

Chores:
- Backfill workspace ownership for existing garden, plants, seeds, supplies, seedtray, and planting records and add migration-time audits that reject inconsistent cross-workspace relationships.