### PR TITLE
feat(api): isolate workspace catalogs and trays

### DIFF
--- a/garden/rest.py
+++ b/garden/rest.py
@@ -3,6 +3,8 @@ Rest for Gardens
 """
 from rest_framework import routers, serializers, viewsets
 
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
 from .models import GardenArea, GardenBed, GardenRow, GardenSquare
 
 
@@ -15,7 +17,7 @@ class GardenAreaSerializer(serializers.ModelSerializer):
         fields = ['pk', 'name', 'size_x', 'size_y']
 
 
-class GardenBedSerializer(serializers.ModelSerializer):
+class GardenBedSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for Garden Bed
     """
@@ -23,8 +25,10 @@ class GardenBedSerializer(serializers.ModelSerializer):
         model = GardenBed
         fields = ['pk', 'area', 'name', 'placement_x', 'placement_y', 'size_x', 'size_y']
 
+    workspace_field_lookups = {'area': 'workspace'}
 
-class GardenRowSerializer(serializers.ModelSerializer):
+
+class GardenRowSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for Garden Row
     """
@@ -32,8 +36,10 @@ class GardenRowSerializer(serializers.ModelSerializer):
         model = GardenRow
         fields = ['pk', 'bed', 'name', 'placement_x', 'placement_y', 'size_x', 'size_y']
 
+    workspace_field_lookups = {'bed': 'workspace'}
 
-class GardenSquareSerializer(serializers.ModelSerializer):
+
+class GardenSquareSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for Garden Square
     """
@@ -41,8 +47,10 @@ class GardenSquareSerializer(serializers.ModelSerializer):
         model = GardenSquare
         fields = ['pk', 'bed', 'name', 'placement_x', 'placement_y', 'size_x', 'size_y']
 
+    workspace_field_lookups = {'bed': 'workspace'}
 
-class GardenAreaViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+
+class GardenAreaViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet for Garden Area
     """
@@ -50,7 +58,7 @@ class GardenAreaViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ance
     serializer_class = GardenAreaSerializer
 
 
-class GardenBedViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenBedViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet for Garden Bed
     """
@@ -58,7 +66,7 @@ class GardenBedViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ances
     serializer_class = GardenBedSerializer
 
 
-class GardenRowViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenRowViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet for Garden Row
     """
@@ -66,7 +74,7 @@ class GardenRowViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ances
     serializer_class = GardenRowSerializer
 
 
-class GardenSquareViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenSquareViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet for Garden Square
     """

--- a/plants/rest.py
+++ b/plants/rest.py
@@ -3,6 +3,8 @@ Rest access for plants
 """
 from rest_framework import routers, serializers, viewsets
 
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
 from .models import PlantFamily, Plant, PlantVariety
 
 
@@ -15,7 +17,7 @@ class PlantFamilySerializer(serializers.ModelSerializer):
         fields = ['pk', 'name', 'notes']
 
 
-class PlantSerializer(serializers.ModelSerializer):
+class PlantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for Plant
     """
@@ -23,8 +25,10 @@ class PlantSerializer(serializers.ModelSerializer):
         model = Plant
         fields = ['pk', 'family', 'name', 'notes', 'spacing', 'inter_row_spacing', 'plants_per_square_foot', 'germination_days_min', 'germination_days_max', 'maturity_days_min', 'maturity_days_max']
 
+    workspace_field_lookups = {'family': 'workspace'}
 
-class PlantVarietySerializer(serializers.ModelSerializer):
+
+class PlantVarietySerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for Plant Variety
     """
@@ -32,8 +36,10 @@ class PlantVarietySerializer(serializers.ModelSerializer):
         model = PlantVariety
         fields = ['pk', 'plant', 'name', 'notes', 'spacing', 'inter_row_spacing', 'plants_per_square_foot', 'germination_days_min', 'germination_days_max', 'maturity_days_min', 'maturity_days_max']
 
+    workspace_field_lookups = {'plant': 'workspace'}
 
-class PlantFamilyViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+
+class PlantFamilyViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of Plant Family
     """
@@ -41,7 +47,7 @@ class PlantFamilyViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-anc
     serializer_class = PlantFamilySerializer
 
 
