### PR TITLE
fix(frontend): keep planting add controls on route

### DIFF
--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -406,9 +406,9 @@ function SeedTrayPlantingTable() {
         <tr>
           <td>
             Plant{' '}
-            <a href="#" onClick={() => setShowPlantingAdd(true)}>
+            <Button variant="link" className="p-0 align-baseline" aria-label="Add seed tray planting" onClick={() => setShowPlantingAdd(true)}>
               +
-            </a>
+            </Button>
           </td>
           <td>Seeds / clusters sown</td>
           <td>Date</td>
@@ -775,9 +775,9 @@ function GardenSquarePlantingTable() {
         <tr key="header">
           <td>
             Plant{' '}
-            <a href="#" onClick={() => setShowPlantingAdd(true)}>
+            <Button variant="link" className="p-0 align-baseline" aria-label="Add garden square planting" onClick={() => setShowPlantingAdd(true)}>
               +
-            </a>
+            </Button>
           </td>
           <td>Quantity</td>
           <td>Date</td>


### PR DESCRIPTION
The planting add links targeted the bare hash, which clears HashRouter's current path and triggers the fallback redirect to the garden selector. Use non-navigating, accessible buttons so opening either planting form only changes local UI state.

## Summary by Sourcery

Replace hash-based planting add links with non-navigating buttons to keep users on the current route when opening planting forms.

Bug Fixes:
- Prevent planting add controls from resetting the HashRouter path and redirecting users away from the current garden view when opening planting forms.

Enhancements:
- Improve accessibility of planting add controls by using labeled button components instead of bare anchor tags.