### PR TITLE
feat(inventory): post stock transactions atomically

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -1,0 +1,582 @@
+"""Transactional services for posting and querying the inventory ledger."""
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Q, Sum
+from django.utils import timezone
+
+from .models import (
+    COST_DECIMAL_PLACES,
+    MONEY_DECIMAL_PLACES,
+    QUANTITY_DECIMAL_PLACES,
+    InventoryItem,
+    StockLot,
+    StockMovement,
+    StockReceipt,
+    Stocktake,
+)
+from .units import convert_standard_quantity
+
+
+QUANTITY_QUANTUM = Decimal(1).scaleb(-QUANTITY_DECIMAL_PLACES)
+MONEY_QUANTUM = Decimal(1).scaleb(-MONEY_DECIMAL_PLACES)
+COST_QUANTUM = Decimal(1).scaleb(-COST_DECIMAL_PLACES)
+
+
+class MovementRequest(NamedTuple):
+    """Validated caller intent for one standalone stock movement."""
+
+    lot: StockLot
+    movement_type: str
+    quantity: Decimal
+    source: object = None
+    destination: object = None
+    occurred_at: object = None
+    reason: str = ''
+    reference: str = ''
+
+
+class OpeningBalanceRequest(NamedTuple):
+    """Caller intent for a costed opening lot and movement."""
+
+    item: InventoryItem
+    quantity: Decimal
+    destination: object
+    acquisition_total: Decimal
+    received_on: object
+    supplier_lot_reference: str = ''
+    expires_on: object = None
+    occurred_at: object = None
+    reason: str = ''
+
+
+class MovementEntry(NamedTuple):
+    """Complete internal data needed to append one movement row."""
+
+    workspace: object
+    user: object
+    lot: StockLot
+    movement_type: str
+    quantity: Decimal
+    source: object = None
+    destination: object = None
+    occurred_at: object = None
+    reason: str = ''
+    reference: str = ''
+    reversal_of: object = None
+    receipt_line: object = None
+    stocktake_line: object = None
+
+
+def quantize_quantity(value):
+    """Return a canonical base-unit quantity at ledger precision."""
+    return Decimal(value).quantize(QUANTITY_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def normalize_quantity(item, quantity, unit_code=None, unit_conversion=None):
+    """Normalize one controlled or item-package display quantity."""
+    if bool(unit_code) == bool(unit_conversion):
+        raise ValidationError(
+            {'unit_code': 'Select exactly one controlled unit or item conversion.'},
+        )
+    if unit_conversion:
+        if unit_conversion.item_id != item.pk:
+            raise ValidationError(
+                {'unit_conversion': 'The conversion does not belong to this item.'},
+            )
+        normalized = Decimal(quantity) * unit_conversion.multiplier
+    else:
+        normalized = convert_standard_quantity(quantity, unit_code, item.base_unit)
+    normalized = quantize_quantity(normalized)
+    if normalized <= 0:
+        raise ValidationError({'quantity': 'Quantity must be greater than zero.'})
+    return normalized
+
+
+def physical_balance(lot, location):
+    """Derive one lot/location balance from append-only movement rows."""
+    totals = StockMovement.objects.filter(lot=lot).aggregate(
+        incoming=Sum('quantity', filter=Q(destination=location)),
+        outgoing=Sum('quantity', filter=Q(source=location)),
+    )
+    return (totals['incoming'] or Decimal('0')) - (
+        totals['outgoing'] or Decimal('0')
+    )
+
+
+def lock_lots(workspace, lot_ids):
+    """Lock and return exact workspace lots in deterministic primary-key order."""
+    requested = sorted(set(lot_ids))
+    lots = list(
+        StockLot.objects.select_for_update()
+        .select_related('item')
+        .filter(workspace=workspace, pk__in=requested)
+        .order_by('pk')
+    )
+    if len(lots) != len(requested):
+        raise ValidationError({'lot': 'One or more lots are unavailable.'})
+    return {lot.pk: lot for lot in lots}
+
+
+def _validate_location(location, workspace, field_name, require_active=True):
+    """Require an operation location in the current workspace."""
+    if not location or location.workspace_id != workspace.pk:
+        raise ValidationError(
+            {field_name: 'The location belongs to a different workspace.'},
+        )
+    if require_active and not location.active:
+        raise ValidationError({field_name: 'The location is inactive.'})
+
+
+def _validate_source_balance(lot, source, quantity):
+    """Reject an outbound effect that exceeds physical stock at its source."""
+    available = physical_balance(lot, source)
+    if quantity > available:
+        raise ValidationError(
+            {
+                'quantity': (
+                    f'Only {available:.9f} {lot.item.base_unit} is available '
+                    f'at {source.name}.'
+                ),
+            },
+        )
+
+
+def _create_movement(entry):
+    """Create a validated movement after callers acquire the lot lock."""
+    quantity = quantize_quantity(entry.quantity)
+    if entry.source:
+        _validate_source_balance(entry.lot, entry.source, quantity)
+    return StockMovement.objects.create(
+        workspace=entry.workspace,
+        created_by=entry.user,
+        lot=entry.lot,
+        movement_type=entry.movement_type,
+        quantity=quantity,
+        source=entry.source,
+        destination=entry.destination,
+        occurred_at=entry.occurred_at or timezone.now(),
+        reason=entry.reason.strip(),
+        reference=entry.reference.strip(),
+        reversal_of=entry.reversal_of,
+        receipt_line=entry.receipt_line,
+        stocktake_line=entry.stocktake_line,
+    )
+
+
+@transaction.atomic
+def post_stock_movement(workspace, user, request):
+    """Post one typed non-document movement under an exact lot lock."""
+    allowed = {
+        StockMovement.MovementType.CONSUMPTION,
+        StockMovement.MovementType.TRANSFER,
+        StockMovement.MovementType.ADJUSTMENT_GAIN,
+        StockMovement.MovementType.ADJUSTMENT_LOSS,
+        StockMovement.MovementType.WASTE,
+        StockMovement.MovementType.SALE,
+        StockMovement.MovementType.CUSTOMER_RETURN,
+    }
+    if request.movement_type not in allowed:
+        raise ValidationError({'movement_type': 'Use a supported domain action.'})
+    locked_lot = lock_lots(workspace, [request.lot.pk])[request.lot.pk]
+    if not locked_lot.item.active:
+        raise ValidationError({'lot': 'The lot item is inactive.'})
+    if request.source:
+        _validate_location(request.source, workspace, 'source')
+    if request.destination:
+        _validate_location(request.destination, workspace, 'destination')
+    if request.movement_type in {
+        StockMovement.MovementType.ADJUSTMENT_GAIN,
+        StockMovement.MovementType.ADJUSTMENT_LOSS,
+        StockMovement.MovementType.WASTE,
+    } and not request.reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+    return _create_movement(MovementEntry(
+        workspace=workspace,
+        user=user,
+        lot=locked_lot,
+        movement_type=request.movement_type,
+        quantity=request.quantity,
+        source=request.source,
+        destination=request.destination,
+        occurred_at=request.occurred_at,
+        reason=request.reason,
+        reference=request.reference,
+    ))
+
+
+@transaction.atomic
+def post_opening_balance(workspace, user, request):
+    """Create a costed opening lot and its initial inbound movement."""
+    item = InventoryItem.objects.select_for_update().get(
+        workspace=workspace,
+        pk=request.item.pk,
+    )
+    if not item.active:
+        raise ValidationError({'item': 'The item is inactive.'})
+    _validate_location(request.destination, workspace, 'destination')
+    quantity = quantize_quantity(request.quantity)
+    if quantity <= 0:
+        raise ValidationError({'quantity': 'Quantity must be greater than zero.'})
+    total = Decimal(request.acquisition_total).quantize(
+        MONEY_QUANTUM,
+        rounding=ROUND_HALF_UP,
+    )
+    if total < 0:
+        raise ValidationError(
+            {'acquisition_total': 'Acquisition total cannot be negative.'},
+        )
+    unit_cost = (total / quantity).quantize(
+        COST_QUANTUM,
+        rounding=ROUND_HALF_UP,
+    )
+    lot = StockLot.objects.create(
+        workspace=workspace,
+        item=item,
+        origin=StockLot.Origin.OPENING,
+        supplier_lot_reference=request.supplier_lot_reference.strip(),
+        received_on=request.received_on,
+        expires_on=request.expires_on,
+        initial_base_quantity=quantity,
+        acquisition_total=total,
+        base_unit_cost=unit_cost,
+        currency_code=workspace.currency_code,
+    )
+    movement = _create_movement(MovementEntry(
+        workspace=workspace,
+        user=user,
+        lot=lot,
+        movement_type=StockMovement.MovementType.OPENING,
+        quantity=quantity,
+        destination=request.destination,
+        occurred_at=request.occurred_at,
+        reason=request.reason,
+    ))
+    item.mark_stock_history_started(movement.occurred_at)
+    return lot, movement
+
+
+def _receipt_acquisition_cost(receipt, line):
+    """Return acquisition total excluding only recoverable tax."""
+    line_cost = line.line_cost_ex_tax.quantize(
+        MONEY_QUANTUM,
+        rounding=ROUND_HALF_UP,
+    )
+    if receipt.tax_recoverable:
+        return line_cost
+    tax = (line_cost * receipt.tax_rate / Decimal('100')).quantize(
+        MONEY_QUANTUM,
+        rounding=ROUND_HALF_UP,
+    )
+    return line_cost + tax
+
+
+@transaction.atomic
+def post_receipt(receipt, user):
+    """Create all receipt lots and movements or roll the document back."""
+    receipt = StockReceipt.objects.select_for_update().select_related(
+        'workspace',
+    ).get(pk=receipt.pk)
+    if receipt.status != StockReceipt.Status.DRAFT:
+        raise ValidationError({'status': 'Only draft receipts can be posted.'})
+    if receipt.currency_code != receipt.workspace.currency_code:
+        raise ValidationError(
+            {'currency_code': 'Receipts must use the workspace currency.'},
+        )
+    lines = list(
+        receipt.lines.select_related(
+            'item',
+            'unit_conversion',
+            'destination',
+        ).order_by('pk')
+    )
+    if not lines:
+        raise ValidationError({'lines': 'Add at least one receipt line.'})
+    item_ids = sorted({line.item_id for line in lines})
+    locked_items = {
+        item.pk: item
+        for item in InventoryItem.objects.select_for_update()
+        .filter(workspace=receipt.workspace, pk__in=item_ids)
+        .order_by('pk')
+    }
+    if len(locked_items) != len(item_ids):
+        raise ValidationError({'lines': 'One or more items are unavailable.'})
+    for line in lines:
+        line.full_clean()
+        if not locked_items[line.item_id].active:
+            raise ValidationError({'lines': f'Item {line.item_id} is inactive.'})
+        if not line.destination.active:
+            raise ValidationError(
+                {'lines': f'Location {line.destination_id} is inactive.'},
+            )
+        if line.unit_conversion_id and not line.unit_conversion.active:
+            raise ValidationError(
+                {'lines': f'Conversion {line.unit_conversion_id} is inactive.'},
+            )
+
+    posted_at = timezone.now()
+    lots = []
+    for line in lines:
+        acquisition_total = _receipt_acquisition_cost(receipt, line)
+        unit_cost = (acquisition_total / line.base_quantity).quantize(
+            COST_QUANTUM,
+            rounding=ROUND_HALF_UP,
+        )
+        lot = StockLot.objects.create(
+            workspace=receipt.workspace,
+            item=line.item,
+            origin=StockLot.Origin.RECEIPT,
+            receipt_line=line,
+            supplier_lot_reference=line.supplier_lot_reference,
+            received_on=receipt.received_date,
+            expires_on=line.expires_on,
+            initial_base_quantity=line.base_quantity,
+            acquisition_total=acquisition_total,
+            base_unit_cost=unit_cost,
+            currency_code=receipt.currency_code,
+        )
+        _create_movement(MovementEntry(
+            workspace=receipt.workspace,
+            user=user,
+            lot=lot,
+            movement_type=StockMovement.MovementType.RECEIPT,
+            quantity=line.base_quantity,
+            destination=line.destination,
+            occurred_at=posted_at,
+            reference=receipt.supplier_reference,
+            receipt_line=line,
+        ))
+        lots.append(lot)
+    InventoryItem.objects.filter(
+        pk__in=item_ids,
+        stock_history_started_at__isnull=True,
+    ).update(stock_history_started_at=posted_at)
+    StockReceipt.objects.filter(pk=receipt.pk).update(
+        status=StockReceipt.Status.POSTED,
+        posted_at=posted_at,
+        updated=posted_at,
+    )
+    receipt.refresh_from_db()
+    return receipt, lots
+
+
+def _validate_reversible(original, reason, allow_receipt, allow_stocktake):
+    """Validate one original before any reversal row is written."""
+    if not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+    if original.movement_type == StockMovement.MovementType.REVERSAL:
+        raise ValidationError({'movement': 'A reversal cannot itself be reversed.'})
+    if hasattr(original, 'reversal'):
+        raise ValidationError({'movement': 'This movement is already reversed.'})
+    if original.receipt_line_id and not allow_receipt:
+        raise ValidationError(
+            {'movement': 'Reverse receipt movements through their receipt.'},
+        )
+    if original.stocktake_line_id and not allow_stocktake:
+        raise ValidationError(
+            {'movement': 'Reverse stocktake movements through their stocktake.'},
+        )
+    if original.destination_id:
+        _validate_source_balance(
+            original.lot,
+            original.destination,
+            original.quantity,
+        )
+
+
+def _create_reversal(original, user, reason, occurred_at):
+    """Append an inverse movement after validation and lot locking."""
+    return _create_movement(MovementEntry(
+        workspace=original.workspace,
+        user=user,
+        lot=original.lot,
+        movement_type=StockMovement.MovementType.REVERSAL,
+        quantity=original.quantity,
+        source=original.destination,
+        destination=original.source,
+        occurred_at=occurred_at,
+        reason=reason,
+        reference=f'Reversal of movement {original.pk}',
+        reversal_of=original,
+    ))
+
+
+@transaction.atomic
+def reverse_movement(original, user, reason, occurred_at=None):
+    """Reverse one standalone movement while retaining the original row."""
+    lot = lock_lots(original.workspace, [original.lot_id])[original.lot_id]
+    original = StockMovement.objects.select_for_update().select_related(
+        'workspace',
+        'source',
+        'destination',
+    ).get(pk=original.pk)
+    original.lot = lot
+    _validate_reversible(original, reason, False, False)
+    return _create_reversal(
+        original,
+        user,
+        reason,
+        occurred_at or timezone.now(),
+    )
+
+
+def _reverse_document_movements(
+    workspace,
+    movements,
+    user,
+    reason,
+    document_kind,
+):
+    """Validate and reverse a complete document under deterministic lot locks."""
+    locked_lots = lock_lots(workspace, [row.lot_id for row in movements])
+    occurred_at = timezone.now()
+    for original in movements:
+        original.lot = locked_lots[original.lot_id]
+        _validate_reversible(
+            original,
+            reason,
+            document_kind == 'receipt',
+            document_kind == 'stocktake',
+        )
+    return [
+        _create_reversal(original, user, reason, occurred_at)
+        for original in movements
+    ]
+
+
+@transaction.atomic
+def reverse_receipt(receipt, user, reason):
+    """Reverse every lot created by one posted receipt atomically."""
+    receipt = StockReceipt.objects.select_for_update().select_related(
+        'workspace',
+    ).get(pk=receipt.pk)
+    if receipt.status != StockReceipt.Status.POSTED:
+        raise ValidationError({'status': 'Only posted receipts can be reversed.'})
+    movements = list(
+        StockMovement.objects.select_for_update()
+        .select_related('lot__item', 'workspace', 'source', 'destination')
+        .filter(receipt_line__receipt=receipt)
+        .order_by('pk')
+    )
+    reversals = _reverse_document_movements(
+        receipt.workspace,
+        movements,
+        user,
+        reason,
+        'receipt',
+    )
+    reversed_at = timezone.now()
+    StockReceipt.objects.filter(pk=receipt.pk).update(
+        status=StockReceipt.Status.REVERSED,
+        reversed_at=reversed_at,
+        updated=reversed_at,
+    )
+    receipt.refresh_from_db()
+    return receipt, reversals
+
+
+@transaction.atomic
+def post_stocktake(stocktake, user):
+    """Snapshot expected counts and post all non-zero variances atomically."""
+    stocktake = Stocktake.objects.select_for_update().select_related(
+        'workspace',
+    ).get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.DRAFT:
+        raise ValidationError({'status': 'Only draft stocktakes can be posted.'})
+    lines = list(
+        stocktake.lines.select_related(
+            'lot__item',
+            'location',
+            'unit_conversion',
+        ).order_by('pk')
+    )
+    if not lines:
+        raise ValidationError({'lines': 'Add at least one stocktake line.'})
+    locked_lots = lock_lots(stocktake.workspace, [line.lot_id for line in lines])
+    for line in lines:
+        line.lot = locked_lots[line.lot_id]
+        line.full_clean()
+        _validate_location(line.location, stocktake.workspace, 'location')
+        expected = quantize_quantity(physical_balance(line.lot, line.location))
+        variance = quantize_quantity(line.counted_base_quantity - expected)
+        if variance and not line.reason.strip():
+            raise ValidationError(
+                {'lines': f'A reason is required for variance line {line.pk}.'},
+            )
+        line.expected_base_quantity = expected
+        line.variance_base_quantity = variance
+
+    posted_at = timezone.now()
+    movements = []
+    for line in lines:
+        type(line).objects.filter(pk=line.pk).update(
+            expected_base_quantity=line.expected_base_quantity,
+            variance_base_quantity=line.variance_base_quantity,
+            updated=posted_at,
+        )
+        variance = line.variance_base_quantity
+        if not variance:
+            continue
+        movement_type = StockMovement.MovementType.ADJUSTMENT_GAIN
+        source = None
+        destination = line.location
+        if variance < 0:
+            movement_type = StockMovement.MovementType.ADJUSTMENT_LOSS
+            source = line.location
+            destination = None
+        movements.append(
+            _create_movement(MovementEntry(
+                workspace=stocktake.workspace,
+                user=user,
+                lot=line.lot,
+                movement_type=movement_type,
+                quantity=abs(variance),
+                source=source,
+                destination=destination,
+                occurred_at=stocktake.counted_at,
+                reason=line.reason,
+                reference=f'Stocktake {stocktake.pk}',
+                stocktake_line=line,
+            )),
+        )
+    Stocktake.objects.filter(pk=stocktake.pk).update(
+        status=Stocktake.Status.POSTED,
+        posted_at=posted_at,
+        updated=posted_at,
+    )
+    stocktake.refresh_from_db()
+    return stocktake, movements
+
+
+@transaction.atomic
+def reverse_stocktake(stocktake, user, reason):
+    """Reverse every non-zero stocktake variance atomically."""
+    stocktake = Stocktake.objects.select_for_update().select_related(
+        'workspace',
+    ).get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.POSTED:
+        raise ValidationError({'status': 'Only posted stocktakes can be reversed.'})
+    movements = list(
+        StockMovement.objects.select_for_update()
+        .select_related('lot__item', 'workspace', 'source', 'destination')
+        .filter(stocktake_line__stocktake=stocktake)
+        .order_by('pk')
+    )
+    reversals = _reverse_document_movements(
+        stocktake.workspace,
+        movements,
+        user,
+        reason,
+        'stocktake',
+    )
+    reversed_at = timezone.now()
+    Stocktake.objects.filter(pk=stocktake.pk).update(
+        status=Stocktake.Status.REVERSED,
+        reversed_at=reversed_at,
+        updated=reversed_at,
+    )
+    stocktake.refresh_from_db()
+    return stocktake, reversals

--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -408,7 +408,7 @@ def _create_reversal(original, user, reason, occurred_at):
 def reverse_movement(original, user, reason, occurred_at=None):
     """Reverse one standalone movement while retaining the original row."""
     lot = lock_lots(original.workspace, [original.lot_id])[original.lot_id]
-    original = StockMovement.objects.select_for_update().select_related(
+    original = StockMovement.objects.select_for_update(of=('self',)).select_related(
         'workspace',
         'source',
         'destination',
@@ -456,7 +456,7 @@ def reverse_receipt(receipt, user, reason):
     if receipt.status != StockReceipt.Status.POSTED:
         raise ValidationError({'status': 'Only posted receipts can be reversed.'})
     movements = list(
-        StockMovement.objects.select_for_update()
+        StockMovement.objects.select_for_update(of=('self',))
         .select_related('lot__item', 'workspace', 'source', 'destination')
         .filter(receipt_line__receipt=receipt)
         .order_by('pk')
@@ -560,7 +560,7 @@ def reverse_stocktake(stocktake, user, reason):
     if stocktake.status != Stocktake.Status.POSTED:
         raise ValidationError({'status': 'Only posted stocktakes can be reversed.'})
     movements = list(
-        StockMovement.objects.select_for_update()
+        StockMovement.objects.select_for_update(of=('self',))
         .select_related('lot__item', 'workspace', 'source', 'destination')
         .filter(stocktake_line__stocktake=stocktake)
         .order_by('pk')

--- a/inventory/test_ledger.py
+++ b/inventory/test_ledger.py
@@ -1,0 +1,324 @@
+"""Transactional behavior tests for exact-lot inventory services."""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from supplies.models import Supplier
+from workspaces.models import get_current_workspace
+
+from .ledger import (
+    MovementRequest,
+    OpeningBalanceRequest,
+    physical_balance,
+    post_opening_balance,
+    post_receipt,
+    post_stock_movement,
+    post_stocktake,
+    reverse_movement,
+    reverse_receipt,
+    reverse_stocktake,
+)
+from .models import (
+    InventoryItem,
+    InventoryLocation,
+    StockLot,
+    StockMovement,
+    StockReceipt,
+    StockReceiptLine,
+    Stocktake,
+    StocktakeLine,
+)
+from .units import UnitCode
+
+
+class LedgerServiceTests(TestCase):
+    """Posting services maintain balances and document audit trails atomically."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.currency_code = 'NZD'
+        self.workspace.default_tax_rate = Decimal('15')
+        self.workspace.save()
+        self.user = get_user_model().objects.create_user(username='ledger-service-user')
+        self.supplier = Supplier.objects.create(
+            workspace=self.workspace,
+            name='Service Supplier',
+        )
+        self.item = InventoryItem.objects.create(
+            workspace=self.workspace,
+            name='Service media',
+            category=InventoryItem.Category.GROWING_MEDIA,
+            base_unit=UnitCode.MILLILITRE,
+        )
+        self.store = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Store',
+            code='STORE',
+            location_type=InventoryLocation.LocationType.STORAGE,
+        )
+        self.growing = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Propagation house',
+            code='PROP',
+            location_type=InventoryLocation.LocationType.GROWING,
+        )
+
+    def make_receipt(self, **overrides):
+        """Create a draft receipt with workspace financial defaults."""
+        values = {
+            'workspace': self.workspace,
+            'supplier': self.supplier,
+            'received_date': date(2026, 8, 1),
+            'currency_code': self.workspace.currency_code,
+            'tax_rate': self.workspace.default_tax_rate,
+            'created_by': self.user,
+        }
+        values.update(overrides)
+        return StockReceipt.objects.create(**values)
+
+    def add_receipt_line(self, receipt, **overrides):
+        """Add one normalized media line to a draft receipt."""
+        values = {
+            'receipt': receipt,
+            'item': self.item,
+            'quantity': Decimal('2'),
+            'unit_code': UnitCode.LITRE,
+            'base_quantity': Decimal('2000'),
+            'line_cost_ex_tax': Decimal('10'),
+            'destination': self.store,
+        }
+        values.update(overrides)
+        return StockReceiptLine.objects.create(**values)
+
+    def make_opening(self, quantity=Decimal('100')):
+        """Post a costed opening balance into the store."""
+        return post_opening_balance(
+            self.workspace,
+            self.user,
+            OpeningBalanceRequest(
+                item=self.item,
+                quantity=quantity,
+                destination=self.store,
+                acquisition_total=Decimal('25'),
+                received_on=date(2026, 8, 1),
+                reason='Audited opening balance',
+            ),
+        )
+
+    def test_post_receipt_creates_exact_lots_costs_and_balances(self):
+        """Every line becomes one immutable valued lot and receipt movement."""
+        receipt = self.make_receipt(
+            supplier_reference='INV-100',
+            tax_recoverable=False,
+        )
+        first_line = self.add_receipt_line(receipt)
+        second_item = InventoryItem.objects.create(
+            workspace=self.workspace,
+            name='Labels',
+            category=InventoryItem.Category.LABEL,
+            base_unit=UnitCode.EACH,
+        )
+        second_line = self.add_receipt_line(
+            receipt,
+            item=second_item,
+            quantity=Decimal('100'),
+            unit_code=UnitCode.EACH,
+            base_quantity=Decimal('100'),
+            line_cost_ex_tax=Decimal('20'),
+        )
+
+        posted, lots = post_receipt(receipt, self.user)
+
+        self.assertEqual(posted.status, StockReceipt.Status.POSTED)
+        self.assertEqual(len(lots), 2)
+        first_lot = StockLot.objects.get(receipt_line=first_line)
+        second_lot = StockLot.objects.get(receipt_line=second_line)
+        self.assertTrue(first_lot.identifier.startswith('LOT-'))
+        self.assertNotEqual(first_lot.identifier, second_lot.identifier)
+        self.assertEqual(first_lot.acquisition_total, Decimal('11.5000'))
+        self.assertEqual(first_lot.base_unit_cost, Decimal('0.005750000000'))
+        self.assertEqual(physical_balance(first_lot, self.store), Decimal('2000'))
+        self.assertEqual(physical_balance(second_lot, self.store), Decimal('100'))
+        self.assertIsNotNone(self.item.refresh_from_db() or self.item.stock_history_started_at)
+        self.assertEqual(
+            StockMovement.objects.filter(
+                receipt_line__receipt=receipt,
+                movement_type=StockMovement.MovementType.RECEIPT,
+            ).count(),
+            2,
+        )
+
+    def test_receipt_validation_rolls_back_every_line(self):
+        """An invalid later line prevents every lot and movement from posting."""
+        receipt = self.make_receipt()
+        self.add_receipt_line(receipt)
+        inactive = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Closed store',
+            code='CLOSED',
+            location_type=InventoryLocation.LocationType.STORAGE,
+            active=False,
+        )
+        self.add_receipt_line(receipt, destination=inactive)
+
+        with self.assertRaises(ValidationError):
+            post_receipt(receipt, self.user)
+
+        receipt.refresh_from_db()
+        self.assertEqual(receipt.status, StockReceipt.Status.DRAFT)
+        self.assertFalse(StockLot.objects.filter(receipt_line__receipt=receipt).exists())
+        self.assertFalse(StockMovement.objects.filter(receipt_line__receipt=receipt).exists())
+
+    def test_receipt_requires_current_workspace_currency(self):
+        """V1 does not silently treat a foreign-currency amount as local cost."""
+        receipt = self.make_receipt(currency_code='USD')
+        self.add_receipt_line(receipt)
+        with self.assertRaises(ValidationError) as context:
+            post_receipt(receipt, self.user)
+        self.assertIn('currency_code', context.exception.message_dict)
+
+    def test_transfer_consumption_and_reversal_reconcile_locations(self):
+        """Location effects remain explicit while total physical stock reconciles."""
+        lot, _opening = self.make_opening()
+        transfer = post_stock_movement(
+            self.workspace,
+            self.user,
+            MovementRequest(
+                lot=lot,
+                movement_type=StockMovement.MovementType.TRANSFER,
+                quantity=Decimal('40'),
+                source=self.store,
+                destination=self.growing,
+            ),
+        )
+        consumption = post_stock_movement(
+            self.workspace,
+            self.user,
+            MovementRequest(
+                lot=lot,
+                movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=Decimal('10'),
+                source=self.growing,
+                reference='Propagation batch 1',
+            ),
+        )
+
+        self.assertEqual(physical_balance(lot, self.store), Decimal('60'))
+        self.assertEqual(physical_balance(lot, self.growing), Decimal('30'))
+        reverse_movement(consumption, self.user, 'Consumption entered twice')
+        self.assertEqual(physical_balance(lot, self.growing), Decimal('40'))
+        reverse_movement(transfer, self.user, 'Wrong destination')
+        self.assertEqual(physical_balance(lot, self.store), Decimal('100'))
+        self.assertEqual(physical_balance(lot, self.growing), Decimal('0'))
+
+    def test_outbound_and_inbound_reversals_cannot_create_negative_stock(self):
+        """Consumption and receipt reversals validate the currently affected place."""
+        lot, opening = self.make_opening(Decimal('10'))
+        post_stock_movement(
+            self.workspace,
+            self.user,
+            MovementRequest(
+                lot=lot,
+                movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=Decimal('6'),
+                source=self.store,
+            ),
+        )
+        with self.assertRaises(ValidationError) as context:
+            post_stock_movement(
+                self.workspace,
+                self.user,
+                MovementRequest(
+                    lot=lot,
+                    movement_type=StockMovement.MovementType.WASTE,
+                    quantity=Decimal('5'),
+                    source=self.store,
+                    reason='Damaged',
+                ),
+            )
+        self.assertIn('quantity', context.exception.message_dict)
+        with self.assertRaises(ValidationError):
+            reverse_movement(opening, self.user, 'Opening was wrong')
+
+    def test_receipt_reversal_is_document_scoped_and_atomic(self):
+        """Receipt rows cannot diverge from their header reversal state."""
+        receipt = self.make_receipt()
+        self.add_receipt_line(receipt)
+        posted, lots = post_receipt(receipt, self.user)
+        original = StockMovement.objects.get(receipt_line__receipt=receipt)
+        with self.assertRaises(ValidationError):
+            reverse_movement(original, self.user, 'Wrong delivery')
+
+        reversed_receipt, reversals = reverse_receipt(
+            posted,
+            self.user,
+            'Supplier delivery cancelled',
+        )
+        self.assertEqual(reversed_receipt.status, StockReceipt.Status.REVERSED)
+        self.assertEqual(len(reversals), 1)
+        self.assertEqual(physical_balance(lots[0], self.store), Decimal('0'))
+
+    def test_stocktake_posts_and_reverses_explicit_variances(self):
+        """A count snapshots expected stock and keeps its adjustment linkage."""
+        lot, _opening = self.make_opening()
+        stocktake = Stocktake.objects.create(
+            workspace=self.workspace,
+            counted_at=timezone.now(),
+            notes='Weekly count',
+            created_by=self.user,
+        )
+        line = StocktakeLine.objects.create(
+            stocktake=stocktake,
+            lot=lot,
+            location=self.store,
+            counted_quantity=Decimal('90'),
+            unit_code=UnitCode.MILLILITRE,
+            counted_base_quantity=Decimal('90'),
+            reason='Container spill',
+        )
+
+        posted, movements = post_stocktake(stocktake, self.user)
+        line.refresh_from_db()
+        self.assertEqual(posted.status, Stocktake.Status.POSTED)
+        self.assertEqual(line.expected_base_quantity, Decimal('100'))
+        self.assertEqual(line.variance_base_quantity, Decimal('-10'))
+        self.assertEqual(movements[0].movement_type, StockMovement.MovementType.ADJUSTMENT_LOSS)
+        self.assertEqual(physical_balance(lot, self.store), Decimal('90'))
+
+        reversed_stocktake, reversals = reverse_stocktake(
+            posted,
+            self.user,
+            'Count used the wrong container',
+        )
+        self.assertEqual(reversed_stocktake.status, Stocktake.Status.REVERSED)
+        self.assertEqual(len(reversals), 1)
+        self.assertEqual(physical_balance(lot, self.store), Decimal('100'))
+
+    def test_adjustment_and_waste_require_reasons(self):
+        """Unexplained corrections cannot enter the audit trail."""
+        lot, _opening = self.make_opening()
+        for movement_type, source, destination in (
+            (StockMovement.MovementType.ADJUSTMENT_GAIN, None, self.store),
+            (StockMovement.MovementType.ADJUSTMENT_LOSS, self.store, None),
+            (StockMovement.MovementType.WASTE, self.store, None),
+        ):
+            with self.subTest(movement_type=movement_type):
+                with self.assertRaises(ValidationError) as context:
+                    post_stock_movement(
+                        self.workspace,
+                        self.user,
+                        MovementRequest(
+                            lot=lot,
+                            movement_type=movement_type,
+                            quantity=Decimal('1'),
+                            source=source,
+                            destination=destination,
+                        ),
+                    )
+                self.assertIn('reason', context.exception.message_dict)

--- a/inventory/test_ledger_concurrency.py
+++ b/inventory/test_ledger_concurrency.py
@@ -1,0 +1,103 @@
+"""PostgreSQL row-locking tests for inventory availability."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+
+from workspaces.models import get_current_workspace
+
+from .ledger import (
+    MovementRequest,
+    OpeningBalanceRequest,
+    post_opening_balance,
+    post_stock_movement,
+)
+from .models import InventoryItem, InventoryLocation, StockLot, StockMovement
+from .units import UnitCode
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentLedgerTests(TransactionTestCase):
+    """A locked lot serializes competing final-quantity consumers."""
+
+    def setUp(self):
+        super().setUp()
+        workspace = get_current_workspace()
+        workspace.currency_code = 'NZD'
+        workspace.save()
+        self.user = get_user_model().objects.create_user(
+            username='ledger-concurrency-user',
+        )
+        item = InventoryItem.objects.create(
+            workspace=workspace,
+            name='Final quantity item',
+            category=InventoryItem.Category.PACKAGING,
+            base_unit=UnitCode.EACH,
+        )
+        location = InventoryLocation.objects.create(
+            workspace=workspace,
+            name='Concurrency store',
+            code='CONCURRENT',
+            location_type=InventoryLocation.LocationType.STORAGE,
+        )
+        lot, _movement = post_opening_balance(
+            workspace,
+            self.user,
+            OpeningBalanceRequest(
+                item=item,
+                quantity=Decimal('10'),
+                destination=location,
+                acquisition_total=Decimal('10'),
+                received_on=date(2026, 8, 1),
+            ),
+        )
+        self.workspace_pk = workspace.pk
+        self.lot_pk = lot.pk
+        self.location_pk = location.pk
+
+    def _consume_final_quantity(self):
+        """Attempt one independent transaction from a separate DB connection."""
+        close_old_connections()
+        workspace = get_current_workspace()
+        lot = StockLot.objects.get(pk=self.lot_pk)
+        location = InventoryLocation.objects.get(pk=self.location_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            post_stock_movement(
+                workspace,
+                user,
+                MovementRequest(
+                    lot=lot,
+                    movement_type=StockMovement.MovementType.CONSUMPTION,
+                    quantity=Decimal('10'),
+                    source=location,
+                ),
+            )
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'posted'
+        close_old_connections()
+        return result
+
+    def test_only_one_request_consumes_the_final_available_quantity(self):
+        """The second transaction observes the first transaction's committed row."""
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(
+                lambda _index: self._consume_final_quantity(),
+                range(2),
+            ))
+
+        self.assertCountEqual(results, ['posted', 'rejected'])
+        self.assertEqual(
+            StockMovement.objects.filter(
+                lot_id=self.lot_pk,
+                movement_type=StockMovement.MovementType.CONSUMPTION,
+            ).count(),
+            1,
+        )

--- a/inventory/test_ledger_concurrency.py
+++ b/inventory/test_ledger_concurrency.py
@@ -4,12 +4,13 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import date
 from decimal import Decimal
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import close_old_connections
 from django.test import TransactionTestCase, skipUnlessDBFeature
 
-from workspaces.models import get_current_workspace
+from workspaces.models import Workspace, get_current_workspace
 
 from .ledger import (
     MovementRequest,
@@ -24,6 +25,15 @@ from .units import UnitCode
 @skipUnlessDBFeature('has_select_for_update')
 class ConcurrentLedgerTests(TransactionTestCase):
     """A locked lot serializes competing final-quantity consumers."""
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Receipts, stocktakes, standalone movements, and reversals must serialize on exact lots and validate complete operations before writing so concurrent requests cannot create negative balances or partial audit history.

## Summary by Sourcery

Introduce transactional inventory ledger services that serialize exact-lot stock operations to maintain consistent balances and audit trails.

New Features:
- Add service layer for posting standalone stock movements, opening balances, receipts, stocktakes, and reversals under atomic transactions.
- Provide quantity normalization and physical balance helpers to support precise, base-unit inventory calculations.

Bug Fixes:
- Prevent stock movements and reversals from creating negative lot/location balances by validating available quantities under row locks.
- Ensure receipt, stocktake, and reversal operations validate complete documents so partial postings cannot diverge from header state.

Tests:
- Add unit tests covering ledger posting behavior, validation rollbacks, and document-scoped reversals for receipts and stocktakes.
- Add PostgreSQL concurrency tests verifying select-for-update lot locking serializes competing final-quantity consumption requests.