### PR TITLE
feat(plantings): enforce workspace isolation

### DIFF
--- a/plantings/management/commands/convert_legacy_transplant.py
+++ b/plantings/management/commands/convert_legacy_transplant.py
@@ -11,6 +11,7 @@ from plantings.models import (
     SpecificPlant,
     SpecificPlantLocation,
 )
+from workspaces.models import get_current_workspace
 
 
 class Command(BaseCommand):
@@ -108,7 +109,7 @@ class Command(BaseCommand):
         queryset = GardenSquareTransplant.objects.select_related(
             'original_planting__seeds_used__seeds__plant_variety__plant',
             'location__bed__area',
-        )
+        ).filter(workspace=get_current_workspace())
         if for_update:
             queryset = queryset.select_for_update()
         try:
@@ -158,7 +159,11 @@ class Command(BaseCommand):
 
     @staticmethod
     def _get_cell_planting(cell_planting_id, transplant, *, for_update):
-        queryset = SeedTrayCellPlanting.objects.select_related('cell__tray__model')
+        queryset = SeedTrayCellPlanting.objects.select_related(
+            'cell__tray__model',
+        ).filter(
+            seed_tray_planting__workspace=transplant.workspace,
+        )
         if for_update:
             queryset = queryset.select_for_update()
         try:
@@ -201,7 +206,10 @@ class Command(BaseCommand):
                 'Existing plant count cannot exceed the aggregate target quantity.'
             )
 
-        queryset = SpecificPlant.objects.filter(pk__in=plant_ids)
+        queryset = SpecificPlant.objects.filter(
+            pk__in=plant_ids,
+            workspace=transplant.workspace,
+        )
         if for_update:
             queryset = queryset.select_for_update()
         plants_by_id = {plant.pk: plant for plant in queryset}
