### PR TITLE
feat(inventory): transact serialized stock units

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -1,9 +1,9 @@
 """Transactional services for posting and querying the inventory ledger."""
 
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, ROUND_DOWN, ROUND_HALF_UP
 from typing import NamedTuple
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Q, Sum
 from django.utils import timezone
@@ -13,6 +13,8 @@ from .models import (
     MONEY_DECIMAL_PLACES,
     QUANTITY_DECIMAL_PLACES,
     InventoryItem,
+    InventoryUnit,
+    InventoryUnitReconciliation,
     QuantityCertainty,
     StockLot,
     StockMovement,
@@ -41,6 +43,27 @@ class MovementRequest(NamedTuple):
     enforce_source_balance: bool = True
 
 
+class UnitMovementRequest(NamedTuple):
+    """Caller intent for one exact serialized-unit movement."""
+
+    unit: InventoryUnit
+    movement_type: str
+    destination: object = None
+    occurred_at: object = None
+    reason: str = ''
+    reference: str = ''
+
+
+class UnitReconciliationRequest(NamedTuple):
+    """Caller intent for one legacy unit opening reconciliation."""
+
+    unit: InventoryUnit
+    acquisition_cost: Decimal
+    destination: object
+    occurred_at: object = None
+    reason: str = ''
+
+
 class OpeningBalanceRequest(NamedTuple):
     """Caller intent for a costed opening lot and movement."""
 
@@ -63,6 +86,7 @@ class MovementEntry(NamedTuple):
     lot: StockLot
     movement_type: str
     quantity: Decimal
+    unit: InventoryUnit = None
     source: object = None
     destination: object = None
     occurred_at: object = None
@@ -130,6 +154,20 @@ def lock_lots(workspace, lot_ids):
     return {lot.pk: lot for lot in lots}
 
 
+def lock_units(workspace, unit_ids):
+    """Lock exact workspace units in deterministic primary-key order."""
+    requested = sorted(set(unit_ids))
+    units = list(
+        InventoryUnit.objects.select_for_update(of=('self',))
+        .select_related('item', 'source_lot', 'current_location')
+        .filter(workspace=workspace, pk__in=requested)
+        .order_by('pk')
+    )
+    if len(units) != len(requested):
+        raise ValidationError({'unit': 'One or more serialized units are unavailable.'})
+    return {unit.pk: unit for unit in units}
+
+
 def _validate_location(location, workspace, field_name, require_active=True):
     """Require an operation location in the current workspace."""
     if not location or location.workspace_id != workspace.pk:
@@ -159,10 +197,11 @@ def _create_movement(entry):
     quantity = quantize_quantity(entry.quantity)
     if entry.source and entry.enforce_source_balance:
         _validate_source_balance(entry.lot, entry.source, quantity)
-    return StockMovement.objects.create(
+    movement = StockMovement.objects.create(
         workspace=entry.workspace,
         created_by=entry.user,
         lot=entry.lot,
+        unit=entry.unit,
         movement_type=entry.movement_type,
         quantity=quantity,
         source=entry.source,
@@ -174,6 +213,36 @@ def _create_movement(entry):
         receipt_line=entry.receipt_line,
         stocktake_line=entry.stocktake_line,
     )
+    if entry.unit:
+        _sync_unit_after_movement(entry.unit, movement)
+    return movement
+
+
+def _sync_unit_after_movement(unit, movement):
+    """Maintain the lockable current location and active-state projection."""
+    location_id = movement.destination_id
+    active = True
+    if movement.source_id and not movement.destination_id:
+        location_id = None
+        if movement.movement_type in {
+            StockMovement.MovementType.SALE,
+            StockMovement.MovementType.WASTE,
+        }:
+            active = False
+        elif movement.movement_type == StockMovement.MovementType.REVERSAL:
+            active = movement.reversal_of.movement_type not in {
+                StockMovement.MovementType.RECEIPT,
+                StockMovement.MovementType.OPENING,
+            }
+        else:
+            active = unit.active
+    InventoryUnit.objects.filter(pk=unit.pk).update(
+        current_location_id=location_id,
+        active=active,
+        updated=timezone.now(),
+    )
+    unit.current_location_id = location_id
+    unit.active = active
 
 
 @transaction.atomic
@@ -191,6 +260,10 @@ def post_stock_movement(workspace, user, request):
     if request.movement_type not in allowed:
         raise ValidationError({'movement_type': 'Use a supported domain action.'})
     locked_lot = lock_lots(workspace, [request.lot.pk])[request.lot.pk]
+    if locked_lot.item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+        raise ValidationError({
+            'lot': 'Use a serialized-unit action for serialized stock.',
+        })
     if not locked_lot.item.active:
         raise ValidationError({'lot': 'The lot item is inactive.'})
     if request.source:
@@ -275,6 +348,10 @@ def post_opening_balance(workspace, user, request):
     )
     if not item.active:
         raise ValidationError({'item': 'The item is inactive.'})
+    if item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+        raise ValidationError({
+            'item': 'Receive serialized items through their unit workflow.',
+        })
     _validate_location(request.destination, workspace, 'destination')
     quantity = quantize_quantity(request.quantity)
     if quantity <= 0:
@@ -332,8 +409,31 @@ def _receipt_acquisition_cost(receipt, line):
     return line_cost + tax
 
 
+def _serialized_unit_costs(total, quantity):
+    """Split a receipt total exactly at stored currency precision."""
+    count = int(quantity)
+    share = (total / count).quantize(MONEY_QUANTUM, rounding=ROUND_DOWN)
+    remainder_steps = int((total - (share * count)) / MONEY_QUANTUM)
+    return [
+        share + (MONEY_QUANTUM if index < remainder_steps else Decimal('0'))
+        for index in range(count)
+    ]
+
+
+def _validate_serialized_receipt_line(line):
+    """Require a whole, exact count for individually created units."""
+    if line.quantity_certainty != QuantityCertainty.EXACT:
+        raise ValidationError({
+            'lines': f'Serialized line {line.pk} requires an exact quantity.',
+        })
+    if line.base_quantity != line.base_quantity.to_integral_value():
+        raise ValidationError({
+            'lines': f'Serialized line {line.pk} requires a whole quantity.',
+        })
+
+
 @transaction.atomic
-def post_receipt(receipt, user):
+def post_receipt(receipt, user):  # pylint: disable=too-many-branches
     """Create all receipt lots and movements or roll the document back."""
     receipt = StockReceipt.objects.select_for_update().select_related(
         'workspace',
@@ -374,6 +474,8 @@ def post_receipt(receipt, user):
             raise ValidationError(
                 {'lines': f'Conversion {line.unit_conversion_id} is inactive.'},
             )
+        if line.item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+            _validate_serialized_receipt_line(line)
 
     posted_at = timezone.now()
     lots = []
@@ -399,7 +501,31 @@ def post_receipt(receipt, user):
             base_unit_cost=unit_cost,
             currency_code=receipt.currency_code,
         )
-        if line.quantity_certainty != QuantityCertainty.UNKNOWN:
+        if line.item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+            for acquisition_cost in _serialized_unit_costs(
+                acquisition_total,
+                line.base_quantity,
+            ):
+                unit = InventoryUnit.objects.create(
+                    workspace=receipt.workspace,
+                    item=line.item,
+                    source_lot=lot,
+                    acquisition_cost=acquisition_cost,
+                    currency_code=receipt.currency_code,
+                )
+                _create_movement(MovementEntry(
+                    workspace=receipt.workspace,
+                    user=user,
+                    lot=lot,
+                    unit=unit,
+                    movement_type=StockMovement.MovementType.RECEIPT,
+                    quantity=Decimal('1'),
+                    destination=line.destination,
+                    occurred_at=posted_at,
+                    reference=receipt.supplier_reference,
+                    receipt_line=line,
+                ))
+        elif line.quantity_certainty != QuantityCertainty.UNKNOWN:
             _create_movement(MovementEntry(
                 workspace=receipt.workspace,
                 user=user,
@@ -447,6 +573,11 @@ def _validate_reversible(original, reason, allow_receipt, allow_stocktake):
             original.destination,
             original.quantity,
         )
+    removes_unit = original.unit_id and original.destination_id and not original.source_id
+    if removes_unit and unit_is_in_use(original.unit):
+        raise ValidationError({
+            'unit': 'Move or dispose of active plants before removing this tray.',
+        })
 
 
 def _create_reversal(original, user, reason, occurred_at):
@@ -455,6 +586,7 @@ def _create_reversal(original, user, reason, occurred_at):
         workspace=original.workspace,
         user=user,
         lot=original.lot,
+        unit=original.unit,
         movement_type=StockMovement.MovementType.REVERSAL,
         quantity=original.quantity,
         source=original.destination,
@@ -470,12 +602,16 @@ def _create_reversal(original, user, reason, occurred_at):
 def reverse_movement(original, user, reason, occurred_at=None):
     """Reverse one standalone movement while retaining the original row."""
     lot = lock_lots(original.workspace, [original.lot_id])[original.lot_id]
+    unit = None
+    if original.unit_id:
+        unit = lock_units(original.workspace, [original.unit_id])[original.unit_id]
     original = StockMovement.objects.select_for_update(of=('self',)).select_related(
         'workspace',
         'source',
         'destination',
     ).get(pk=original.pk)
     original.lot = lot
+    original.unit = unit
     _validate_reversible(original, reason, False, False)
     return _create_reversal(
         original,
@@ -494,9 +630,15 @@ def _reverse_document_movements(
 ):
     """Validate and reverse a complete document under deterministic lot locks."""
     locked_lots = lock_lots(workspace, [row.lot_id for row in movements])
+    locked_units = lock_units(
+        workspace,
+        [row.unit_id for row in movements if row.unit_id],
+    )
     occurred_at = timezone.now()
     for original in movements:
         original.lot = locked_lots[original.lot_id]
+        if original.unit_id:
+            original.unit = locked_units[original.unit_id]
         _validate_reversible(
             original,
             reason,
@@ -507,6 +649,170 @@ def _reverse_document_movements(
         _create_reversal(original, user, reason, occurred_at)
         for original in movements
     ]
+
+
+def unit_is_in_use(unit):
+    """Return whether cultivation still occupies the linked physical tray."""
+    try:
+        tray = unit.seed_tray
+    except ObjectDoesNotExist:
+        return False
+    from plantings.models import SeedTrayPlanting, SpecificPlantLocation  # pylint: disable=import-outside-toplevel
+
+    active_sowing = SeedTrayPlanting.objects.filter(
+        seed_tray=tray,
+        removed=False,
+    ).exists()
+    active_plant = SpecificPlantLocation.objects.filter(
+        seed_tray_cell__tray=tray,
+        ended__isnull=True,
+    ).exists()
+    return active_sowing or active_plant
+
+
+def unit_physical_state(unit):
+    """Derive a unit state from non-reversed movements and current location."""
+    if unit.current_location_id:
+        if unit.current_location.location_type == unit.current_location.LocationType.QUARANTINE:
+            return 'quarantined'
+        latest = _latest_effective_unit_movement(unit)
+        if latest and latest.movement_type in {
+            StockMovement.MovementType.ADJUSTMENT_GAIN,
+            StockMovement.MovementType.CUSTOMER_RETURN,
+        }:
+            return 'returned'
+        return 'available'
+    latest = _latest_effective_unit_movement(unit)
+    if latest:
+        states = {
+            StockMovement.MovementType.ADJUSTMENT_LOSS: 'lost',
+            StockMovement.MovementType.WASTE: 'retired',
+            StockMovement.MovementType.SALE: 'dispatched',
+        }
+        if latest.movement_type in states:
+            return states[latest.movement_type]
+    return 'retired'
+
+
+def _latest_effective_unit_movement(unit):
+    """Ignore reversal pairs when locating the unit's latest real event."""
+    return (
+        StockMovement.objects.filter(unit=unit, reversal_of__isnull=True)
+        .filter(reversal__isnull=True)
+        .order_by('-occurred_at', '-pk')
+        .first()
+    )
+
+
+@transaction.atomic
+def post_unit_movement(workspace, user, request):
+    """Post one physical action against an exact locked serialized unit."""
+    lot = lock_lots(workspace, [request.unit.source_lot_id])[
+        request.unit.source_lot_id
+    ]
+    unit = lock_units(workspace, [request.unit.pk])[request.unit.pk]
+    if not unit.item.active:
+        raise ValidationError({'unit': 'The serialized item is inactive.'})
+    if request.destination:
+        _validate_location(request.destination, workspace, 'destination')
+    state = unit_physical_state(unit)
+    source = unit.current_location
+    destination = request.destination
+    allowed = {
+        StockMovement.MovementType.TRANSFER,
+        StockMovement.MovementType.ADJUSTMENT_LOSS,
+        StockMovement.MovementType.WASTE,
+        StockMovement.MovementType.ADJUSTMENT_GAIN,
+    }
+    if request.movement_type not in allowed:
+        raise ValidationError({'movement_type': 'Use a supported unit action.'})
+    if request.movement_type == StockMovement.MovementType.TRANSFER:
+        if not source:
+            raise ValidationError({'unit': 'The unit is not currently on hand.'})
+        if not destination or source.pk == destination.pk:
+            raise ValidationError({'destination': 'Choose a different destination.'})
+    elif request.movement_type in {
+        StockMovement.MovementType.ADJUSTMENT_LOSS,
+        StockMovement.MovementType.WASTE,
+    }:
+        if not source:
+            raise ValidationError({'unit': 'The unit is not currently on hand.'})
+        if unit_is_in_use(unit):
+            raise ValidationError({
+                'unit': 'Move or dispose of active plants before removing this tray.',
+            })
+        destination = None
+    else:
+        if state not in {'lost', 'retired'}:
+            raise ValidationError({'unit': 'Only a lost or retired unit can be returned.'})
+        if not destination:
+            raise ValidationError({'destination': 'A return destination is required.'})
+        source = None
+    movement = _create_movement(MovementEntry(
+        workspace=workspace,
+        user=user,
+        lot=lot,
+        unit=unit,
+        movement_type=request.movement_type,
+        quantity=Decimal('1'),
+        source=source,
+        destination=destination,
+        occurred_at=request.occurred_at,
+        reason=request.reason,
+        reference=request.reference,
+    ))
+    return movement
+
+
+@transaction.atomic
+def reconcile_unit_opening(workspace, user, request):
+    """Supply audited cost and location for one migrated tray unit."""
+    lot = lock_lots(workspace, [request.unit.source_lot_id])[
+        request.unit.source_lot_id
+    ]
+    unit = lock_units(workspace, [request.unit.pk])[request.unit.pk]
+    if hasattr(unit, 'opening_reconciliation'):
+        raise ValidationError({'unit': 'This unit has already been reconciled.'})
+    if unit.source_lot.origin != StockLot.Origin.OPENING:
+        raise ValidationError({'unit': 'Only opening units can be reconciled.'})
+    if not unit.current_location_id or unit.current_location.code != 'SYSTEM-TRAY-UNKNOWN':
+        raise ValidationError({'unit': 'The unit is no longer at its unknown location.'})
+    _validate_location(request.destination, workspace, 'destination')
+    if request.destination.pk == unit.current_location_id:
+        raise ValidationError({'destination': 'Choose an audited physical location.'})
+    cost = Decimal(request.acquisition_cost).quantize(
+        MONEY_QUANTUM,
+        rounding=ROUND_HALF_UP,
+    )
+    if cost < 0:
+        raise ValidationError({'acquisition_cost': 'Cost cannot be negative.'})
+    movement = _create_movement(MovementEntry(
+        workspace=workspace,
+        user=user,
+        lot=lot,
+        unit=unit,
+        movement_type=StockMovement.MovementType.TRANSFER,
+        quantity=Decimal('1'),
+        source=unit.current_location,
+        destination=request.destination,
+        occurred_at=request.occurred_at,
+        reason=request.reason,
+        reference='Opening inventory reconciliation',
+    ))
+    InventoryUnit.objects.filter(pk=unit.pk).update(
+        acquisition_cost=cost,
+        updated=timezone.now(),
+    )
+    reconciliation = InventoryUnitReconciliation.objects.create(
+        workspace=workspace,
+        unit=unit,
+        acquisition_cost=cost,
+        movement=movement,
+        reason=request.reason,
+        recorded_by=user,
+    )
+    unit.acquisition_cost = cost
+    return reconciliation
 
 
 @transaction.atomic
@@ -569,6 +875,10 @@ def post_stocktake(stocktake, user):
     for line in lines:
         line.lot = locked_lots[line.lot_id]
         line.full_clean()
+        if line.lot.item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+            raise ValidationError({
+                'lines': 'Count serialized stock through unit actions.',
+            })
         if not line.lot.item.active:
             raise ValidationError(
                 {'lines': f'Item {line.lot.item_id} is inactive.'},

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -1,5 +1,7 @@
 """REST resources and explicit actions for the exact-lot stock ledger."""
 
+# pylint: disable=too-many-lines
+
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -83,6 +85,10 @@ class InventoryLocationSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         """Reserve packet-container locations for the seed workflow."""
+        if self.instance and self.instance.code == 'SYSTEM-TRAY-UNKNOWN':
+            raise ValidationError({
+                'location': 'The legacy tray location is system-managed.',
+            })
         current_type = getattr(self.instance, 'location_type', None)
         requested_type = attrs.get('location_type', current_type)
         if requested_type == InventoryLocation.LocationType.SEED_PACKET:
@@ -304,6 +310,7 @@ class StockMovementSerializer(serializers.ModelSerializer):
         fields = [
             'pk',
             'lot',
+            'unit',
             'movement_type',
             'quantity',
             'base_unit',
@@ -634,9 +641,10 @@ class InventoryLocationViewSet(
         return queryset
 
     def perform_destroy(self, instance):
-        if instance.location_type == InventoryLocation.LocationType.SEED_PACKET:
+        seed_packet = instance.location_type == InventoryLocation.LocationType.SEED_PACKET
+        if seed_packet or instance.code == 'SYSTEM-TRAY-UNKNOWN':
             raise ValidationError({
-                'location': 'Seed packet locations are system-managed.',
+                'location': 'This inventory location is system-managed.',
             })
         try:
             instance.delete()
@@ -766,6 +774,7 @@ class StockMovementViewSet(
 
     queryset = StockMovement.objects.select_related(
         'lot__item',
+        'unit',
         'source',
         'destination',
         'created_by',
@@ -777,6 +786,7 @@ class StockMovementViewSet(
         queryset = super().get_queryset()
         lot = _parse_integer(self.request.query_params.get('lot'), 'lot')
         item = _parse_integer(self.request.query_params.get('item'), 'item')
+        unit = _parse_integer(self.request.query_params.get('unit'), 'unit')
         location = _parse_integer(
             self.request.query_params.get('location'),
             'location',
@@ -785,6 +795,8 @@ class StockMovementViewSet(
             queryset = queryset.filter(lot_id=lot)
         if item is not None:
             queryset = queryset.filter(lot__item_id=item)
+        if unit is not None:
+            queryset = queryset.filter(unit_id=unit)
         if location is not None:
             queryset = queryset.filter(Q(source_id=location) | Q(destination_id=location))
         movement_type = self.request.query_params.get('movement_type')
@@ -992,8 +1004,11 @@ class StocktakeViewSet(
 
 def register_ledger_routes(router):
     """Attach ledger viewsets to the inventory API router."""
+    from .serialized_rest import InventoryUnitViewSet  # pylint: disable=import-outside-toplevel
+
     router.register(r'locations', InventoryLocationViewSet)
     router.register(r'receipts', StockReceiptViewSet)
     router.register(r'lots', StockLotViewSet)
+    router.register(r'serialized-units', InventoryUnitViewSet)
     router.register(r'movements', StockMovementViewSet)
     router.register(r'stocktakes', StocktakeViewSet)

--- a/inventory/serialized_rest.py
+++ b/inventory/serialized_rest.py
@@ -1,0 +1,325 @@
+"""Read-only serialized inventory resources and explicit unit actions."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+)
+
+from .ledger import (
+    UnitMovementRequest,
+    UnitReconciliationRequest,
+    post_unit_movement,
+    reconcile_unit_opening,
+    unit_is_in_use,
+    unit_physical_state,
+)
+from .models import InventoryLocation, InventoryUnit, StockLot, StockMovement
+from .rest_query import parse_boolean, parse_integer
+
+
+def _model_errors(error):
+    """Translate model validation errors into REST response details."""
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
+
+
+def _run_domain_action(function, *args):
+    """Invoke a unit service with field-friendly API errors."""
+    try:
+        return function(*args)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+class ActionSerializer(serializers.Serializer):
+    """Validation-only serializer base for unit actions."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class UnitMovementSerializer(serializers.ModelSerializer):
+    """Serialize the immutable result of one unit action."""
+
+    reversed_by = serializers.SerializerMethodField()
+
+    class Meta:
+        model = StockMovement
+        fields = [
+            'pk',
+            'lot',
+            'unit',
+            'movement_type',
+            'quantity',
+            'source',
+            'destination',
+            'occurred_at',
+            'created_by',
+            'reason',
+            'reference',
+            'reversal_of',
+            'reversed_by',
+            'created',
+        ]
+        read_only_fields = fields
+
+    def get_reversed_by(self, movement):
+        """Return the inverse row when one exists."""
+        try:
+            return movement.reversal.pk
+        except StockMovement.DoesNotExist:
+            return None
+
+
+class InventoryUnitSerializer(serializers.ModelSerializer):
+    """Serialize exact unit identity, provenance, and derived state."""
+
+    item_name = serializers.CharField(source='item.name', read_only=True)
+    receipt_line = serializers.IntegerField(
+        source='source_lot.receipt_line_id',
+        read_only=True,
+    )
+    physical_state = serializers.SerializerMethodField()
+    in_use = serializers.SerializerMethodField()
+    reconciliation_required = serializers.SerializerMethodField()
+    movement_ids = serializers.SerializerMethodField()
+
+    class Meta:
+        model = InventoryUnit
+        fields = [
+            'pk',
+            'item',
+            'item_name',
+            'source_lot',
+            'receipt_line',
+            'asset_code',
+            'acquisition_cost',
+            'currency_code',
+            'current_location',
+            'physical_state',
+            'in_use',
+            'reconciliation_required',
+            'active',
+            'movement_ids',
+            'created',
+            'updated',
+        ]
+        read_only_fields = fields
+
+    def get_physical_state(self, unit):
+        """Return the unit's movement-derived physical state."""
+        return unit_physical_state(unit)
+
+    def get_in_use(self, unit):
+        """Return whether cultivation currently occupies this unit."""
+        return unit_is_in_use(unit)
+
+    def get_reconciliation_required(self, unit):
+        """Flag migrated opening identities whose facts remain unknown."""
+        is_opening = unit.source_lot.origin == StockLot.Origin.OPENING
+        return is_opening and unit.acquisition_cost is None and not hasattr(unit, 'opening_reconciliation')
+
+    def get_movement_ids(self, unit):
+        """Return immutable movement history in posting order."""
+        return list(unit.movements.order_by('occurred_at', 'pk').values_list('pk', flat=True))
+
+
+class UnitMovementActionSerializer(
+    CurrentWorkspaceSerializerMixin,
+    ActionSerializer,
+):  # pylint: disable=abstract-method
+    """Validate a destination and audit metadata for one unit action."""
+
+    destination = serializers.PrimaryKeyRelatedField(
+        queryset=InventoryLocation.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=True, required=False, default='')
+    reference = serializers.CharField(allow_blank=True, required=False, default='')
+    workspace_field_lookups = {'destination': 'workspace'}
+
+
+class UnitReconciliationActionSerializer(
+    CurrentWorkspaceSerializerMixin,
+    ActionSerializer,
+):  # pylint: disable=abstract-method
+    """Validate one legacy unit's opening cost and physical location."""
+
+    acquisition_cost = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=4,
+        min_value=Decimal('0'),
+    )
+    destination = serializers.PrimaryKeyRelatedField(
+        queryset=InventoryLocation.objects.all(),
+    )
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+    workspace_field_lookups = {'destination': 'workspace'}
+
+
+class InventoryUnitViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Read serialized stock and post exact-unit physical actions."""
+
+    queryset = InventoryUnit.objects.select_related(
+        'item',
+        'source_lot__receipt_line',
+        'current_location',
+    ).prefetch_related('movements')
+    serializer_class = InventoryUnitSerializer
+
+    def get_queryset(self):
+        """Apply identity, location, state, and cultivation filters."""
+        queryset = super().get_queryset()
+        item = parse_integer(self.request.query_params.get('item'), 'item')
+        location = parse_integer(
+            self.request.query_params.get('location'),
+            'location',
+        )
+        active = parse_boolean(self.request.query_params.get('active'), 'active')
+        if item is not None:
+            queryset = queryset.filter(item_id=item)
+        if location is not None:
+            queryset = queryset.filter(current_location_id=location)
+        if active is not None:
+            queryset = queryset.filter(active=active)
+        asset_code = self.request.query_params.get('asset_code', '').strip()
+        if asset_code:
+            queryset = queryset.filter(asset_code__icontains=asset_code)
+        queryset = self._filter_state(queryset)
+        return self._filter_in_use(queryset)
+
+    def _filter_state(self, queryset):
+        """Filter by the movement-derived state when requested."""
+        state = self.request.query_params.get('physical_state')
+        if not state:
+            return queryset
+        valid_states = {
+            'available',
+            'quarantined',
+            'lost',
+            'retired',
+            'dispatched',
+            'returned',
+        }
+        if state not in valid_states:
+            raise ValidationError({
+                'physical_state': 'Select a valid physical state.',
+            })
+        return queryset.filter(
+            pk__in=[
+                unit.pk
+                for unit in queryset
+                if unit_physical_state(unit) == state
+            ],
+        )
+
+    def _filter_in_use(self, queryset):
+        """Filter by cultivation occupancy when requested."""
+        in_use = parse_boolean(self.request.query_params.get('in_use'), 'in_use')
+        if in_use is None:
+            return queryset
+        return queryset.filter(
+            pk__in=[
+                unit.pk
+                for unit in queryset
+                if unit_is_in_use(unit) == in_use
+            ],
+        )
+
+    def _post_action(self, request, movement_type, require_reason=False):
+        """Validate and post one typed exact-unit action."""
+        serializer = UnitMovementActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        if require_reason and not values['reason'].strip():
+            raise ValidationError({'reason': 'A reason is required.'})
+        movement = _run_domain_action(
+            post_unit_movement,
+            self.get_current_workspace(),
+            request.user,
+            UnitMovementRequest(
+                unit=self.get_object(),
+                movement_type=movement_type,
+                destination=values.get('destination'),
+                occurred_at=values.get('occurred_at'),
+                reason=values['reason'],
+                reference=values['reference'],
+            ),
+        )
+        return Response(
+            UnitMovementSerializer(movement).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=['post'])
+    def transfer(self, request, pk=None):  # pylint: disable=unused-argument
+        """Transfer one on-hand unit to a different location."""
+        return self._post_action(request, StockMovement.MovementType.TRANSFER)
+
+    @action(detail=True, methods=['post'])
+    def loss(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record that one on-hand unit is lost."""
+        return self._post_action(
+            request,
+            StockMovement.MovementType.ADJUSTMENT_LOSS,
+            require_reason=True,
+        )
+
+    @action(detail=True, methods=['post'])
+    def retire(self, request, pk=None):  # pylint: disable=unused-argument
+        """Retire one on-hand unit from service."""
+        return self._post_action(
+            request,
+            StockMovement.MovementType.WASTE,
+            require_reason=True,
+        )
+
+    @action(detail=True, methods=['post'], url_path='return')
+    def return_unit(self, request, pk=None):  # pylint: disable=unused-argument
+        """Return one lost or retired unit to a physical location."""
+        return self._post_action(
+            request,
+            StockMovement.MovementType.ADJUSTMENT_GAIN,
+            require_reason=True,
+        )
+
+    @action(detail=True, methods=['post'], url_path='reconcile-opening')
+    def reconcile_opening(self, request, pk=None):  # pylint: disable=unused-argument
+        """Audit the cost and real location of one legacy opening unit."""
+        serializer = UnitReconciliationActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        reconciliation = _run_domain_action(
+            reconcile_unit_opening,
+            self.get_current_workspace(),
+            request.user,
+            UnitReconciliationRequest(
+                unit=self.get_object(),
+                acquisition_cost=values['acquisition_cost'],
+                destination=values['destination'],
+                occurred_at=values.get('occurred_at'),
+                reason=values['reason'],
+            ),
+        )
+        reconciliation.unit.refresh_from_db()
+        return Response(self.get_serializer(reconciliation.unit).data)

--- a/inventory/test_serialized.py
+++ b/inventory/test_serialized.py
@@ -1,0 +1,252 @@
+"""Behavioral tests for exact serialized-unit stock workflows."""
+
+# pylint: disable=duplicate-code
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from supplies.models import Supplier
+from workspaces.models import get_current_workspace
+
+from .ledger import unit_physical_state
+from .models import (
+    InventoryItem,
+    InventoryLocation,
+    InventoryUnit,
+    InventoryUnitReconciliation,
+    StockLot,
+    StockMovement,
+    StockReceipt,
+    StockReceiptLine,
+)
+from .units import UnitCode
+
+
+class SerializedInventoryTests(TestCase):
+    """Receipts and unit actions preserve exact identity and audit history."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.user = get_user_model().objects.create_user(username='unit-user')
+        self.client.force_login(self.user)
+        self.supplier = Supplier.objects.create(
+            workspace=self.workspace,
+            name='Tray supplier',
+        )
+        self.item = InventoryItem.objects.create(
+            workspace=self.workspace,
+            name='72-cell tray',
+            category=InventoryItem.Category.TRAY,
+            base_unit=UnitCode.EACH,
+            tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
+        )
+        self.store = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Tray store',
+            code='TRAY-STORE',
+            location_type=InventoryLocation.LocationType.STORAGE,
+        )
+        self.growing = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Propagation house',
+            code='PROP-HOUSE',
+            location_type=InventoryLocation.LocationType.GROWING,
+        )
+
+    def create_receipt(self, quantity='3', cost='10.0000'):
+        """Create one valid serialized draft receipt."""
+        receipt = StockReceipt.objects.create(
+            workspace=self.workspace,
+            supplier=self.supplier,
+            received_date=date(2026, 8, 2),
+            currency_code=self.workspace.currency_code,
+            created_by=self.user,
+        )
+        StockReceiptLine.objects.create(
+            receipt=receipt,
+            item=self.item,
+            quantity=Decimal(quantity),
+            unit_code=UnitCode.EACH,
+            base_quantity=Decimal(quantity),
+            line_cost_ex_tax=Decimal(cost),
+            destination=self.store,
+        )
+        return receipt
+
+    def post_receipt(self, **overrides):
+        """Post one serialized receipt through its public action."""
+        receipt = self.create_receipt(**overrides)
+        response = self.client.post(f'/inventory/receipts/{receipt.pk}/post/')
+        self.assertEqual(response.status_code, 200, response.data)
+        return receipt
+
+    def test_receipt_creates_one_costed_unit_and_movement_per_each(self):
+        """Per-unit costs retain the receipt total despite currency rounding."""
+        receipt = self.post_receipt()
+        units = list(
+            InventoryUnit.objects.filter(source_lot__receipt_line__receipt=receipt)
+            .order_by('acquisition_cost', 'pk')
+        )
+        self.assertEqual(len(units), 3)
+        self.assertEqual(
+            [unit.acquisition_cost for unit in units],
+            [Decimal('3.3333'), Decimal('3.3333'), Decimal('3.3334')],
+        )
+        self.assertEqual(sum(unit.acquisition_cost for unit in units), Decimal('10'))
+        self.assertEqual(len({unit.asset_code for unit in units}), 3)
+        self.assertEqual(
+            StockMovement.objects.filter(unit__in=units, movement_type='receipt').count(),
+            3,
+        )
+        self.assertTrue(all(unit.current_location_id == self.store.pk for unit in units))
+
+    def test_serialized_receipt_rejects_fractional_or_unknown_quantity(self):
+        """Every posted unit must correspond to one exact physical each."""
+        for quantity in ('1.5',):
+            with self.subTest(quantity=quantity):
+                receipt = self.create_receipt(quantity=quantity)
+                response = self.client.post(f'/inventory/receipts/{receipt.pk}/post/')
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(InventoryUnit.objects.count(), 0)
+
+        receipt = self.create_receipt(quantity='1')
+        line = receipt.lines.get()
+        line.quantity_certainty = 'estimated'
+        line.save()
+        response = self.client.post(f'/inventory/receipts/{receipt.pk}/post/')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(InventoryUnit.objects.count(), 0)
+
+    def test_transfer_loss_return_and_reversal_keep_unit_specific_history(self):
+        """Moving one unit never changes another unit from the same lot."""
+        self.post_receipt(quantity='2', cost='12')
+        first, second = InventoryUnit.objects.order_by('pk')
+
+        response = self.client.post(
+            f'/inventory/serialized-units/{first.pk}/transfer/',
+            {'destination': self.growing.pk, 'reason': 'Move into production'},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.current_location_id, self.growing.pk)
+        self.assertEqual(second.current_location_id, self.store.pk)
+
+        response = self.client.post(
+            f'/inventory/serialized-units/{first.pk}/loss/',
+            {'reason': 'Could not locate tray'},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        first.refresh_from_db()
+        self.assertIsNone(first.current_location_id)
+        self.assertEqual(unit_physical_state(first), 'lost')
+
+        response = self.client.post(
+            f'/inventory/serialized-units/{first.pk}/return/',
+            {'destination': self.store.pk, 'reason': 'Tray recovered'},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return_movement = StockMovement.objects.get(pk=response.data['pk'])
+        first.refresh_from_db()
+        self.assertEqual(unit_physical_state(first), 'returned')
+
+        response = self.client.post(
+            f'/inventory/movements/{return_movement.pk}/reverse/',
+            {'reason': 'Recovery entered in error'},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        first.refresh_from_db()
+        self.assertIsNone(first.current_location_id)
+        self.assertEqual(unit_physical_state(first), 'lost')
+
+    def test_serialized_collection_filters_and_generic_actions_reject_units(self):
+        """The public collection reports derived unit facts without lot writes."""
+        self.post_receipt(quantity='1', cost='5')
+        unit = InventoryUnit.objects.get()
+        response = self.client.get(
+            '/inventory/serialized-units/',
+            {'physical_state': 'available', 'in_use': 'false'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([row['pk'] for row in response.data], [unit.pk])
+        self.assertEqual(response.data[0]['asset_code'], unit.asset_code)
+        self.assertFalse(response.data[0]['reconciliation_required'])
+
+        response = self.client.post(
+            '/inventory/movements/transfer/',
+            {
+                'lot': unit.source_lot_id,
+                'quantity': '1',
+                'unit_code': UnitCode.EACH,
+                'source': self.store.pk,
+                'destination': self.growing.pk,
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('lot', response.data)
+
+    def test_legacy_opening_reconciliation_sets_cost_and_location_once(self):
+        """Unknown opening facts become audited without rewriting the opening."""
+        unknown = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Unknown tray location',
+            code='SYSTEM-TRAY-UNKNOWN',
+            location_type=InventoryLocation.LocationType.ADJUSTMENT,
+        )
+        lot = StockLot.objects.create(
+            workspace=self.workspace,
+            item=self.item,
+            origin=StockLot.Origin.OPENING,
+            received_on=date(2026, 1, 1),
+            initial_base_quantity=Decimal('1'),
+            acquisition_total=None,
+            base_unit_cost=None,
+            currency_code=self.workspace.currency_code,
+        )
+        unit = InventoryUnit.objects.create(
+            workspace=self.workspace,
+            item=self.item,
+            source_lot=lot,
+            acquisition_cost=None,
+            currency_code=self.workspace.currency_code,
+            current_location=unknown,
+        )
+        StockMovement.objects.create(
+            workspace=self.workspace,
+            lot=lot,
+            unit=unit,
+            movement_type=StockMovement.MovementType.OPENING,
+            quantity=Decimal('1'),
+            destination=unknown,
+            occurred_at=timezone.now(),
+        )
+
+        response = self.client.post(
+            f'/inventory/serialized-units/{unit.pk}/reconcile-opening/',
+            {
+                'acquisition_cost': '7.2500',
+                'destination': self.store.pk,
+                'reason': 'Counted and valued opening stock',
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        unit.refresh_from_db()
+        self.assertEqual(unit.acquisition_cost, Decimal('7.2500'))
+        self.assertEqual(unit.current_location_id, self.store.pk)
+        self.assertTrue(InventoryUnitReconciliation.objects.filter(unit=unit).exists())
+        self.assertIsNone(lot.acquisition_total)
+
+        response = self.client.post(
+            f'/inventory/serialized-units/{unit.pk}/reconcile-opening/',
+            {
+                'acquisition_cost': '8.0000',
+                'destination': self.growing.pk,
+                'reason': 'Try again',
+            },
+        )
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
Aggregate lot movements cannot prove which durable tray moved or what it cost. Post receipts and physical actions against locked units so location, state, valuation, and reversals remain exact and concurrency-safe.

## Summary by Sourcery

Introduce serialized inventory units with dedicated workflows for posting, moving, and reconciling tray-level stock, and prevent generic lot actions from mutating serialized items.

New Features:
- Add support for serialized inventory units, including per-unit acquisition cost, current location tracking, and movement history.
- Expose a read-only REST API for serialized units with filters on identity, physical state, and cultivation use, plus typed unit actions (transfer, loss, retire, return, opening reconciliation).

Bug Fixes:
- Ensure destructive unit movements are blocked while a tray is still in cultivation use.

Enhancements:
- Extend stock movements to optionally reference an exact serialized unit and keep unit state in sync with movements, including reversals.
- Enforce that serialized items are received, counted, and adjusted exclusively through unit workflows rather than aggregate lot and stocktake actions.
- Add system-managed inventory locations for unknown legacy tray positions and prevent manual modification or deletion of these locations.

Tests:
- Add behavioral tests covering serialized receipt posting, per-unit costing and asset identity, unit movement and reversal flows, opening reconciliation, and collection filtering for serialized units.