### PR TITLE
feat(seedtrays): receive trays as exact stock

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -525,6 +525,7 @@ def post_receipt(receipt, user):  # pylint: disable=too-many-branches
                     reference=receipt.supplier_reference,
                     receipt_line=line,
                 ))
+                _create_seed_tray_for_unit(unit)
         elif line.quantity_certainty != QuantityCertainty.UNKNOWN:
             _create_movement(MovementEntry(
                 workspace=receipt.workspace,
@@ -549,6 +550,13 @@ def post_receipt(receipt, user):  # pylint: disable=too-many-branches
     )
     receipt.refresh_from_db()
     return receipt, lots
+
+
+def _create_seed_tray_for_unit(unit):
+    """Create a tray when the serialized item maps to tray geometry."""
+    from seedtrays.services import create_tray_for_unit  # pylint: disable=import-outside-toplevel
+
+    return create_tray_for_unit(unit)
 
 
 def _validate_reversible(original, reason, allow_receipt, allow_stocktake):

--- a/seedtrays/rest.py
+++ b/seedtrays/rest.py
@@ -1,25 +1,43 @@
 """
 Rest related classes for seed trays
 """
-from itertools import product
+# pylint: disable=duplicate-code
+from decimal import Decimal
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.shortcuts import get_object_or_404
-from rest_framework import serializers, viewsets
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
 from rest_framework_nested import routers
 
+from inventory.ledger import post_receipt, unit_is_in_use, unit_physical_state
+from inventory.models import (
+    InventoryItem,
+    InventoryLocation,
+    StockReceipt,
+    StockReceiptLine,
+)
+from inventory.serialized_rest import InventoryUnitSerializer
+from inventory.units import UnitCode
+from supplies.models import Supplier
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .models import SeedTrayModel, SeedTray, SeedTrayCell
 
 
-class SeedTrayModelSerializer(serializers.ModelSerializer):
+class SeedTrayModelSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a SeedTrayModel
     """
     class Meta:
         model = SeedTrayModel
-        fields = ['pk', 'identifier', 'description', 'height', 'x_size', 'y_size', 'x_cells', 'y_cells', 'cell_size_ml']
+        fields = ['pk', 'identifier', 'inventory_item', 'description', 'height', 'x_size', 'y_size', 'x_cells', 'y_cells', 'cell_size_ml']
+        extra_kwargs = {'inventory_item': {'required': False}}
+
+    workspace_field_lookups = {'inventory_item': 'workspace'}
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """Keep cell-grid dimensions stable after trays have been created."""
@@ -28,6 +46,18 @@ class SeedTrayModelSerializer(serializers.ModelSerializer):
             for field in ('x_cells', 'y_cells'):
                 if field in data and data[field] != getattr(self.instance, field):
                     errors[field] = 'Cannot change cell dimensions after trays have been created.'
+        item = data.get('inventory_item')
+        if item:
+            if item.category != InventoryItem.Category.TRAY:
+                errors['inventory_item'] = 'Select a tray-category inventory item.'
+            elif item.tracking_mode != InventoryItem.TrackingMode.SERIALIZED:
+                errors['inventory_item'] = 'Select a serialized inventory item.'
+            elif item.base_unit != UnitCode.EACH:
+                errors['inventory_item'] = 'Tray inventory items must use each.'
+            if self.instance and item.pk != self.instance.inventory_item_id:
+                has_history = self.instance.seedtray_set.exists() or self.instance.inventory_item.stock_history_started_at
+                if has_history:
+                    errors['inventory_item'] = 'Cannot change the inventory item after tray or stock history exists.'
         if errors:
             raise serializers.ValidationError(errors)
         return data
@@ -37,9 +67,12 @@ class SeedTraySerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSeria
     """
     Serializer for a Seed Tray
     """
+    inventory = InventoryUnitSerializer(source='inventory_unit', read_only=True)
+
     class Meta:
         model = SeedTray
-        fields = ['pk', 'model', 'created', 'notes']
+        fields = ['pk', 'model', 'inventory_unit', 'inventory', 'created', 'notes']
+        read_only_fields = ['inventory_unit', 'inventory', 'created']
 
     workspace_field_lookups = {'model': 'workspace'}
 
@@ -52,21 +85,44 @@ class SeedTraySerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSeria
                 })
         return data
 
-    def create(self, validated_data):
-        """
-        Override create to automatically generate SeedTrayCells
-        """
-        with transaction.atomic():
-            seed_tray = super().create(validated_data)
-            model = seed_tray.model
 
-            # Create a cell for each position in the tray
-            cells = [
-                SeedTrayCell(tray=seed_tray, x_position=x, y_position=y)
-                for x, y in product(range(model.x_cells), range(model.y_cells))
-            ]
-            SeedTrayCell.objects.bulk_create(cells)
-        return seed_tray
+class SeedTrayReceiptSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.Serializer,
+):
+    """Validate an immediately posted receipt for one tray model."""
+
+    supplier = serializers.PrimaryKeyRelatedField(queryset=Supplier.objects.all())
+    received_date = serializers.DateField()
+    supplier_reference = serializers.CharField(allow_blank=True, required=False, default='')
+    quantity = serializers.IntegerField(min_value=1)
+    line_cost_ex_tax = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=4,
+        min_value=Decimal('0'),
+    )
+    destination = serializers.PrimaryKeyRelatedField(
+        queryset=InventoryLocation.objects.all(),
+    )
+    tax_rate = serializers.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        min_value=Decimal('0'),
+        max_value=Decimal('100'),
+        required=False,
+    )
+    tax_recoverable = serializers.BooleanField(required=False, default=True)
+    notes = serializers.CharField(allow_blank=True, required=False, default='')
+    workspace_field_lookups = {
+        'supplier': 'workspace',
+        'destination': 'workspace',
+    }
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
 
 
 class SeedTrayCellSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
@@ -118,14 +174,117 @@ class SeedTrayModelsViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet)
     queryset = SeedTrayModel.objects.all()
     serializer_class = SeedTrayModelSerializer
 
+    @action(detail=True, methods=['post'])
+    @transaction.atomic
+    def receive(self, request, pk=None):  # pylint: disable=unused-argument
+        """Receive and serialize exact physical trays for this model."""
+        tray_model = self.get_object()
+        serializer = SeedTrayReceiptSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        workspace = self.get_current_workspace()
+        receipt = StockReceipt.objects.create(
+            workspace=workspace,
+            supplier=values['supplier'],
+            received_date=values['received_date'],
+            supplier_reference=values['supplier_reference'],
+            currency_code=workspace.currency_code,
+            tax_rate=values.get('tax_rate', workspace.default_tax_rate),
+            tax_recoverable=values['tax_recoverable'],
+            notes=values['notes'],
+            created_by=request.user,
+        )
+        line = StockReceiptLine.objects.create(
+            receipt=receipt,
+            item=tray_model.inventory_item,
+            quantity=Decimal(values['quantity']),
+            unit_code=UnitCode.EACH,
+            base_quantity=Decimal(values['quantity']),
+            line_cost_ex_tax=values['line_cost_ex_tax'],
+            destination=values['destination'],
+        )
+        try:
+            receipt, lots = post_receipt(receipt, request.user)
+        except DjangoValidationError as exc:
+            details = exc.message_dict if hasattr(exc, 'message_dict') else exc.messages
+            raise ValidationError(details) from exc
+        trays = SeedTray.objects.filter(
+            inventory_unit__source_lot__in=lots,
+        ).select_related(
+            'model',
+            'inventory_unit__item',
+            'inventory_unit__source_lot',
+            'inventory_unit__current_location',
+        ).order_by('pk')
+        return Response(
+            {
+                'receipt': receipt.pk,
+                'receipt_line': line.pk,
+                'trays': SeedTraySerializer(trays, many=True).data,
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
 
 class SeedTrayAllViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of all SeedTrays
     """
-    queryset = SeedTray.objects.all()
+    queryset = SeedTray.objects.select_related(
+        'model',
+        'inventory_unit__item',
+        'inventory_unit__source_lot__receipt_line',
+        'inventory_unit__current_location',
+    ).prefetch_related('inventory_unit__movements')
     serializer_class = SeedTraySerializer
     http_method_names = ['get', 'patch', 'head', 'options']
+
+    def get_queryset(self):
+        """Filter trays by model and serialized inventory state."""
+        queryset = super().get_queryset()
+        model = self.request.query_params.get('model')
+        location = self.request.query_params.get('location')
+        if model:
+            try:
+                queryset = queryset.filter(model_id=int(model))
+            except ValueError as exc:
+                raise ValidationError({'model': 'Use an integer model ID.'}) from exc
+        if location:
+            try:
+                queryset = queryset.filter(inventory_unit__current_location_id=int(location))
+            except ValueError as exc:
+                raise ValidationError({'location': 'Use an integer location ID.'}) from exc
+        state = self.request.query_params.get('physical_state')
+        if state:
+            if state not in {
+                'available',
+                'quarantined',
+                'lost',
+                'retired',
+                'dispatched',
+                'returned',
+            }:
+                raise ValidationError({'physical_state': 'Select a valid physical state.'})
+            queryset = queryset.filter(
+                pk__in=[
+                    tray.pk
+                    for tray in queryset
+                    if unit_physical_state(tray.inventory_unit) == state
+                ],
+            )
+        in_use = self.request.query_params.get('in_use')
+        if in_use is not None:
+            if in_use not in {'true', 'false'}:
+                raise ValidationError({'in_use': 'Use true or false.'})
+            expected = in_use == 'true'
+            queryset = queryset.filter(
+                pk__in=[
+                    tray.pk
+                    for tray in queryset
+                    if unit_is_in_use(tray.inventory_unit) == expected
+                ],
+            )
+        return queryset
 
 
 class SeedTrayCellViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors

--- a/seedtrays/services.py
+++ b/seedtrays/services.py
@@ -1,0 +1,36 @@
+"""Transactional helpers connecting serialized units to physical seed trays."""
+
+from itertools import product
+
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import transaction
+
+from .models import SeedTray, SeedTrayCell
+
+
+@transaction.atomic
+def create_tray_for_unit(unit, notes=''):
+    """Create one stable tray and complete cell grid for a mapped unit."""
+    try:
+        tray_model = unit.item.seed_tray_model
+    except ObjectDoesNotExist:
+        return None
+    if unit.workspace_id != tray_model.workspace_id:
+        raise ValidationError({'unit': 'The unit and tray model workspaces differ.'})
+    if hasattr(unit, 'seed_tray'):
+        raise ValidationError({'unit': 'This unit already has a seed tray.'})
+    tray = SeedTray.objects.create(
+        workspace=unit.workspace,
+        model=tray_model,
+        inventory_unit=unit,
+        notes=notes,
+    )
+    cells = [
+        SeedTrayCell(tray=tray, x_position=x_position, y_position=y_position)
+        for x_position, y_position in product(
+            range(tray_model.x_cells),
+            range(tray_model.y_cells),
+        )
+    ]
+    SeedTrayCell.objects.bulk_create(cells)
+    return tray

--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -7,10 +7,17 @@ import json
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from inventory.models import InventoryLocation, InventoryUnit, StockMovement
+from plantings.models import SeedTrayPlanting
 from tests.api import RESTContractTestCase
-from tests.factories import make_seed_tray, make_seed_tray_cell
+from tests.factories import (
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_supplier,
+)
 
-from .models import SeedTrayCell, SeedTrayModel
+from .models import SeedTray, SeedTrayCell, SeedTrayModel
 
 
 class SeedTrayRESTContractTests(RESTContractTestCase):
@@ -54,11 +61,41 @@ class SeedTrayRESTContractTests(RESTContractTestCase):
                 'cell_size_ml': 45,
             },
         )
