### PR TITLE
feat(plantings): add audited batch lifecycle operations

### DIFF
--- a/plantings/batches.py
+++ b/plantings/batches.py
@@ -1,0 +1,299 @@
+"""Transactional lifecycle services for shared production batches."""
+
+# pylint: disable=duplicate-code
+
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Sum
+from django.utils import timezone
+
+from .models import (
+    GardenRowDirectSowPlanting,
+    GardenSquareDirectSowPlanting,
+    ProductionBatch,
+    ProductionBatchTransition,
+    SeedTrayPlanting,
+    SpecificPlant,
+)
+
+
+SOWING_MODELS = (
+    GardenRowDirectSowPlanting,
+    GardenSquareDirectSowPlanting,
+    SeedTrayPlanting,
+)
+
+REOPEN_TARGETS = {
+    ProductionBatch.Status.OUTPUT_FINALIZED: ProductionBatch.Status.ACTIVE,
+    ProductionBatch.Status.COMPLETED: ProductionBatch.Status.OUTPUT_FINALIZED,
+}
+
+#: Lifecycle stamps cleared when a batch moves back to an earlier status.
+SUPERSEDED_TIMESTAMPS = {
+    ProductionBatch.Status.ACTIVE: ('output_finalized_at', 'completed_at', 'cancelled_at'),
+    ProductionBatch.Status.OUTPUT_FINALIZED: ('completed_at', 'cancelled_at'),
+    ProductionBatch.Status.PLANNED: (
+        'actual_start',
+        'output_finalized_at',
+        'completed_at',
+        'cancelled_at',
+    ),
+}
+
+
+class BatchRequest(NamedTuple):
+    """Caller intent for one new standalone production batch."""
+
+    code: str
+    variety: object
+    planned_start: object = None
+    notes: str = ''
+
+
+def _sowing_querysets(batch):
+    """Return one queryset of attached sowings per concrete planting model."""
+    return [model.objects.filter(batch=batch) for model in SOWING_MODELS]
+
+
+def batch_sowing_count(batch):
+    """Return how many sowings of any kind belong to this batch."""
+    return sum(queryset.count() for queryset in _sowing_querysets(batch))
+
+
+def batch_seeds_sown(batch):
+    """Return the total seeds or seed clusters sown into this batch."""
+    total = 0
+    for queryset in _sowing_querysets(batch):
+        total += queryset.aggregate(total=Sum('quantity'))['total'] or 0
+    return total
+
+
+def batch_open_sowings(batch):
+    """Return the labels and IDs of sowing activities still open."""
+    open_sowings = []
+    for queryset in _sowing_querysets(batch):
+        for pk in queryset.filter(removed=False).order_by('pk').values_list('pk', flat=True):
+            open_sowings.append(f'{queryset.model.__name__} #{pk}')
+    return open_sowings
+
+
+def batch_specific_plants(batch):
+    """Return every individual plant observed from this batch's sowings."""
+    return SpecificPlant.objects.filter(
+        cell_planting__seed_tray_planting__batch=batch,
+    )
+
+
+def batch_unresolved_plant_ids(batch):
+    """Return plants without a final disposition, newest task 41 pending.
+
+    Until lifecycle outcomes exist, an observed plant is always unresolved:
+    an ended location records where a plant stopped being, not what became
+    of it.
+    """
+    return list(batch_specific_plants(batch).order_by('pk').values_list('pk', flat=True))
+
+
+def _record_transition(batch, previous_status, user, reason=''):
+    """Append one immutable row describing a lifecycle change."""
+    return ProductionBatchTransition.objects.create(
+        batch=batch,
+        previous_status=previous_status,
+        new_status=batch.status,
+        created_by=user if user is not None and user.is_authenticated else None,
+        reason=reason,
+    )
+
+
+def _lock_batch(batch):
+    """Reload one batch under a row lock for a lifecycle change."""
+    return ProductionBatch.objects.select_for_update().get(pk=batch.pk)
+
+
+def _require_status(batch, allowed, action):
+    """Reject a lifecycle action that its current status does not permit."""
+    if batch.status not in allowed:
+        raise ValidationError({
+            'status': f'A {batch.get_status_display().lower()} batch cannot {action}.',
+        })
+
+
+def _require_reason(reason):
+    """Reject an audit-critical action without a stated reason."""
+    if not reason or not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+
+
+def _clear_superseded(batch, status):
+    """Blank the lifecycle stamps that a move back to `status` supersedes."""
+    for field in SUPERSEDED_TIMESTAMPS.get(status, ()):
+        setattr(batch, field, None)
+
+
+@transaction.atomic
+def create_batch(workspace, user, request):
+    """Create one planned batch and record its opening transition."""
+    batch = ProductionBatch(
+        workspace=workspace,
+        code=request.code,
+        variety=request.variety,
+        status=ProductionBatch.Status.PLANNED,
+        planned_start=request.planned_start,
+        notes=request.notes,
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+    batch.save()
+    _record_transition(batch, '', user, 'Batch created.')
+    return batch
+
+
+@transaction.atomic
+def activate_batch(batch, user, actual_start=None, reason=''):
+    """Start a planned batch at a supplied or current time."""
+    batch = _lock_batch(batch)
+    _require_status(batch, {ProductionBatch.Status.PLANNED}, 'be activated')
+    previous_status = batch.status
+    batch.status = ProductionBatch.Status.ACTIVE
+    batch.actual_start = actual_start or timezone.now()
+    batch.save()
+    _record_transition(batch, previous_status, user, reason)
+    return batch
+
+
+@transaction.atomic
+def create_and_activate_batch(workspace, user, request, actual_start=None):
+    """Create and start one batch atomically for an inline sowing."""
+    batch = create_batch(workspace, user, request)
+    return activate_batch(
+        batch,
+        user,
+        actual_start=actual_start,
+        reason='Created with its first sowing.',
+    )
+
+
+@transaction.atomic
+def finalize_batch_output(batch, user, reason=''):
+    """Declare that no further seedlings will come from this batch."""
+    batch = _lock_batch(batch)
+    _require_status(batch, {ProductionBatch.Status.ACTIVE}, 'finalize its output')
+    if batch_sowing_count(batch) == 0:
+        raise ValidationError({
+            'detail': 'Record at least one sowing before finalizing output.',
+        })
+    open_sowings = batch_open_sowings(batch)
+    if open_sowings:
+        raise ValidationError({
+            'detail': (
+                'Close every sowing activity before finalizing output. '
+                f'Still open: {", ".join(open_sowings)}.'
+            ),
+        })
+    previous_status = batch.status
+    batch.status = ProductionBatch.Status.OUTPUT_FINALIZED
+    batch.output_finalized_at = timezone.now()
+    batch.save()
+    _record_transition(batch, previous_status, user, reason)
+    return batch
+
+
+@transaction.atomic
+def complete_batch(batch, user, reason=''):
+    """Complete a batch once every output has a final disposition."""
+    batch = _lock_batch(batch)
+    _require_status(batch, {ProductionBatch.Status.OUTPUT_FINALIZED}, 'be completed')
+    unresolved = batch_unresolved_plant_ids(batch)
+    if unresolved:
+        raise ValidationError({
+            'detail': (
+                f'{len(unresolved)} observed plants have no final disposition: '
+                f'{unresolved}. Record their outcomes before completing this batch.'
+            ),
+        })
+    previous_status = batch.status
+    batch.status = ProductionBatch.Status.COMPLETED
+    batch.completed_at = timezone.now()
+    batch.save()
+    _record_transition(batch, previous_status, user, reason)
+    return batch
+
+
+@transaction.atomic
+def cancel_batch(batch, user, reason):
+    """Abandon a batch that produced no tracked individual outputs."""
+    _require_reason(reason)
+    batch = _lock_batch(batch)
+    _require_status(
+        batch,
+        {ProductionBatch.Status.PLANNED, ProductionBatch.Status.ACTIVE},
+        'be cancelled',
+    )
+    if batch.status == ProductionBatch.Status.ACTIVE:
+        open_sowings = batch_open_sowings(batch)
+        if open_sowings:
+            raise ValidationError({
+                'detail': (
+                    'Close every sowing activity before cancelling. '
+                    f'Still open: {", ".join(open_sowings)}.'
+                ),
+            })
+        observed = batch_specific_plants(batch).count()
+        if observed:
+            raise ValidationError({
+                'detail': (
+                    f'{observed} observed plants came from this batch, so it '
+                    'produced output and cannot be cancelled.'
+                ),
+            })
+    previous_status = batch.status
+    batch.status = ProductionBatch.Status.CANCELLED
+    batch.cancelled_at = timezone.now()
+    batch.save()
+    _record_transition(batch, previous_status, user, reason)
+    return batch
+
+
+def _reopen_target(batch):
+    """Return the status one audited correction step back."""
+    if batch.status == ProductionBatch.Status.CANCELLED:
+        if batch.actual_start is None:
+            return ProductionBatch.Status.PLANNED
+        return ProductionBatch.Status.ACTIVE
+    return REOPEN_TARGETS[batch.status]
+
+
+@transaction.atomic
+def reopen_batch(batch, user, reason):
+    """Correct a lifecycle mistake by returning to the previous status."""
+    _require_reason(reason)
+    batch = _lock_batch(batch)
+    _require_status(batch, set(REOPEN_TARGETS) | {ProductionBatch.Status.CANCELLED}, 'be reopened')
+    previous_status = batch.status
+    batch.status = _reopen_target(batch)
+    _clear_superseded(batch, batch.status)
+    batch.save()
+    _record_transition(batch, previous_status, user, reason)
+    return batch
+
+
+def validate_batch_for_sowing(batch, packet, workspace):
+    """Reject attaching a sowing to an unusable or mismatched batch."""
+    errors = {}
+    if batch.workspace_id != workspace.pk:
+        errors['batch'] = 'The batch belongs to a different workspace.'
+    elif batch.status != ProductionBatch.Status.ACTIVE:
+        errors['batch'] = 'Sowings can only join an active batch.'
+    elif batch.variety_id != packet.seeds.plant_variety_id:
+        errors['batch'] = 'The batch grows a different plant variety.'
+    if errors:
+        raise ValidationError(errors)
+
+
+@transaction.atomic
+def lock_batch_for_sowing(batch, packet, workspace):
+    """Lock and revalidate a batch so work cannot attach after finalization."""
+    locked = _lock_batch(batch)
+    validate_batch_for_sowing(locked, packet, workspace)
+    return locked

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -99,7 +99,7 @@ class ProductionBatch(WorkspaceOwnedModel):
             raise ValidationError(errors)
 
     def save(self, *args, **kwargs):
-        self.full_clean(validate_unique=False, validate_constraints=False)
+        self.full_clean()
         super().save(*args, **kwargs)
 
 

--- a/plantings/test_batches.py
+++ b/plantings/test_batches.py
@@ -1,0 +1,366 @@
+"""Tests for the production batch lifecycle services."""
+# pylint: disable=duplicate-code
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone as datetime_timezone
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+
+from tests.factories import (
+    make_batch_for_packet,
+    make_garden_square_sowing,
+    make_seed_packet,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+)
+from workspaces.models import Workspace, get_current_workspace
+
+from .batches import (
+    BatchRequest,
+    activate_batch,
+    batch_seeds_sown,
+    cancel_batch,
+    complete_batch,
+    create_and_activate_batch,
+    create_batch,
+    finalize_batch_output,
+    reopen_batch,
+    validate_batch_for_sowing,
+)
+from .models import ProductionBatch
+
+
+class BatchLifecycleTests(TestCase):
+    """Batch statuses only change through explicit, audited operations."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username='batch-operator')
+        self.workspace = get_current_workspace()
+        self.packet = make_seed_packet()
+
+    def _planned_batch(self, **overrides):
+        """Create one planned batch owned by the current workspace."""
+        values = {
+            'code': 'BATCH-1',
+            'variety': self.packet.seeds.plant_variety,
+            'notes': 'Spring sowing',
+        }
+        values.update(overrides)
+        return create_batch(self.workspace, self.user, BatchRequest(**values))
+
+    def _closed_direct_sow_batch(self):
+        """Return an active batch whose single direct sowing is closed."""
+        batch = make_batch_for_packet(self.packet)
+        make_garden_square_sowing(
+            seeds_used=self.packet,
+            batch=batch,
+            removed=True,
+        )
+        return batch
+
+    def _statuses(self, batch):
+        """Return the recorded transition history as status pairs."""
+        return [
+            (transition.previous_status, transition.new_status)
+            for transition in batch.transitions.all()
+        ]
+
+    def test_created_batch_is_planned_and_records_its_creation(self):
+        """A standalone batch starts planned with an opening transition."""
+        batch = self._planned_batch()
+
+        self.assertEqual(batch.status, ProductionBatch.Status.PLANNED)
+        self.assertIsNone(batch.actual_start)
+        self.assertEqual(batch.created_by, self.user)
+        self.assertEqual(self._statuses(batch), [('', ProductionBatch.Status.PLANNED)])
+
+    def test_activation_records_a_supplied_or_current_start(self):
+        """Activating stamps the supplied actual start when one is given."""
+        supplied = datetime(2026, 3, 1, 9, 0, tzinfo=datetime_timezone.utc)
+
+        batch = activate_batch(self._planned_batch(), self.user, actual_start=supplied)
+
+        self.assertEqual(batch.status, ProductionBatch.Status.ACTIVE)
+        self.assertEqual(batch.actual_start, supplied)
+        self.assertEqual(
+            self._statuses(batch),
+            [
+                ('', ProductionBatch.Status.PLANNED),
+                (ProductionBatch.Status.PLANNED, ProductionBatch.Status.ACTIVE),
+            ],
+        )
+
+    def test_activation_defaults_to_now_and_rejects_repeat_activation(self):
+        """Only a planned batch can be activated, and only once."""
+        batch = activate_batch(self._planned_batch(), self.user)
+
+        self.assertIsNotNone(batch.actual_start)
+        with self.assertRaisesMessage(ValidationError, 'cannot be activated'):
+            activate_batch(batch, self.user)
+
+    def test_inline_creation_activates_atomically(self):
+        """An inline batch is created and started in one operation."""
+        planted = datetime(2026, 4, 2, 7, 30, tzinfo=datetime_timezone.utc)
+
+        batch = create_and_activate_batch(
+            self.workspace,
+            self.user,
+            BatchRequest(code='INLINE-1', variety=self.packet.seeds.plant_variety),
+            actual_start=planted,
+        )
+
+        self.assertEqual(batch.status, ProductionBatch.Status.ACTIVE)
+        self.assertEqual(batch.actual_start, planted)
+        self.assertEqual(batch.transitions.count(), 2)
+
+    def test_output_finalization_requires_a_closed_sowing(self):
+        """Output cannot be finalized while any sowing activity is open."""
+        batch = make_batch_for_packet(self.packet)
+        with self.assertRaisesMessage(ValidationError, 'at least one sowing'):
+            finalize_batch_output(batch, self.user)
+
+        sowing = make_garden_square_sowing(seeds_used=self.packet, batch=batch)
+        with self.assertRaisesMessage(ValidationError, 'Close every sowing activity'):
+            finalize_batch_output(batch, self.user)
+
+        sowing.removed = True
+        sowing.save(update_fields=['removed'])
+        finalized = finalize_batch_output(batch, self.user)
+
+        self.assertEqual(finalized.status, ProductionBatch.Status.OUTPUT_FINALIZED)
+        self.assertIsNotNone(finalized.output_finalized_at)
+
+    def test_direct_sow_batches_complete_after_output_finalization(self):
+        """A batch with no individual outputs completes cleanly."""
+        batch = finalize_batch_output(self._closed_direct_sow_batch(), self.user)
+
+        completed = complete_batch(batch, self.user)
+
+        self.assertEqual(completed.status, ProductionBatch.Status.COMPLETED)
+        self.assertIsNotNone(completed.completed_at)
+
+    def test_completion_reports_observed_plants_as_unmet_conditions(self):
+        """Observed plants block completion until their outcomes exist."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=batch,
+            removed=True,
+        )
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        plants = [
+            make_specific_plant(cell_planting=cell_planting),
+            make_specific_plant(cell_planting=cell_planting),
+        ]
+        finalize_batch_output(batch, self.user)
+
+        with self.assertRaises(ValidationError) as caught:
+            complete_batch(batch, self.user)
+
+        message = caught.exception.message_dict['detail'][0]
+        self.assertIn('2 observed plants', message)
+        for plant in plants:
+            self.assertIn(str(plant.pk), message)
+        batch.refresh_from_db()
+        self.assertEqual(batch.status, ProductionBatch.Status.OUTPUT_FINALIZED)
+
+    def test_ended_locations_are_not_treated_as_dispositions(self):
+        """A plant whose location ended still has no final outcome."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=batch,
+            removed=True,
+        )
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        plant = make_specific_plant(cell_planting=cell_planting)
+        plant.locations.create(
+            location_type='seed_tray_cell',
+            seed_tray_cell=cell_planting.cell,
+            started=datetime(2026, 4, 1, 8, 0, tzinfo=datetime_timezone.utc),
+            ended=datetime(2026, 5, 1, 8, 0, tzinfo=datetime_timezone.utc),
+        )
+        finalize_batch_output(batch, self.user)
+
+        with self.assertRaisesMessage(ValidationError, '1 observed plants'):
+            complete_batch(batch, self.user)
+
+    def test_completion_requires_output_finalization_first(self):
+        """An active batch cannot skip straight to completion."""
+        with self.assertRaisesMessage(ValidationError, 'cannot be completed'):
+            complete_batch(self._closed_direct_sow_batch(), self.user)
+
+    def test_planned_batches_cancel_directly_with_a_reason(self):
+        """Cancelling a planned batch needs only an audit reason."""
+        batch = self._planned_batch()
+
+        with self.assertRaisesMessage(ValidationError, 'A reason is required.'):
+            cancel_batch(batch, self.user, '  ')
+
+        cancelled = cancel_batch(batch, self.user, 'Seed order fell through')
+
+        self.assertEqual(cancelled.status, ProductionBatch.Status.CANCELLED)
+        self.assertIsNotNone(cancelled.cancelled_at)
+        self.assertEqual(
+            cancelled.transitions.last().reason,
+            'Seed order fell through',
+        )
+
+    def test_active_cancellation_requires_closed_sowings_and_no_plants(self):
+        """A batch that produced plants records an outcome instead of vanishing."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(seeds_used=self.packet, batch=batch)
+
+        with self.assertRaisesMessage(ValidationError, 'Close every sowing activity'):
+            cancel_batch(batch, self.user, 'Nothing came up')
+
+        sowing.removed = True
+        sowing.save(update_fields=['removed'])
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        make_specific_plant(cell_planting=cell_planting)
+
+        with self.assertRaisesMessage(ValidationError, 'cannot be cancelled'):
+            cancel_batch(batch, self.user, 'Nothing came up')
+
+    def test_zero_germination_batches_may_cancel_once_closed(self):
+        """A closed sowing with no germination is a legitimate cancellation."""
+        cancelled = cancel_batch(
+            self._closed_direct_sow_batch(),
+            self.user,
+            'Zero germination',
+        )
+
+        self.assertEqual(cancelled.status, ProductionBatch.Status.CANCELLED)
+
+    def test_reopening_steps_back_and_clears_superseded_timestamps(self):
+        """Each reopen is one audited correction that retains its history."""
+        batch = complete_batch(
+            finalize_batch_output(self._closed_direct_sow_batch(), self.user),
+            self.user,
+        )
+
+        with self.assertRaisesMessage(ValidationError, 'A reason is required.'):
+            reopen_batch(batch, self.user, '')
+
+        reopened = reopen_batch(batch, self.user, 'Completed by mistake')
+        self.assertEqual(reopened.status, ProductionBatch.Status.OUTPUT_FINALIZED)
+        self.assertIsNone(reopened.completed_at)
+        self.assertIsNotNone(reopened.output_finalized_at)
+
+        reopened = reopen_batch(reopened, self.user, 'More seedlings expected')
+        self.assertEqual(reopened.status, ProductionBatch.Status.ACTIVE)
+        self.assertIsNone(reopened.output_finalized_at)
+        self.assertIsNotNone(reopened.actual_start)
+        self.assertEqual(reopened.transitions.count(), 5)
+
+    def test_reopening_a_cancelled_batch_restores_its_started_state(self):
+        """A cancelled batch returns to active when it had already started."""
+        started = reopen_batch(
+            cancel_batch(self._closed_direct_sow_batch(), self.user, 'Mistake'),
+            self.user,
+            'Cancelled the wrong batch',
+        )
+        self.assertEqual(started.status, ProductionBatch.Status.ACTIVE)
+        self.assertIsNone(started.cancelled_at)
+
+        never_started = reopen_batch(
+            cancel_batch(self._planned_batch(code='BATCH-2'), self.user, 'Mistake'),
+            self.user,
+            'Cancelled the wrong batch',
+        )
+        self.assertEqual(never_started.status, ProductionBatch.Status.PLANNED)
+        self.assertIsNone(never_started.actual_start)
+
+    def test_active_batches_cannot_be_reopened(self):
+        """Reopening is a correction, not a generic status edit."""
+        with self.assertRaisesMessage(ValidationError, 'cannot be reopened'):
+            reopen_batch(make_batch_for_packet(self.packet), self.user, 'No reason')
+
+    def test_seeds_sown_totals_every_attached_sowing(self):
+        """The sown total spans direct-sow and tray sowings alike."""
+        batch = make_batch_for_packet(self.packet)
+        make_garden_square_sowing(seeds_used=self.packet, batch=batch, quantity=3)
+        make_seed_tray_planting(seeds_used=self.packet, batch=batch, quantity=4)
+
+        self.assertEqual(batch_seeds_sown(batch), 7)
+
+    def test_sowings_only_attach_to_a_compatible_active_batch(self):
+        """Workspace, status, and variety must all agree before attaching."""
+        planned = self._planned_batch(code='BATCH-3')
+        with self.assertRaisesMessage(ValidationError, 'only join an active batch'):
+            validate_batch_for_sowing(planned, self.packet, self.workspace)
+
+        other_variety_batch = make_batch_for_packet(make_seed_packet())
+        with self.assertRaisesMessage(ValidationError, 'different plant variety'):
+            validate_batch_for_sowing(
+                other_variety_batch,
+                self.packet,
+                self.workspace,
+            )
+
+        validate_batch_for_sowing(
+            make_batch_for_packet(self.packet),
+            self.packet,
+            self.workspace,
+        )
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentBatchTransitionTests(TransactionTestCase):
+    """A locked batch admits only one lifecycle transition at a time."""
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='batch-racer')
+        packet = make_seed_packet()
+        batch = make_batch_for_packet(packet)
+        make_garden_square_sowing(seeds_used=packet, batch=batch, removed=True)
+        self.batch_pk = batch.pk
+
+    def _finalize_output(self):
+        """Attempt output finalization from an independent connection."""
+        close_old_connections()
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            finalize_batch_output(batch, user)
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'finalized'
+        close_old_connections()
+        return result
+
+    def test_only_one_concurrent_finalization_succeeds(self):
+        """The loser is rejected instead of appending a second transition."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._finalize_output),
+                    pool.submit(self._finalize_output),
+                ]
+            )
+
+        self.assertEqual(results, ['finalized', 'rejected'])
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        self.assertEqual(batch.status, ProductionBatch.Status.OUTPUT_FINALIZED)
+        self.assertEqual(
+            batch.transitions.filter(
+                new_status=ProductionBatch.Status.OUTPUT_FINALIZED,
+            ).count(),
+            1,
+        )


### PR DESCRIPTION
Batch statuses now change only through explicit transactional operations. Create, activate, finalize output, complete, cancel, and reopen each lock the batch, validate what the current status permits, and append an immutable transition carrying its actor and reason, so concurrent requests cannot produce an invalid history.

Output finalization requires an active batch with at least one sowing and every attached sowing activity closed. Completion requires output-finalized status and reports observed plants as unmet conditions, because an ended location records where a plant stopped being rather than what became of it; task 41 will supply those dispositions. Direct- sow and zero-germination batches therefore complete or cancel cleanly today. Cancellation and reopening require a reason, and reopening clears the lifecycle stamps it supersedes while retaining the history.

## Summary by Sourcery

Introduce transactional, audited lifecycle operations for production batches, enforcing valid status transitions and concurrency-safe updates.

New Features:
- Add service layer functions to create, activate, finalize output, complete, cancel, reopen, and lock production batches, with validation of sowings, plants, and workspace/variety constraints.
- Provide utility functions for aggregating sowing counts, seeds sown, open sowings, and unresolved plants associated with a batch.

Bug Fixes:
- Ensure model saves run full validation, including uniqueness and constraints, by enabling full_clean defaults.

Tests:
- Add comprehensive unit and transactional concurrency tests covering batch lifecycle transitions, validation rules, cancellation/reopen behavior, and sowing attachment constraints.