-class PlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class PlantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of Plants
     """
@@ -49,7 +55,7 @@ class PlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     serializer_class = PlantSerializer
 
 
-class PlantVarietyViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class PlantVarietyViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of Plant Varieties
     """

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -3,10 +3,12 @@ Rest related classes for seeds
 """
 from rest_framework import routers, serializers, viewsets
 
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
 from .models import Seeds, SeedPacket
 
 
-class SeedsSerializer(serializers.ModelSerializer):
+class SeedsSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a Seeds Supply
     """
@@ -14,8 +16,13 @@ class SeedsSerializer(serializers.ModelSerializer):
         model = Seeds
         fields = ['pk', 'supplier', 'plant_variety', 'supplier_code', 'url', 'notes']
 
+    workspace_field_lookups = {
+        'supplier': 'workspace',
+        'plant_variety': 'workspace',
+    }
 
-class SeedPacketSerializer(serializers.ModelSerializer):
+
+class SeedPacketSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a Seed Packet
     """
@@ -23,8 +30,10 @@ class SeedPacketSerializer(serializers.ModelSerializer):
         model = SeedPacket
         fields = ['pk', 'seeds', 'purchase_date', 'sow_by', 'empty', 'notes']
 
+    workspace_field_lookups = {'seeds': 'workspace'}
 
-class SeedsViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+
+class SeedsViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of Seeds
     """
@@ -32,7 +41,7 @@ class SeedsViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     serializer_class = SeedsSerializer
 
 
-class SeedPacketCurrentViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedPacketCurrentViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of non-empty SeedPackets
     """
@@ -40,7 +49,7 @@ class SeedPacketCurrentViewSet(viewsets.ModelViewSet):  # pylint: disable=too-ma
     serializer_class = SeedPacketSerializer
 
 
-class SeedPacketAllViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedPacketAllViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of all SeedPackets
     """

--- a/seedtrays/rest.py
+++ b/seedtrays/rest.py
@@ -8,6 +8,8 @@ from django.shortcuts import get_object_or_404
 from rest_framework import serializers, viewsets
 from rest_framework_nested import routers
 
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
 from .models import SeedTrayModel, SeedTray, SeedTrayCell
 
 
@@ -31,13 +33,15 @@ class SeedTrayModelSerializer(serializers.ModelSerializer):
         return data
 
 
-class SeedTraySerializer(serializers.ModelSerializer):
+class SeedTraySerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a Seed Tray
     """
     class Meta:
         model = SeedTray
         fields = ['pk', 'model', 'created', 'notes']
+
+    workspace_field_lookups = {'model': 'workspace'}
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """A created tray keeps the model that defined its generated cell grid."""
@@ -65,13 +69,15 @@ class SeedTraySerializer(serializers.ModelSerializer):
         return seed_tray
 
 
-class SeedTrayCellSerializer(serializers.ModelSerializer):
+class SeedTrayCellSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a Seed Tray Cell
     """
     class Meta:
         model = SeedTrayCell
         fields = ['pk', 'tray', 'x_position', 'y_position']
+
+    workspace_field_lookups = {'tray': 'workspace'}
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """Keep a cell on its original tray and within that tray's grid."""
@@ -105,7 +111,7 @@ class NestedSeedTrayCellSerializer(SeedTrayCellSerializer):
         extra_kwargs = {'tray': {'read_only': True}}
 
 
-class SeedTrayModelsViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedTrayModelsViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SeedTrayModels
     """
@@ -113,7 +119,7 @@ class SeedTrayModelsViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-
     serializer_class = SeedTrayModelSerializer
 
 
-class SeedTrayAllViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedTrayAllViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of all SeedTrays
     """
@@ -121,20 +127,24 @@ class SeedTrayAllViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-anc
     serializer_class = SeedTraySerializer
 
 
