### PR TITLE
feat(seeds): receive and reconcile packet stock

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -13,6 +13,7 @@ from .models import (
     MONEY_DECIMAL_PLACES,
     QUANTITY_DECIMAL_PLACES,
     InventoryItem,
+    QuantityCertainty,
     StockLot,
     StockMovement,
     StockReceipt,
@@ -327,10 +328,12 @@ def post_receipt(receipt, user):
     lots = []
     for line in lines:
         acquisition_total = _receipt_acquisition_cost(receipt, line)
-        unit_cost = (acquisition_total / line.base_quantity).quantize(
-            COST_QUANTUM,
-            rounding=ROUND_HALF_UP,
-        )
+        unit_cost = None
+        if line.base_quantity is not None:
+            unit_cost = (acquisition_total / line.base_quantity).quantize(
+                COST_QUANTUM,
+                rounding=ROUND_HALF_UP,
+            )
         lot = StockLot.objects.create(
             workspace=receipt.workspace,
             item=line.item,
@@ -340,21 +343,23 @@ def post_receipt(receipt, user):
             received_on=receipt.received_date,
             expires_on=line.expires_on,
             initial_base_quantity=line.base_quantity,
+            quantity_certainty=line.quantity_certainty,
             acquisition_total=acquisition_total,
             base_unit_cost=unit_cost,
             currency_code=receipt.currency_code,
         )
-        _create_movement(MovementEntry(
-            workspace=receipt.workspace,
-            user=user,
-            lot=lot,
-            movement_type=StockMovement.MovementType.RECEIPT,
-            quantity=line.base_quantity,
-            destination=line.destination,
-            occurred_at=posted_at,
-            reference=receipt.supplier_reference,
-            receipt_line=line,
-        ))
+        if line.quantity_certainty != QuantityCertainty.UNKNOWN:
+            _create_movement(MovementEntry(
+                workspace=receipt.workspace,
+                user=user,
+                lot=lot,
+                movement_type=StockMovement.MovementType.RECEIPT,
+                quantity=line.base_quantity,
+                destination=line.destination,
+                occurred_at=posted_at,
+                reference=receipt.supplier_reference,
+                receipt_line=line,
+            ))
         lots.append(lot)
     InventoryItem.objects.filter(
         pk__in=item_ids,
@@ -467,6 +472,14 @@ def reverse_receipt(receipt, user, reason):
         .filter(receipt_line__receipt=receipt)
         .order_by('pk')
     )
+    receipt_lot_ids = list(
+        StockLot.objects.filter(receipt_line__receipt=receipt)
+        .values_list('pk', flat=True)
+    )
+    if not movements and StockMovement.objects.filter(lot_id__in=receipt_lot_ids).exists():
+        raise ValidationError({
+            'status': 'A quantity-unknown receipt cannot be reversed after stock use.',
+        })
     reversals = _reverse_document_movements(
         receipt.workspace,
         movements,

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -32,6 +32,7 @@ from .models import (
     InventoryItem,
     InventoryLocation,
     ItemUnitConversion,
+    QuantityCertainty,
     StockLot,
     StockMovement,
     StockReceipt,
@@ -80,6 +81,16 @@ class InventoryLocationSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['created', 'updated']
 
+    def validate(self, attrs):
+        """Reserve packet-container locations for the seed workflow."""
+        current_type = getattr(self.instance, 'location_type', None)
+        requested_type = attrs.get('location_type', current_type)
+        if requested_type == InventoryLocation.LocationType.SEED_PACKET:
+            raise ValidationError({
+                'location_type': 'Seed packet locations are system-managed.',
+            })
+        return attrs
+
 
 class StockReceiptLineSerializer(
     CurrentWorkspaceSerializerMixin,
@@ -103,6 +114,7 @@ class StockReceiptLineSerializer(
             'supplier_lot_reference',
             'expires_on',
             'quantity',
+            'quantity_certainty',
             'unit_code',
             'unit_conversion',
             'base_quantity',
@@ -141,15 +153,26 @@ class StockReceiptLineSerializer(
             )
         if destination and not destination.active:
             raise ValidationError({'destination': 'The location is inactive.'})
-        try:
-            attrs['base_quantity'] = normalize_quantity(
-                item,
-                attrs.get('quantity'),
-                attrs.get('unit_code'),
-                conversion,
-            )
-        except DjangoValidationError as exc:
-            raise ValidationError(_model_errors(exc)) from exc
+        certainty = attrs.get(
+            'quantity_certainty',
+            getattr(self.instance, 'quantity_certainty', QuantityCertainty.EXACT),
+        )
+        if certainty == QuantityCertainty.UNKNOWN:
+            if attrs.get('quantity') is not None:
+                raise ValidationError({
+                    'quantity': 'Unknown quantities must not include a number.',
+                })
+            attrs['base_quantity'] = None
+        else:
+            try:
+                attrs['base_quantity'] = normalize_quantity(
+                    item,
+                    attrs.get('quantity'),
+                    attrs.get('unit_code'),
+                    conversion,
+                )
+            except DjangoValidationError as exc:
+                raise ValidationError(_model_errors(exc)) from exc
         return attrs
 
 
@@ -208,6 +231,10 @@ class StockReceiptSerializer(
 
     def validate(self, attrs):
         """Apply workspace financial defaults to new draft documents."""
+        if self.instance and hasattr(self.instance, 'seed_packet_draft'):
+            raise ValidationError({
+                'status': 'Edit seed packet drafts through the seed receipt API.',
+            })
         if self.instance and self.instance.status != StockReceipt.Status.DRAFT:
             raise ValidationError({'status': 'Posted receipts are immutable.'})
         if self.instance is None:
@@ -257,6 +284,7 @@ class StockLotSerializer(serializers.ModelSerializer):
             'received_on',
             'expires_on',
             'initial_base_quantity',
+            'quantity_certainty',
             'acquisition_total',
             'base_unit_cost',
             'currency_code',
@@ -606,6 +634,10 @@ class InventoryLocationViewSet(
         return queryset
 
     def perform_destroy(self, instance):
+        if instance.location_type == InventoryLocation.LocationType.SEED_PACKET:
+            raise ValidationError({
+                'location': 'Seed packet locations are system-managed.',
+            })
         try:
             instance.delete()
         except ProtectedError as exc:
@@ -635,6 +667,10 @@ class StockReceiptViewSet(
         )
 
     def perform_destroy(self, instance):
+        if hasattr(instance, 'seed_packet_draft'):
+            raise ValidationError({
+                'status': 'Cancel seed packet drafts through the seed receipt API.',
+            })
         try:
             instance.delete()
         except DjangoValidationError as exc:
@@ -670,9 +706,14 @@ class StockReceiptViewSet(
     @action(detail=True, methods=['post'])
     def post(self, request, pk=None):  # pylint: disable=unused-argument
         """Post every draft line as one exact lot and receipt movement."""
+        receipt = self.get_object()
+        if hasattr(receipt, 'seed_packet_draft'):
+            raise ValidationError({
+                'status': 'Post seed packet drafts through the seed receipt API.',
+            })
         receipt, _lots = _run_domain_action(
             post_receipt,
-            self.get_object(),
+            receipt,
             request.user,
         )
         return Response(self.get_serializer(receipt).data)

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -1,63 +1,413 @@
-"""
-Rest related classes for seeds
-"""
-from rest_framework import routers, serializers, viewsets
+"""REST resources for seed catalogs, packet receipts, and stock metadata."""
 
-from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+from decimal import Decimal
 
-from .models import Seeds, SeedPacket
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.response import Response
+
+from inventory.models import QuantityCertainty
+from inventory.units import UnitCode
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+)
+
+from .models import SeedPacket, SeedPacketReceiptDraft, Seeds
+from .services import (
+    create_packet_receipt_draft,
+    create_seed_inventory_item,
+    delete_packet_receipt_draft,
+    packet_inventory_snapshot,
+    post_packet_receipt,
+    reconcile_packet_quantity,
+    set_seed_inventory_unit,
+    update_packet_receipt_draft,
+)
+
+
+def _model_errors(error):
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
 
 
 class SeedsSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
-    """
-    Serializer for a Seeds Supply
-    """
+    """Serialize one supplier/variety seed catalog and its semantic unit."""
+
+    base_unit = serializers.ChoiceField(
+        choices=(UnitCode.SEED, UnitCode.SEED_CLUSTER),
+        required=False,
+        default=UnitCode.SEED,
+    )
+    inventory_item = serializers.PrimaryKeyRelatedField(read_only=True)
+
     class Meta:
         model = Seeds
-        fields = ['pk', 'supplier', 'plant_variety', 'supplier_code', 'url', 'notes']
+        fields = [
+            'pk',
+            'supplier',
+            'plant_variety',
+            'supplier_code',
+            'url',
+            'notes',
+            'inventory_item',
+            'base_unit',
+        ]
 
     workspace_field_lookups = {
         'supplier': 'workspace',
         'plant_variety': 'workspace',
     }
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['base_unit'] = (
+            instance.inventory_item.base_unit
+            if instance.inventory_item_id
+            else None
+        )
+        return data
 
-class SeedPacketSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
-    """
-    Serializer for a Seed Packet
-    """
+    @transaction.atomic
+    def create(self, validated_data):
+        base_unit = validated_data.pop('base_unit', UnitCode.SEED)
+        seeds = Seeds.objects.create(**validated_data)
+        item = create_seed_inventory_item(seeds.workspace, seeds, base_unit)
+        seeds.inventory_item = item
+        seeds.save(update_fields=['inventory_item'])
+        return seeds
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        base_unit = validated_data.pop('base_unit', None)
+        instance = super().update(instance, validated_data)
+        if base_unit and instance.inventory_item.base_unit != base_unit:
+            try:
+                set_seed_inventory_unit(instance, base_unit)
+            except DjangoValidationError as exc:
+                raise ValidationError(_model_errors(exc)) from exc
+        return instance
+
+
+class SeedPacketSerializer(serializers.ModelSerializer):
+    """Expose the packet selector with truthful inventory metadata."""
+
+    purchase_date = serializers.SerializerMethodField()
+    sow_by = serializers.SerializerMethodField()
+    empty = serializers.SerializerMethodField()
+    inventory = serializers.SerializerMethodField()
+
     class Meta:
         model = SeedPacket
-        fields = ['pk', 'seeds', 'purchase_date', 'sow_by', 'empty', 'notes']
+        fields = [
+            'pk',
+            'seeds',
+            'purchase_date',
+            'sow_by',
+            'empty',
+            'notes',
+            'inventory',
+        ]
+        read_only_fields = [
+            'pk',
+            'seeds',
+            'purchase_date',
+            'sow_by',
+            'empty',
+            'inventory',
+        ]
+
+    @staticmethod
+    def _snapshot(packet):
+        if not packet.stock_lot_id or not packet.storage_location_id:
+            return None
+        return packet_inventory_snapshot(packet)
+
+    def get_purchase_date(self, packet):
+        """Read the authoritative receipt date from the linked lot."""
+        if packet.stock_lot_id:
+            return packet.stock_lot.received_on
+        return packet.purchase_date
+
+    def get_sow_by(self, packet):
+        """Read the authoritative expiry/sow-by date from the linked lot."""
+        if packet.stock_lot_id:
+            return packet.stock_lot.expires_on
+        return packet.sow_by
+
+    def get_empty(self, packet):
+        """Return a boolean only when an exact balance establishes it."""
+        snapshot = self._snapshot(packet)
+        return snapshot['empty'] if snapshot else None
+
+    def get_inventory(self, packet):
+        """Return nested truthful quantity and valuation metadata."""
+        return self._snapshot(packet)
+
+
+class PacketReceiptDraftSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.Serializer,
+):
+    """Validate and render one seed-focused one-line receipt draft."""
+
+    pk = serializers.IntegerField(read_only=True)
+    seeds = serializers.PrimaryKeyRelatedField(queryset=Seeds.objects.all())
+    status = serializers.CharField(read_only=True)
+    quantity_certainty = serializers.ChoiceField(
+        choices=QuantityCertainty.choices,
+    )
+    quantity = serializers.DecimalField(
+        max_digits=24,
+        decimal_places=9,
+        allow_null=True,
+        required=False,
+    )
+    base_unit = serializers.CharField(read_only=True)
+    line_price = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=4,
+        min_value=Decimal('0'),
+    )
+    supplier_lot_reference = serializers.CharField(
+        allow_blank=True,
+        required=False,
+    )
+    received_date = serializers.DateField()
+    sow_by = serializers.DateField(allow_null=True, required=False)
+    supplier_reference = serializers.CharField(
+        allow_blank=True,
+        required=False,
+    )
+    tax_rate = serializers.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        min_value=Decimal('0'),
+        required=False,
+    )
+    tax_recoverable = serializers.BooleanField(required=False)
+    notes = serializers.CharField(allow_blank=True, required=False)
+    packet = serializers.PrimaryKeyRelatedField(read_only=True)
 
     workspace_field_lookups = {'seeds': 'workspace'}
 
+    def validate(self, attrs):
+        existing_line = self.instance.receipt.lines.get() if self.instance else None
+        certainty = attrs.get(
+            'quantity_certainty',
+            existing_line.quantity_certainty if existing_line else None,
+        )
+        quantity = attrs.get(
+            'quantity',
+            existing_line.quantity if existing_line else None,
+        )
+        if certainty == QuantityCertainty.UNKNOWN and quantity is not None:
+            raise ValidationError({
+                'quantity': 'Leave quantity blank when it is unknown.',
+            })
+        if certainty != QuantityCertainty.UNKNOWN:
+            if quantity is None or quantity <= 0:
+                raise ValidationError({
+                    'quantity': 'Exact and estimated packets require a positive quantity.',
+                })
+        if self.instance and 'seeds' in attrs:
+            if attrs['seeds'].pk != self.instance.seeds_id:
+                raise ValidationError({
+                    'seeds': 'Create a new draft to change the seed catalog.',
+                })
+        return attrs
 
-class SeedsViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
-    """
-    ViewSet of Seeds
-    """
-    queryset = Seeds.objects.all()
+    def create(self, validated_data):
+        request = self.context['request']
+        try:
+            return create_packet_receipt_draft(
+                self.context['view'].get_current_workspace(),
+                request.user,
+                validated_data,
+            )
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+
+    def update(self, instance, validated_data):
+        try:
+            return update_packet_receipt_draft(instance, validated_data)
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+
+    def to_representation(self, instance):
+        """Flatten the linked receipt and its one line for the seed UI."""
+        draft = instance
+        line = draft.receipt.lines.get()
+        return {
+            'pk': draft.pk,
+            'seeds': draft.seeds_id,
+            'status': draft.receipt.status,
+            'quantity_certainty': line.quantity_certainty,
+            'quantity': (
+                f'{line.quantity:.9f}' if line.quantity is not None else None
+            ),
+            'base_unit': line.item.base_unit,
+            'line_price': f'{line.line_cost_ex_tax:.4f}',
+            'supplier_lot_reference': line.supplier_lot_reference,
+            'received_date': draft.receipt.received_date,
+            'sow_by': line.expires_on,
+            'supplier_reference': draft.receipt.supplier_reference,
+            'tax_rate': f'{draft.receipt.tax_rate:.4f}',
+            'tax_recoverable': draft.receipt.tax_recoverable,
+            'notes': draft.notes,
+            'packet': draft.packet_id,
+        }
+
+
+class PacketReconciliationSerializer(serializers.Serializer):
+    """Validate an explicit physical packet count."""
+
+    counted_quantity = serializers.DecimalField(
+        max_digits=24,
+        decimal_places=9,
+        min_value=Decimal('0'),
+    )
+    quantity_certainty = serializers.ChoiceField(
+        choices=(QuantityCertainty.EXACT, QuantityCertainty.ESTIMATED),
+    )
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class SeedsViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Configure seed catalogs and their paired inventory units."""
+
+    queryset = Seeds.objects.select_related('inventory_item')
     serializer_class = SeedsSerializer
 
 
-class SeedPacketCurrentViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
-    """
-    ViewSet of non-empty SeedPackets
-    """
-    queryset = SeedPacket.objects.filter(empty=False)
+class SeedPacketCurrentViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Expose usable packet selectors and explicit physical counts."""
+
+    queryset = SeedPacket.objects.select_related(
+        'stock_lot__item',
+        'storage_location',
+    )
     serializer_class = SeedPacketSerializer
+    http_method_names = ['get', 'patch', 'head', 'options', 'post']
+
+    def create(self, request, *args, **kwargs):
+        """Require packet creation to go through an auditable receipt."""
+        del args, kwargs
+        raise MethodNotAllowed(
+            request.method,
+            detail='Receive seed packets through /seeds/packet-receipts/.',
+        )
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.action != 'list':
+            return queryset
+        usable_ids = []
+        for packet in queryset:
+            if not packet.stock_lot_id or not packet.storage_location_id:
+                if not packet.empty:
+                    usable_ids.append(packet.pk)
+                continue
+            snapshot = packet_inventory_snapshot(packet)
+            remaining = snapshot['remaining_quantity']
+            if remaining is None or remaining > 0:
+                usable_ids.append(packet.pk)
+        return queryset.filter(pk__in=usable_ids)
+
+    @action(detail=True, methods=['post'])
+    def reconcile(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record a physical count and return the refreshed packet balance."""
+        serializer = PacketReconciliationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        try:
+            reconciliation = reconcile_packet_quantity(
+                self.get_object(),
+                request.user,
+                values['counted_quantity'],
+                values['quantity_certainty'],
+                values['reason'],
+            )
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+        packet = self.get_queryset().get(pk=reconciliation.packet_id)
+        return Response(self.get_serializer(packet).data)
 
 
-class SeedPacketAllViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
-    """
-    ViewSet of all SeedPackets
-    """
-    queryset = SeedPacket.objects.all()
+class SeedPacketAllViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Expose all packet states while allowing notes-only updates."""
+
+    queryset = SeedPacket.objects.select_related(
+        'stock_lot__item',
+        'storage_location',
+    )
     serializer_class = SeedPacketSerializer
+    http_method_names = ['get', 'patch', 'head', 'options']
+
+
+class PacketReceiptDraftViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Edit, confirm, or cancel seed-focused receipt drafts."""
+
+    queryset = SeedPacketReceiptDraft.objects.select_related(
+        'seeds',
+        'receipt',
+        'storage_location',
+        'packet',
+    ).prefetch_related('receipt__lines__item')
+    serializer_class = PacketReceiptDraftSerializer
+    bind_workspace_on_create = False
+    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
+
+    def perform_create(self, serializer):
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        try:
+            delete_packet_receipt_draft(instance)
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+
+    @action(detail=True, methods=['post'])
+    def post(self, request, pk=None):  # pylint: disable=unused-argument
+        """Confirm a draft and return its newly usable packet."""
+        try:
+            _receipt, packet = post_packet_receipt(
+                self.get_object(),
+                request.user,
+            )
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+        return Response(
+            SeedPacketSerializer(packet).data,
+            status=status.HTTP_201_CREATED,
+        )
 
 
 router = routers.DefaultRouter()
 router.register(r'seeds', SeedsViewSet)
+router.register(r'packet-receipts', PacketReceiptDraftViewSet)
 router.register(r'packets/all', SeedPacketAllViewSet, 'AllSeedPackets')
 router.register(r'packets', SeedPacketCurrentViewSet)

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -1,0 +1,357 @@
+"""Transactional seed catalog, packet receiving, and counting services."""
+
+from decimal import Decimal
+from uuid import uuid4
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Q, Sum
+from django.utils import timezone
+
+from inventory.ledger import (
+    COST_QUANTUM,
+    MovementRequest,
+    physical_balance,
+    post_receipt,
+    post_stock_movement,
+    quantize_quantity,
+)
+from inventory.models import (
+    InventoryItem,
+    InventoryLocation,
+    QuantityCertainty,
+    StockMovement,
+    StockReceipt,
+    StockReceiptLine,
+)
+
+from .models import (
+    SeedPacket,
+    SeedPacketQuantityReconciliation,
+    SeedPacketReceiptDraft,
+    Seeds,
+)
+
+
+def create_seed_inventory_item(workspace, seeds, base_unit):
+    """Create the inventory identity paired with one seed catalog row."""
+    return InventoryItem.objects.create(
+        workspace=workspace,
+        name=str(seeds),
+        category=InventoryItem.Category.SEED,
+        base_unit=base_unit,
+        tracking_mode=InventoryItem.TrackingMode.LOT,
+        default_usage_basis=InventoryItem.UsageBasis.MANUAL,
+    )
+
+
+def set_seed_inventory_unit(seeds, base_unit):
+    """Change semantic seed units only before packet stock history exists."""
+    item = seeds.inventory_item
+    if item.stock_history_started_at or seeds.seedpacket_set.filter(
+        quantity_reconciliations__isnull=False,
+    ).exists():
+        raise ValidationError({
+            'base_unit': 'Seed units cannot change after packet stock history exists.',
+        })
+    item.base_unit = base_unit
+    item.save(update_fields=['base_unit', 'updated'])
+    return item
+
+
+def _packet_location(workspace):
+    token = uuid4().hex.upper()
+    return InventoryLocation.objects.create(
+        workspace=workspace,
+        name=f'Seed packet {token[:8]}',
+        code=f'SEED-PACKET-{token}',
+        location_type=InventoryLocation.LocationType.SEED_PACKET,
+        notes='System-managed seed packet container.',
+    )
+
+
+@transaction.atomic
+def create_packet_receipt_draft(workspace, user, values):
+    """Create one ordinary receipt line backed by a packet container."""
+    seeds = Seeds.objects.select_for_update().select_related(
+        'supplier',
+        'inventory_item',
+    ).get(pk=values['seeds'].pk, workspace=workspace)
+    if not seeds.inventory_item_id:
+        raise ValidationError({'seeds': 'The seed catalog has no inventory item.'})
+    location = _packet_location(workspace)
+    receipt = StockReceipt.objects.create(
+        workspace=workspace,
+        supplier=seeds.supplier,
+        received_date=values['received_date'],
+        supplier_reference=values.get('supplier_reference', ''),
+        currency_code=workspace.currency_code,
+        tax_rate=values.get('tax_rate', workspace.default_tax_rate),
+        tax_recoverable=values.get('tax_recoverable', False),
+        notes=values.get('notes', ''),
+        created_by=user,
+    )
+    quantity = values.get('quantity')
+    certainty = values['quantity_certainty']
+    base_quantity = None
+    if certainty != QuantityCertainty.UNKNOWN:
+        base_quantity = quantize_quantity(quantity)
+    StockReceiptLine.objects.create(
+        receipt=receipt,
+        item=seeds.inventory_item,
+        supplier_lot_reference=values.get('supplier_lot_reference', ''),
+        expires_on=values.get('sow_by'),
+        quantity=quantity,
+        quantity_certainty=certainty,
+        unit_code=seeds.inventory_item.base_unit,
+        base_quantity=base_quantity,
+        line_cost_ex_tax=values['line_price'],
+        destination=location,
+    )
+    return SeedPacketReceiptDraft.objects.create(
+        workspace=workspace,
+        seeds=seeds,
+        receipt=receipt,
+        storage_location=location,
+        notes=values.get('notes', ''),
+    )
+
+
+@transaction.atomic
+def update_packet_receipt_draft(draft, values):
+    """Update an unposted one-line seed packet receipt."""
+    draft = SeedPacketReceiptDraft.objects.select_for_update().select_related(
+        'receipt',
+        'seeds__inventory_item',
+    ).get(pk=draft.pk)
+    if draft.receipt.status != StockReceipt.Status.DRAFT:
+        raise ValidationError({'status': 'Posted packet receipts are immutable.'})
+    receipt = draft.receipt
+    for field in (
+        'received_date',
+        'supplier_reference',
+        'tax_rate',
+        'tax_recoverable',
+        'notes',
+    ):
+        if field in values:
+            setattr(receipt, field, values[field])
+    receipt.save()
+    line = receipt.lines.select_for_update().get()
+    for field in ('supplier_lot_reference', 'expires_on', 'line_cost_ex_tax'):
+        source = 'sow_by' if field == 'expires_on' else 'line_price' if field == 'line_cost_ex_tax' else field
+        if source in values:
+            setattr(line, field, values[source])
+    if 'quantity_certainty' in values or 'quantity' in values:
+        certainty = values.get('quantity_certainty', line.quantity_certainty)
+        quantity = values.get('quantity', line.quantity)
+        if certainty == QuantityCertainty.UNKNOWN:
+            quantity = None
+            base_quantity = None
+        else:
+            base_quantity = quantize_quantity(quantity)
+        line.quantity_certainty = certainty
+        line.quantity = quantity
+        line.base_quantity = base_quantity
+    line.save()
+    if 'notes' in values:
+        draft.notes = values['notes']
+        draft.save(update_fields=['notes'])
+    return draft
+
+
+@transaction.atomic
+def delete_packet_receipt_draft(draft):
+    """Delete an unposted draft and its unused packet container."""
+    draft = SeedPacketReceiptDraft.objects.select_for_update().select_related(
+        'receipt',
+        'storage_location',
+    ).get(pk=draft.pk)
+    if draft.receipt.status != StockReceipt.Status.DRAFT:
+        raise ValidationError({'status': 'Only draft packet receipts can be deleted.'})
+    receipt = draft.receipt
+    location = draft.storage_location
+    draft.delete()
+    receipt.delete()
+    location.delete()
+
+
+@transaction.atomic
+def post_packet_receipt(draft, user):
+    """Post a seed receipt and create its public packet atomically."""
+    draft = SeedPacketReceiptDraft.objects.select_for_update().select_related(
+        'receipt',
+        'seeds',
+        'storage_location',
+    ).get(pk=draft.pk)
+    if draft.packet_id:
+        raise ValidationError({'status': 'This packet receipt is already posted.'})
+    receipt, lots = post_receipt(draft.receipt, user)
+    if len(lots) != 1:
+        raise ValidationError({'lines': 'A seed packet receipt requires one line.'})
+    lot = lots[0]
+    packet = SeedPacket.objects.create(
+        workspace=draft.workspace,
+        seeds=draft.seeds,
+        stock_lot=lot,
+        storage_location=draft.storage_location,
+        purchase_date=lot.received_on,
+        sow_by=lot.expires_on,
+        notes=draft.notes,
+    )
+    draft.packet = packet
+    draft.save(update_fields=['packet'])
+    return receipt, packet
+
+
+def _latest_reconciliation(packet):
+    return packet.quantity_reconciliations.order_by('-created', '-pk').first()
+
+
+def packet_quantity_certainty(packet):
+    """Return the latest asserted certainty for one packet."""
+    reconciliation = _latest_reconciliation(packet)
+    if reconciliation:
+        return reconciliation.quantity_certainty
+    return packet.stock_lot.quantity_certainty
+
+
+def packet_effective_initial_quantity(packet):
+    """Return the latest reconstructed opening quantity, if numeric."""
+    reconciliation = _latest_reconciliation(packet)
+    if reconciliation:
+        return reconciliation.reconstructed_initial_quantity
+    return packet.stock_lot.initial_base_quantity
+
+
+def packet_remaining_quantity(packet):
+    """Return a usable numeric balance or None when it remains unknown."""
+    if packet_quantity_certainty(packet) == QuantityCertainty.UNKNOWN:
+        return None
+    return quantize_quantity(physical_balance(
+        packet.stock_lot,
+        packet.storage_location,
+    ))
+
+
+def _movement_totals(packet):
+    movements = StockMovement.objects.filter(
+        lot=packet.stock_lot,
+    )
+    consumed = movements.filter(
+        movement_type=StockMovement.MovementType.CONSUMPTION,
+        source=packet.storage_location,
+    ).aggregate(total=Sum('quantity'))['total'] or Decimal('0')
+    reversed_consumption = movements.filter(
+        movement_type=StockMovement.MovementType.REVERSAL,
+        destination=packet.storage_location,
+        reversal_of__movement_type=StockMovement.MovementType.CONSUMPTION,
+    ).aggregate(total=Sum('quantity'))['total'] or Decimal('0')
+    adjustments = movements.filter(
+        Q(movement_type=StockMovement.MovementType.ADJUSTMENT_GAIN) | Q(movement_type=StockMovement.MovementType.ADJUSTMENT_LOSS),
+    ).aggregate(total=Sum('quantity'))['total'] or Decimal('0')
+    return (
+        quantize_quantity(consumed - reversed_consumption),
+        quantize_quantity(adjustments),
+    )
+
+
+def packet_inventory_snapshot(packet):
+    """Return truthful packet balance, valuation, and warning metadata."""
+    certainty = packet_quantity_certainty(packet)
+    initial = packet_effective_initial_quantity(packet)
+    remaining = packet_remaining_quantity(packet)
+    sown, adjustments = _movement_totals(packet)
+    unit_cost = None
+    if initial and packet.stock_lot.acquisition_total is not None:
+        unit_cost = (packet.stock_lot.acquisition_total / initial).quantize(
+            COST_QUANTUM,
+        )
+    warnings = []
+    if certainty == QuantityCertainty.UNKNOWN:
+        warnings.append('Packet quantity and remaining balance are unknown.')
+    elif certainty == QuantityCertainty.ESTIMATED:
+        warnings.append('Packet quantity and valuation are estimated.')
+    if packet.stock_lot.acquisition_total is None:
+        warnings.append('Packet cost is unknown.')
+    empty = None
+    if certainty == QuantityCertainty.EXACT:
+        empty = remaining == 0
+    return {
+        'lot': packet.stock_lot_id,
+        'location': packet.storage_location_id,
+        'quantity_certainty': certainty,
+        'received_quantity': initial,
+        'sown_quantity': sown,
+        'adjustment_quantity': adjustments,
+        'remaining_quantity': remaining,
+        'base_unit': packet.stock_lot.item.base_unit,
+        'acquisition_total': packet.stock_lot.acquisition_total,
+        'effective_base_unit_cost': unit_cost,
+        'currency_code': packet.stock_lot.currency_code,
+        'empty': empty,
+        'warnings': warnings,
+    }
+
+
+@transaction.atomic
+def reconcile_packet_quantity(packet, user, count, certainty, reason):
+    """Record a count and bring the packet's numeric ledger balance to it."""
+    if certainty == QuantityCertainty.UNKNOWN:
+        raise ValidationError({
+            'quantity_certainty': 'A physical count must be exact or estimated.',
+        })
+    packet = SeedPacket.objects.select_for_update().select_related(
+        'stock_lot__item',
+        'storage_location',
+    ).get(pk=packet.pk)
+    if not packet.stock_lot_id or not packet.storage_location_id:
+        raise ValidationError({'packet': 'The packet has no inventory identity.'})
+    counted = quantize_quantity(count)
+    if counted < 0:
+        raise ValidationError({'counted_quantity': 'Quantity cannot be negative.'})
+    raw_balance = quantize_quantity(physical_balance(
+        packet.stock_lot,
+        packet.storage_location,
+    ))
+    previous_initial = packet_effective_initial_quantity(packet)
+    delta = quantize_quantity(counted - raw_balance)
+    reconstructed = quantize_quantity((previous_initial or Decimal('0')) + delta)
+    if reconstructed < 0:
+        raise ValidationError({
+            'counted_quantity': 'The count cannot produce a negative opening quantity.',
+        })
+    movement = None
+    if delta:
+        movement_type = StockMovement.MovementType.ADJUSTMENT_GAIN
+        source = None
+        destination = packet.storage_location
+        if delta < 0:
+            movement_type = StockMovement.MovementType.ADJUSTMENT_LOSS
+            source = packet.storage_location
+            destination = None
+        movement = post_stock_movement(
+            packet.workspace,
+            user,
+            MovementRequest(
+                lot=packet.stock_lot,
+                movement_type=movement_type,
+                quantity=abs(delta),
+                source=source,
+                destination=destination,
+                reason=reason,
+                reference=f'Seed packet {packet.pk} physical count',
+            ),
+        )
+    reconciliation = SeedPacketQuantityReconciliation.objects.create(
+        workspace=packet.workspace,
+        packet=packet,
+        counted_quantity=counted,
+        quantity_certainty=certainty,
+        reconstructed_initial_quantity=reconstructed,
+        movement=movement,
+        reason=reason,
+        recorded_by=user,
+    )
+    packet.stock_lot.item.mark_stock_history_started(timezone.now())
+    return reconciliation

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -23,6 +23,7 @@ from inventory.models import (
     StockMovement,
     StockReceipt,
     StockReceiptLine,
+    StockLot,
 )
 
 from .models import (
@@ -75,7 +76,6 @@ def create_packet_receipt_draft(workspace, user, values):
     """Create one ordinary receipt line backed by a packet container."""
     seeds = Seeds.objects.select_for_update().select_related(
         'supplier',
-        'inventory_item',
     ).get(pk=values['seeds'].pk, workspace=workspace)
     if not seeds.inventory_item_id:
         raise ValidationError({'seeds': 'The seed catalog has no inventory item.'})
@@ -122,7 +122,7 @@ def update_packet_receipt_draft(draft, values):
     """Update an unposted one-line seed packet receipt."""
     draft = SeedPacketReceiptDraft.objects.select_for_update().select_related(
         'receipt',
-        'seeds__inventory_item',
+        'seeds',
     ).get(pk=draft.pk)
     if draft.receipt.status != StockReceipt.Status.DRAFT:
         raise ValidationError({'status': 'Posted packet receipts are immutable.'})
@@ -301,12 +301,12 @@ def reconcile_packet_quantity(packet, user, count, certainty, reason):
         raise ValidationError({
             'quantity_certainty': 'A physical count must be exact or estimated.',
         })
-    packet = SeedPacket.objects.select_for_update().select_related(
-        'stock_lot__item',
-        'storage_location',
-    ).get(pk=packet.pk)
+    packet = SeedPacket.objects.select_for_update().get(pk=packet.pk)
     if not packet.stock_lot_id or not packet.storage_location_id:
         raise ValidationError({'packet': 'The packet has no inventory identity.'})
+    packet.stock_lot = StockLot.objects.select_for_update().select_related(
+        'item',
+    ).get(pk=packet.stock_lot_id)
     counted = quantize_quantity(count)
     if counted < 0:
         raise ValidationError({'counted_quantity': 'Quantity cannot be negative.'})

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -1,6 +1,12 @@
 """
 Tests related to seeds
 """
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from inventory.models import QuantityCertainty, StockMovement, StockReceipt
 from plantings.models import (
     GardenSquareDirectSowPlanting,
     GardenSquareTransplant,
@@ -12,9 +18,11 @@ from plantings.models import (
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_garden_square,
+    make_plant_variety,
     make_seed_packet,
     make_seed_tray,
     make_seed_tray_cell,
+    make_supplier,
 )
 
 
@@ -40,7 +48,7 @@ class SeedRESTContractTests(RESTContractTestCase):
         self.assert_list_contract(self.LIST_URLS)
 
     def test_resources_round_trip(self):
-        """Seed products and packets survive create and retrieve."""
+        """Seed products create inventory identities and packets require receipts."""
         seeds = self.assert_create_retrieve(
             '/seeds/seeds/',
             {
@@ -49,9 +57,11 @@ class SeedRESTContractTests(RESTContractTestCase):
                 'supplier_code': 'CARROT-01',
                 'url': 'https://seeds.example.com/carrot',
                 'notes': 'Pelleted seed',
+                'base_unit': 'seed_cluster',
             },
         )
-        self.assert_create_retrieve(
+        self.assertEqual(seeds['base_unit'], 'seed_cluster')
+        response = self.client.post(
             '/seeds/packets/',
             {
                 'seeds': seeds['pk'],
@@ -60,7 +70,9 @@ class SeedRESTContractTests(RESTContractTestCase):
                 'empty': False,
                 'notes': 'Opened packet',
             },
+            format='json',
         )
+        self.assertEqual(response.status_code, 405)
 
     def test_current_and_all_packet_routes_apply_empty_filter(self):
         """The current route omits empty packets while the all route retains them."""
@@ -200,3 +212,139 @@ class SeedRESTContractTests(RESTContractTestCase):
                 )
                 self.assertEqual(summary['seeds_planted_trays'], 2)
                 self.assertEqual(summary['transplanted_count'], 5)
+
+
+class SeedPacketInventoryWorkflowTests(APITestCase):
+    """Seed receipt drafts preserve exact, estimated, and unknown stock truth."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='packet-stock')
+        self.client.force_authenticate(self.user)
+        supplier = make_supplier()
+        variety = make_plant_variety()
+        response = self.client.post(
+            '/seeds/seeds/',
+            {
+                'supplier': supplier.pk,
+                'plant_variety': variety.pk,
+                'supplier_code': 'BEET-CLUSTER',
+                'base_unit': 'seed_cluster',
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201)
+        self.seeds_pk = response.data['pk']
+
+    def create_draft(self, certainty, quantity=None, price='6.0000'):
+        """Create one packet receipt through the public seed workflow."""
+        payload = {
+            'seeds': self.seeds_pk,
+            'quantity_certainty': certainty,
+            'line_price': price,
+            'received_date': '2026-08-02',
+            'sow_by': '2028-08-02',
+            'supplier_lot_reference': 'SUPPLIER-LOT-1',
+            'notes': 'Silverbeet clusters',
+        }
+        if quantity is not None:
+            payload['quantity'] = quantity
+        response = self.client.post(
+            '/seeds/packet-receipts/',
+            payload,
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201)
+        return response.data
+
+    def post_draft(self, draft_pk):
+        """Confirm a receipt draft and return the packet response."""
+        response = self.client.post(
+            f'/seeds/packet-receipts/{draft_pk}/post/',
+            {},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201)
+        return response.data
+
+    def test_unknown_receipt_posts_lot_without_inventing_quantity(self):
+        """A priced packet can be received while its contents remain unknown."""
+        draft = self.create_draft(QuantityCertainty.UNKNOWN)
+        packet = self.post_draft(draft['pk'])
+
+        self.assertEqual(packet['inventory']['quantity_certainty'], 'unknown')
+        self.assertIsNone(packet['inventory']['received_quantity'])
+        self.assertIsNone(packet['inventory']['remaining_quantity'])
+        self.assertIsNone(packet['empty'])
+        receipt = StockReceipt.objects.get(seed_packet_draft__pk=draft['pk'])
+        self.assertEqual(receipt.status, StockReceipt.Status.POSTED)
+        self.assertFalse(
+            StockMovement.objects.filter(receipt_line__receipt=receipt).exists(),
+        )
+
+    def test_unknown_packet_count_establishes_balance_and_effective_cost(self):
+        """A later count fills the missing inbound quantity without rewriting receipt."""
+        packet = self.post_draft(
+            self.create_draft(QuantityCertainty.UNKNOWN)['pk'],
+        )
+        response = self.client.post(
+            f"/seeds/packets/{packet['pk']}/reconcile/",
+            {
+                'counted_quantity': '24',
+                'quantity_certainty': QuantityCertainty.EXACT,
+                'reason': 'Counted packet contents',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        inventory = response.data['inventory']
+        self.assertEqual(inventory['quantity_certainty'], 'exact')
+        self.assertEqual(inventory['received_quantity'], Decimal('24'))
+        self.assertEqual(inventory['remaining_quantity'], Decimal('24'))
+        self.assertEqual(
+            inventory['effective_base_unit_cost'],
+            Decimal('0.250000000000'),
+        )
+        self.assertFalse(response.data['empty'])
+
+    def test_estimated_packet_count_posts_audited_loss(self):
+        """A low physical count corrects the balance instead of editing receipt history."""
+        packet = self.post_draft(
+            self.create_draft(QuantityCertainty.ESTIMATED, '30')['pk'],
+        )
+        response = self.client.post(
+            f"/seeds/packets/{packet['pk']}/reconcile/",
+            {
+                'counted_quantity': '27',
+                'quantity_certainty': QuantityCertainty.EXACT,
+                'reason': 'Counted three fewer clusters',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data['inventory']['remaining_quantity'],
+            Decimal('27'),
+        )
+        self.assertTrue(StockMovement.objects.filter(
+            lot_id=packet['inventory']['lot'],
+            movement_type=StockMovement.MovementType.ADJUSTMENT_LOSS,
+            quantity=Decimal('3'),
+        ).exists())
+
+    def test_draft_can_be_cancelled_but_posted_packet_cannot(self):
+        """Draft cleanup removes its reserved container without erasing history."""
+        draft = self.create_draft(QuantityCertainty.EXACT, '10')
+        response = self.client.delete(
+            f"/seeds/packet-receipts/{draft['pk']}/",
+        )
+        self.assertEqual(response.status_code, 204)
+
+        posted = self.create_draft(QuantityCertainty.EXACT, '10')
+        self.post_draft(posted['pk'])
+        response = self.client.delete(
+            f"/seeds/packet-receipts/{posted['pk']}/",
+        )
+        self.assertEqual(response.status_code, 400)

--- a/seeds/views.py
+++ b/seeds/views.py
@@ -20,6 +20,7 @@ from plantings.models import (
 from workspaces.models import get_current_workspace
 
 from .models import SeedPacket
+from .services import packet_inventory_snapshot, reconcile_packet_quantity
 
 
 def coalesced_sum(model, lookup):
@@ -80,6 +81,14 @@ def get_transplanted_counts(packet_ids):
     return transplanted_counts
 
 
+def _packet_is_usable(packet):
+    """Keep unknown and positive packets available to sowing selectors."""
+    if not packet.stock_lot_id or not packet.storage_location_id:
+        return not packet.empty
+    remaining = packet_inventory_snapshot(packet)['remaining_quantity']
+    return remaining is None or remaining > 0
+
+
 @login_required
 def packets_current(request):
     """
@@ -87,14 +96,22 @@ def packets_current(request):
     """
     packets = list(
         SeedPacket.objects
-        .select_related('seeds', 'seeds__plant_variety', 'seeds__plant_variety__plant', 'seeds__supplier')
-        .filter(empty=False, workspace=get_current_workspace())
+        .select_related(
+            'seeds',
+            'seeds__plant_variety',
+            'seeds__plant_variety__plant',
+            'seeds__supplier',
+            'stock_lot__item',
+            'storage_location',
+        )
+        .filter(workspace=get_current_workspace())
         .annotate(
             seeds_planted_trays=coalesced_sum(SeedTrayPlanting, 'seeds_used'),
             seeds_planted_direct=coalesced_sum(GardenSquareDirectSowPlanting, 'seeds_used'),
         )
         .order_by('seeds__plant_variety__plant__name', 'seeds__plant_variety__name')
     )
+    packets = [packet for packet in packets if _packet_is_usable(packet)]
     transplanted_counts = get_transplanted_counts([packet.pk for packet in packets])
     packet_data = [
         {
@@ -108,6 +125,11 @@ def packets_current(request):
             'seeds_planted_trays': packet.seeds_planted_trays,
             'seeds_planted_direct': packet.seeds_planted_direct,
             'transplanted_count': transplanted_counts[packet.pk],
+            'inventory': (
+                packet_inventory_snapshot(packet)
+                if packet.stock_lot_id and packet.storage_location_id
+                else None
+            ),
         }
         for packet in packets
     ]
@@ -129,6 +151,15 @@ def packets_empty(request):
         pk=data.get('packet'),
         workspace=get_current_workspace(),
     )
-    packet.empty = True
-    packet.save()
+    if packet.stock_lot_id and packet.storage_location_id:
+        reconcile_packet_quantity(
+            packet,
+            request.user,
+            0,
+            'exact',
+            'Marked physically empty through the compatibility endpoint.',
+        )
+    else:
+        packet.empty = True
+        packet.save(update_fields=['empty'])
     return HttpResponse(status=204)

--- a/workspaces/test_isolation.py
+++ b/workspaces/test_isolation.py
@@ -217,7 +217,15 @@ class ResourceIsolationTests(APITestCase):
                 '/seeds/seeds/',
                 {'supplier': self.supplier.pk, 'plant_variety': self.variety.pk},
             ),
-            ('/seeds/packets/', {'seeds': self.seeds.pk}),
+            (
+                '/seeds/packet-receipts/',
+                {
+                    'seeds': self.seeds.pk,
+                    'quantity_certainty': 'unknown',
+                    'line_price': '5.0000',
+                    'received_date': '2026-08-02',
+                },
+            ),
             (
                 '/garden/beds/',
                 {


### PR DESCRIPTION
Commercial seed packets often have estimated or unstated contents. Add seed-focused receipt drafts, nullable quantity posting, physical-count reconciliation, derived balances and valuation warnings so provenance and usage remain auditable without presenting guesses as facts.

## Summary by Sourcery

Introduce seed packet receipt drafts, inventory integration, and physical-count reconciliation to support unknown or estimated packet quantities while maintaining auditable stock history.

New Features:
- Expose seed catalog base units and link each seed to a dedicated inventory item.
- Add REST and HTML workflows for seed packet receipt drafts that post into inventory and create seed packets.
- Provide packet-level inventory snapshots including quantity certainty, balances, unit costs, and warnings.
- Allow recording and reconciling physical packet counts that adjust stock via audited movements.

Bug Fixes:
- Ensure current packet selectors and views respect inventory-based emptiness and usability rather than a simple empty flag.
- Prevent user-managed creation, deletion, or posting of seed-related inventory locations and receipts through generic inventory APIs.

Enhancements:
- Extend inventory ledger support for quantity certainty, including unknown quantities with optional movements and non-invented unit costs.
- Guard inventory and receipt APIs against direct mutation of seed packet workflows, delegating to specialized seed endpoints.
- Refine seed packet serializers and viewsets to expose truthful, read-only inventory and lifecycle metadata.

Tests:
- Add API tests covering seed packet receipt drafts, posting, unknown quantities, physical reconciliations, and draft cancellation constraints.