### PR TITLE
feat(frontend): add workspace profile settings

### DIFF
--- a/frontend/js/api/workspace.ts
+++ b/frontend/js/api/workspace.ts
@@ -1,0 +1,15 @@
+import { Workspace, WorkspaceUpdate } from '../types/workspace'
+import { csrfPatch, fetchAsJson } from '../utils'
+
+const WORKSPACE_URL = '/settings/workspace/'
+
+function getWorkspace(signal?: AbortSignal): Promise<Workspace> {
+  return fetchAsJson<Workspace>(WORKSPACE_URL, signal)
+}
+
+async function updateWorkspace(update: WorkspaceUpdate): Promise<Workspace> {
+  const response = await csrfPatch(WORKSPACE_URL, update)
+  return response.json() as Promise<Workspace>
+}
+
+export { getWorkspace, updateWorkspace }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -3,7 +3,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
-import { QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider, useQuery } from '@tanstack/react-query'
 import { HashRouter, Navigate, Route, Routes, useParams } from 'react-router'
 
 import { GPTopBar } from './menu.js'
@@ -13,8 +13,10 @@ import { GardenSquarePlantingTable, SeedTrayPlantingTable } from './planting.js'
 import { GardenDisplay } from './garden.js'
 import { SeedTrayModelsTable, SeedTraysTable } from './seedtrays.js'
 import { ApiErrorAlert } from './api_error_alert.js'
-import { queryClient } from './query.js'
+import { queryClient, queryKeys } from './query.js'
 import { SeedTrayDetails } from './seedtray/seedtray_details.js'