-class SeedTrayCellViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedTrayCellViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of all SeedTrayCells
     """
     queryset = SeedTrayCell.objects.all()
     serializer_class = SeedTrayCellSerializer
+    workspace_lookup = 'tray__workspace'
+    bind_workspace_on_create = False
 
 
-class SeedTrayCellFilteredViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SeedTrayCellFilteredViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SeedTrayCells filtered by tray
     """
     queryset = SeedTrayCell.objects.all()
     serializer_class = NestedSeedTrayCellSerializer
+    workspace_lookup = 'tray__workspace'
+    bind_workspace_on_create = False
     _parent_tray = None
 
     def get_parent_tray(self):
@@ -143,11 +153,12 @@ class SeedTrayCellFilteredViewSet(viewsets.ModelViewSet):  # pylint: disable=too
             self._parent_tray = get_object_or_404(
                 SeedTray.objects.select_related('model'),
                 pk=self.kwargs['seedtray_pk'],
+                workspace=self.get_current_workspace(),
             )
         return self._parent_tray
 
     def get_queryset(self):
-        return self.queryset.filter(tray=self.get_parent_tray())
+        return super().get_queryset().filter(tray=self.get_parent_tray())
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/seedtrays/views.py
+++ b/seedtrays/views.py
@@ -3,6 +3,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views import View
 from django.shortcuts import get_object_or_404, render
 
+from workspaces.models import get_current_workspace
+
 from .models import SeedTray
 
 
@@ -11,7 +13,11 @@ class SeedTrayDetailView(LoginRequiredMixin, View):
 
     def get(self, request, pk):
         """Render the requested seed tray."""
-        seed_tray = get_object_or_404(SeedTray, pk=pk)
+        seed_tray = get_object_or_404(
+            SeedTray,
+            pk=pk,
+            workspace=get_current_workspace(),
+        )
         context = {
             'seed_tray': seed_tray
         }

