### PR TITLE
feat(plantings): expose production batch resources and actions

### DIFF
--- a/plantings/batch_rest.py
+++ b/plantings/batch_rest.py
@@ -1,0 +1,460 @@
+"""REST resources and explicit lifecycle actions for production batches."""
+
+# pylint: disable=duplicate-code
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import Count
+from rest_framework import serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+)
+
+from .batches import (
+    BatchRequest,
+    SOWING_MODELS,
+    activate_batch,
+    batch_plants_with_active_location,
+    batch_seeds_sown,
+    batch_specific_plants,
+    batch_unresolved_plant_ids,
+    cancel_batch,
+    complete_batch,
+    create_batch,
+    finalize_batch_output,
+    reopen_batch,
+)
+from .models import ProductionBatch, ProductionBatchTransition, SpecificPlantLocation
+
+
+def _model_errors(error):
+    """Translate model validation errors into DRF response details."""
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
+
+
+def _run_domain_action(function, *args, **kwargs):
+    """Invoke a batch service with field-friendly API errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+class ActionSerializer(serializers.Serializer):
+    """Validation-only serializer base for batch lifecycle actions."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class ActivateBatchSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Validate an optional supplied actual-start time."""
+
+    actual_start = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=True, required=False, default='')
+
+
+class OptionalReasonSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Validate audit metadata for an action that does not require a reason."""
+
+    reason = serializers.CharField(allow_blank=True, required=False, default='')
+
+
+class RequiredReasonSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Validate the reason an audited correction always requires."""
+
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
+class ProductionBatchTransitionSerializer(serializers.ModelSerializer):
+    """Serialize one immutable lifecycle history row."""
+
+    class Meta:
+        model = ProductionBatchTransition
+        fields = [
+            'pk',
+            'previous_status',
+            'new_status',
+            'created_by',
+            'reason',
+            'created',
+        ]
+        read_only_fields = fields
+
+
+class BatchSowingSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Serialize one attached sowing without its model-specific write rules."""
+
+    pk = serializers.IntegerField(read_only=True)
+    sowing_type = serializers.CharField(read_only=True)
+    planted = serializers.DateTimeField(read_only=True)
+    quantity = serializers.IntegerField(read_only=True)
+    removed = serializers.BooleanField(read_only=True)
+    seeds_used = serializers.IntegerField(read_only=True)
+    seed_lot = serializers.IntegerField(read_only=True, allow_null=True)
+    seed_tray = serializers.IntegerField(read_only=True, allow_null=True)
+    location = serializers.CharField(read_only=True, allow_null=True)
+    notes = serializers.CharField(read_only=True, allow_null=True)
+    cells = serializers.ListField(read_only=True)
+    plants_observed = serializers.IntegerField(read_only=True)
+
+
+def _describe_cells(sowing):
+    """Describe one tray sowing's cell allocations and their germinations."""
+    cell_plantings = sowing.cell_plantings.select_related('cell').annotate(
+        observed=Count('specific_plants'),
+    ).order_by('pk')
+    return [
+        {
+            'pk': cell_planting.pk,
+            'cell': cell_planting.cell_id,
+            'x_position': cell_planting.cell.x_position,
+            'y_position': cell_planting.cell.y_position,
+            'quantity': cell_planting.quantity,
+            'plants_observed': cell_planting.observed,
+        }
+        for cell_planting in cell_plantings
+    ]
+
+
+def _describe_sowing(sowing):
+    """Return one sowing's batch-level summary in a display-neutral shape."""
+    is_tray = hasattr(sowing, 'cell_plantings')
+    location = getattr(sowing, 'location', None)
+    cells = _describe_cells(sowing) if is_tray else []
+    return {
+        'pk': sowing.pk,
+        'sowing_type': type(sowing).__name__,
+        'planted': sowing.planted,
+        'quantity': sowing.quantity,
+        'removed': sowing.removed,
+        'seeds_used': sowing.seeds_used_id,
+        'seed_lot': sowing.seeds_used.stock_lot_id,
+        'seed_tray': getattr(sowing, 'seed_tray_id', None),
+        'location': None if location is None else str(location),
+        'notes': sowing.notes,
+        'cells': cells,
+        'plants_observed': sum(cell['plants_observed'] for cell in cells),
+    }
+
+
+def _batch_sowings(batch):
+    """Return every attached sowing across the concrete planting models."""
+    sowings = []
+    for model in SOWING_MODELS:
+        queryset = model.objects.filter(batch=batch).select_related(
+            'seeds_used',
+        ).order_by('planted', 'pk')
+        sowings.extend(_describe_sowing(sowing) for sowing in queryset)
+    return sowings
+
+
+def _current_locations(batch):
+    """Describe where this batch's individual plants are living now."""
+    locations = SpecificPlantLocation.objects.filter(
+        specific_plant__cell_planting__seed_tray_planting__batch=batch,
+        ended__isnull=True,
+    ).select_related('seed_tray_cell', 'garden_square').order_by('pk')
+    return [
+        {
+            'specific_plant': location.specific_plant_id,
+            'location_type': location.location_type,
+            'seed_tray_cell': location.seed_tray_cell_id,
+            'garden_square': location.garden_square_id,
+            'started': location.started,
+            'label': str(location.seed_tray_cell or location.garden_square),
+        }
+        for location in locations
+    ]
+
+
+class ProductionBatchSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.ModelSerializer,
+):
+    """Serialize batch identity, lifecycle state, and output summary counts."""
+
+    variety_name = serializers.CharField(source='variety.name', read_only=True)
+    plant_name = serializers.CharField(source='variety.plant.name', read_only=True)
+    sowing_count = serializers.SerializerMethodField()
+    seeds_sown = serializers.SerializerMethodField()
+    plants_observed = serializers.SerializerMethodField()
+    plants_with_active_location = serializers.SerializerMethodField()
+    final_outcomes = serializers.SerializerMethodField()
+    unresolved_plants = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ProductionBatch
+        fields = [
+            'pk',
+            'code',
+            'variety',
+            'variety_name',
+            'plant_name',
+            'status',
+            'planned_start',
+            'actual_start',
+            'output_finalized_at',
+            'completed_at',
+            'cancelled_at',
+            'notes',
+            'created_by',
+            'repair_state',
+            'repair_details',
+            'sowing_count',
+            'seeds_sown',
+            'plants_observed',
+            'plants_with_active_location',
+            'final_outcomes',
+            'unresolved_plants',
+            'created',
+            'updated',
+        ]
+        read_only_fields = [
+            'status',
+            'actual_start',
+            'output_finalized_at',
+            'completed_at',
+            'cancelled_at',
+            'created_by',
+            'repair_state',
+            'repair_details',
+            'created',
+            'updated',
+        ]
+
+    workspace_field_lookups = {'variety': 'workspace'}
+
+    def get_sowing_count(self, batch):
+        """Return how many sowings this batch groups."""
+        return sum(
+            model.objects.filter(batch=batch).count()
+            for model in SOWING_MODELS
+        )
+
+    def get_seeds_sown(self, batch):
+        """Return the seeds or seed clusters sown, not the plants raised."""
+        return batch_seeds_sown(batch)
+
+    def get_plants_observed(self, batch):
+        """Return the individual plants germinated from this batch."""
+        return batch_specific_plants(batch).count()
+
+    def get_plants_with_active_location(self, batch):
+        """Return the plants currently occupying a tracked location."""
+        return batch_plants_with_active_location(batch).count()
+
+    def get_final_outcomes(self, batch):  # pylint: disable=unused-argument
+        """Return recorded final dispositions, which task 41 will supply."""
+        return 0
+
+    def get_unresolved_plants(self, batch):
+        """Return the plants blocking completion of this batch."""
+        return batch_unresolved_plant_ids(batch)
+
+    def _has_sowings(self):
+        """Return whether the batch being edited already groups sowings."""
+        return any(
+            model.objects.filter(batch=self.instance).exists()
+            for model in SOWING_MODELS
+        )
+
+    def validate_code(self, value):
+        """Keep batch codes unique and meaningful inside one workspace."""
+        code = value.strip()
+        if not code:
+            raise serializers.ValidationError('A batch code is required.')
+        duplicates = ProductionBatch.objects.filter(
+            workspace=self.context['view'].get_current_workspace(),
+            code=code,
+        )
+        if self.instance is not None:
+            duplicates = duplicates.exclude(pk=self.instance.pk)
+        if duplicates.exists():
+            raise serializers.ValidationError(
+                'Another batch in this workspace already uses that code.',
+            )
+        return code
+
+    def validate(self, attrs):
+        """Lock the variety once a status or a sowing depends on it."""
+        if self.instance is None or 'variety' not in attrs:
+            return attrs
+        if attrs['variety'].pk == self.instance.variety_id:
+            return attrs
+        if self.instance.status != ProductionBatch.Status.PLANNED:
+            raise serializers.ValidationError({
+                'variety': 'Only a planned batch can change its variety.',
+            })
+        if self._has_sowings():
+            raise serializers.ValidationError({
+                'variety': 'Cannot change the variety after a sowing exists.',
+            })
+        return attrs
+
+    def create(self, validated_data):
+        """Create the batch and its opening transition in one operation."""
+        return _run_domain_action(
+            create_batch,
+            self.context['view'].get_current_workspace(),
+            self.context['request'].user,
+            BatchRequest(
+                code=validated_data['code'],
+                variety=validated_data['variety'],
+                planned_start=validated_data.get('planned_start'),
+                notes=validated_data.get('notes', ''),
+            ),
+        )
+
+
+class ProductionBatchDetailSerializer(ProductionBatchSerializer):
+    """Add the grouped cultivation detail one batch screen needs."""
+
+    sowings = serializers.SerializerMethodField()
+    current_locations = serializers.SerializerMethodField()
+    transitions = ProductionBatchTransitionSerializer(many=True, read_only=True)
+
+    class Meta(ProductionBatchSerializer.Meta):
+        fields = ProductionBatchSerializer.Meta.fields + [
+            'sowings',
+            'current_locations',
+            'transitions',
+        ]
+
+    def get_sowings(self, batch):
+        """Return each attached sowing with its lot, cells, and germinations."""
+        return BatchSowingSerializer(_batch_sowings(batch), many=True).data
+
+    def get_current_locations(self, batch):
+        """Return where this batch's individual plants are living now."""
+        return _current_locations(batch)
+
+
+class ProductionBatchViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Manage batch identity and post explicit lifecycle transitions."""
+
+    queryset = ProductionBatch.objects.select_related(
+        'variety__plant',
+    ).prefetch_related('transitions')
+    serializer_class = ProductionBatchSerializer
+    http_method_names = ['get', 'post', 'patch', 'put', 'head', 'options']
+    bind_workspace_on_create = False
+
+    def get_serializer_class(self):
+        """Use the richer serializer for a single batch."""
+        if self.action == 'retrieve':
+            return ProductionBatchDetailSerializer
+        return ProductionBatchSerializer
+
+    def get_queryset(self):
+        """Apply the status, variety, and repair filters the screens use."""
+        queryset = super().get_queryset()
+        status_filter = self.request.query_params.get('status')
+        if status_filter:
+            valid = {choice.value for choice in ProductionBatch.Status}
+            if status_filter not in valid:
+                raise ValidationError({'status': 'Select a valid batch status.'})
+            queryset = queryset.filter(status=status_filter)
+        variety = self.request.query_params.get('variety')
+        if variety:
+            if not variety.isdigit():
+                raise ValidationError({'variety': 'Enter a variety ID.'})
+            queryset = queryset.filter(variety_id=int(variety))
+        code = self.request.query_params.get('code', '').strip()
+        if code:
+            queryset = queryset.filter(code__icontains=code)
+        if self.request.query_params.get('needs_repair') == 'true':
+            queryset = queryset.filter(
+                repair_state=ProductionBatch.RepairState.NEEDS_REPAIR,
+            )
+        return queryset
+
+    def _detail_response(self, batch):
+        """Return one batch through the detail contract after an action."""
+        batch.refresh_from_db()
+        return Response(ProductionBatchDetailSerializer(batch).data)
+
+    @action(detail=True, methods=['post'])
+    def activate(self, request, pk=None):  # pylint: disable=unused-argument
+        """Start a planned batch at a supplied or current time."""
+        values = self._action_values(request, ActivateBatchSerializer)
+        batch = _run_domain_action(
+            activate_batch,
+            self.get_object(),
+            request.user,
+            actual_start=values.get('actual_start'),
+            reason=values['reason'],
+        )
+        return self._detail_response(batch)
+
+    @action(detail=True, methods=['post'], url_path='finalize-output')
+    def finalize_output(self, request, pk=None):  # pylint: disable=unused-argument
+        """Declare that no further seedlings will come from this batch."""
+        values = self._action_values(request, OptionalReasonSerializer)
+        batch = _run_domain_action(
+            finalize_batch_output,
+            self.get_object(),
+            request.user,
+            reason=values['reason'],
+        )
+        return self._detail_response(batch)
+
+    @action(detail=True, methods=['post'])
+    def complete(self, request, pk=None):  # pylint: disable=unused-argument
+        """Complete a batch whose outputs all have final dispositions."""
+        values = self._action_values(request, OptionalReasonSerializer)
+        batch = _run_domain_action(
+            complete_batch,
+            self.get_object(),
+            request.user,
+            reason=values['reason'],
+        )
+        return self._detail_response(batch)
+
+    @action(detail=True, methods=['post'])
+    def cancel(self, request, pk=None):  # pylint: disable=unused-argument
+        """Abandon a batch that produced no tracked individual outputs."""
+        values = self._action_values(request, RequiredReasonSerializer)
+        batch = _run_domain_action(
+            cancel_batch,
+            self.get_object(),
+            request.user,
+            values['reason'],
+        )
+        return self._detail_response(batch)
+
+    @action(detail=True, methods=['post'])
+    def reopen(self, request, pk=None):  # pylint: disable=unused-argument
+        """Correct a lifecycle mistake by stepping one status back."""
+        values = self._action_values(request, RequiredReasonSerializer)
+        batch = _run_domain_action(
+            reopen_batch,
+            self.get_object(),
+            request.user,
+            values['reason'],
+        )
+        return self._detail_response(batch)
+
+    @staticmethod
+    def _action_values(request, serializer_class):
+        """Validate one action payload and return its cleaned values."""
+        serializer = serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
+
+def register_batch_routes(router):
+    """Attach the production batch resources to the planting API router."""
+    router.register(r'batches', ProductionBatchViewSet)

--- a/plantings/batches.py
+++ b/plantings/batches.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Sum
+from django.db.models import Exists, OuterRef, Sum
 from django.utils import timezone
 
 from .models import (
@@ -16,6 +16,7 @@ from .models import (
     ProductionBatchTransition,
     SeedTrayPlanting,
     SpecificPlant,
+    SpecificPlantLocation,
 )
 
 
@@ -84,6 +85,19 @@ def batch_specific_plants(batch):
     return SpecificPlant.objects.filter(
         cell_planting__seed_tray_planting__batch=batch,
     )
+
+
+def batch_plants_with_active_location(batch):
+    """Return this batch's plants that currently occupy a tracked location.
+
+    An `ended__isnull=True` join would also match plants with no location
+    history at all, so the presence of an open interval is asserted directly.
+    """
+    open_location = SpecificPlantLocation.objects.filter(
+        specific_plant=OuterRef('pk'),
+        ended__isnull=True,
+    )
+    return batch_specific_plants(batch).filter(Exists(open_location))
 
 
 def batch_unresolved_plant_ids(batch):

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -14,6 +14,7 @@ from seedtrays.models import SeedTray
 from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
+from .batch_rest import register_batch_routes
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 from .sowing import correct_sowing_consumption, post_sowing_consumption
 
@@ -928,6 +929,7 @@ class SpecificPlantLocationByPlantViewSet(CurrentWorkspaceViewSetMixin, viewsets
 
 
 router = routers.SimpleRouter()
+register_batch_routes(router)
 router.register(r'directsowgardenrow', GardenRowDirectSowPlantingViewSet)
 router.register(r'directsowgardensquare', GardenSquareDirectSowPlantingViewSet)
 router.register(r'seedtray', SeedTrayPlantingViewSet)

--- a/plantings/test_batch_rest.py
+++ b/plantings/test_batch_rest.py
@@ -1,0 +1,281 @@
+"""Tests for the production batch REST resources and lifecycle actions."""
+# pylint: disable=duplicate-code
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_batch_for_packet,
+    make_garden_square_sowing,
+    make_plant_variety,
+    make_seed_packet,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+
+from .models import ProductionBatch
+
+
+class ProductionBatchRESTTests(RESTContractTestCase):
+    """The batch API exposes identity, summaries, and explicit actions."""
+
+    url = '/plantings/batches/'
+
+    def setUp(self):
+        super().setUp()
+        self.packet = make_seed_packet()
+        self.variety = self.packet.seeds.plant_variety
+
+    def _create(self, **overrides):
+        """Create one batch through the API and return its response data."""
+        payload = {
+            'code': 'BATCH-1',
+            'variety': self.variety.pk,
+            'planned_start': '2026-03-01',
+            'notes': 'Spring sowing',
+        }
+        payload.update(overrides)
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def _post_action(self, batch_pk, action, payload=None):
+        """Post one lifecycle action and return the response."""
+        return self.client.post(
+            f'{self.url}{batch_pk}/{action}/',
+            payload or {},
+            format='json',
+        )
+
+    def test_list_route_requires_authentication_and_returns_a_list(self):
+        """Batches follow the common authenticated collection contract."""
+        self.assert_authentication_required([self.url])
+        self.assert_list_contract([self.url])
+
+    def test_create_starts_a_planned_batch_with_its_history(self):
+        """A created batch is planned and already carries a transition."""
+        created = self._create()
+
+        self.assertEqual(created['status'], ProductionBatch.Status.PLANNED)
+        self.assertEqual(created['planned_start'], '2026-03-01')
+        self.assertIsNone(created['actual_start'])
+
+        detail = self.client.get(f'{self.url}{created["pk"]}/')
+        self.assertEqual(detail.status_code, 200)
+        self.assertEqual(len(detail.data['transitions']), 1)
+        self.assertEqual(detail.data['transitions'][0]['previous_status'], '')
+        self.assertEqual(detail.data['variety_name'], self.variety.name)
+
+    def test_duplicate_codes_are_rejected_inside_one_workspace(self):
+        """Batch codes stay unique so they can identify a crop."""
+        self._create()
+
+        response = self.client.post(
+            self.url,
+            {'code': 'BATCH-1', 'variety': self.variety.pk},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('code', response.data)
+
+    def test_generic_updates_edit_only_descriptive_fields(self):
+        """Status and lifecycle timestamps are action-controlled."""
+        created = self._create()
+
+        response = self.client.patch(
+            f'{self.url}{created["pk"]}/',
+            {
+                'code': 'BATCH-RENAMED',
+                'planned_start': '2026-04-01',
+                'notes': 'Delayed',
+                'status': ProductionBatch.Status.COMPLETED,
+                'actual_start': '2026-03-05T08:00:00Z',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['code'], 'BATCH-RENAMED')
+        self.assertEqual(response.data['planned_start'], '2026-04-01')
+        self.assertEqual(response.data['status'], ProductionBatch.Status.PLANNED)
+        self.assertIsNone(response.data['actual_start'])
+
+    def test_variety_is_editable_only_while_planned_and_unsown(self):
+        """A batch's crop identity locks as soon as anything depends on it."""
+        created = self._create()
+        replacement = make_plant_variety()
+
+        response = self.client.patch(
+            f'{self.url}{created["pk"]}/',
+            {'variety': replacement.pk},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['variety'], replacement.pk)
+
+        batch = make_batch_for_packet(self.packet)
+        make_garden_square_sowing(seeds_used=self.packet, batch=batch)
+        blocked = self.client.patch(
+            f'{self.url}{batch.pk}/',
+            {'variety': replacement.pk},
+            format='json',
+        )
+        self.assertEqual(blocked.status_code, 400)
+        self.assertIn('variety', blocked.data)
+
+    def test_lifecycle_actions_walk_a_direct_sow_batch_to_completion(self):
+        """Each action advances the batch and appends its transition."""
+        created = self._create()
+        activated = self._post_action(
+            created['pk'],
+            'activate',
+            {'actual_start': '2026-03-05T08:00:00Z'},
+        )
+        self.assertEqual(activated.status_code, 200, activated.data)
+        self.assertEqual(activated.data['status'], ProductionBatch.Status.ACTIVE)
+        self.assertEqual(activated.data['actual_start'], '2026-03-05T08:00:00Z')
+
+        sowing = make_garden_square_sowing(
+            seeds_used=self.packet,
+            batch=ProductionBatch.objects.get(pk=created['pk']),
+            quantity=6,
+            removed=True,
+        )
+
+        finalized = self._post_action(created['pk'], 'finalize-output')
+        self.assertEqual(finalized.status_code, 200, finalized.data)
+        self.assertEqual(
+            finalized.data['status'],
+            ProductionBatch.Status.OUTPUT_FINALIZED,
+        )
+        self.assertEqual(finalized.data['seeds_sown'], 6)
+        self.assertEqual(finalized.data['sowing_count'], 1)
+        self.assertEqual(finalized.data['sowings'][0]['pk'], sowing.pk)
+
+        completed = self._post_action(created['pk'], 'complete')
+        self.assertEqual(completed.status_code, 200, completed.data)
+        self.assertEqual(completed.data['status'], ProductionBatch.Status.COMPLETED)
+        self.assertEqual(len(completed.data['transitions']), 4)
+
+    def test_output_finalization_reports_open_sowings(self):
+        """The API explains which sowing activity still has to close."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_garden_square_sowing(seeds_used=self.packet, batch=batch)
+
+        response = self._post_action(batch.pk, 'finalize-output')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(str(sowing.pk), response.data['detail'][0])
+
+    def test_completion_reports_observed_plants_until_outcomes_exist(self):
+        """Observed plants are reported as unmet conditions, not guessed at."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=batch,
+            removed=True,
+        )
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        plant = make_specific_plant(cell_planting=cell_planting)
+        self._post_action(batch.pk, 'finalize-output')
+
+        response = self._post_action(batch.pk, 'complete')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(str(plant.pk), response.data['detail'][0])
+
+    def test_cancel_and_reopen_require_reasons(self):
+        """Audited corrections never happen without a stated reason."""
+        created = self._create()
+
+        blank = self._post_action(created['pk'], 'cancel', {'reason': '   '})
+        self.assertEqual(blank.status_code, 400)
+        self.assertIn('reason', blank.data)
+
+        cancelled = self._post_action(
+            created['pk'],
+            'cancel',
+            {'reason': 'Seed order fell through'},
+        )
+        self.assertEqual(cancelled.status_code, 200, cancelled.data)
+        self.assertEqual(cancelled.data['status'], ProductionBatch.Status.CANCELLED)
+
+        missing = self._post_action(created['pk'], 'reopen', {})
+        self.assertEqual(missing.status_code, 400)
+
+        reopened = self._post_action(
+            created['pk'],
+            'reopen',
+            {'reason': 'Cancelled the wrong batch'},
+        )
+        self.assertEqual(reopened.status_code, 200, reopened.data)
+        self.assertEqual(reopened.data['status'], ProductionBatch.Status.PLANNED)
+        self.assertIsNone(reopened.data['cancelled_at'])
+
+    def test_invalid_transitions_are_rejected(self):
+        """An action a status does not permit leaves the batch untouched."""
+        created = self._create()
+
+        response = self._post_action(created['pk'], 'complete')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('status', response.data)
+        detail = self.client.get(f'{self.url}{created["pk"]}/')
+        self.assertEqual(detail.data['status'], ProductionBatch.Status.PLANNED)
+        self.assertEqual(len(detail.data['transitions']), 1)
+
+    def test_summary_counts_are_reported_separately(self):
+        """Seeds sown, plants observed, active locations, and outcomes differ."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=batch,
+            quantity=2,
+        )
+        cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=sowing,
+            quantity=2,
+        )
+        housed = make_specific_plant(cell_planting=cell_planting)
+        make_specific_plant_location(specific_plant=housed)
+        make_specific_plant(cell_planting=cell_planting)
+        make_specific_plant(cell_planting=cell_planting)
+
+        response = self.client.get(f'{self.url}{batch.pk}/')
+
+        self.assertEqual(response.data['seeds_sown'], 2)
+        self.assertEqual(response.data['plants_observed'], 3)
+        self.assertEqual(response.data['plants_with_active_location'], 1)
+        self.assertEqual(response.data['final_outcomes'], 0)
+        self.assertEqual(len(response.data['unresolved_plants']), 3)
+        self.assertEqual(len(response.data['current_locations']), 1)
+        self.assertEqual(response.data['sowings'][0]['plants_observed'], 3)
+        self.assertEqual(response.data['sowings'][0]['cells'][0]['quantity'], 2)
+
+    def test_batches_are_filterable_by_status_variety_and_repair_state(self):
+        """The batch screens can narrow a long list without extra endpoints."""
+        active = make_batch_for_packet(self.packet)
+        ProductionBatch.objects.filter(pk=active.pk).update(
+            repair_state=ProductionBatch.RepairState.NEEDS_REPAIR,
+        )
+        self._create(code='BATCH-PLANNED')
+
+        by_status = self.client.get(self.url, {'status': 'active'})
+        self.assertEqual([row['pk'] for row in by_status.data], [active.pk])
+
+        by_variety = self.client.get(self.url, {'variety': self.variety.pk})
+        self.assertEqual(len(by_variety.data), 2)
+
+        needs_repair = self.client.get(self.url, {'needs_repair': 'true'})
+        self.assertEqual([row['pk'] for row in needs_repair.data], [active.pk])
+
+        invalid = self.client.get(self.url, {'status': 'growing'})
+        self.assertEqual(invalid.status_code, 400)
+
+    def test_batches_cannot_be_deleted(self):
+        """Cultivation identity is corrected through actions, not removal."""
+        created = self._create()
+
+        response = self.client.delete(f'{self.url}{created["pk"]}/')
+
+        self.assertEqual(response.status_code, 405)

--- a/plantings/test_batches.py
+++ b/plantings/test_batches.py
@@ -16,13 +16,16 @@ from tests.factories import (
     make_seed_tray_cell_planting,
     make_seed_tray_planting,
     make_specific_plant,
+    make_specific_plant_location,
 )
 from workspaces.models import Workspace, get_current_workspace
 
 from .batches import (
     BatchRequest,
     activate_batch,
+    batch_plants_with_active_location,
     batch_seeds_sown,
+    batch_unresolved_plant_ids,
     cancel_batch,
     complete_batch,
     create_and_activate_batch,
@@ -287,6 +290,26 @@ class BatchLifecycleTests(TestCase):
         make_seed_tray_planting(seeds_used=self.packet, batch=batch, quantity=4)
 
         self.assertEqual(batch_seeds_sown(batch), 7)
+
+    def test_plants_without_any_location_are_not_counted_as_housed(self):
+        """Only an open interval means a plant currently occupies a place."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(seeds_used=self.packet, batch=batch)
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        housed = make_specific_plant(cell_planting=cell_planting)
+        make_specific_plant_location(specific_plant=housed)
+        ended = make_specific_plant(cell_planting=cell_planting)
+        make_specific_plant_location(
+            specific_plant=ended,
+            started=datetime(2026, 4, 1, 8, 0, tzinfo=datetime_timezone.utc),
+            ended=datetime(2026, 5, 1, 8, 0, tzinfo=datetime_timezone.utc),
+        )
+        make_specific_plant(cell_planting=cell_planting)
+
+        housed_plants = batch_plants_with_active_location(batch)
+
+        self.assertEqual([plant.pk for plant in housed_plants], [housed.pk])
+        self.assertEqual(len(batch_unresolved_plant_ids(batch)), 3)
 
     def test_sowings_only_attach_to_a_compatible_active_batch(self):
         """Workspace, status, and variety must all agree before attaching."""