+import { getWorkspace } from './api/workspace.js'
+import { WorkspaceModeRoute, WorkspaceSettings } from './workspace.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -28,9 +30,26 @@ function SeedTrayDetailsRoute() {
 }
 
 function FrontEndPage() {
+  const { data: workspace, isPending } = useQuery({
+    queryKey: queryKeys.workspace.current,
+    queryFn: ({ signal }) => getWorkspace(signal)
+  })
+
+  if (isPending) {
+    return <div className="container py-3">Loading workspace…</div>
+  }
+  if (!workspace) {
+    return (
+      <div className="container py-3">
+        <ApiErrorAlert />
+        <div>Workspace settings are unavailable.</div>
+      </div>
+    )
+  }
+
   return (
     <>
-      <GPTopBar />
+      <GPTopBar workspace={workspace} />
       <ApiErrorAlert />
       <Routes>
         <Route path="/gardens" element={<GardenDisplay />} />
@@ -44,6 +63,14 @@ function FrontEndPage() {
         <Route path="/seedtrays/:trayId" element={<SeedTrayDetailsRoute />} />
         <Route path="/plantings/seedtrays" element={<SeedTrayPlantingTable />} />
         <Route path="/plantings/garden-squares" element={<GardenSquarePlantingTable />} />
+        <Route
+          path="/settings"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['garden', 'nursery']}>
+              <WorkspaceSettings workspace={workspace} />
+            </WorkspaceModeRoute>
+          }
+        />
         <Route path="*" element={<Navigate to="/gardens" replace />} />
       </Routes>
     </>

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -5,8 +5,13 @@ import 'bootstrap/dist/css/bootstrap.css'
 
 import { Nav, Navbar, NavDropdown } from 'react-bootstrap'
 import { NavLink, useLocation } from 'react-router'
+import { Workspace } from './types/workspace'
 
-function GPTopBar() {
+interface GPTopBarProps {
+  workspace: Workspace
+}
+
+function GPTopBar({ workspace }: GPTopBarProps) {
   const { pathname } = useLocation()
   const seedsActive = pathname === '/seeds' || pathname.startsWith('/seeds/')
   const seedTraysActive = pathname === '/seedtrays' || pathname.startsWith('/seedtrays/')
@@ -14,6 +19,9 @@ function GPTopBar() {
 
   return (
     <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
+      <Navbar.Brand as={NavLink} to="/gardens">
+        {workspace.name} · {workspace.mode === 'garden' ? 'Garden' : 'Nursery'}
+      </Navbar.Brand>
       <Navbar.Toggle aria-controls="responsive-navbar-nav" />
       <Navbar.Collapse id="responsive-navbar-nav">
         <Nav>
@@ -50,6 +58,9 @@ function GPTopBar() {
               Garden Squares
             </NavDropdown.Item>
           </NavDropdown>
+          <Nav.Link as={NavLink} to="/settings">
+            Settings
+          </Nav.Link>
         </Nav>
       </Navbar.Collapse>
     </Navbar>

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -1,6 +1,10 @@
 import { QueryClient } from '@tanstack/react-query'
 
 const queryKeys = {
+  workspace: {
+    all: ['workspace'] as const,
+    current: ['workspace', 'current'] as const
+  },
   garden: {
     all: ['garden'] as const,
     areas: ['garden', 'areas'] as const,

--- a/frontend/js/types/workspace.ts
+++ b/frontend/js/types/workspace.ts
@@ -1,0 +1,17 @@
+type WorkspaceMode = 'garden' | 'nursery'
+type MeasurementSystem = 'metric' | 'imperial'
+
+interface Workspace {
+  name: string
+  mode: WorkspaceMode
+  currency_code: string
+  default_tax_rate: string
+  timezone: string
+  measurement_system: MeasurementSystem
+  created: string
+  updated: string
+}
+
+type WorkspaceUpdate = Pick<Workspace, 'name' | 'mode' | 'currency_code' | 'default_tax_rate' | 'timezone' | 'measurement_system'>
+
+export { MeasurementSystem, Workspace, WorkspaceMode, WorkspaceUpdate }

--- a/frontend/js/workspace.tsx
+++ b/frontend/js/workspace.tsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Alert, Button, Form } from 'react-bootstrap'
+
+import { updateWorkspace } from './api/workspace'
+import { queryKeys } from './query'
+import { Workspace, WorkspaceMode, WorkspaceUpdate } from './types/workspace'
+
+interface WorkspaceSettingsProps {
+  workspace: Workspace
+}
+
+interface WorkspaceModeRouteProps {
+  workspace: Workspace
+  enabledModes: ReadonlyArray<WorkspaceMode>
+  children: React.ReactNode
+}
+
+function WorkspaceModeRoute({ workspace, enabledModes, children }: WorkspaceModeRouteProps) {
+  if (!enabledModes.includes(workspace.mode)) {
+    const profile = workspace.mode === 'garden' ? 'Garden' : 'Nursery'
+    return <Alert variant="warning">This feature is not enabled for the {profile} profile.</Alert>
+  }
+  return children
+}
+
+function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
+  const queryClient = useQueryClient()
+  const [form, setForm] = React.useState<WorkspaceUpdate>({
+    name: workspace.name,
+    mode: workspace.mode,
+    currency_code: workspace.currency_code,
+    default_tax_rate: workspace.default_tax_rate,
+    timezone: workspace.timezone,
+    measurement_system: workspace.measurement_system
+  })
+  const mutation = useMutation({
+    mutationFn: updateWorkspace,
+    onSuccess: (updated) => queryClient.setQueryData(queryKeys.workspace.current, updated)
+  })
+
+  React.useEffect(() => {
+    setForm({
+      name: workspace.name,
+      mode: workspace.mode,
+      currency_code: workspace.currency_code,
+      default_tax_rate: workspace.default_tax_rate,
+      timezone: workspace.timezone,
+      measurement_system: workspace.measurement_system
+    })
+  }, [workspace])
+
+  function updateField<Field extends keyof WorkspaceUpdate>(field: Field, value: WorkspaceUpdate[Field]) {
+    setForm((current) => ({ ...current, [field]: value }))
+  }
+
+  function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    mutation.mutate({ ...form, currency_code: form.currency_code.toUpperCase() })
+  }
+
+  return (
+    <main className="container py-3">
+      <h1>Workspace settings</h1>
+      <p>Profile changes alter presentation and defaults without deleting cultivation data.</p>
+      <Form onSubmit={submit}>
+        <Form.Group className="mb-3" controlId="workspace-name">
+          <Form.Label>Workspace name</Form.Label>
+          <Form.Control required maxLength={255} value={form.name} onChange={(event) => updateField('name', event.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-mode">
+          <Form.Label>Profile</Form.Label>
+          <Form.Select value={form.mode} onChange={(event) => updateField('mode', event.target.value as WorkspaceMode)}>
+            <option value="garden">Garden</option>
+            <option value="nursery">Nursery</option>
+          </Form.Select>
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-currency">
+          <Form.Label>Currency code</Form.Label>
+          <Form.Control
+            required
+            minLength={3}
+            maxLength={3}
+            pattern="[A-Za-z]{3}"
+            value={form.currency_code}
+            onChange={(event) => updateField('currency_code', event.target.value)}
+            aria-describedby="workspace-currency-help"
+          />
+          <Form.Text id="workspace-currency-help">Three-letter ISO 4217 code, such as USD or NZD.</Form.Text>
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-tax-rate">
+          <Form.Label>Default tax rate (%)</Form.Label>
+          <Form.Control
+            required
+            type="number"
+            min="0"
+            max="100"
+            step="0.0001"
+            value={form.default_tax_rate}
+            onChange={(event) => updateField('default_tax_rate', event.target.value)}
+          />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-timezone">
+          <Form.Label>Timezone</Form.Label>
+          <Form.Control
+            required
+            maxLength={64}
+            value={form.timezone}
+            onChange={(event) => updateField('timezone', event.target.value)}
+            aria-describedby="workspace-timezone-help"
+          />
+          <Form.Text id="workspace-timezone-help">IANA name, such as UTC or Pacific/Auckland.</Form.Text>
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-measurement">
+          <Form.Label>Display measurements</Form.Label>
+          <Form.Select value={form.measurement_system} onChange={(event) => updateField('measurement_system', event.target.value as WorkspaceUpdate['measurement_system'])}>
+            <option value="metric">Metric</option>
+            <option value="imperial">Imperial</option>
+          </Form.Select>
+        </Form.Group>
+        <Button type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? 'Saving…' : 'Save settings'}
+        </Button>
+        {mutation.isSuccess && <span className="ms-3 text-success">Settings saved.</span>}
+      </Form>
+    </main>
+  )
+}
+
+export { WorkspaceModeRoute, WorkspaceSettings }

--- a/workspaces/tests.py
+++ b/workspaces/tests.py
@@ -156,6 +156,30 @@ class WorkspaceEndpointTests(APITestCase):
             },
         )
 
+    def test_two_users_share_mode_changes_without_data_loss(self):
+        """Profile switching is shared presentation state and retains records."""
+        supplier = Supplier.objects.create(name='Persistent supplier')
+        first_response = self.client.patch(
+            self.url,
+            {'mode': 'nursery'},
+            format='json',
+        )
+        second_user = get_user_model().objects.create_user(
+            username='second-workspace-user',
+        )
+        self.client.force_authenticate(second_user)
+        shared_response = self.client.get(self.url)
+        garden_response = self.client.patch(
+            self.url,
+            {'mode': 'garden'},
+            format='json',
+        )
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(shared_response.data['mode'], 'nursery')
+        self.assertEqual(garden_response.status_code, 200)
+        self.assertTrue(Supplier.objects.filter(pk=supplier.pk).exists())
+
     def test_put_post_and_delete_are_not_supported(self):
         """The singleton resource supports partial updates only."""
         for method in ('put', 'post', 'delete'):


### PR DESCRIPTION
Users need to correct deployment defaults and understand the active Garden or Nursery profile. Load the singleton profile before routing, expose an editable settings screen, and update shared workspace branding without hiding cultivation tools.

## Summary by Sourcery

Load the current workspace profile before rendering the frontend and expose a settings page for updating workspace branding and defaults while keeping cultivation data shared.

New Features:
- Add a workspace settings screen allowing users to edit name, profile mode, currency, tax rate, timezone, and measurement system.
- Display the active workspace name and profile (Garden or Nursery) in the top navigation bar, with a direct link to settings.

Bug Fixes:
- Ensure workspace profile mode changes are shared across users without affecting underlying supplier records.

Enhancements:
- Introduce workspace-aware routing that gates features based on the active profile mode and surfaces warnings when a feature is disabled.
- Integrate workspace data into the global query cache for consistent usage across the frontend.

Tests:
- Add a backend test verifying that two users see shared workspace mode changes without losing cultivation-related data.