### PR TITLE
feat(frontend): add audited seed stock workflow

### DIFF
--- a/frontend/js/api/errors.ts
+++ b/frontend/js/api/errors.ts
@@ -1,4 +1,4 @@
-type ApiRequestMethod = 'GET' | 'POST' | 'PATCH'
+type ApiRequestMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE'
 
 interface ApiErrorOptions {
   method: ApiRequestMethod

--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -12,7 +12,8 @@ import {
   SpecificPlant,
   SpecificPlantCreate,
   SpecificPlantLocationCreate,
-  SpecificPlantMove
+  SpecificPlantMove,
+  SowingCorrection
 } from '../types/plantings'
 
 function getPlantingDirectSowGardenRows(signal?: AbortSignal): Promise<Array<GardenRowDirectPlanting>> {
@@ -37,6 +38,10 @@ function completePlantingDirectSowGardenSquare(plantingPk: number) {
   })
 }
 
+function correctGardenSquareSowing(plantingPk: number, data: SowingCorrection) {
+  return csrfPost(`/plantings/directsowgardensquare/${plantingPk}/correct-sowing/`, data)
+}
+
 function getPlantingSeedTrays(signal?: AbortSignal): Promise<Array<SeedTrayPlanting>> {
   return fetchAsJson<Array<SeedTrayPlanting>>('/plantings/seedtray/', signal)
 }