-        response = self.client.post(
-            '/seedtrays/seedtrays/',
-            {'model': tray_model['pk'], 'notes': 'Spring sowing'},
+        supplier = make_supplier()
+        location = InventoryLocation.objects.create(
+            name='Receipt store',
+            code='RECEIPT-STORE',
+            location_type=InventoryLocation.LocationType.STORAGE,
         )
-        self.assertEqual(response.status_code, 405)
+        response = self.client.post(
+            f"/seedtrays/seedtraymodels/{tray_model['pk']}/receive/",
+            {
+                'supplier': supplier.pk,
+                'received_date': '2026-08-02',
+                'quantity': 1,
+                'line_cost_ex_tax': '5.0000',
+                'destination': location.pk,
+                'notes': 'Spring sowing',
+            },
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        tray = response.data['trays'][0]
+        retrieved = self.client.get(f"/seedtrays/seedtrays/{tray['pk']}/")
+        self.assertEqual(retrieved.status_code, 200)
+        self.assertEqual(retrieved.data, tray)
+        cell = SeedTrayCell.objects.get(
+            tray_id=tray['pk'],
+            x_position=2,
+            y_position=1,
+        )
+        response = self.client.get(f'/seedtrays/seedtraycells/{cell.pk}/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {
+            'pk': cell.pk,
+            'tray': tray['pk'],
+            'x_position': 2,
+            'y_position': 1,
+        })
 
         self.assert_create_retrieve(
             '/seedtrays/seedtraycells/',
@@ -86,6 +123,14 @@ class SeedTrayRESTContractTests(RESTContractTestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client.get(f'{nested_url}{other_cell.pk}/')
         self.assertEqual(response.status_code, 404)
+
+    def test_bare_tray_creation_is_replaced_by_receiving(self):
+        """A physical tray cannot bypass unit provenance and stock posting."""
+        response = self.client.post(
+            '/seedtrays/seedtrays/',
+            {'model': self.tray.model_id},
+        )
+        self.assertEqual(response.status_code, 405)
 
 
 class SeedTrayCellIntegrityTests(TestCase):
@@ -115,6 +160,12 @@ class SeedTrayCellIntegrityTests(TestCase):
         )
         self.tray = make_seed_tray(model=self.tray_model)
         self.other_tray = make_seed_tray(model=self.other_model)
+        self.supplier = make_supplier()
+        self.location = InventoryLocation.objects.create(
+            name='Tray receiving',
+            code='TRAY-RECEIVING',
+            location_type=InventoryLocation.LocationType.RECEIVING,
+        )
 
     def test_detail_view_requires_login(self):
         """Anonymous visitors cannot discover seed tray detail pages."""
@@ -127,18 +178,97 @@ class SeedTrayCellIntegrityTests(TestCase):
             f'/accounts/login/?next=/seedtrays/seedtray/{self.tray.pk}/',
         )
 
-    def test_bare_tray_creation_is_rejected(self):
-        """A physical tray cannot bypass its inventory identity."""
+    def test_receiving_tray_generates_complete_cell_grid(self):
+        """Receiving a tray generates every model cell exactly once."""
         response = self.client.post(
-            '/seedtrays/seedtrays/',
+            f'/seedtrays/seedtraymodels/{self.other_model.pk}/receive/',
             data=json.dumps({
-                'model': self.other_model.pk,
+                'supplier': self.supplier.pk,
+                'received_date': '2026-08-02',
+                'quantity': 1,
+                'line_cost_ex_tax': '6.0000',
+                'destination': self.location.pk,
                 'notes': 'Propagation tray',
             }),
             content_type='application/json',
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 201)
+        tray = SeedTray.objects.get(pk=response.json()['trays'][0]['pk'])
+        self.assertEqual(
+            set(tray.seedtraycell_set.values_list('x_position', 'y_position')),
+            {
+                (x_position, y_position)
+                for x_position in range(self.other_model.x_cells)
+                for y_position in range(self.other_model.y_cells)
+            },
+        )
+
+    def test_receiving_multiple_trays_keeps_identity_and_cost_exact(self):
+        """One receipt creates distinct units, trays, cells, and movement rows."""
+        response = self.client.post(
+            f'/seedtrays/seedtraymodels/{self.other_model.pk}/receive/',
+            {
+                'supplier': self.supplier.pk,
+                'received_date': '2026-08-02',
+                'quantity': 3,
+                'line_cost_ex_tax': '10.0000',
+                'destination': self.location.pk,
+            },
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        trays = response.data['trays']
+        self.assertEqual(len(trays), 3)
+        self.assertEqual(len({tray['inventory_unit'] for tray in trays}), 3)
+        units = InventoryUnit.objects.filter(
+            pk__in=[tray['inventory_unit'] for tray in trays],
+        )
+        self.assertEqual(sum(unit.acquisition_cost for unit in units), 10)
+        self.assertEqual(
+            StockMovement.objects.filter(unit__in=units, movement_type='receipt').count(),
+            3,
+        )
+        self.assertTrue(all(
+            SeedTrayCell.objects.filter(tray_id=tray['pk']).count() == 9
+            for tray in trays
+        ))
+
+    def test_active_cultivation_blocks_loss_but_allows_transfer(self):
+        """A tray stays on hand while occupied and cannot silently leave stock."""
+        tray = self.tray
+        planting = SeedTrayPlanting.objects.create(
+            seeds_used=make_seed_packet(),
+            quantity=1,
+            seed_tray=tray,
+        )
+        unit = tray.inventory_unit
+        response = self.client.get(
+            '/seedtrays/seedtrays/',
+            {'in_use': 'true'},
+        )
+        self.assertIn(tray.pk, [row['pk'] for row in response.data])
+
+        response = self.client.post(
+            f'/inventory/serialized-units/{unit.pk}/loss/',
+            {'reason': 'Incorrectly remove occupied tray'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('unit', response.data)
+
+        destination = InventoryLocation.objects.create(
+            name='Growing bench',
+            code='GROWING-BENCH',
+            location_type=InventoryLocation.LocationType.GROWING,
+        )
+        response = self.client.post(
+            f'/inventory/serialized-units/{unit.pk}/transfer/',
+            {'destination': destination.pk, 'reason': 'Move occupied tray'},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        planting.refresh_from_db()
+        unit.refresh_from_db()
+        self.assertFalse(planting.removed)
+        self.assertEqual(unit.current_location_id, destination.pk)
 
     def test_nested_create_uses_url_tray_instead_of_payload_tray(self):
         """


### PR DESCRIPTION
Bare tray creation omitted provenance, cost, and location and could not distinguish physical units. Tie model geometry to serialized catalog items and create trays with their cells only through audited receipt posting.

## Summary by Sourcery

Route seed tray creation through serialized inventory receipts to maintain provenance, cost, and physical identity, and expose trays and cells via inventory-aware APIs.

New Features:
- Add a receipt-based endpoint to receive physical seed trays for a given tray model and automatically create associated trays and cell grids.
- Associate seed tray models with serialized tray inventory items and expose inventory unit details on seed tray resources.
- Introduce inventory-aware filtering on seed tray listings by model, location, physical state, and in-use status.

Bug Fixes:
- Prevent direct bare seed tray creation so physical trays cannot bypass inventory provenance and stock posting.
- Ensure tray creation respects workspace alignment between inventory units and tray models and avoids duplicate tray associations.

Enhancements:
- Create seed trays and their cells from serialized inventory units during stock receipt posting to keep inventory and cultivation models synchronized.
- Optimize seed tray queries with select_related and prefetch_related for inventory relationships.
- Extend tests to cover tray receiving, grid completeness, cost allocation, stock movements, and cultivation-aware inventory constraints.

Tests:
- Expand REST and integrity tests to validate receipt-based tray creation, inventory unit linkage, movement records, and cultivation constraints on loss and transfer operations.