### PR TITLE
feat(frontend): manage serialized tray stock

### DIFF
--- a/frontend/js/api/inventory.ts
+++ b/frontend/js/api/inventory.ts
@@ -1,4 +1,4 @@
-import { InventoryItem, InventoryItemCreate, InventoryItemFilters, InventoryUnit, ItemUnitConversion, ItemUnitConversionCreate } from '../types/inventory'
+import { InventoryItem, InventoryItemCreate, InventoryItemFilters, InventoryLocation, InventoryUnit, ItemUnitConversion, ItemUnitConversionCreate } from '../types/inventory'
 import { csrfPatch, csrfPost, fetchAsJson } from '../utils'
 
 const ITEMS_URL = '/inventory/items/'
@@ -6,6 +6,10 @@ const CONVERSIONS_URL = '/inventory/conversions/'
 
 function getInventoryUnits(signal?: AbortSignal): Promise<Array<InventoryUnit>> {
   return fetchAsJson<Array<InventoryUnit>>('/inventory/units/', signal)
+}
+
+function getInventoryLocations(signal?: AbortSignal): Promise<Array<InventoryLocation>> {
+  return fetchAsJson<Array<InventoryLocation>>('/inventory/locations/?active=true', signal)
 }
 
 function getInventoryItems(filters: InventoryItemFilters, signal?: AbortSignal): Promise<Array<InventoryItem>> {
@@ -43,4 +47,13 @@ async function setItemUnitConversionActive(pk: number, active: boolean): Promise
   return response.json() as Promise<ItemUnitConversion>
 }
 
-export { createInventoryItem, createItemUnitConversion, getInventoryItems, getInventoryUnits, getItemUnitConversions, setInventoryItemActive, setItemUnitConversionActive }
+export {
+  createInventoryItem,
+  createItemUnitConversion,
+  getInventoryItems,
+  getInventoryLocations,
+  getInventoryUnits,
+  getItemUnitConversions,
+  setInventoryItemActive,
+  setItemUnitConversionActive
+}