@@ -53,6 +58,10 @@ function completePlantingSeedTray(plantingPk: number) {
   return csrfPost('/plantings/seedtray/complete/', {
     planting: plantingPk
   })
+}
+
+function correctSeedTraySowing(plantingPk: number, data: SowingCorrection) {
+  return csrfPost(`/plantings/seedtray/${plantingPk}/correct-sowing/`, data)
 }
 
 function getPlantingTransplantedGardenSquares(signal?: AbortSignal): Promise<Array<GardenSquareTransplanting>> {
@@ -99,10 +108,12 @@ export {
   getPlantingDirectSowGardenSquares,
   addPlantingDirectSowGardenSquare,
   completePlantingDirectSowGardenSquare,
+  correctGardenSquareSowing,
   getPlantingSeedTrays,
   getPlantingSeedTray,
   addPlantingSeedTray,
   completePlantingSeedTray,
+  correctSeedTraySowing,
   getPlantingTransplantedGardenSquares,
   completePlantingTransplantedGardenSquare,
   getPlantingSeedTrayCurrent,

--- a/frontend/js/api/seeds.ts
+++ b/frontend/js/api/seeds.ts
@@ -1,5 +1,5 @@
-import { Seed, SeedCreate, SeedPacket, SeedPacketCreate, SeedPacketDetails } from '../types/seeds'
-import { csrfPost, fetchAsJson } from '../utils'
+import { Seed, SeedCreate, SeedPacket, SeedPacketDetails, SeedPacketReceiptCreate, SeedPacketReceiptDraft, SeedPacketReconciliation } from '../types/seeds'
+import { csrfDelete, csrfPost, fetchAsJson } from '../utils'
 
 function getSeeds(signal?: AbortSignal): Promise<Array<Seed>> {
   return fetchAsJson<Array<Seed>>('/seeds/seeds/', signal)
@@ -13,16 +13,46 @@ function getSeedPackets(signal?: AbortSignal): Promise<Array<SeedPacket>> {
   return fetchAsJson<Array<SeedPacket>>('/seeds/packets/', signal)
 }
 
-function addSeedPacket(packet: SeedPacketCreate) {
-  return csrfPost('/seeds/packets/', packet)
+function getAllSeedPackets(signal?: AbortSignal): Promise<Array<SeedPacket>> {
+  return fetchAsJson<Array<SeedPacket>>('/seeds/packets/all/', signal)
+}
+
+function getSeedPacketReceipts(signal?: AbortSignal): Promise<Array<SeedPacketReceiptDraft>> {
+  return fetchAsJson<Array<SeedPacketReceiptDraft>>('/seeds/packet-receipts/', signal)
+}
+
+async function createSeedPacketReceipt(receipt: SeedPacketReceiptCreate): Promise<SeedPacketReceiptDraft> {
+  const response = await csrfPost('/seeds/packet-receipts/', receipt)
+  return response.json() as Promise<SeedPacketReceiptDraft>
+}
+
+async function postSeedPacketReceipt(pk: number): Promise<SeedPacket> {
+  const response = await csrfPost(`/seeds/packet-receipts/${pk}/post/`, {})
+  return response.json() as Promise<SeedPacket>
+}
+
+function cancelSeedPacketReceipt(pk: number): Promise<Response> {
+  return csrfDelete(`/seeds/packet-receipts/${pk}/`)
+}
+
+async function reconcileSeedPacket(pk: number, data: SeedPacketReconciliation): Promise<SeedPacket> {
+  const response = await csrfPost(`/seeds/packets/${pk}/reconcile/`, data)
+  return response.json() as Promise<SeedPacket>
 }
 
 function getSeedPacketsCurrent(signal?: AbortSignal): Promise<Array<SeedPacketDetails>> {
   return fetchAsJson<{ packets: Array<SeedPacketDetails> }>('/seeds/packets/current/', signal).then((data) => data.packets)
 }
 
-function emptySeedPacket(pk: number) {
-  return csrfPost('/seeds/packets/empty/', { packet: pk })
+export {
+  addSeed,
+  cancelSeedPacketReceipt,
+  createSeedPacketReceipt,
+  getAllSeedPackets,
+  getSeedPacketReceipts,
+  getSeedPackets,
+  getSeedPacketsCurrent,
+  getSeeds,
+  postSeedPacketReceipt,
+  reconcileSeedPacket
 }
-
-export { getSeeds, getSeedPackets, getSeedPacketsCurrent, addSeed, addSeedPacket, emptySeedPacket }

--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -11,7 +11,7 @@ import { Supplier } from './types/suppliers'
 import { PlantVariety } from './types/plants'
 import { Seed, SeedPacket } from './types/seeds'
 import { GardenBed, GardenSquare } from './types/garden'
-import { GardenSquareDirectPlantingCreate, GardenSquarePlanting, SeedTrayPlantingCreate, SeedTrayPlantingDetails } from './types/plantings'
+import { GardenSquareDirectPlantingCreate, GardenSquarePlanting, SeedTrayPlantingCreate, SeedTrayPlantingDetails, SowingCorrection } from './types/plantings'
 import { SeedTray, SeedTrayModel } from './types/seedtrays'
 import { SelectOption } from './types/others'
 import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
@@ -24,6 +24,8 @@ import {
   completePlantingDirectSowGardenSquare,
   completePlantingTransplantedGardenSquare,
   completePlantingSeedTray,
+  correctGardenSquareSowing,
+  correctSeedTraySowing,
   endSpecificPlantLocation
 } from './api/plantings'
 import { getPlantVarieties } from './api/plants'
@@ -32,6 +34,14 @@ import { getSeedTrayModels, getSeedTrays, getSeedTrayCells } from './api/seedtra
 import { SeedTrayCell } from './types/seedtrays'
 import { getSuppliers } from './api/supplies'
 import { queryKeys } from './query'
+
+function packetBalanceLabel(packet: SeedPacket): string {
+  const inventory = packet.inventory
+  if (!inventory || inventory.remaining_quantity === null) {
+    return `quantity unknown; ${inventory?.sown_quantity ?? '0'} sown`
+  }
+  return `${inventory.remaining_quantity} ${inventory.base_unit} remaining (${inventory.quantity_certainty})`
+}
 
 interface SeedTrayCellGridProps {
   cells: Array<SeedTrayCell>
@@ -197,7 +207,7 @@ function NewSeedTrayPlantingRow({ suppliers, varieties, seeds, seedPackets, seed
     const variety = varieties.find((candidate) => candidate.pk === seedData?.plant_variety)
     packetOptions.push(
       <option key={seedPacketData.pk} value={seedPacketData.pk}>
-        {variety?.name} from {supplier?.name} (Sow By: {seedPacketData.sow_by})
+        {variety?.name} from {supplier?.name} (Sow by: {seedPacketData.sow_by || 'unknown'}; {packetBalanceLabel(seedPacketData)})
       </option>
     )
   }
@@ -248,47 +258,67 @@ function NewSeedTrayPlantingRow({ suppliers, varieties, seeds, seedPackets, seed
 
 interface SeedTrayPlantingRowProps {
   planting: SeedTrayPlantingDetails
+  seedPackets: Array<SeedPacket>
   completePlanting: (plantingPk: number) => Promise<void>
+  correctPlanting: (plantingPk: number, data: SowingCorrection) => Promise<void>
 }
 
-class SeedTrayPlantingRow extends React.Component<SeedTrayPlantingRowProps> {
-  constructor(props: SeedTrayPlantingRowProps) {
-    super(props)
+function SeedTrayPlantingRow({ planting, seedPackets, completePlanting, correctPlanting }: SeedTrayPlantingRowProps) {
+  const [correcting, setCorrecting] = React.useState(false)
+  const [packetPk, setPacketPk] = React.useState(planting.seeds_used)
+  const [quantity, setQuantity] = React.useState(planting.quantity)
+  const [reason, setReason] = React.useState('')
 
-    this.empty = this.empty.bind(this)
+  async function correct() {
+    await correctPlanting(planting.pk, { seeds_used: packetPk, quantity, reason })
+    setCorrecting(false)
+    setReason('')
   }
 
-  async empty() {
-    await this.props.completePlanting(this.props.planting.pk)
-  }
-
-  render() {
-    return (
-      <tr>
-        <td>
-          {this.props.planting.plant} - {this.props.planting.variety}
-        </td>
-        <td>
-          <span title="Number of seeds or seed clusters sown">Sown: {this.props.planting.quantity}</span> (
-          <span title="Number of individual plants that have germinated">Germinated: {this.props.planting.germinated_count}</span>,{' '}
-          <span title="Number that have been transplanted to a garden square">Transplanted: {this.props.planting.transplanted_count}</span>)
-        </td>
-        <td>{formatDate(this.props.planting.planted)}</td>
-        <td>{this.props.planting.seed_tray}</td>
-        <td>{this.props.planting.location}</td>
-        <td>{formatDateRange(this.props.planting.germination_date_early, this.props.planting.germination_date_late)}</td>
-        <td>{this.props.planting.notes}</td>
-        <td>
-          {this.props.planting.seed_tray && (
-            <Link className="btn btn-primary" to={`/seedtrays/${this.props.planting.seed_tray}`}>
-              Manage Plants
-            </Link>
-          )}
-          <Button onClick={this.empty}>Empty</Button>
-        </td>
-      </tr>
-    )
-  }
+  return (
+    <tr>
+      <td>
+        {planting.plant} - {planting.variety}
+      </td>
+      <td>
+        <span title="Number of seeds or seed clusters sown">Sown: {planting.quantity}</span> (
+        <span title="Number of individual plants that have germinated">Germinated: {planting.germinated_count}</span>,{' '}
+        <span title="Number that have been transplanted to a garden square">Transplanted: {planting.transplanted_count}</span>)
+      </td>
+      <td>{formatDate(planting.planted)}</td>
+      <td>{planting.seed_tray}</td>
+      <td>{planting.location}</td>
+      <td>{formatDateRange(planting.germination_date_early, planting.germination_date_late)}</td>
+      <td>{planting.notes}</td>
+      <td>
+        {planting.seed_tray && (
+          <Link className="btn btn-primary" to={`/seedtrays/${planting.seed_tray}`}>
+            Manage Plants
+          </Link>
+        )}
+        <Button onClick={() => completePlanting(planting.pk)}>Empty</Button>
+        <Button variant="outline-secondary" onClick={() => setCorrecting((current) => !current)}>
+          Correct sowing
+        </Button>
+        {correcting && (
+          <div>
+            <select value={packetPk} onChange={(event) => setPacketPk(Number(event.target.value))}>
+              {seedPackets.map((packet) => (
+                <option key={packet.pk} value={packet.pk}>
+                  Packet #{packet.pk}: {packetBalanceLabel(packet)}
+                </option>
+              ))}
+            </select>
+            <input type="number" min="1" value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+            <input required placeholder="Correction reason" value={reason} onChange={(event) => setReason(event.target.value)} />
+            <Button size="sm" disabled={!reason} onClick={correct}>
+              Apply correction
+            </Button>
+          </div>
+        )}
+      </td>
+    </tr>
+  )
 }
 
 function SeedTrayPlantingTable() {
@@ -330,6 +360,10 @@ function SeedTrayPlantingTable() {
     mutationFn: completePlantingSeedTray,
     onSuccess: () => Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.plantings.all }), queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })])
   })
+  const correctionMutation = useMutation({
+    mutationFn: ({ pk, data }: { pk: number; data: SowingCorrection }) => correctSeedTraySowing(pk, data),
+    onSuccess: () => Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.plantings.all }), queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })])
+  })
   const seedTrayModels = seedTrayModelList.reduce<Record<number, SeedTrayModel>>((models, model) => {
     models[model.pk] = model
     return models
@@ -341,6 +375,10 @@ function SeedTrayPlantingTable() {
 
   async function completePlanting(plantingPk: number) {
     await completeMutation.mutateAsync(plantingPk)
+  }
+
+  async function correctPlanting(plantingPk: number, data: SowingCorrection) {
+    await correctionMutation.mutateAsync({ pk: plantingPk, data })
   }
 
   const rows = []
@@ -360,7 +398,7 @@ function SeedTrayPlantingTable() {
     )
   }
   for (const planting of plantings) {
-    rows.push(<SeedTrayPlantingRow key={planting.pk} planting={planting} completePlanting={completePlanting} />)
+    rows.push(<SeedTrayPlantingRow key={planting.pk} planting={planting} seedPackets={seedPackets} completePlanting={completePlanting} correctPlanting={correctPlanting} />)
   }
   return (
     <Table>
@@ -477,7 +515,10 @@ class NewGardenSquarePlantingRow extends React.Component<NewGardenSquarePlanting
       const seeds = this.props.seeds.find((s) => s.pk === seedPacketData.seeds)
       const supplier = this.props.suppliers.find((s) => s.pk === seeds?.supplier)
       const variety = this.props.varieties.find((v) => v.pk === seeds?.plant_variety)
-      seedPackets.push({ value: seedPacketData.pk, label: `${variety?.name} from ${supplier?.name} (Sow By: ${seedPacketData.sow_by})` })
+      seedPackets.push({
+        value: seedPacketData.pk,
+        label: `${variety?.name} from ${supplier?.name} (Sow by: ${seedPacketData.sow_by || 'unknown'}; ${packetBalanceLabel(seedPacketData)})`
+      })
     }
     const locations = []
     for (const b in this.props.gardenBeds) {
@@ -514,46 +555,64 @@ class NewGardenSquarePlantingRow extends React.Component<NewGardenSquarePlanting
 
 interface GardenSquarePlantingRowProps {
   planting: GardenSquarePlanting
+  seedPackets: Array<SeedPacket>
   completePlanting: (planting: GardenSquarePlanting) => Promise<void>
+  correctPlanting: (plantingPk: number, data: SowingCorrection) => Promise<void>
 }
 
-class GardenSquarePlantingRow extends React.Component<GardenSquarePlantingRowProps> {
-  constructor(props: GardenSquarePlantingRowProps) {
-    super(props)
+function GardenSquarePlantingRow({ planting, seedPackets, completePlanting, correctPlanting }: GardenSquarePlantingRowProps) {
+  const [correcting, setCorrecting] = React.useState(false)
+  const [packetPk, setPacketPk] = React.useState(planting.seeds_used)
+  const [quantity, setQuantity] = React.useState(planting.quantity)
+  const [reason, setReason] = React.useState('')
+  const planted = planting.transplanted ? `${formatDate(planting.transplanted)} (S: ${formatDate(planting.planted)})` : formatDate(planting.planted)
+  const directSowing = !planting.transplanted && planting.specific_plant_pk === undefined
 
-    this.empty = this.empty.bind(this)
+  async function correct() {
+    await correctPlanting(planting.planting_pk, { seeds_used: packetPk, quantity, reason })
+    setCorrecting(false)
+    setReason('')
   }
 
-  async empty() {
-    await this.props.completePlanting(this.props.planting)
-  }
-
-  render() {
-    let planted = ''
-    if (this.props.planting.transplanted) {
-      planted = `${formatDate(this.props.planting.transplanted)} (S: ${formatDate(this.props.planting.planted)})`
-    } else {
-      planted = formatDate(this.props.planting.planted)
-    }
-    return (
-      <tr>
-        <td>
-          {this.props.planting.plant} - {this.props.planting.variety}
-        </td>
-        <td>{this.props.planting.quantity}</td>
-        <td>{planted}</td>
-        <td>
-          {this.props.planting.location.area} - {this.props.planting.location.bed} - {this.props.planting.location.name}
-        </td>
-        <td>{formatDateRange(this.props.planting.germination_date_early, this.props.planting.germination_date_late)}</td>
-        <td>{formatDateRange(this.props.planting.maturity_date_early, this.props.planting.maturity_date_late)}</td>
-        <td>{this.props.planting.notes}</td>
-        <td>
-          <Button onClick={this.empty}>Harvested</Button>
-        </td>
-      </tr>
-    )
-  }
+  return (
+    <tr>
+      <td>
+        {planting.plant} - {planting.variety}
+      </td>
+      <td>{planting.quantity}</td>
+      <td>{planted}</td>
+      <td>
+        {planting.location.area} - {planting.location.bed} - {planting.location.name}
+      </td>
+      <td>{formatDateRange(planting.germination_date_early, planting.germination_date_late)}</td>
+      <td>{formatDateRange(planting.maturity_date_early, planting.maturity_date_late)}</td>
+      <td>{planting.notes}</td>
+      <td>
+        <Button onClick={() => completePlanting(planting)}>Harvested</Button>
+        {directSowing && (
+          <Button variant="outline-secondary" onClick={() => setCorrecting((current) => !current)}>
+            Correct sowing
+          </Button>
+        )}
+        {correcting && (
+          <div>
+            <select value={packetPk} onChange={(event) => setPacketPk(Number(event.target.value))}>
+              {seedPackets.map((packet) => (
+                <option key={packet.pk} value={packet.pk}>
+                  Packet #{packet.pk}: {packetBalanceLabel(packet)}
+                </option>
+              ))}
+            </select>
+            <input type="number" min="1" value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+            <input required placeholder="Correction reason" value={reason} onChange={(event) => setReason(event.target.value)} />
+            <Button size="sm" disabled={!reason} onClick={correct}>
+              Apply correction
+            </Button>
+          </div>
+        )}
+      </td>
+    </tr>
+  )
 }
 
 function GardenSquarePlantingTable() {
@@ -607,6 +666,10 @@ function GardenSquarePlantingTable() {
     mutationFn: completePlantingTransplantedGardenSquare,
     onSuccess: invalidatePlantingsAndPackets
   })
+  const correctionMutation = useMutation({
+    mutationFn: ({ pk, data }: { pk: number; data: SowingCorrection }) => correctGardenSquareSowing(pk, data),
+    onSuccess: invalidatePlantingsAndPackets
+  })
   const endLocationMutation = useMutation({
     mutationFn: endSpecificPlantLocation,
     onSuccess: () =>
@@ -646,6 +709,10 @@ function GardenSquarePlantingTable() {
     } else {
       await completeDirectMutation.mutateAsync(planting.planting_pk)
     }
+  }
+
+  async function correctPlanting(plantingPk: number, data: SowingCorrection) {
+    await correctionMutation.mutateAsync({ pk: plantingPk, data })
   }
 
   const areas = gardenAreas.map((area) => (
@@ -692,7 +759,13 @@ function GardenSquarePlantingTable() {
       (gardenAreas.find((area) => area.pk === filterGardenArea)?.name === planting.location.area && (!filterGardenBed || filterGardenBed === planting.location.bed))
     ) {
       rows.push(
-        <GardenSquarePlantingRow key={planting.transplanting_pk ? 't' + planting.transplanting_pk : planting.planting_pk} planting={planting} completePlanting={completePlanting} />
+        <GardenSquarePlantingRow
+          key={planting.transplanting_pk ? 't' + planting.transplanting_pk : planting.planting_pk}
+          planting={planting}
+          seedPackets={seedPackets}
+          completePlanting={completePlanting}
+          correctPlanting={correctPlanting}
+        />
       )
     }
   }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -34,7 +34,8 @@ const queryKeys = {
       all: ['seeds', 'packets'] as const,
       raw: ['seeds', 'packets', 'raw'] as const,
       current: ['seeds', 'packets', 'current'] as const
-    }
+    },
+    packetReceipts: ['seeds', 'packetReceipts'] as const
   },
   seedTrays: {
     all: ['seedTrays'] as const,

--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -2,16 +2,25 @@ import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
-import { Table, Button } from 'react-bootstrap'
+import { Alert, Button, Form, Table } from 'react-bootstrap'
 import Select from 'react-select'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { Supplier, SupplierCreate } from './types/suppliers'
-import { Seed, SeedCreate, SeedPacketCreate, SeedPacketDetails } from './types/seeds'
+import { Seed, SeedCreate, SeedPacket, SeedPacketReceiptCreate, SeedPacketReceiptDraft, SeedPacketReconciliation, SeedQuantityCertainty } from './types/seeds'
 import { PlantVariety } from './types/plants'
 import { SelectOption } from './types/others'
 import { getPlantVarieties } from './api/plants'
-import { addSeed, addSeedPacket, emptySeedPacket, getSeedPacketsCurrent, getSeeds } from './api/seeds'
+import {
+  addSeed,
+  cancelSeedPacketReceipt,
+  createSeedPacketReceipt,
+  getAllSeedPackets,
+  getSeedPacketReceipts,
+  getSeeds,
+  postSeedPacketReceipt,
+  reconcileSeedPacket
+} from './api/seeds'
 import { addSupplier, getSuppliers } from './api/supplies'
 import { queryKeys } from './query'
 
@@ -167,6 +176,7 @@ interface NewSeedRowState {
   supplierCode?: string
   website?: string
   notes?: string
+  baseUnit: 'seed' | 'seed_cluster'
 }
 
 class NewSeedRow extends React.Component<NewSeedRowProps, NewSeedRowState> {
@@ -178,7 +188,8 @@ class NewSeedRow extends React.Component<NewSeedRowProps, NewSeedRowState> {
       variety: undefined,
       supplierCode: undefined,
       website: undefined,
-      notes: undefined
+      notes: undefined,
+      baseUnit: 'seed'
     }
 
     this.updateSupplier = this.updateSupplier.bind(this)
@@ -240,6 +251,7 @@ class NewSeedRow extends React.Component<NewSeedRowProps, NewSeedRowState> {
     const data: SeedCreate = {
       supplier: supplier,
       plant_variety: variety,
+      base_unit: this.state.baseUnit,
       notes: this.state.notes
     }
     if (this.state.supplierCode !== undefined && this.state.supplierCode !== '') {
@@ -278,6 +290,12 @@ class NewSeedRow extends React.Component<NewSeedRowProps, NewSeedRowState> {
           <input type="text" onChange={this.updateWebsite} />
         </td>
         <td>
+          <select value={this.state.baseUnit} onChange={(event) => this.setState({ baseUnit: event.target.value as 'seed' | 'seed_cluster' })}>
+            <option value="seed">Individual seeds</option>
+            <option value="seed_cluster">Multigerm seed clusters</option>
+          </select>
+        </td>
+        <td>
           <textarea onChange={this.updateNotes} />
         </td>
         <td>
@@ -307,6 +325,7 @@ class SeedRow extends React.Component<SeedRowProps> {
         <td>
           <a href={this.props.seed.url}>{this.props.seed.url}</a>
         </td>
+        <td>{this.props.seed.base_unit === 'seed_cluster' ? 'Seed clusters' : 'Seeds'}</td>
         <td>{this.props.seed.notes}</td>
       </tr>
     )
@@ -352,6 +371,7 @@ function SeedTable() {
           <td>Variety</td>
           <td>Supplier Code</td>
           <td>Link</td>
+          <td>Inventory unit</td>
           <td>Notes</td>
           <td>
             <a href="#" onClick={() => setShowSeedAdd(true)}>
@@ -365,217 +385,266 @@ function SeedTable() {
   )
 }
 
-interface NewSeedPacketRowProps {
+function seedLabel(seedPk: number, seeds: Array<Seed>, suppliers: Array<Supplier>, varieties: Array<PlantVariety>): string {
+  const seed = seeds.find((candidate) => candidate.pk === seedPk)
+  const supplier = suppliers.find((candidate) => candidate.pk === seed?.supplier)
+  const variety = varieties.find((candidate) => candidate.pk === seed?.plant_variety)
+  return `${variety?.name ?? 'Unknown variety'} from ${supplier?.name ?? 'unknown supplier'}`
+}
+
+interface PacketReceiptFormProps {
+  seeds: Array<Seed>
   suppliers: Array<Supplier>
   varieties: Array<PlantVariety>
-  seeds: Array<Seed>
-  done: () => void
-  createPacket: (data: SeedPacketCreate) => Promise<void>
+  onCreate: (data: SeedPacketReceiptCreate) => Promise<void>
+  onCancel: () => void
 }
 
-interface NewSeedPacketRowState {
-  seeds?: number
-  purchaseDate?: string
-  sowBy?: string
-  notes?: string
+function PacketReceiptForm({ seeds, suppliers, varieties, onCreate, onCancel }: PacketReceiptFormProps) {
+  const [seedPk, setSeedPk] = React.useState<number>()
+  const [certainty, setCertainty] = React.useState<SeedQuantityCertainty>('unknown')
+  const [quantity, setQuantity] = React.useState('')
+  const [price, setPrice] = React.useState('')
+  const [receivedDate, setReceivedDate] = React.useState(new Date().toISOString().slice(0, 10))
+  const [sowBy, setSowBy] = React.useState('')
+  const [supplierLot, setSupplierLot] = React.useState('')
+  const [notes, setNotes] = React.useState('')
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const selectedSeed = seedPk ?? seeds[0]?.pk
+    if (!selectedSeed) return
+    const data: SeedPacketReceiptCreate = {
+      seeds: selectedSeed,
+      quantity_certainty: certainty,
+      line_price: price,
+      received_date: receivedDate
+    }
+    if (certainty !== 'unknown') data.quantity = quantity
+    if (sowBy) data.sow_by = sowBy
+    if (supplierLot) data.supplier_lot_reference = supplierLot
+    if (notes) data.notes = notes
+    await onCreate(data)
+  }
+
+  return (
+    <tr>
+      <td colSpan={8}>
+        <Form onSubmit={submit} className="row g-2 align-items-end">
+          <Form.Group className="col-md-3">
+            <Form.Label>Seed catalog</Form.Label>
+            <Form.Select required value={seedPk ?? ''} onChange={(event) => setSeedPk(Number(event.target.value))}>
+              <option value="">Select…</option>
+              {seeds.map((seed) => (
+                <option key={seed.pk} value={seed.pk}>
+                  {seedLabel(seed.pk, seeds, suppliers, varieties)} ({seed.base_unit})
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+          <Form.Group className="col-md-2">
+            <Form.Label>Quantity certainty</Form.Label>
+            <Form.Select value={certainty} onChange={(event) => setCertainty(event.target.value as SeedQuantityCertainty)}>
+              <option value="unknown">Unknown</option>
+              <option value="estimated">Estimated</option>
+              <option value="exact">Exact</option>
+            </Form.Select>
+          </Form.Group>
+          <Form.Group className="col-md-2">
+            <Form.Label>Quantity</Form.Label>
+            <Form.Control
+              required={certainty !== 'unknown'}
+              disabled={certainty === 'unknown'}
+              type="number"
+              min="0.000000001"
+              step="0.000000001"
+              value={quantity}
+              onChange={(event) => setQuantity(event.target.value)}
+            />
+          </Form.Group>
+          <Form.Group className="col-md-2">
+            <Form.Label>Line price</Form.Label>
+            <Form.Control required type="number" min="0" step="0.0001" value={price} onChange={(event) => setPrice(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-md-2">
+            <Form.Label>Received</Form.Label>
+            <Form.Control required type="date" value={receivedDate} onChange={(event) => setReceivedDate(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-md-2">
+            <Form.Label>Sow by</Form.Label>
+            <Form.Control type="date" value={sowBy} onChange={(event) => setSowBy(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-md-3">
+            <Form.Label>Supplier lot/reference</Form.Label>
+            <Form.Control value={supplierLot} onChange={(event) => setSupplierLot(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-md-4">
+            <Form.Label>Notes</Form.Label>
+            <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </Form.Group>
+          <div className="col-md-3">
+            <Button type="submit">Save draft</Button>{' '}
+            <Button variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+          </div>
+        </Form>
+      </td>
+    </tr>
+  )
 }
 
-class NewSeedPacketRow extends React.Component<NewSeedPacketRowProps, NewSeedPacketRowState> {
-  constructor(props: NewSeedPacketRowProps) {
-    super(props)
+interface ReceiptDraftRowProps {
+  draft: SeedPacketReceiptDraft
+  label: string
+  onPost: (pk: number) => Promise<void>
+  onCancel: (pk: number) => Promise<void>
+}
 
-    this.state = {
-      seeds: undefined,
-      purchaseDate: undefined,
-      sowBy: undefined,
-      notes: undefined
-    }
-
-    this.updateSeeds = this.updateSeeds.bind(this)
-    this.updatePurchaseDate = this.updatePurchaseDate.bind(this)
-    this.updateSowBy = this.updateSowBy.bind(this)
-    this.updateNotes = this.updateNotes.bind(this)
-
-    this.add = this.add.bind(this)
-  }
-
-  updateSeeds(selectedSeeds: SelectOption | null) {
-    const value = selectedSeeds?.value
-
-    if (value === undefined || value === null) {
-      this.setState({ seeds: undefined })
-      return
-    }
-
-    this.setState({ seeds: Number(value) })
-  }
-
-  updatePurchaseDate(event: React.ChangeEvent<HTMLInputElement>) {
-    const { value } = event.target
-
-    this.setState({ purchaseDate: value })
-  }
-
-  updateSowBy(event: React.ChangeEvent<HTMLInputElement>) {
-    const { value } = event.target
-
-    this.setState({ sowBy: value })
-  }
-
-  updateNotes(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    const { value } = event.target
-
-    this.setState({ notes: value })
-  }
-
-  async add() {
-    let { seeds } = this.state
-    if (!seeds) {
-      seeds = this.props.seeds[0].pk
-    }
-    const data: SeedPacketCreate = {
-      seeds: seeds,
-      notes: this.state.notes
-    }
-    if (this.state.purchaseDate !== undefined && this.state.purchaseDate !== '') {
-      data.purchase_date = this.state.purchaseDate
-    }
-    if (this.state.sowBy !== undefined && this.state.sowBy !== '') {
-      data.sow_by = this.state.sowBy
-    }
-    await this.props.createPacket(data)
-    this.props.done()
-  }
-
-  render() {
-    const seeds = []
-    for (const s in this.props.seeds) {
-      const seedsData = this.props.seeds[s]
-      const supplier = this.props.suppliers.find((s) => s.pk === seedsData.supplier)
-      const variety = this.props.varieties.find((v) => v.pk === seedsData.plant_variety)
-      seeds.push({ value: seedsData.pk, label: `${variety?.name} from ${supplier?.name}` })
-    }
-    return (
-      <tr>
-        <td>
-          <Select onChange={this.updateSeeds} options={seeds} value={seeds.find((o) => o.value === this.state.seeds)} />
-        </td>
-        <td>
-          <input type="text" onChange={this.updatePurchaseDate} />
-        </td>
-        <td>
-          <input type="text" onChange={this.updateSowBy} />
-        </td>
-        <td>
-          <textarea onChange={this.updateNotes} />
-        </td>
-        <td>
-          <Button onClick={this.add}>Add</Button>
-          <Button onClick={this.props.done}>Cancel</Button>
-        </td>
-      </tr>
-    )
-  }
+function ReceiptDraftRow({ draft, label, onPost, onCancel }: ReceiptDraftRowProps) {
+  if (draft.status !== 'draft') return null
+  return (
+    <tr className="table-warning">
+      <td>{label}</td>
+      <td>{draft.received_date}</td>
+      <td>{draft.sow_by || '—'}</td>
+      <td>
+        {draft.quantity_certainty === 'unknown' ? 'Unknown' : `${draft.quantity} ${draft.base_unit}`} ({draft.quantity_certainty})
+      </td>
+      <td>{draft.line_price}</td>
+      <td colSpan={2}>Draft — confirm these normalized receipt details before posting.</td>
+      <td>
+        <Button size="sm" onClick={() => onPost(draft.pk)}>
+          Post receipt
+        </Button>{' '}
+        <Button size="sm" variant="outline-danger" onClick={() => onCancel(draft.pk)}>
+          Cancel
+        </Button>
+      </td>
+    </tr>
+  )
 }
 
 interface SeedPacketRowProps {
-  seedPacket: SeedPacketDetails
-  emptyPacket: (packetPk: number) => Promise<void>
+  packet: SeedPacket
+  label: string
+  onReconcile: (pk: number, data: SeedPacketReconciliation) => Promise<void>
 }
 
-class SeedPacketRow extends React.Component<SeedPacketRowProps> {
-  constructor(props: SeedPacketRowProps) {
-    super(props)
+function SeedPacketRow({ packet, label, onReconcile }: SeedPacketRowProps) {
+  const [count, setCount] = React.useState('')
+  const [certainty, setCertainty] = React.useState<'exact' | 'estimated'>('exact')
+  const [reason, setReason] = React.useState('')
+  const inventory = packet.inventory
 
-    this.empty = this.empty.bind(this)
+  async function reconcile() {
+    if (!count || !reason) return
+    await onReconcile(packet.pk, { counted_quantity: count, quantity_certainty: certainty, reason })
+    setCount('')
+    setReason('')
   }
 
-  async empty() {
-    await this.props.emptyPacket(this.props.seedPacket.pk)
-  }
-
-  render() {
-    return (
-      <tr>
-        <td>
-          {this.props.seedPacket.plant}, {this.props.seedPacket.variety} from {this.props.seedPacket.supplier}
-        </td>
-        <td>{this.props.seedPacket.purchase_date}</td>
-        <td>{this.props.seedPacket.sow_by}</td>
-        <td>{this.props.seedPacket.seeds_planted_direct}</td>
-        <td>
-          {this.props.seedPacket.transplanted_count} plants / {this.props.seedPacket.seeds_planted_trays} sown
-        </td>
-        <td>{this.props.seedPacket.notes}</td>
-        <td>
-          <Button onClick={this.empty}>Empty</Button>
-        </td>
-      </tr>
-    )
-  }
+  return (
+    <tr>
+      <td>{label}</td>
+      <td>{packet.purchase_date || '—'}</td>
+      <td>{packet.sow_by || '—'}</td>
+      <td>
+        {inventory?.received_quantity ?? 'Unknown'} {inventory?.base_unit} ({inventory?.quantity_certainty ?? 'unlinked'})
+      </td>
+      <td>
+        {inventory?.acquisition_total ?? 'Unknown'} {inventory?.currency_code}
+        {inventory?.effective_base_unit_cost && ` (${inventory.effective_base_unit_cost}/${inventory.base_unit})`}
+      </td>
+      <td>
+        {inventory?.sown_quantity ?? '0'} sown; {inventory?.adjustment_quantity ?? '0'} adjusted
+      </td>
+      <td>
+        {inventory?.remaining_quantity ?? 'Unknown'} {inventory?.base_unit}
+        {inventory?.warnings.map((warning) => (
+          <Alert key={warning} variant="warning" className="p-1 my-1">
+            {warning}
+          </Alert>
+        ))}
+        {inventory && <small>Lot #{inventory.lot}</small>}
+      </td>
+      <td>
+        <Form.Control size="sm" type="number" min="0" step="0.000000001" placeholder="Physical count" value={count} onChange={(event) => setCount(event.target.value)} />
+        <Form.Select size="sm" value={certainty} onChange={(event) => setCertainty(event.target.value as 'exact' | 'estimated')}>
+          <option value="exact">Exact count</option>
+          <option value="estimated">Estimated count</option>
+        </Form.Select>
+        <Form.Control size="sm" placeholder="Reason" value={reason} onChange={(event) => setReason(event.target.value)} />
+        <Button size="sm" disabled={!count || !reason} onClick={reconcile}>
+          Reconcile
+        </Button>
+      </td>
+    </tr>
+  )
 }
 
 function SeedStockTable() {
   const queryClient = useQueryClient()
-  const [showSeedPacketAdd, setShowSeedPacketAdd] = React.useState(false)
-  const { data: suppliers = [] } = useQuery({
-    queryKey: queryKeys.suppliers.all,
-    queryFn: ({ signal }) => getSuppliers(signal)
-  })
-  const { data: varieties = [] } = useQuery({
-    queryKey: queryKeys.plants.varieties,
-    queryFn: ({ signal }) => getPlantVarieties(signal)
-  })
-  const { data: seeds = [] } = useQuery({
-    queryKey: queryKeys.seeds.catalog,
-    queryFn: ({ signal }) => getSeeds(signal)
-  })
-  const { data: seedPackets = [] } = useQuery({
-    queryKey: queryKeys.seeds.packets.current,
-    queryFn: ({ signal }) => getSeedPacketsCurrent(signal)
-  })
-  const packetMutation = useMutation({
-    mutationFn: addSeedPacket,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })
-  })
-  const emptyPacketMutation = useMutation({
-    mutationFn: emptySeedPacket,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })
+  const [showReceipt, setShowReceipt] = React.useState(false)
+  const { data: suppliers = [] } = useQuery({ queryKey: queryKeys.suppliers.all, queryFn: ({ signal }) => getSuppliers(signal) })
+  const { data: varieties = [] } = useQuery({ queryKey: queryKeys.plants.varieties, queryFn: ({ signal }) => getPlantVarieties(signal) })
+  const { data: seeds = [] } = useQuery({ queryKey: queryKeys.seeds.catalog, queryFn: ({ signal }) => getSeeds(signal) })
+  const { data: packets = [] } = useQuery({ queryKey: queryKeys.seeds.packets.raw, queryFn: ({ signal }) => getAllSeedPackets(signal) })
+  const { data: drafts = [] } = useQuery({ queryKey: queryKeys.seeds.packetReceipts, queryFn: ({ signal }) => getSeedPacketReceipts(signal) })
+
+  const invalidateStock = () =>
+    Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packets.all }), queryClient.invalidateQueries({ queryKey: queryKeys.seeds.packetReceipts })])
+  const createMutation = useMutation({ mutationFn: createSeedPacketReceipt, onSuccess: invalidateStock })
+  const postMutation = useMutation({ mutationFn: postSeedPacketReceipt, onSuccess: invalidateStock })
+  const cancelMutation = useMutation({ mutationFn: cancelSeedPacketReceipt, onSuccess: invalidateStock })
+  const reconcileMutation = useMutation({
+    mutationFn: ({ pk, data }: { pk: number; data: SeedPacketReconciliation }) => reconcileSeedPacket(pk, data),
+    onSuccess: invalidateStock
   })
 
-  async function createPacket(data: SeedPacketCreate) {
-    await packetMutation.mutateAsync(data)
+  async function createReceipt(data: SeedPacketReceiptCreate) {
+    await createMutation.mutateAsync(data)
+    setShowReceipt(false)
   }
 
-  async function emptyPacket(packetPk: number) {
-    await emptyPacketMutation.mutateAsync(packetPk)
-  }
-
-  const rows = []
-  if (showSeedPacketAdd) {
-    rows.push(<NewSeedPacketRow key="new" suppliers={suppliers} varieties={varieties} seeds={seeds} createPacket={createPacket} done={() => setShowSeedPacketAdd(false)} />)
-  }
-  for (const seedPacket of seedPackets) {
-    rows.push(<SeedPacketRow key={seedPacket.pk} seedPacket={seedPacket} emptyPacket={emptyPacket} />)
-  }
   return (
-    <Table>
+    <Table responsive>
       <thead>
         <tr>
-          <td>Seeds</td>
-          <td>Purchase Date</td>
-          <td>Sow By</td>
-          <td>Direct Planted</td>
-          <td>Transplanted plants / seeds or clusters sown in trays</td>
-          <td>Notes</td>
-          <td>
-            <a href="#" onClick={() => setShowSeedPacketAdd(true)}>
-              +
-            </a>
-          </td>
+          <th>Seeds</th>
+          <th>Received</th>
+          <th>Sow by</th>
+          <th>Received quantity</th>
+          <th>Cost</th>
+          <th>Usage</th>
+          <th>Remaining / warnings</th>
+          <th>
+            <Button size="sm" onClick={() => setShowReceipt(true)}>
+              Receive packet
+            </Button>
+          </th>
         </tr>
       </thead>
-      <tbody>{rows}</tbody>
+      <tbody>
+        {showReceipt && <PacketReceiptForm seeds={seeds} suppliers={suppliers} varieties={varieties} onCreate={createReceipt} onCancel={() => setShowReceipt(false)} />}
+        {drafts.map((draft) => (
+          <ReceiptDraftRow
+            key={`draft-${draft.pk}`}
+            draft={draft}
+            label={seedLabel(draft.seeds, seeds, suppliers, varieties)}
+            onPost={(pk) => postMutation.mutateAsync(pk).then(() => undefined)}
+            onCancel={(pk) => cancelMutation.mutateAsync(pk).then(() => undefined)}
+          />
+        ))}
+        {packets.map((packet) => (
+          <SeedPacketRow
+            key={packet.pk}
+            packet={packet}
+            label={seedLabel(packet.seeds, seeds, suppliers, varieties)}
+            onReconcile={(pk, data) => reconcileMutation.mutateAsync({ pk, data }).then(() => undefined)}
+          />
+        ))}
+      </tbody>
     </Table>
   )
 }

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -53,6 +53,7 @@ interface GardenSquareTransplanting extends Planting {
 
 interface SeedTrayPlantingDetails {
   pk: number
+  seeds_used: number
   plant: string
   variety: string
   planted: string
@@ -77,6 +78,7 @@ interface GardenSquarePlanting {
   transplanting_pk?: number
   transplanted?: string
   planting_pk: number
+  seeds_used?: number
   plant: string
   variety: string
   quantity: number
@@ -131,6 +133,12 @@ interface SpecificPlantCreate {
   notes?: string
 }
 
+interface SowingCorrection {
+  seeds_used?: number
+  quantity?: number
+  reason: string
+}
+
 export {
   Planting,
   GardenRowDirectPlanting,
@@ -146,5 +154,6 @@ export {
   SpecificPlantCreate,
   SpecificPlantLocation,
   SpecificPlantLocationCreate,
-  SpecificPlantMove
+  SpecificPlantMove,
+  SowingCorrection
 }

--- a/frontend/js/types/seeds.ts
+++ b/frontend/js/types/seeds.ts
@@ -1,3 +1,7 @@
+import { UnitCode } from './inventory'
+
+type SeedQuantityCertainty = 'exact' | 'estimated' | 'unknown'
+
 interface Seed {
   pk: number
   supplier: number
@@ -5,30 +9,70 @@ interface Seed {
   supplier_code: string
   url: string
   notes: string
+  inventory_item: number | null
+  base_unit: 'seed' | 'seed_cluster' | null
 }
 
 interface SeedCreate {
   supplier: number
   plant_variety: number
+  base_unit: 'seed' | 'seed_cluster'
   supplier_code?: string
   url?: string
   notes?: string
 }
 
+interface SeedPacketInventory {
+  lot: number
+  location: number
+  quantity_certainty: SeedQuantityCertainty
+  received_quantity: string | null
+  sown_quantity: string
+  adjustment_quantity: string
+  remaining_quantity: string | null
+  base_unit: UnitCode
+  acquisition_total: string | null
+  effective_base_unit_cost: string | null
+  currency_code: string
+  empty: boolean | null
+  warnings: Array<string>
+}
+
 interface SeedPacket {
   pk: number
   seeds: number
-  purchase_date: string
-  sow_by: string
-  empty: boolean
+  purchase_date: string | null
+  sow_by: string | null
+  empty: boolean | null
   notes: string
+  inventory: SeedPacketInventory | null
 }
 
-interface SeedPacketCreate {
+interface SeedPacketReceiptCreate {
   seeds: number
-  purchase_date?: string
+  quantity_certainty: SeedQuantityCertainty
+  quantity?: string
+  line_price: string
+  supplier_lot_reference?: string
+  received_date: string
   sow_by?: string
+  supplier_reference?: string
+  tax_rate?: string
+  tax_recoverable?: boolean
   notes?: string
+}
+
+interface SeedPacketReceiptDraft extends SeedPacketReceiptCreate {
+  pk: number
+  status: 'draft' | 'posted' | 'reversed'
+  base_unit: UnitCode
+  packet: number | null
+}
+
+interface SeedPacketReconciliation {
+  counted_quantity: string
+  quantity_certainty: Exclude<SeedQuantityCertainty, 'unknown'>
+  reason: string
 }
 
 interface SeedPacketDetails {
@@ -42,6 +86,7 @@ interface SeedPacketDetails {
   seeds_planted_trays: number
   seeds_planted_direct: number
   transplanted_count: number
+  inventory: SeedPacketInventory | null
 }
 
-export { Seed, SeedPacket, SeedPacketDetails, SeedCreate, SeedPacketCreate }
+export { Seed, SeedCreate, SeedPacket, SeedPacketDetails, SeedPacketInventory, SeedPacketReceiptCreate, SeedPacketReceiptDraft, SeedPacketReconciliation, SeedQuantityCertainty }

--- a/frontend/js/utils.tsx
+++ b/frontend/js/utils.tsx
@@ -124,14 +124,14 @@ async function checkResponse(method: ApiRequestMethod, url: string, response: Re
   }
 }
 
-async function csrfRequest(method: 'POST' | 'PATCH', url: string, data: object): Promise<Response> {
+async function csrfRequest(method: 'POST' | 'PATCH' | 'DELETE', url: string, data?: object): Promise<Response> {
   const response = await fetchResponse(method, url, {
     method,
     headers: {
       'Content-Type': 'application/json',
       'X-CSRFToken': Cookies.get('csrftoken') || ''
     },
-    body: JSON.stringify(data)
+    body: data === undefined ? undefined : JSON.stringify(data)
   })
   await checkResponse(method, url, response)
   return response
@@ -139,6 +139,10 @@ async function csrfRequest(method: 'POST' | 'PATCH', url: string, data: object):
 
 function csrfPost(url: string, data: object): Promise<Response> {
   return csrfRequest('POST', url, data)
+}
+
+function csrfDelete(url: string): Promise<Response> {
+  return csrfRequest('DELETE', url)
 }
 
 async function fetchAsJson<T = unknown>(url: string, signal?: AbortSignal): Promise<T> {
@@ -220,4 +224,4 @@ function formatDateRange(start: string | null | undefined, end: string | null | 
   return `${formatDate(start ?? '')} - ${formatDate(end ?? '')}`
 }
 
-export { ApiError, csrfPost, csrfPatch, fetchAsJson, localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime, formatDateRange }
+export { ApiError, csrfDelete, csrfPost, csrfPatch, fetchAsJson, localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime, formatDateRange }

--- a/plantings/test_sowing_inventory.py
+++ b/plantings/test_sowing_inventory.py
@@ -155,11 +155,11 @@ class SowingInventoryTests(APITestCase):
         self.assertEqual(count.status_code, 200)
         self.assertEqual(
             count.data['inventory']['received_quantity'],
-            Decimal('19'),
+            '19.000000000',
         )
         self.assertEqual(
             count.data['inventory']['remaining_quantity'],
-            Decimal('12'),
+            '12.000000000',
         )
 
     def test_correction_reverses_and_reposts_without_silent_edits(self):

--- a/plantings/views.py
+++ b/plantings/views.py
@@ -64,6 +64,7 @@ def seedtray_current(request):
         germination_min, germination_max, _, _ = _get_variety_days(variety)
         planting_data.append({
             'pk': planting.pk,
+            'seeds_used': planting.seeds_used_id,
             'plant': variety.plant.name,
             'variety': variety.name,
             'planted': planting.planted,
@@ -139,6 +140,7 @@ def gardensquare_current(request):
         germination_min, germination_max, maturity_min, maturity_max = _get_variety_days(variety)
         planting_data.append({
             'planting_pk': planting.pk,
+            'seeds_used': planting.seeds_used_id,
             'plant': planting.seeds_used.seeds.plant_variety.plant.name,
             'variety': planting.seeds_used.seeds.plant_variety.name,
             'planted': planting.planted,

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -147,7 +147,22 @@ class SeedPacketSerializer(serializers.ModelSerializer):
 
     def get_inventory(self, packet):
         """Return nested truthful quantity and valuation metadata."""
-        return self._snapshot(packet)
+        snapshot = self._snapshot(packet)
+        if snapshot is None:
+            return None
+        for field, places in (
+            ('received_quantity', 9),
+            ('sown_quantity', 9),
+            ('adjustment_quantity', 9),
+            ('remaining_quantity', 9),
+            ('acquisition_total', 4),
+            ('effective_base_unit_cost', 12),
+        ):
+            value = snapshot[field]
+            snapshot[field] = (
+                f'{value:.{places}f}' if value is not None else None
+            )
+        return snapshot
 
 
 class PacketReceiptDraftSerializer(

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -300,11 +300,11 @@ class SeedPacketInventoryWorkflowTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         inventory = response.data['inventory']
         self.assertEqual(inventory['quantity_certainty'], 'exact')
-        self.assertEqual(inventory['received_quantity'], Decimal('24'))
-        self.assertEqual(inventory['remaining_quantity'], Decimal('24'))
+        self.assertEqual(inventory['received_quantity'], '24.000000000')
+        self.assertEqual(inventory['remaining_quantity'], '24.000000000')
         self.assertEqual(
             inventory['effective_base_unit_cost'],
-            Decimal('0.250000000000'),
+            '0.250000000000',
         )
         self.assertFalse(response.data['empty'])
 
@@ -326,7 +326,7 @@ class SeedPacketInventoryWorkflowTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.data['inventory']['remaining_quantity'],
-            Decimal('27'),
+            '27.000000000',
         )
         self.assertTrue(StockMovement.objects.filter(
             lot_id=packet['inventory']['lot'],


### PR DESCRIPTION
Users need to receive packets without inventing a count, confirm drafts, reconcile physical counts, see provisional balance and cost warnings, and correct posted sowings without bypassing ledger history.

## Summary by Sourcery

Introduce an audited seed stock workflow with tracked inventory units, packet receipts, reconciliations, and sowing corrections across seed and planting UIs.

New Features:
- Allow seeds to specify an inventory base unit (individual seeds vs multigerm seed clusters) and display it in the catalog.
- Add a seed packet receipt drafting and posting flow with quantity certainty, pricing, dates, and supplier references, surfaced in the seed stock table.
- Expose per-packet inventory balances, costs, and warnings in the seed stock UI, including physical count reconciliation actions.
- Enable sowing corrections for seed tray and direct garden square plantings while preserving underlying inventory and ledger history.

Bug Fixes:
- Normalize inventory quantity and cost fields to formatted strings in the seeds API to align with frontend expectations and updated tests.

Enhancements:
- Extend planting UIs to show provisional packet balances in selection labels for better stock awareness.
- Propagate inventory and sowing metadata through new frontend and API types for seeds, packets, plantings, and packet receipts.

Tests:
- Update seeds and planting inventory tests to assert on formatted string quantities and costs and cover corrected audited stock behaviors.