@@ -266,6 +274,7 @@ class Command(BaseCommand):
         )
         for _index in range(new_plant_count):
             plant = SpecificPlant.objects.create(
+                workspace=transplant.workspace,
                 cell_planting=cell_planting,
                 germinated=germinated_at,
                 notes=recovery_note,

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -10,11 +10,13 @@ from django.utils import timezone
 from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from seedtrays.models import SeedTray
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 
 
-class GardenRowDirectSowPlantingSerializer(serializers.ModelSerializer):
+class GardenRowDirectSowPlantingSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for GardenRowDirectSowPlanting
     """
@@ -22,8 +24,13 @@ class GardenRowDirectSowPlantingSerializer(serializers.ModelSerializer):
         model = GardenRowDirectSowPlanting
         fields = ['pk', 'planted', 'seeds_used', 'quantity', 'location', 'removed', 'notes']
 
+    workspace_field_lookups = {
+        'seeds_used': 'workspace',
+        'location': 'workspace',
+    }
 
-class GardenSquareDirectSowSerializer(serializers.ModelSerializer):
+
+class GardenSquareDirectSowSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for GardenSquareDirectSowPlanting
     """
@@ -31,12 +38,19 @@ class GardenSquareDirectSowSerializer(serializers.ModelSerializer):
         model = GardenSquareDirectSowPlanting
         fields = ['pk', 'planted', 'seeds_used', 'quantity', 'location', 'removed', 'notes']
 
+    workspace_field_lookups = {
+        'seeds_used': 'workspace',
+        'location': 'workspace',
+    }
 
-class SeedTrayCellPlantingNestedSerializer(serializers.ModelSerializer):
+
+class SeedTrayCellPlantingNestedSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """Nested serializer for creating/updating cell plantings inside a SeedTrayPlanting"""
     class Meta:
         model = SeedTrayCellPlanting
         fields = ['pk', 'cell', 'quantity']
+
+    workspace_field_lookups = {'cell': 'tray__workspace'}
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """Require complete entries because the parent replaces rather than patches them."""
@@ -50,7 +64,7 @@ class SeedTrayCellPlantingNestedSerializer(serializers.ModelSerializer):
         return data
 
 
-class SeedTrayPlantingSerializer(serializers.ModelSerializer):
+class SeedTrayPlantingSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for SeedTrayPlanting
     """
@@ -62,6 +76,11 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
             'pk', 'planted', 'seeds_used', 'quantity',
             'seed_tray', 'location', 'removed', 'notes', 'cell_plantings',
         ]
+
+    workspace_field_lookups = {
+        'seeds_used': 'workspace',
+        'seed_tray': 'workspace',
+    }
 
     def _get_effective_cell_plantings(self, data):
         """Return submitted replacements or the retained cell plantings."""
@@ -241,13 +260,19 @@ class SeedTrayPlantingSerializer(serializers.ModelSerializer):
         return instance
 
 
-class SpecificPlantLocationSerializer(serializers.ModelSerializer):
+class SpecificPlantLocationSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for SpecificPlantLocation
     """
     class Meta:
         model = SpecificPlantLocation
         fields = ['pk', 'specific_plant', 'location_type', 'seed_tray_cell', 'garden_square', 'started', 'ended', 'notes']
+
+    workspace_field_lookups = {
+        'specific_plant': 'workspace',
+        'seed_tray_cell': 'tray__workspace',
+        'garden_square': 'workspace',
+    }
 
     def _get_effective_history_fields(self, data):
         """Resolve the interval and plant represented by create or partial update data."""
@@ -317,7 +342,7 @@ class SpecificPlantLocationSerializer(serializers.ModelSerializer):
             return super().update(instance, validated_data)
 
 
-class SpecificPlantMoveSerializer(serializers.ModelSerializer):
+class SpecificPlantMoveSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for moving a SpecificPlant to a new active location.
     """
@@ -328,6 +353,11 @@ class SpecificPlantMoveSerializer(serializers.ModelSerializer):
             'started': {'required': False},
         }
 
+    workspace_field_lookups = {
+        'seed_tray_cell': 'tray__workspace',
+        'garden_square': 'workspace',
+    }
+
     def validate(self, data):  # pylint: disable=arguments-renamed
         validate_specific_plant_location(
             location_type=data.get('location_type'),
@@ -337,7 +367,7 @@ class SpecificPlantMoveSerializer(serializers.ModelSerializer):
         return data
 
 
-class SpecificPlantSerializer(serializers.ModelSerializer):
+class SpecificPlantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for SpecificPlant — includes nested location history.
     On create, automatically records the initial seed tray cell location.
@@ -347,6 +377,10 @@ class SpecificPlantSerializer(serializers.ModelSerializer):
     class Meta:
         model = SpecificPlant
         fields = ['pk', 'cell_planting', 'germinated', 'notes', 'locations']
+
+    workspace_field_lookups = {
+        'cell_planting': 'seed_tray_planting__workspace',
+    }
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """Keep a plant attached to the cell allocation it germinated from."""
@@ -380,13 +414,18 @@ class SpecificPlantSerializer(serializers.ModelSerializer):
         return plant
 
 
-class GardenSquareTransplantSerializer(serializers.ModelSerializer):
+class GardenSquareTransplantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for GardenSquareTransplant
     """
     class Meta:
         model = GardenSquareTransplant
         fields = ['pk', 'transplanted', 'original_planting', 'quantity', 'location', 'removed', 'notes']
+
+    workspace_field_lookups = {
+        'original_planting': 'workspace',
+        'location': 'workspace',
+    }
 
 
 _FIELD_MISSING = object()
@@ -502,7 +541,11 @@ def move_specific_plant(plant, move_data):
     started = move_data.get('started') or timezone.now()
     move_payload = {**move_data, 'started': started}
     with transaction.atomic():
-        plant = get_object_or_404(SpecificPlant.objects.select_for_update(), pk=plant.pk)
+        plant = get_object_or_404(
+            SpecificPlant.objects.select_for_update(),
+            pk=plant.pk,
+            workspace=plant.workspace,
+        )
         active_location = get_single_active_location_for_update(plant)
 
         if active_location:
@@ -533,7 +576,7 @@ def move_specific_plant(plant, move_data):
             }) from exc
 
 
-class GardenRowDirectSowPlantingViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenRowDirectSowPlantingViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of GardenRowDirectSowPlanting
     """
@@ -541,7 +584,7 @@ class GardenRowDirectSowPlantingViewSet(viewsets.ModelViewSet):  # pylint: disab
     serializer_class = GardenRowDirectSowPlantingSerializer
 
 
-class GardenSquareDirectSowPlantingViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenSquareDirectSowPlantingViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of GardenSquareDirectSowPlanting
     """
@@ -566,6 +609,7 @@ class ProtectedSeedTrayPlantingDestroyMixin:  # pylint: disable=too-few-public-m
 
 class SeedTrayPlantingViewSet(
     ProtectedSeedTrayPlantingDestroyMixin,
+    CurrentWorkspaceViewSetMixin,
     viewsets.ModelViewSet,
 ):  # pylint: disable=too-many-ancestors
     """
@@ -577,6 +621,7 @@ class SeedTrayPlantingViewSet(
 
 class SeedTrayPlantingViewSeedTraySet(
     ProtectedSeedTrayPlantingDestroyMixin,
+    CurrentWorkspaceViewSetMixin,
     viewsets.ModelViewSet,
 ):  # pylint: disable=too-many-ancestors
     """
@@ -584,12 +629,29 @@ class SeedTrayPlantingViewSeedTraySet(
     """
     queryset = SeedTrayPlanting.objects.all()
     serializer_class = SeedTrayPlantingSerializer
+    _parent_seed_tray = None
+
+    def get_parent_seed_tray(self):
+        """Resolve the nested tray inside the current workspace."""
+        if self._parent_seed_tray is None:
+            self._parent_seed_tray = get_object_or_404(
+                SeedTray,
+                pk=self.kwargs['seed_tray_pk'],
+                workspace=self.get_current_workspace(),
+            )
+        return self._parent_seed_tray
 
     def get_queryset(self):
-        return self.queryset.filter(seed_tray__pk=self.kwargs['seed_tray_pk'])
+        return super().get_queryset().filter(seed_tray=self.get_parent_seed_tray())
+
+    def perform_create(self, serializer):
+        serializer.save(
+            workspace=self.get_current_workspace(),
+            seed_tray=self.get_parent_seed_tray(),
+        )
 
 
-class GardenSquareTransplantViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
+class GardenSquareTransplantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
     """
     Read-only access to legacy aggregate transplant records.
 
@@ -599,7 +661,7 @@ class GardenSquareTransplantViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: d
     serializer_class = GardenSquareTransplantSerializer
 
 
-class SpecificPlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SpecificPlantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SpecificPlant
     """
@@ -622,26 +684,38 @@ class SpecificPlantViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-a
         return Response(SpecificPlantLocationSerializer(location).data, status=status.HTTP_201_CREATED)
 
 
-class SpecificPlantBySeedTrayViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
+class SpecificPlantBySeedTrayViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SpecificPlant filtered by SeedTray
     """
     queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square')
     serializer_class = SpecificPlantSerializer
+    _parent_seed_tray = None
+
+    def get_parent_seed_tray(self):
+        """Resolve the filtered tray inside the current workspace."""
+        if self._parent_seed_tray is None:
+            self._parent_seed_tray = get_object_or_404(
+                SeedTray,
+                pk=self.kwargs['seed_tray_pk'],
+                workspace=self.get_current_workspace(),
+            )
+        return self._parent_seed_tray
 
     def get_queryset(self):
-        tray_pk = self.kwargs['seed_tray_pk']
-        currently_here = self.queryset.filter(
+        tray_pk = self.get_parent_seed_tray().pk
+        queryset = super().get_queryset()
+        currently_here = queryset.filter(
             locations__seed_tray_cell__tray__pk=tray_pk,
             locations__ended__isnull=True,
         )
-        originated_here = self.queryset.filter(
+        originated_here = queryset.filter(
             cell_planting__seed_tray_planting__seed_tray__pk=tray_pk,
         )
         return (currently_here | originated_here).distinct()
 
 
-class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SpecificPlantLocationViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SpecificPlantLocation
 
@@ -650,6 +724,8 @@ class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=to
     queryset = SpecificPlantLocation.objects.select_related('seed_tray_cell', 'garden_square')
     serializer_class = SpecificPlantLocationSerializer
     http_method_names = ['get', 'post', 'patch', 'head', 'options']
+    workspace_lookup = 'specific_plant__workspace'
+    bind_workspace_on_create = False
 
     @action(detail=True, methods=['post'])
     def end(self, request, pk=None):  # pylint: disable=unused-argument
@@ -658,6 +734,7 @@ class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=to
             location = get_object_or_404(
                 SpecificPlantLocation.objects.select_for_update(),
                 pk=pk,
+                specific_plant__workspace=self.get_current_workspace(),
             )
             self.check_object_permissions(request, location)
             if location.ended is None:
@@ -674,15 +751,22 @@ class SpecificPlantLocationViewSet(viewsets.ModelViewSet):  # pylint: disable=to
         return Response(self.get_serializer(location).data)
 
 
-class SpecificPlantLocationByPlantViewSet(viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
+class SpecificPlantLocationByPlantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SpecificPlantLocation filtered by SpecificPlant
     """
     queryset = SpecificPlantLocation.objects.select_related('seed_tray_cell', 'garden_square')
     serializer_class = SpecificPlantLocationSerializer
+    workspace_lookup = 'specific_plant__workspace'
+    bind_workspace_on_create = False
 
     def get_queryset(self):
-        return self.queryset.filter(specific_plant__pk=self.kwargs['specific_plant_pk'])
+        plant = get_object_or_404(
+            SpecificPlant,
+            pk=self.kwargs['specific_plant_pk'],
+            workspace=self.get_current_workspace(),
+        )
+        return super().get_queryset().filter(specific_plant=plant)
 
 
 router = routers.SimpleRouter()

--- a/plantings/views.py
+++ b/plantings/views.py
@@ -10,6 +10,7 @@ from django.http import HttpResponseNotAllowed, JsonResponse, HttpResponse
 from django.shortcuts import get_object_or_404
 
 from gp.utils import get_request_data
+from workspaces.models import get_current_workspace
 from .models import SeedTrayPlanting, GardenSquareDirectSowPlanting, GardenSquareTransplant, SpecificPlant, SpecificPlantLocation
 
 
@@ -18,15 +19,17 @@ def seedtray_current(request):
     """
     List the seedtray plantings that are currently growing
     """
+    workspace = get_current_workspace()
     plantings = (
         SeedTrayPlanting.objects
-        .filter(removed=False)
+        .filter(removed=False, workspace=workspace)
         .order_by('planted')
         .select_related('seeds_used__seeds__plant_variety__plant', 'seed_tray')
         .prefetch_related('cell_plantings__cell')
     )
     garden_square_location_counts = dict(
         SpecificPlantLocation.objects.filter(
+            specific_plant__workspace=workspace,
             location_type=SpecificPlantLocation.GARDEN_SQUARE,
             specific_plant__cell_planting__seed_tray_planting__in=plantings,
         )
@@ -35,14 +38,17 @@ def seedtray_current(request):
     )
     germinated_counts = dict(
         SpecificPlant.objects
-        .filter(cell_planting__seed_tray_planting__in=plantings)
+        .filter(
+            workspace=workspace,
+            cell_planting__seed_tray_planting__in=plantings,
+        )
         .values('cell_planting__seed_tray_planting')
         .annotate(total=Count('id'))
         .values_list('cell_planting__seed_tray_planting', 'total')
     )
     transplanted_counts = dict(
         GardenSquareTransplant.objects
-        .filter(original_planting__in=plantings)
+        .filter(workspace=workspace, original_planting__in=plantings)
         .values('original_planting')
         .annotate(total=Sum('quantity'))
         .values_list('original_planting', 'total')
@@ -87,7 +93,11 @@ def seedtray_complete(request):
 
     data = get_request_data(request)
 
-    planting = get_object_or_404(SeedTrayPlanting, pk=data.get('planting'))
+    planting = get_object_or_404(
+        SeedTrayPlanting,
+        pk=data.get('planting'),
+        workspace=get_current_workspace(),
+    )
     planting.removed = True
     planting.save()
     return HttpResponse(status=204)
@@ -116,9 +126,10 @@ def gardensquare_current(request):
     """
     List the GardenSquare plantings that are currently growing
     """
+    workspace = get_current_workspace()
     plantings = (
         GardenSquareDirectSowPlanting.objects
-        .filter(removed=False)
+        .filter(removed=False, workspace=workspace)
         .order_by('planted')
         .select_related('seeds_used__seeds__plant_variety__plant', 'location__bed__area')
     )
@@ -140,6 +151,7 @@ def gardensquare_current(request):
             'maturity_date_late': _add_nullable_days(planting.planted, maturity_max)
         })
     specific_garden_locations = SpecificPlantLocation.objects.filter(
+        specific_plant__workspace=workspace,
         location_type=SpecificPlantLocation.GARDEN_SQUARE,
         specific_plant__cell_planting__seed_tray_planting_id=OuterRef(
             'original_planting_id'
@@ -147,7 +159,7 @@ def gardensquare_current(request):
     )
     transplantings = (
         GardenSquareTransplant.objects
-        .filter(removed=False)
+        .filter(removed=False, workspace=workspace)
         .annotate(
             has_specific_representation=Exists(specific_garden_locations),
         )
@@ -174,6 +186,7 @@ def gardensquare_current(request):
             'maturity_date_late': _add_nullable_days(transplanting.transplanted, maturity_max)
         })
     specific_plant_locations = SpecificPlantLocation.objects.filter(
+        specific_plant__workspace=workspace,
         location_type=SpecificPlantLocation.GARDEN_SQUARE,
         ended__isnull=True,
     ).select_related(
@@ -213,7 +226,11 @@ def gardensquare_complete(request):
 
     data = get_request_data(request)
 
-    planting = get_object_or_404(GardenSquareDirectSowPlanting, pk=data.get('planting'))
+    planting = get_object_or_404(
+        GardenSquareDirectSowPlanting,
+        pk=data.get('planting'),
+        workspace=get_current_workspace(),
+    )
     planting.removed = True
     planting.save()
     return HttpResponse(status=204)
@@ -229,7 +246,11 @@ def gardensquare_transplant_complete(request):
 
     data = get_request_data(request)
 
-    planting = get_object_or_404(GardenSquareTransplant, pk=data.get('planting'))
+    planting = get_object_or_404(
+        GardenSquareTransplant,
+        pk=data.get('planting'),
+        workspace=get_current_workspace(),
+    )
     planting.removed = True
     planting.save()
     return HttpResponse(status=204)

--- a/seeds/views.py
+++ b/seeds/views.py
@@ -17,6 +17,8 @@ from plantings.models import (
     SpecificPlantLocation,
 )
 
+from workspaces.models import get_current_workspace
+
 from .models import SeedPacket
 
 
@@ -86,7 +88,7 @@ def packets_current(request):
     packets = list(
         SeedPacket.objects
         .select_related('seeds', 'seeds__plant_variety', 'seeds__plant_variety__plant', 'seeds__supplier')
-        .filter(empty=False)
+        .filter(empty=False, workspace=get_current_workspace())
         .annotate(
             seeds_planted_trays=coalesced_sum(SeedTrayPlanting, 'seeds_used'),
             seeds_planted_direct=coalesced_sum(GardenSquareDirectSowPlanting, 'seeds_used'),
@@ -122,7 +124,11 @@ def packets_empty(request):
 
     data = get_request_data(request)
 
-    packet = get_object_or_404(SeedPacket, pk=data.get('packet'))
+    packet = get_object_or_404(
+        SeedPacket,
+        pk=data.get('packet'),
+        workspace=get_current_workspace(),
+    )
     packet.empty = True
     packet.save()
     return HttpResponse(status=204)

--- a/workspaces/test_isolation.py
+++ b/workspaces/test_isolation.py
@@ -6,10 +6,20 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
 from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
+from plantings.models import (
+    GardenRowDirectSowPlanting,
+    GardenSquareDirectSowPlanting,
+    GardenSquareTransplant,
+    SeedTrayCellPlanting,
+    SeedTrayPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
 from plants.models import Plant, PlantFamily, PlantVariety
 from seeds.models import SeedPacket, Seeds
 from seedtrays.models import SeedTray, SeedTrayCell, SeedTrayModel
 from supplies.models import Supplier
+from tests.factories import make_garden_square
 
 from .models import Workspace, get_current_workspace
 
@@ -103,6 +113,44 @@ class ResourceIsolationTests(APITestCase):
             tray=self.tray,
             x_position=0,
             y_position=0,
+        )
+        self.row_sowing = GardenRowDirectSowPlanting.objects.create(
+            workspace=self.other,
+            seeds_used=self.packet,
+            location=self.row,
+            quantity=2,
+        )
+        self.square_sowing = GardenSquareDirectSowPlanting.objects.create(
+            workspace=self.other,
+            seeds_used=self.packet,
+            location=self.square,
+            quantity=2,
+        )
+        self.tray_sowing = SeedTrayPlanting.objects.create(
+            workspace=self.other,
+            seeds_used=self.packet,
+            seed_tray=self.tray,
+            quantity=2,
+        )
+        self.cell_planting = SeedTrayCellPlanting.objects.create(
+            seed_tray_planting=self.tray_sowing,
+            cell=self.cell,
+            quantity=2,
+        )
+        self.specific_plant = SpecificPlant.objects.create(
+            workspace=self.other,
+            cell_planting=self.cell_planting,
+        )
+        self.location = SpecificPlantLocation.objects.create(
+            specific_plant=self.specific_plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=self.cell,
+        )
+        self.transplant = GardenSquareTransplant.objects.create(
+            workspace=self.other,
+            original_planting=self.tray_sowing,
+            location=self.square,
+            quantity=1,
         )
 
     def test_lists_and_details_hide_other_workspace_records(self):
@@ -223,3 +271,133 @@ class ResourceIsolationTests(APITestCase):
 
         self.assertEqual(nested.status_code, 404)
         self.assertEqual(detail.status_code, 404)
+
+    def test_planting_routes_and_summaries_hide_other_workspace(self):
+        """Cultivation records cannot enter direct, nested, or summary responses."""
+        resources = (
+            ('/plantings/directsowgardenrow/', self.row_sowing.pk),
+            ('/plantings/directsowgardensquare/', self.square_sowing.pk),
+            ('/plantings/seedtray/', self.tray_sowing.pk),
+            ('/plantings/transplantedgardensquare/', self.transplant.pk),
+            ('/plantings/specificplants/', self.specific_plant.pk),
+            ('/plantings/specificplantlocations/', self.location.pk),
+        )
+        for url, record_pk in resources:
+            with self.subTest(url=url):
+                self.assertEqual(self.client.get(url).data, [])
+                self.assertEqual(
+                    self.client.get(f'{url}{record_pk}/').status_code,
+                    404,
+                )
+
+        nested_urls = (
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/',
+            f'/plantings/seedtray-data/{self.tray.pk}/specificplants/',
+            f'/plantings/specificplants/{self.specific_plant.pk}/locations/',
+        )
+        for url in nested_urls:
+            with self.subTest(url=url):
+                self.assertEqual(self.client.get(url).status_code, 404)
+
+        self.assertEqual(
+            self.client.get('/plantings/seedtray/current/').json(),
+            {'plantings': []},
+        )
+        self.assertEqual(
+            self.client.get('/plantings/garden/squares/current/').json(),
+            {'plantings': []},
+        )
+        self.assertEqual(
+            self.client.get('/seeds/packets/current/').json(),
+            {'packets': []},
+        )
+
+    def test_planting_foreign_keys_are_workspace_scoped(self):
+        """Sowing, allocation, germination, and location writes reject foreign IDs."""
+        requests = (
+            (
+                '/plantings/directsowgardenrow/',
+                {
+                    'seeds_used': self.packet.pk,
+                    'location': self.row.pk,
+                    'quantity': 1,
+                },
+            ),
+            (
+                '/plantings/directsowgardensquare/',
+                {
+                    'seeds_used': self.packet.pk,
+                    'location': self.square.pk,
+                    'quantity': 1,
+                },
+            ),
+            (
+                '/plantings/seedtray/',
+                {
+                    'seeds_used': self.packet.pk,
+                    'seed_tray': self.tray.pk,
+                    'quantity': 1,
+                    'cell_plantings': [
+                        {'cell': self.cell.pk, 'quantity': 1},
+                    ],
+                },
+            ),
+            (
+                '/plantings/specificplants/',
+                {'cell_planting': self.cell_planting.pk},
+            ),
+            (
+                '/plantings/specificplantlocations/',
+                {
+                    'specific_plant': self.specific_plant.pk,
+                    'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                    'garden_square': self.square.pk,
+                },
+            ),
+        )
+        for url, payload in requests:
+            with self.subTest(url=url):
+                response = self.client.post(url, payload, format='json')
+                self.assertEqual(response.status_code, 400, response.data)
+
+    def test_mutations_cannot_target_other_workspace(self):
+        """Completion, emptying, moving, and ending foreign records return 404."""
+        current_square = make_garden_square()
+        requests = (
+            ('/plantings/seedtray/complete/', {'planting': self.tray_sowing.pk}),
+            (
+                '/plantings/garden/squares/complete/',
+                {'planting': self.square_sowing.pk},
+            ),
+            (
+                '/plantings/garden/squares/transplant/complete/',
+                {'planting': self.transplant.pk},
+            ),
+            ('/seeds/packets/empty/', {'packet': self.packet.pk}),
+            (
+                f'/plantings/specificplants/{self.specific_plant.pk}/move/',
+                {
+                    'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                    'garden_square': current_square.pk,
+                },
+            ),
+            (
+                f'/plantings/specificplantlocations/{self.location.pk}/end/',
+                {},
+            ),
+        )
+        for url, payload in requests:
+            with self.subTest(url=url):
+                response = self.client.post(url, payload, format='json')
+                self.assertEqual(response.status_code, 404)
+
+        self.packet.refresh_from_db()
+        self.tray_sowing.refresh_from_db()
+        self.square_sowing.refresh_from_db()
+        self.transplant.refresh_from_db()
+        self.location.refresh_from_db()
+        self.assertFalse(self.packet.empty)
+        self.assertFalse(self.tray_sowing.removed)
+        self.assertFalse(self.square_sowing.removed)
+        self.assertFalse(self.transplant.removed)
+        self.assertIsNone(self.location.ended)


### PR DESCRIPTION
Cultivation workflows combine seeds, trays, gardens, and individual histories, making them the highest-risk cross-workspace path. Scope every view, nested route, summary, action, and recovery mutation and reject foreign relationship IDs.

## Summary by Sourcery

Enforce workspace isolation across cultivation workflows so plantings, specific plants, and related seed/summary endpoints only expose and mutate records in the current workspace.

New Features:
- Scope planting viewsets, nested tray and specific-plant routes, and HTML summary views to the current workspace context.
- Add workspace-aware validation on planting and location serializers to reject foreign relationship IDs.

Bug Fixes:
- Prevent completion, movement, and ending mutations from targeting plantings, packets, and locations in other workspaces.
- Ensure legacy transplant conversion only reads and writes cell plantings and specific plants belonging to the transplant’s workspace.
- Restrict current seed packet listings and empty operations to packets in the active workspace.

Tests:
- Extend workspace isolation tests to cover planting list/detail endpoints, nested routes, current-summary views, foreign-key writes, and mutations against cross-workspace records.