### PR TITLE
test: add virtualenv test runner

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -40,7 +40,7 @@ jobs:
           ./setup-venv.sh
       - name: Test
         run:
-          venv/bin/python manage.py test
+          ./test-venv.sh
       - name: check-code
         run:
           ./check-code.sh

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Project layout (high level)
 
 Contributing
 - Fork, create a feature branch, add tests, and open a PR.
-- Please run linting and tests locally before submitting.
+- Run backend tests with `./test-venv.sh` and linting with `./check-code.sh` before submitting.
 - Consider adding a CONTRIBUTING.md and CODE_OF_CONDUCT.md if you want contribution guidelines formalised.
 
 License

--- a/test-venv.sh
+++ b/test-venv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+venv/bin/python manage.py test "$@"


### PR DESCRIPTION
A single repository entry point makes the backend suite easy to run locally with the configured virtualenv. Reuse it in CI and document it so the local and automated commands cannot drift.

## Summary by Sourcery

Introduce a reusable virtualenv-based backend test runner script and adopt it in CI and documentation.

CI:
- Update CI workflow to use the shared virtualenv test runner script instead of invoking the test command directly.

Documentation:
- Document the new backend test runner script and linting command in the README for contributors.

Tests:
- Add a shell script entry point that runs the backend test suite via the configured virtualenv.