--- a/frontend/js/api/seedtrays.ts
+++ b/frontend/js/api/seedtrays.ts
@@ -1,4 +1,5 @@
-import { SeedTray, SeedTrayCell, SeedTrayCreate, SeedTrayModel, SeedTrayModelCreate } from '../types/seedtrays'
+import { SerializedStockMovement } from '../types/inventory'
+import { SeedTray, SeedTrayCell, SeedTrayFilters, SeedTrayModel, SeedTrayModelCreate, SeedTrayReceiptCreate, SeedTrayReceiptResponse } from '../types/seedtrays'
 import { csrfPost, fetchAsJson } from '../utils'
 
 function getSeedTrayModels(signal?: AbortSignal): Promise<Array<SeedTrayModel>> {
@@ -9,16 +10,31 @@ function addSeedTrayModel(model: SeedTrayModelCreate) {
   return csrfPost('/seedtrays/seedtraymodels/', model)
 }
 
-function getSeedTrays(signal?: AbortSignal): Promise<Array<SeedTray>> {
-  return fetchAsJson<Array<SeedTray>>('/seedtrays/seedtrays/', signal)
+function getSeedTrays(signal?: AbortSignal, filters: SeedTrayFilters = {}): Promise<Array<SeedTray>> {
+  const params = new URLSearchParams()
+  if (filters.model) params.set('model', String(filters.model))
+  if (filters.location) params.set('location', String(filters.location))
+  if (filters.physical_state) params.set('physical_state', filters.physical_state)
+  if (filters.in_use !== undefined) params.set('in_use', String(filters.in_use))
+  const query = params.size ? `?${params.toString()}` : ''
+  return fetchAsJson<Array<SeedTray>>(`/seedtrays/seedtrays/${query}`, signal)
 }
 
-function addSeedTray(tray: SeedTrayCreate) {
-  return csrfPost('/seedtrays/seedtrays/', tray)
+async function receiveSeedTrays(model: number, receipt: SeedTrayReceiptCreate): Promise<SeedTrayReceiptResponse> {
+  const response = await csrfPost(`/seedtrays/seedtraymodels/${model}/receive/`, receipt)
+  return response.json() as Promise<SeedTrayReceiptResponse>
 }
 
 function getSeedTrayCells(trayPk: number, signal?: AbortSignal): Promise<Array<SeedTrayCell>> {
   return fetchAsJson<Array<SeedTrayCell>>(`/seedtrays/seedtrays/${trayPk}/cells/`, signal)
 }
 
-export { getSeedTrayModels, getSeedTrays, addSeedTrayModel, addSeedTray, getSeedTrayCells }
+function getSerializedUnitMovements(unitPk: number, signal?: AbortSignal): Promise<Array<SerializedStockMovement>> {
+  return fetchAsJson<Array<SerializedStockMovement>>(`/inventory/movements/?unit=${unitPk}`, signal)
+}
+
+async function postSerializedUnitAction(unitPk: number, action: 'transfer' | 'loss' | 'retire' | 'return' | 'reconcile-opening', data: object): Promise<void> {
+  await csrfPost(`/inventory/serialized-units/${unitPk}/${action}/`, data)
+}
+
+export { addSeedTrayModel, getSeedTrayCells, getSeedTrayModels, getSeedTrays, getSerializedUnitMovements, postSerializedUnitAction, receiveSeedTrays }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -8,6 +8,7 @@ const queryKeys = {
   inventory: {
     all: ['inventory'] as const,
     units: ['inventory', 'units'] as const,
+    locations: ['inventory', 'locations'] as const,
     items: (search: string, category: string, trackingMode: string, status: string) => ['inventory', 'items', search, category, trackingMode, status] as const,
     conversions: (itemPk: number) => ['inventory', 'conversions', itemPk] as const
   },
@@ -41,6 +42,7 @@ const queryKeys = {
     all: ['seedTrays'] as const,
     models: ['seedTrays', 'models'] as const,
     trays: ['seedTrays', 'trays'] as const,
+    movements: (unitPk: number) => ['seedTrays', 'movements', unitPk] as const,
     cells: (trayPk: number) => ['seedTrays', 'cells', trayPk] as const
   },
   plantings: {

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -4,8 +4,8 @@ import { QueryClientProvider, useMutation, useQuery, useQueryClient } from '@tan
 
 import { SeedTray, SeedTrayCell, SeedTrayModel } from '../types/seedtrays'
 import { localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime } from '../utils'
-import { getSeedTrayModels, getSeedTrays, getSeedTrayCells } from '../api/seedtrays'
-import { Button, Table } from 'react-bootstrap'
+import { getSeedTrayModels, getSeedTrays, getSeedTrayCells, getSerializedUnitMovements, postSerializedUnitAction } from '../api/seedtrays'
+import { Alert, Button, Card, Form, Table } from 'react-bootstrap'
 import { SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
 import { getPlantingSeedTray, getSpecificPlantsBySeedTray, addSpecificPlant, moveSpecificPlant } from '../api/plantings'
 import { ApiErrorAlert } from '../api_error_alert'
@@ -13,6 +13,7 @@ import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
 import { GardenSquare } from '../types/garden'
 import { getGardenSquares } from '../api/garden'
+import { getInventoryLocations } from '../api/inventory'
 import { queryClient, queryKeys } from '../query'
 
 interface SeedTrayDetailsProps {
@@ -38,6 +39,7 @@ type SeedTrayMove = {
 }
 
 type MoveForm = BaseMoveForm & (GardenSquareMove | SeedTrayMove)
+type InventoryAction = 'transfer' | 'loss' | 'retire' | 'return' | 'reconcile-opening'
 
 type CellPlantingEntry = { cellPlantingPk: number; quantity: number; plantingPk: number }
 
@@ -331,6 +333,10 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const [germinationDate, setGerminationDate] = React.useState(localDatetimeInputValue())
   const [germinationNotes, setGerminationNotes] = React.useState('')
   const [moveForm, setMoveForm] = React.useState<MoveForm>()
+  const [inventoryAction, setInventoryAction] = React.useState<InventoryAction>()
+  const [inventoryDestination, setInventoryDestination] = React.useState<number>()
+  const [inventoryReason, setInventoryReason] = React.useState('')
+  const [inventoryCost, setInventoryCost] = React.useState('0.0000')
   const seedTrayModelsQuery = useQuery({
     queryKey: queryKeys.seedTrays.models,
     queryFn: ({ signal }) => getSeedTrayModels(signal)
@@ -338,6 +344,16 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const seedTraysQuery = useQuery({
     queryKey: queryKeys.seedTrays.trays,
     queryFn: ({ signal }) => getSeedTrays(signal)
+  })
+  const selectedSeedTray = seedTraysQuery.data?.find((tray) => tray.pk === seedTrayPk)
+  const inventoryLocationsQuery = useQuery({
+    queryKey: queryKeys.inventory.locations,
+    queryFn: ({ signal }) => getInventoryLocations(signal)
+  })
+  const inventoryMovementsQuery = useQuery({
+    queryKey: queryKeys.seedTrays.movements(selectedSeedTray?.inventory_unit ?? 0),
+    queryFn: ({ signal }) => getSerializedUnitMovements(selectedSeedTray?.inventory_unit as number, signal),
+    enabled: Boolean(selectedSeedTray?.inventory_unit)
   })
   const seedTrayCellsQuery = useQuery({
     queryKey: queryKeys.seedTrays.cells(seedTrayPk),
@@ -383,6 +399,14 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
         cache.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })
       ])
   })
+  const inventoryMutation = useMutation({
+    mutationFn: ({ unit, action, data }: { unit: number; action: InventoryAction; data: object }) => postSerializedUnitAction(unit, action, data),
+    onSuccess: () =>
+      Promise.all([
+        cache.invalidateQueries({ queryKey: queryKeys.seedTrays.trays }),
+        cache.invalidateQueries({ queryKey: queryKeys.seedTrays.movements(selectedSeedTray?.inventory_unit ?? 0) })
+      ])
+  })
 
   const seedTrayModels = seedTrayModelsQuery.data ?? []
   const seedTrays = seedTraysQuery.data ?? []
@@ -391,7 +415,14 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const seedPacketDetails = seedPacketsQuery.data ?? []
   const specificPlants = specificPlantsQuery.data ?? []
   const gardenSquares = gardenSquaresQuery.data ?? []
-  const seedTray = seedTrays.find((tray) => tray.pk === seedTrayPk)
+  const inventoryLocations = inventoryLocationsQuery.data ?? []
+  const inventoryDestinations = inventoryLocations.filter((location) => location.code !== 'SYSTEM-TRAY-UNKNOWN' && location.location_type !== 'seed_packet')
+  const inventoryMovements = inventoryMovementsQuery.data ?? []
+  const inventoryLocationMap = inventoryLocations.reduce<Record<number, string>>((locations, location) => {
+    locations[location.pk] = location.name
+    return locations
+  }, {})
+  const seedTray = selectedSeedTray
   const seedTrayModel = seedTrayModels.find((model) => model.pk === seedTray?.model)
   const seedTrayCells = buildCellGrid(seedTrayModel, allCells)
   const seeds = seedPacketDetails.reduce<Record<number, SeedPacketDetails>>((packets, packet) => {
@@ -399,9 +430,16 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     return packets
   }, {})
   const { cellCurrentPlantMap, cellPlantingMap, germinatedByCellPlanting, cellTotals } = computeCellData(specificPlants, plantings)
-  const isLoading = [seedTrayModelsQuery, seedTraysQuery, seedTrayCellsQuery, plantingsQuery, seedPacketsQuery, specificPlantsQuery, gardenSquaresQuery].some(
-    (query) => query.isPending
-  )
+  const isLoading = [
+    seedTrayModelsQuery,
+    seedTraysQuery,
+    seedTrayCellsQuery,
+    plantingsQuery,
+    seedPacketsQuery,
+    specificPlantsQuery,
+    gardenSquaresQuery,
+    inventoryLocationsQuery
+  ].some((query) => query.isPending)
 
   async function handleRecordGermination() {
     if (!germinatingCellPlantingPk) return
@@ -465,6 +503,23 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     return square ? square.name : `Square #${location.garden_square}`
   }
 
+  async function handleInventoryAction() {
+    if (!seedTray || !inventoryAction) return
+    const needsDestination = inventoryAction === 'transfer' || inventoryAction === 'return' || inventoryAction === 'reconcile-opening'
+    if (needsDestination && !inventoryDestination) return
+    const data: Record<string, string | number> = { reason: inventoryReason }
+    if (inventoryDestination) data.destination = inventoryDestination
+    if (inventoryAction === 'reconcile-opening') data.acquisition_cost = inventoryCost
+    await inventoryMutation.mutateAsync({
+      unit: seedTray.inventory_unit,
+      action: inventoryAction,
+      data
+    })
+    setInventoryAction(undefined)
+    setInventoryDestination(undefined)
+    setInventoryReason('')
+  }
+
   if (isLoading) {
     return <div>Loading...</div>
   }
@@ -481,6 +536,122 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
       </p>
       <p>Created: {formatDate(seedTray.created)}</p>
       <p>Notes: {seedTray.notes}</p>
+      <Card className="mb-3">
+        <Card.Body>
+          <Card.Title>Physical inventory</Card.Title>
+          {seedTray.inventory.reconciliation_required && <Alert variant="warning">Opening cost and physical location require reconciliation.</Alert>}
+          <dl className="row mb-2">
+            <dt className="col-sm-3">Asset code</dt>
+            <dd className="col-sm-9">{seedTray.inventory.asset_code}</dd>
+            <dt className="col-sm-3">State</dt>
+            <dd className="col-sm-9">
+              {seedTray.inventory.physical_state} {seedTray.inventory.in_use ? '(in use)' : '(not in use)'}
+            </dd>
+            <dt className="col-sm-3">Location</dt>
+            <dd className="col-sm-9">{seedTray.inventory.current_location ? inventoryLocationMap[seedTray.inventory.current_location] : 'Off hand'}</dd>
+            <dt className="col-sm-3">Acquisition cost</dt>
+            <dd className="col-sm-9">{seedTray.inventory.acquisition_cost === null ? 'Unknown' : `${seedTray.inventory.acquisition_cost} ${seedTray.inventory.currency_code}`}</dd>
+            <dt className="col-sm-3">Source lot</dt>
+            <dd className="col-sm-9">
+              #{seedTray.inventory.source_lot}
+              {seedTray.inventory.receipt_line ? ` / receipt line #${seedTray.inventory.receipt_line}` : ' / opening balance'}
+            </dd>
+          </dl>
+          <div className="d-flex gap-2 flex-wrap">
+            {seedTray.inventory.current_location && !seedTray.inventory.reconciliation_required && (
+              <Button size="sm" onClick={() => setInventoryAction('transfer')}>
+                Transfer
+              </Button>
+            )}
+            {seedTray.inventory.current_location && !seedTray.inventory.in_use && !seedTray.inventory.reconciliation_required && (
+              <>
+                <Button size="sm" variant="warning" onClick={() => setInventoryAction('loss')}>
+                  Record loss
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => setInventoryAction('retire')}>
+                  Retire
+                </Button>
+              </>
+            )}
+            {(seedTray.inventory.physical_state === 'lost' || seedTray.inventory.physical_state === 'retired') && (
+              <Button size="sm" variant="success" onClick={() => setInventoryAction('return')}>
+                Return to stock
+              </Button>
+            )}
+            {seedTray.inventory.reconciliation_required && (
+              <Button size="sm" variant="outline-primary" onClick={() => setInventoryAction('reconcile-opening')}>
+                Reconcile opening
+              </Button>
+            )}
+          </div>
+          {inventoryAction && (
+            <Form className="border rounded p-2 mt-3">
+              <strong>{inventoryAction.replace('-', ' ')}</strong>
+              {(inventoryAction === 'transfer' || inventoryAction === 'return' || inventoryAction === 'reconcile-opening') && (
+                <Form.Group className="mt-2">
+                  <Form.Label>Destination</Form.Label>
+                  <Form.Select value={inventoryDestination ?? ''} onChange={(event) => setInventoryDestination(event.target.value ? Number(event.target.value) : undefined)}>
+                    <option value="">Select location</option>
+                    {inventoryDestinations.map((location) => (
+                      <option key={location.pk} value={location.pk}>
+                        {location.name}
+                      </option>
+                    ))}
+                  </Form.Select>
+                </Form.Group>
+              )}
+              {inventoryAction === 'reconcile-opening' && (
+                <Form.Group className="mt-2">
+                  <Form.Label>Acquisition cost ({seedTray.inventory.currency_code})</Form.Label>
+                  <Form.Control type="number" min={0} step="0.0001" value={inventoryCost} onChange={(event) => setInventoryCost(event.target.value)} />
+                </Form.Group>
+              )}
+              <Form.Group className="mt-2">
+                <Form.Label>Reason</Form.Label>
+                <Form.Control value={inventoryReason} onChange={(event) => setInventoryReason(event.target.value)} />
+              </Form.Group>
+              <Button
+                className="mt-2"
+                size="sm"
+                onClick={handleInventoryAction}
+                disabled={
+                  inventoryMutation.isPending ||
+                  ((inventoryAction === 'loss' || inventoryAction === 'retire' || inventoryAction === 'return' || inventoryAction === 'reconcile-opening') &&
+                    !inventoryReason.trim())
+                }
+              >
+                Save action
+              </Button>{' '}
+              <Button className="mt-2" size="sm" variant="secondary" onClick={() => setInventoryAction(undefined)}>
+                Cancel
+              </Button>
+            </Form>
+          )}
+          <h6 className="mt-3">Movement history</h6>
+          <Table size="sm">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Type</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Reason/reference</th>
+              </tr>
+            </thead>
+            <tbody>
+              {inventoryMovements.map((movement) => (
+                <tr key={movement.pk}>
+                  <td>{formatDateTime(movement.occurred_at)}</td>
+                  <td>{movement.movement_type}</td>
+                  <td>{movement.source ? inventoryLocationMap[movement.source] : ''}</td>
+                  <td>{movement.destination ? inventoryLocationMap[movement.destination] : ''}</td>
+                  <td>{movement.reason || movement.reference}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </Card.Body>
+      </Card>
       Plantings:
       <Table border={1} cellPadding={5} cellSpacing={0}>
         <thead>

--- a/frontend/js/seedtrays.tsx
+++ b/frontend/js/seedtrays.tsx
@@ -2,13 +2,16 @@ import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
-import { Table } from 'react-bootstrap'
-import Select from 'react-select'
+import { Button, Form, Table } from 'react-bootstrap'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router'
 
-import { SeedTrayModel, SeedTrayModelCreate, SeedTrayCreate } from './types/seedtrays'
-import { getSeedTrayModels, getSeedTrays, addSeedTrayModel, addSeedTray } from './api/seedtrays'
+import { InventoryLocation, SerializedPhysicalState } from './types/inventory'
+import { Supplier } from './types/suppliers'
+import { SeedTrayModel, SeedTrayModelCreate, SeedTrayReceiptCreate } from './types/seedtrays'
+import { getSeedTrayModels, getSeedTrays, addSeedTrayModel, receiveSeedTrays } from './api/seedtrays'
+import { getInventoryLocations } from './api/inventory'
+import { getSuppliers } from './api/supplies'
 import { formatDate } from './utils'
 import { queryKeys } from './query'
 
@@ -123,72 +126,137 @@ function SeedTrayModelsTable() {
   )
 }
 
-interface SeedTrayAddProps {
+interface SeedTrayReceiveProps {
   done: () => void
   models: Array<SeedTrayModel>
-  createTray: (data: SeedTrayCreate) => Promise<void>
+  suppliers: Array<Supplier>
+  locations: Array<InventoryLocation>
+  receiveTrays: (model: number, data: SeedTrayReceiptCreate) => Promise<void>
 }
 
-class SeedTrayAdd extends React.Component<SeedTrayAddProps, SeedTrayCreate> {
-  constructor(props: SeedTrayAddProps) {
-    super(props)
+function SeedTrayReceive({ done, models, suppliers, locations, receiveTrays }: SeedTrayReceiveProps) {
+  const [model, setModel] = React.useState<number>()
+  const [supplier, setSupplier] = React.useState<number>()
+  const [destination, setDestination] = React.useState<number>()
+  const [receivedDate, setReceivedDate] = React.useState(new Date().toISOString().slice(0, 10))
+  const [quantity, setQuantity] = React.useState(1)
+  const [cost, setCost] = React.useState('0.0000')
+  const [reference, setReference] = React.useState('')
+  const [notes, setNotes] = React.useState('')
+  const receivingLocations = locations.filter((location) => location.code !== 'SYSTEM-TRAY-UNKNOWN' && location.location_type !== 'seed_packet')
 
-    this.state = {
-      model: undefined,
-      notes: ''
-    }
+  async function submit() {
+    if (!model || !supplier || !destination || quantity < 1) return
+    await receiveTrays(model, {
+      supplier,
+      destination,
+      received_date: receivedDate,
+      quantity,
+      line_cost_ex_tax: cost,
+      supplier_reference: reference,
+      notes
+    })
+    done()
   }
 
-  private updateModel = (newValue: { value: number; label: string } | null) => {
-    this.setState({ model: newValue?.value || undefined })
-  }
-
-  private updateNotes = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ notes: event.target.value })
-  }
-
-  private createSeedTray = async () => {
-    if (!this.state.model) {
-      return
-    }
-    await this.props.createTray(this.state)
-    this.props.done()
-  }
-
-  render() {
-    return (
-      <tr>
-        <td></td>
-        <td>
-          <Select name="model" onChange={this.updateModel} options={this.props.models.map((model) => ({ value: model.pk, label: model.identifier }))} />
-        </td>
-        <td></td>
-        <td>
-          <input type="text" name="notes" onChange={this.updateNotes} />
-        </td>
-        <td>
-          <button type="button" className="btn btn-primary" onClick={this.createSeedTray}>
-            Create
-          </button>
-        </td>
-      </tr>
-    )
-  }
+  return (
+    <tr>
+      <td colSpan={9}>
+        <Form className="d-flex flex-wrap gap-2 align-items-end">
+          <Form.Group>
+            <Form.Label>Model</Form.Label>
+            <Form.Select value={model ?? ''} onChange={(event) => setModel(event.target.value ? Number(event.target.value) : undefined)}>
+              <option value="">Select model</option>
+              {models.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.identifier}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Supplier</Form.Label>
+            <Form.Select value={supplier ?? ''} onChange={(event) => setSupplier(event.target.value ? Number(event.target.value) : undefined)}>
+              <option value="">Select supplier</option>
+              {suppliers.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Location</Form.Label>
+            <Form.Select value={destination ?? ''} onChange={(event) => setDestination(event.target.value ? Number(event.target.value) : undefined)}>
+              <option value="">Select location</option>
+              {receivingLocations.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Received</Form.Label>
+            <Form.Control type="date" value={receivedDate} onChange={(event) => setReceivedDate(event.target.value)} />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Quantity</Form.Label>
+            <Form.Control type="number" min={1} value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Total cost ex tax</Form.Label>
+            <Form.Control type="number" min={0} step="0.0001" value={cost} onChange={(event) => setCost(event.target.value)} />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Supplier reference</Form.Label>
+            <Form.Control value={reference} onChange={(event) => setReference(event.target.value)} />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Notes</Form.Label>
+            <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </Form.Group>
+          <Button onClick={submit} disabled={!model || !supplier || !destination || !receivedDate || quantity < 1}>
+            Receive
+          </Button>
+          <Button variant="secondary" onClick={done}>
+            Cancel
+          </Button>
+        </Form>
+      </td>
+    </tr>
+  )
 }
 
 function SeedTraysTable() {
   const queryClient = useQueryClient()
   const [showAddRow, setShowAddRow] = React.useState(false)
+  const [physicalState, setPhysicalState] = React.useState<SerializedPhysicalState | ''>('')
+  const [location, setLocation] = React.useState<number>()
+  const [inUse, setInUse] = React.useState<'' | 'true' | 'false'>('')
   const { data: seedTrays = [] } = useQuery({
-    queryKey: queryKeys.seedTrays.trays,
-    queryFn: ({ signal }) => getSeedTrays(signal)
+    queryKey: [...queryKeys.seedTrays.trays, physicalState, location, inUse],
+    queryFn: ({ signal }) =>
+      getSeedTrays(signal, {
+        physical_state: physicalState || undefined,
+        location,
+        in_use: inUse ? inUse === 'true' : undefined
+      })
   })
   const { data: seedTrayModels = [] } = useQuery({
     queryKey: queryKeys.seedTrays.models,
     queryFn: ({ signal }) => getSeedTrayModels(signal)
   })
+  const { data: suppliers = [] } = useQuery({
+    queryKey: queryKeys.suppliers.all,
+    queryFn: ({ signal }) => getSuppliers(signal)
+  })
+  const { data: locations = [] } = useQuery({
+    queryKey: queryKeys.inventory.locations,
+    queryFn: ({ signal }) => getInventoryLocations(signal)
+  })
   const trayMutation = useMutation({
-    mutationFn: addSeedTray,
+    mutationFn: ({ model, receipt }: { model: number; receipt: SeedTrayReceiptCreate }) => receiveSeedTrays(model, receipt),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.seedTrays.trays })
   })
   const seedTrayModelsMap = seedTrayModels.reduce<Record<number, SeedTrayModel>>((models, model) => {
@@ -196,36 +264,81 @@ function SeedTraysTable() {
     return models
   }, {})
 
-  async function createTray(data: SeedTrayCreate) {
-    await trayMutation.mutateAsync(data)
+  const locationsMap = locations.reduce<Record<number, InventoryLocation>>((result, entry) => {
+    result[entry.pk] = entry
+    return result
+  }, {})
+
+  async function receiveTrays(model: number, receipt: SeedTrayReceiptCreate) {
+    await trayMutation.mutateAsync({ model, receipt })
   }
 
   return (
-    <Table>
-      <thead>
-        <tr>
-          <th>
-            ID<button onClick={() => setShowAddRow(true)}>+</button>
-          </th>
-          <th>Model</th>
-          <th>Created</th>
-          <th>Notes</th>
-        </tr>
-      </thead>
-      <tbody>
-        {showAddRow && <SeedTrayAdd key="add" createTray={createTray} done={() => setShowAddRow(false)} models={seedTrayModels} />}
-        {seedTrays.map((tray) => (
-          <tr key={tray.pk}>
-            <td>
-              <Link to={`/seedtrays/${tray.pk}`}>{tray.pk}</Link>
-            </td>
-            <td>{tray.model && seedTrayModelsMap[tray.model]?.identifier}</td>
-            <td>{formatDate(tray.created)}</td>
-            <td>{tray.notes}</td>
+    <>
+      <div className="d-flex gap-2 mb-3">
+        <Form.Select aria-label="Filter tray state" value={physicalState} onChange={(event) => setPhysicalState(event.target.value as SerializedPhysicalState | '')}>
+          <option value="">All physical states</option>
+          {['available', 'quarantined', 'lost', 'retired', 'dispatched', 'returned'].map((state) => (
+            <option key={state} value={state}>
+              {state}
+            </option>
+          ))}
+        </Form.Select>
+        <Form.Select aria-label="Filter tray location" value={location ?? ''} onChange={(event) => setLocation(event.target.value ? Number(event.target.value) : undefined)}>
+          <option value="">All locations</option>
+          {locations.map((entry) => (
+            <option key={entry.pk} value={entry.pk}>
+              {entry.name}
+            </option>
+          ))}
+        </Form.Select>
+        <Form.Select aria-label="Filter trays in use" value={inUse} onChange={(event) => setInUse(event.target.value as '' | 'true' | 'false')}>
+          <option value="">Any cultivation use</option>
+          <option value="true">In use</option>
+          <option value="false">Not in use</option>
+        </Form.Select>
+      </div>
+      <Table>
+        <thead>
+          <tr>
+            <th>
+              ID{' '}
+              <Button size="sm" onClick={() => setShowAddRow(true)}>
+                Receive
+              </Button>
+            </th>
+            <th>Model</th>
+            <th>Asset</th>
+            <th>State</th>
+            <th>Location</th>
+            <th>In use</th>
+            <th>Acquisition cost</th>
+            <th>Created</th>
+            <th>Notes</th>
           </tr>
-        ))}
-      </tbody>
-    </Table>
+        </thead>
+        <tbody>
+          {showAddRow && (
+            <SeedTrayReceive key="receive" receiveTrays={receiveTrays} done={() => setShowAddRow(false)} models={seedTrayModels} suppliers={suppliers} locations={locations} />
+          )}
+          {seedTrays.map((tray) => (
+            <tr key={tray.pk}>
+              <td>
+                <Link to={`/seedtrays/${tray.pk}`}>{tray.pk}</Link>
+              </td>
+              <td>{tray.model && seedTrayModelsMap[tray.model]?.identifier}</td>
+              <td>{tray.inventory.asset_code}</td>
+              <td>{tray.inventory.physical_state}</td>
+              <td>{tray.inventory.current_location ? locationsMap[tray.inventory.current_location]?.name : 'Off hand'}</td>
+              <td>{tray.inventory.in_use ? 'Yes' : 'No'}</td>
+              <td>{tray.inventory.acquisition_cost === null ? 'Unknown' : `${tray.inventory.acquisition_cost} ${tray.inventory.currency_code}`}</td>
+              <td>{formatDate(tray.created)}</td>
+              <td>{tray.notes}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </>
   )
 }
 

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -12,6 +12,54 @@ interface InventoryUnit {
   to_reference_multiplier: string
 }
 
+type SerializedPhysicalState = 'available' | 'quarantined' | 'lost' | 'retired' | 'dispatched' | 'returned'
+
+interface InventoryLocation {
+  pk: number
+  name: string
+  code: string
+  location_type: 'receiving' | 'storage' | 'growing' | 'dispatch' | 'quarantine' | 'adjustment' | 'seed_packet'
+  active: boolean
+  notes: string
+  created: string
+  updated: string
+}
+
+interface SerializedInventoryUnit {
+  pk: number
+  item: number
+  item_name: string
+  source_lot: number
+  receipt_line: number | null
+  asset_code: string
+  acquisition_cost: string | null
+  currency_code: string
+  current_location: number | null
+  physical_state: SerializedPhysicalState
+  in_use: boolean
+  reconciliation_required: boolean
+  active: boolean
+  movement_ids: number[]
+  created: string
+  updated: string
+}
+
+interface SerializedStockMovement {
+  pk: number
+  lot: number
+  unit: number | null
+  movement_type: string
+  quantity: string
+  source: number | null
+  destination: number | null
+  occurred_at: string
+  reason: string
+  reference: string
+  reversal_of: number | null
+  reversed_by: number | null
+  created: string
+}
+
 interface InventoryItem {
   pk: number
   name: string
@@ -75,11 +123,15 @@ export {
   InventoryItem,
   InventoryItemCreate,
   InventoryItemFilters,
+  InventoryLocation,
   InventoryTrackingMode,
   InventoryUnit,
   InventoryUsageBasis,
   ItemUnitConversion,
   ItemUnitConversionCreate,
+  SerializedInventoryUnit,
+  SerializedPhysicalState,
+  SerializedStockMovement,
   UnitCode,
   UnitDimension
 }

--- a/frontend/js/types/seedtrays.ts
+++ b/frontend/js/types/seedtrays.ts
@@ -1,3 +1,5 @@
+import { SerializedInventoryUnit, SerializedPhysicalState } from './inventory'
+
 interface SeedTrayModelCreate {
   identifier: string
   description: string
@@ -10,17 +12,41 @@ interface SeedTrayModelCreate {
 }
 interface SeedTrayModel extends SeedTrayModelCreate {
   pk: number
+  inventory_item: number
 }
 
-interface SeedTrayCreate {
-  model?: number
+interface SeedTrayReceiptCreate {
+  supplier: number
+  received_date: string
+  supplier_reference?: string
+  quantity: number
+  line_cost_ex_tax: string
+  destination: number
+  tax_rate?: string
+  tax_recoverable?: boolean
   notes?: string
 }
 
-type SeedTray = SeedTrayCreate & {
+interface SeedTray {
   pk: number
   model: number
+  inventory_unit: number
+  inventory: SerializedInventoryUnit
   created: string
+  notes?: string
+}
+
+interface SeedTrayFilters {
+  model?: number
+  location?: number
+  physical_state?: SerializedPhysicalState
+  in_use?: boolean
+}
+
+interface SeedTrayReceiptResponse {
+  receipt: number
+  receipt_line: number
+  trays: SeedTray[]
 }
 
 interface SeedTrayCell {
@@ -30,4 +56,4 @@ interface SeedTrayCell {
   y_position: number
 }
 
-export { SeedTrayModel, SeedTray, SeedTrayCell, SeedTrayModelCreate, SeedTrayCreate }
+export { SeedTrayModel, SeedTray, SeedTrayCell, SeedTrayFilters, SeedTrayModelCreate, SeedTrayReceiptCreate, SeedTrayReceiptResponse }

--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -476,6 +476,10 @@ def post_receipt(receipt, user):  # pylint: disable=too-many-branches
             )
         if line.item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
             _validate_serialized_receipt_line(line)
+            if line.destination.code == 'SYSTEM-TRAY-UNKNOWN':
+                raise ValidationError({
+                    'lines': 'The unknown tray location is reserved for migration.',
+                })
 
     posted_at = timezone.now()
     lots = []
@@ -713,7 +717,7 @@ def _latest_effective_unit_movement(unit):
 
 
 @transaction.atomic
-def post_unit_movement(workspace, user, request):
+def post_unit_movement(workspace, user, request):  # pylint: disable=too-many-branches
     """Post one physical action against an exact locked serialized unit."""
     lot = lock_lots(workspace, [request.unit.source_lot_id])[
         request.unit.source_lot_id
@@ -723,9 +727,17 @@ def post_unit_movement(workspace, user, request):
         raise ValidationError({'unit': 'The serialized item is inactive.'})
     if request.destination:
         _validate_location(request.destination, workspace, 'destination')
+        if request.destination.code == 'SYSTEM-TRAY-UNKNOWN':
+            raise ValidationError({
+                'destination': 'The unknown tray location is reserved for migration.',
+            })
     state = unit_physical_state(unit)
     source = unit.current_location
     destination = request.destination
+    if source and source.code == 'SYSTEM-TRAY-UNKNOWN':
+        raise ValidationError({
+            'unit': 'Reconcile this opening unit before another stock action.',
+        })
     allowed = {
         StockMovement.MovementType.TRANSFER,
         StockMovement.MovementType.ADJUSTMENT_LOSS,

--- a/inventory/test_ledger_concurrency.py
+++ b/inventory/test_ledger_concurrency.py
@@ -9,16 +9,19 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import close_old_connections
 from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.utils import timezone
 
 from workspaces.models import Workspace, get_current_workspace
 
 from .ledger import (
     MovementRequest,
     OpeningBalanceRequest,
+    UnitMovementRequest,
     post_opening_balance,
     post_stock_movement,
+    post_unit_movement,
 )
-from .models import InventoryItem, InventoryLocation, StockLot, StockMovement
+from .models import InventoryItem, InventoryLocation, InventoryUnit, StockLot, StockMovement
 from .units import UnitCode
 
 
@@ -108,6 +111,116 @@ class ConcurrentLedgerTests(TransactionTestCase):
             StockMovement.objects.filter(
                 lot_id=self.lot_pk,
                 movement_type=StockMovement.MovementType.CONSUMPTION,
+            ).count(),
+            1,
+        )
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentSerializedUnitTests(TransactionTestCase):
+    """A unit lock prevents two callers moving one physical identity twice."""
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+    def setUp(self):
+        super().setUp()
+        workspace = get_current_workspace()
+        self.user = get_user_model().objects.create_user(
+            username='unit-concurrency-user',
+        )
+        item = InventoryItem.objects.create(
+            workspace=workspace,
+            name='Concurrent serialized tray',
+            category=InventoryItem.Category.TRAY,
+            base_unit=UnitCode.EACH,
+            tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
+        )
+        source = InventoryLocation.objects.create(
+            workspace=workspace,
+            name='Unit source',
+            code='UNIT-SOURCE',
+            location_type=InventoryLocation.LocationType.STORAGE,
+        )
+        destination = InventoryLocation.objects.create(
+            workspace=workspace,
+            name='Unit destination',
+            code='UNIT-DESTINATION',
+            location_type=InventoryLocation.LocationType.GROWING,
+        )
+        lot = StockLot.objects.create(
+            workspace=workspace,
+            item=item,
+            origin=StockLot.Origin.OPENING,
+            received_on=date(2026, 8, 1),
+            initial_base_quantity=Decimal('1'),
+            acquisition_total=Decimal('5'),
+            base_unit_cost=Decimal('5'),
+            currency_code='NZD',
+        )
+        unit = InventoryUnit.objects.create(
+            workspace=workspace,
+            item=item,
+            source_lot=lot,
+            acquisition_cost=Decimal('5'),
+            currency_code='NZD',
+            current_location=source,
+        )
+        StockMovement.objects.create(
+            workspace=workspace,
+            lot=lot,
+            unit=unit,
+            movement_type=StockMovement.MovementType.OPENING,
+            quantity=Decimal('1'),
+            destination=source,
+            occurred_at=timezone.now(),
+        )
+        self.unit_pk = unit.pk
+        self.destination_pk = destination.pk
+
+    def _transfer_unit(self):
+        """Attempt one move from an independent database connection."""
+        close_old_connections()
+        workspace = get_current_workspace()
+        unit = InventoryUnit.objects.get(pk=self.unit_pk)
+        destination = InventoryLocation.objects.get(pk=self.destination_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            post_unit_movement(
+                workspace,
+                user,
+                UnitMovementRequest(
+                    unit=unit,
+                    movement_type=StockMovement.MovementType.TRANSFER,
+                    destination=destination,
+                ),
+            )
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'posted'
+        close_old_connections()
+        return result
+
+    def test_only_one_request_moves_the_unit(self):
+        """The second caller sees the destination committed by the first."""
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(
+                lambda _index: self._transfer_unit(),
+                range(2),
+            ))
+
+        self.assertCountEqual(results, ['posted', 'rejected'])
+        self.assertEqual(
+            StockMovement.objects.filter(
+                unit_id=self.unit_pk,
+                movement_type=StockMovement.MovementType.TRANSFER,
             ).count(),
             1,
         )


### PR DESCRIPTION
Operators need to receive and locate exact trays without falling back to unaudited creation. Add inventory filters, provenance, valuation, actions, history, and reconciliation guidance while enforcing the same unit-lock boundaries on the server.

## Summary by Sourcery

Introduce serialized inventory management for seed trays, including constrained receipt, location tracking, and unit-safe movement actions across frontend and backend.

New Features:
- Add seed tray receipt workflow that records supplier, location, quantity, cost, and references while creating serialized inventory units.
- Expose tray-level inventory details in the seed tray detail view, including asset code, physical state, location, acquisition cost, and source lot metadata.
- Provide filters on the seed trays list for physical state, location, and cultivation use, and display associated inventory information for each tray.
- Add movement history display and inventory action controls (transfer, loss, retire, return, reconcile opening) for serialized tray units.

Bug Fixes:
- Prevent serialized tray receipts and movements from using the reserved unknown tray location and from acting on unreconciled opening units.

Enhancements:
- Extend inventory and seed tray type definitions and APIs to support serialized units, movements, locations, and filtered tray queries.
- Strengthen ledger concurrency guarantees by adding tests that ensure a serialized unit cannot be moved twice concurrently, enforcing unit-level locks.

Tests:
- Add concurrent serialized unit test cases to verify that only one of multiple simultaneous movement requests succeeds for a given physical unit.