--- a/supplies/rest.py
+++ b/supplies/rest.py
@@ -3,6 +3,8 @@ Rest related classes for supplies
 """
 from rest_framework import routers, serializers, viewsets
 
+from workspaces.scoping import CurrentWorkspaceViewSetMixin
+
 from .models import Supplier
 
 
@@ -15,7 +17,10 @@ class SupplierSerializer(serializers.ModelSerializer):
         fields = ['pk', 'name', 'website', 'notes']
 
 
-class SupplierViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SupplierViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
     """
     ViewSet of Suppliers
     """

--- a/workspaces/scoping.py
+++ b/workspaces/scoping.py
@@ -1,0 +1,49 @@
+"""Reusable REST helpers for the single-workspace deployment boundary."""
+
+from .models import get_current_workspace
+
+
+class CurrentWorkspaceSerializerMixin:  # pylint: disable=too-few-public-methods
+    """Limit configured relationship fields to the current workspace."""
+
+    workspace_field_lookups = {}
+
+    def get_fields(self):
+        """Apply current-workspace filters to configured related fields."""
+        fields = super().get_fields()
+        workspace = get_current_workspace()
+        for field_name, workspace_lookup in self.workspace_field_lookups.items():
+            field = fields[field_name]
+            queryset = getattr(field, 'queryset', None)
+            if queryset is not None:
+                field.queryset = queryset.filter(
+                    **{workspace_lookup: workspace},
+                )
+        return fields
+
+
+class CurrentWorkspaceViewSetMixin:
+    """Scope reads and bind direct creates to the current workspace."""
+
+    workspace_lookup = 'workspace'
+    bind_workspace_on_create = True
+    _current_workspace = None
+
+    def get_current_workspace(self):
+        """Resolve and cache the configured workspace for this request."""
+        if self._current_workspace is None:
+            self._current_workspace = get_current_workspace()
+        return self._current_workspace
+
+    def get_queryset(self):
+        """Return records belonging to the configured workspace."""
+        return super().get_queryset().filter(
+            **{self.workspace_lookup: self.get_current_workspace()},
+        )
+
+    def perform_create(self, serializer):
+        """Bind directly owned records to the configured workspace."""
+        if self.bind_workspace_on_create:
+            serializer.save(workspace=self.get_current_workspace())
+        else:
+            super().perform_create(serializer)

--- a/workspaces/test_isolation.py
+++ b/workspaces/test_isolation.py
@@ -1,0 +1,225 @@
+"""Cross-workspace isolation tests for catalogs, gardens, and trays."""
+
+# pylint: disable=duplicate-code,too-many-instance-attributes
+
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
+from plants.models import Plant, PlantFamily, PlantVariety
+from seeds.models import SeedPacket, Seeds
+from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
+from supplies.models import Supplier
+
+from .models import Workspace, get_current_workspace
+
+
+class ResourceIsolationTests(APITestCase):
+    """Current-workspace endpoints neither reveal nor accept foreign records."""
+
+    def setUp(self):
+        super().setUp()
+        self.current = get_current_workspace()
+        self.other = Workspace.objects.create(name='Other workspace')
+        user = get_user_model().objects.create_user(username='isolation-user')
+        self.client.force_authenticate(user)
+        self.client.force_login(user)
+
+        self.supplier = Supplier.objects.create(
+            workspace=self.other,
+            name='Other supplier',
+        )
+        self.family = PlantFamily.objects.create(
+            workspace=self.other,
+            name='Other family',
+        )
+        self.plant = Plant.objects.create(
+            workspace=self.other,
+            family=self.family,
+            name='Other plant',
+        )
+        self.variety = PlantVariety.objects.create(
+            workspace=self.other,
+            plant=self.plant,
+            name='Other variety',
+        )
+        self.seeds = Seeds.objects.create(
+            workspace=self.other,
+            supplier=self.supplier,
+            plant_variety=self.variety,
+        )
+        self.packet = SeedPacket.objects.create(
+            workspace=self.other,
+            seeds=self.seeds,
+        )
+        self.area = GardenArea.objects.create(
+            workspace=self.other,
+            name='Other area',
+            size_x=10,
+            size_y=10,
+        )
+        self.bed = GardenBed.objects.create(
+            workspace=self.other,
+            area=self.area,
+            name='Other bed',
+            placement_x=0,
+            placement_y=0,
+            size_x=5,
+            size_y=5,
+        )
+        self.row = GardenRow.objects.create(
+            workspace=self.other,
+            bed=self.bed,
+            name='Other row',
+            placement_x=0,
+            placement_y=0,
+            size_x=5,
+            size_y=1,
+        )
+        self.square = GardenSquare.objects.create(
+            workspace=self.other,
+            bed=self.bed,
+            name='Other square',
+            placement_x=0,
+            placement_y=0,
+            size_x=1,
+            size_y=1,
+        )
+        self.tray_model = SeedTrayModel.objects.create(
+            workspace=self.other,
+            identifier='Other model',
+            height=10,
+            x_size=20,
+            y_size=20,
+            x_cells=2,
+            y_cells=2,
+            cell_size_ml=40,
+        )
+        self.tray = SeedTray.objects.create(
+            workspace=self.other,
+            model=self.tray_model,
+        )
+        self.cell = SeedTrayCell.objects.create(
+            tray=self.tray,
+            x_position=0,
+            y_position=0,
+        )
+
+    def test_lists_and_details_hide_other_workspace_records(self):
+        """All direct catalog and geometry endpoints present a local namespace."""
+        resources = (
+            ('/supplies/supplier/', self.supplier.pk),
+            ('/plants/family/', self.family.pk),
+            ('/plants/plant/', self.plant.pk),
+            ('/plants/variety/', self.variety.pk),
+            ('/seeds/seeds/', self.seeds.pk),
+            ('/seeds/packets/', self.packet.pk),
+            ('/seeds/packets/all/', self.packet.pk),
+            ('/garden/areas/', self.area.pk),
+            ('/garden/beds/', self.bed.pk),
+            ('/garden/rows/', self.row.pk),
+            ('/garden/squares/', self.square.pk),
+            ('/seedtrays/seedtraymodels/', self.tray_model.pk),
+            ('/seedtrays/seedtrays/', self.tray.pk),
+            ('/seedtrays/seedtraycells/', self.cell.pk),
+        )
+        for url, record_pk in resources:
+            with self.subTest(url=url):
+                list_response = self.client.get(url)
+                self.assertEqual(list_response.status_code, 200)
+                self.assertEqual(list_response.data, [])
+                detail_response = self.client.get(f'{url}{record_pk}/')
+                self.assertEqual(detail_response.status_code, 404)
+
+    def test_creates_are_bound_to_current_workspace(self):
+        """Clients cannot choose ownership for newly created root records."""
+        supplier_response = self.client.post(
+            '/supplies/supplier/',
+            {'name': 'Current supplier', 'workspace': self.other.pk},
+            format='json',
+        )
+        area_response = self.client.post(
+            '/garden/areas/',
+            {
+                'name': 'Current area',
+                'size_x': 10,
+                'size_y': 10,
+                'workspace': self.other.pk,
+            },
+            format='json',
+        )
+
+        self.assertEqual(supplier_response.status_code, 201)
+        self.assertEqual(area_response.status_code, 201)
+        self.assertEqual(
+            Supplier.objects.get(pk=supplier_response.data['pk']).workspace,
+            self.current,
+        )
+        self.assertEqual(
+            GardenArea.objects.get(pk=area_response.data['pk']).workspace,
+            self.current,
+        )
+
+    def test_cross_workspace_foreign_keys_are_rejected(self):
+        """Every catalog, geometry, and tray parent field is workspace-scoped."""
+        requests = (
+            ('/plants/plant/', {'family': self.family.pk, 'name': 'Plant'}),
+            ('/plants/variety/', {'plant': self.plant.pk, 'name': 'Variety'}),
+            (
+                '/seeds/seeds/',
+                {'supplier': self.supplier.pk, 'plant_variety': self.variety.pk},
+            ),
+            ('/seeds/packets/', {'seeds': self.seeds.pk}),
+            (
+                '/garden/beds/',
+                {
+                    'area': self.area.pk,
+                    'name': 'Bed',
+                    'placement_x': 0,
+                    'placement_y': 0,
+                    'size_x': 1,
+                    'size_y': 1,
+                },
+            ),
+            (
+                '/garden/rows/',
+                {
+                    'bed': self.bed.pk,
+                    'name': 'Row',
+                    'placement_x': 0,
+                    'placement_y': 0,
+                    'size_x': 1,
+                    'size_y': 1,
+                },
+            ),
+            (
+                '/garden/squares/',
+                {
+                    'bed': self.bed.pk,
+                    'name': 'Square',
+                    'placement_x': 0,
+                    'placement_y': 0,
+                    'size_x': 1,
+                    'size_y': 1,
+                },
+            ),
+            ('/seedtrays/seedtrays/', {'model': self.tray_model.pk}),
+            (
+                '/seedtrays/seedtraycells/',
+                {'tray': self.tray.pk, 'x_position': 1, 'y_position': 1},
+            ),
+        )
+        for url, payload in requests:
+            with self.subTest(url=url):
+                response = self.client.post(url, payload, format='json')
+                self.assertEqual(response.status_code, 400, response.data)
+
+    def test_nested_and_html_tray_routes_hide_foreign_parent(self):
+        """Parent resolution is scoped before nested or HTML rendering."""
+        nested = self.client.get(
+            f'/seedtrays/seedtrays/{self.tray.pk}/cells/',
+        )
+        detail = self.client.get(f'/seedtrays/seedtray/{self.tray.pk}/')
+
+        self.assertEqual(nested.status_code, 404)
+        self.assertEqual(detail.status_code, 404)


### PR DESCRIPTION
Authenticated accounts must not see or reference records outside the deployment workspace. Scope catalog, garden, seed, tray, nested, and HTML lookups while binding root creates server-side.

## Summary by Sourcery

Enforce workspace isolation across catalog, garden, seed, tray, and HTML endpoints so authenticated users only see and manipulate records in the current deployment workspace.

Enhancements:
- Apply current-workspace scoping mixins to serializers and viewsets for plants, seeds, garden geometry, trays, and suppliers to restrict queries and creation to the active workspace.
- Scope nested seed tray routes and the HTML tray detail view by current workspace to prevent accessing foreign trays.

Tests:
- Add cross-workspace isolation tests verifying that list/detail endpoints hide foreign records, root creations are bound to the current workspace, foreign-key relationships across workspaces are rejected, and nested/HTML tray routes do not expose other-workspace data.