### PR DESCRIPTION
Add workspace-scoped /plantings/batches/ list, create, retrieve, and update resources plus activate, finalize-output, complete, cancel, and reopen detail actions that delegate to the lifecycle services. Generic updates edit only the code, planned start, and notes; the variety is editable only while a planned batch has no sowings, and status and lifecycle timestamps stay action-controlled.

Summary counts are reported separately for seeds or clusters sown, plants observed, plants with an active location, and final outcomes, so a multigerm batch is never described by a single ambiguous number. Final outcomes read zero until task 41 records dispositions. The detail contract nests each attached sowing with its seed lot, cell allocations, germination counts, current locations, and full transition history, and carries no price or customer data so Garden mode reads the same shape.

Counting housed plants uses an explicit open-interval subquery: joining on ended IS NULL would also match plants with no location history.

## Summary by Sourcery

Expose workspace-scoped REST resources and lifecycle actions for production batches, including listing, creation, updates, and status transitions, while enriching batch summaries and plant location handling.

New Features:
- Add REST endpoints to manage production batches with identity, lifecycle state, and summary counts.
- Expose explicit lifecycle actions to activate, finalize output, complete, cancel, and reopen production batches.
- Provide detailed batch views including attached sowings, cell allocations, germination counts, current locations, and lifecycle transitions.

Bug Fixes:
- Ensure housed plant counts only include plants with an explicit active location interval, excluding those without location history.

Enhancements:
- Report separate summary metrics for seeds or clusters sown, plants observed, plants with active locations, and unresolved plants in batch serializers.
- Enforce workspace-unique batch codes, and restrict editable fields so status and lifecycle timestamps are controlled solely by lifecycle actions.
- Constrain variety changes to planned, unsown batches and add filtering of batch listings by status, variety, and repair state.

Tests:
- Add REST contract tests covering batch creation, updates, lifecycle transitions, summary counts, filtering, and deletion constraints.
- Add tests verifying active-location plant counting and unresolved plant identification for batches.