### PR TITLE
feat(plantings): sow into an existing or inline production batch

### DIFF
--- a/plantings/batch_rest.py
+++ b/plantings/batch_rest.py
@@ -3,7 +3,9 @@
 # pylint: disable=duplicate-code
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from django.db.models import Count
+from django.utils import timezone
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -24,8 +26,10 @@ from .batches import (
     batch_unresolved_plant_ids,
     cancel_batch,
     complete_batch,
+    create_and_activate_batch,
     create_batch,
     finalize_batch_output,
+    lock_batch_for_sowing,
     reopen_batch,
 )
 from .models import ProductionBatch, ProductionBatchTransition, SpecificPlantLocation
@@ -337,6 +341,88 @@ class ProductionBatchDetailSerializer(ProductionBatchSerializer):
     def get_current_locations(self, batch):
         """Return where this batch's individual plants are living now."""
         return _current_locations(batch)
+
+
+class InlineBatchSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Validate the batch a sowing form creates alongside its sowing.
+
+    The variety and actual start are derived from the sowing itself, so a
+    caller supplies only the descriptive fields.
+    """
+
+    code = serializers.CharField(max_length=64, allow_blank=False, trim_whitespace=True)
+    planned_start = serializers.DateField(required=False, allow_null=True)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class BatchedSowingSerializerMixin:
+    """Attach each sowing to exactly one production batch for life.
+
+    Concrete sowing serializers declare the `new_batch` field themselves
+    because DRF only collects declared fields from serializer bases.
+    """
+
+    def _validate_batch(self, attrs):
+        """Require exactly one batch choice and keep an existing one fixed."""
+        if self.instance is not None:
+            if 'new_batch' in attrs:
+                raise serializers.ValidationError({
+                    'new_batch': 'An existing sowing already has a batch.',
+                })
+            if 'batch' in attrs and attrs['batch'].pk != self.instance.batch_id:
+                raise serializers.ValidationError({
+                    'batch': 'Cannot move a sowing between batches.',
+                })
+            return
+
+        chosen = [field for field in ('batch', 'new_batch') if attrs.get(field)]
+        if len(chosen) != 1:
+            raise serializers.ValidationError({
+                'batch': 'Supply exactly one of an existing batch or a new batch.',
+            })
+
+    def validate(self, attrs):
+        """Apply the batch guard before the remaining sowing rules."""
+        self._validate_batch(attrs)
+        return super().validate(attrs)
+
+    def _resolve_batch(self, validated_data):
+        """Create or lock the batch this new sowing joins.
+
+        Must be called inside the transaction that creates the sowing so no
+        work can attach to a batch that is finalizing concurrently.
+        """
+        workspace = validated_data['workspace']
+        packet = validated_data['seeds_used']
+        inline = validated_data.pop('new_batch', None)
+        try:
+            if inline is None:
+                validated_data['batch'] = lock_batch_for_sowing(
+                    validated_data['batch'],
+                    packet,
+                    workspace,
+                )
+                return
+            planted = validated_data.setdefault('planted', timezone.now())
+            validated_data['batch'] = create_and_activate_batch(
+                workspace,
+                self.context['request'].user,
+                BatchRequest(
+                    code=inline['code'],
+                    variety=packet.seeds.plant_variety,
+                    planned_start=inline.get('planned_start'),
+                    notes=inline.get('notes', ''),
+                ),
+                actual_start=planted,
+            )
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_model_errors(exc)) from exc
+
+    def create(self, validated_data):
+        """Resolve the batch before the sowing and its consumption exist."""
+        with transaction.atomic():
+            self._resolve_batch(validated_data)
+            return super().create(validated_data)
 
 
 class ProductionBatchViewSet(

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -14,7 +14,7 @@ from seedtrays.models import SeedTray
 from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
-from .batch_rest import register_batch_routes
+from .batch_rest import BatchedSowingSerializerMixin, InlineBatchSerializer, register_batch_routes
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 from .sowing import correct_sowing_consumption, post_sowing_consumption
 
@@ -61,30 +61,16 @@ class PostedSowingSerializerMixin:
             raise serializers.ValidationError(_model_errors(exc)) from exc
 
 
-class BatchedSowingSerializerMixin:  # pylint: disable=too-few-public-methods
-    """Keep a sowing attached to exactly one production batch for life."""
-
-    def _validate_batch(self, attrs):
-        """Reject moving an existing sowing to a different batch."""
-        if self.instance is not None and 'batch' in attrs:
-            if attrs['batch'].pk != self.instance.batch_id:
-                raise serializers.ValidationError({
-                    'batch': 'Cannot move a sowing between batches.',
-                })
-
-    def validate(self, attrs):
-        """Apply the batch guard before the remaining sowing rules."""
-        self._validate_batch(attrs)
-        return super().validate(attrs)
-
-
 class GardenRowDirectSowPlantingSerializer(BatchedSowingSerializerMixin, PostedSowingSerializerMixin, CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for GardenRowDirectSowPlanting
     """
+    new_batch = InlineBatchSerializer(required=False, write_only=True)
+
     class Meta:
         model = GardenRowDirectSowPlanting
-        fields = ['pk', 'planted', 'seeds_used', 'batch', 'quantity', 'location', 'removed', 'notes']
+        fields = ['pk', 'planted', 'seeds_used', 'batch', 'new_batch', 'quantity', 'location', 'removed', 'notes']
+        extra_kwargs = {'batch': {'required': False}}
 
     workspace_field_lookups = {
         'seeds_used': 'workspace',
@@ -97,9 +83,12 @@ class GardenSquareDirectSowSerializer(BatchedSowingSerializerMixin, PostedSowing
     """
     Serializer for GardenSquareDirectSowPlanting
     """
+    new_batch = InlineBatchSerializer(required=False, write_only=True)
+
     class Meta:
         model = GardenSquareDirectSowPlanting
-        fields = ['pk', 'planted', 'seeds_used', 'batch', 'quantity', 'location', 'removed', 'notes']
+        fields = ['pk', 'planted', 'seeds_used', 'batch', 'new_batch', 'quantity', 'location', 'removed', 'notes']
+        extra_kwargs = {'batch': {'required': False}}
 
     workspace_field_lookups = {
         'seeds_used': 'workspace',
@@ -133,13 +122,15 @@ class SeedTrayPlantingSerializer(BatchedSowingSerializerMixin, PostedSowingSeria
     Serializer for SeedTrayPlanting
     """
     cell_plantings = SeedTrayCellPlantingNestedSerializer(many=True, required=False)
+    new_batch = InlineBatchSerializer(required=False, write_only=True)
 
     class Meta:
         model = SeedTrayPlanting
         fields = [
-            'pk', 'planted', 'seeds_used', 'batch', 'quantity',
+            'pk', 'planted', 'seeds_used', 'batch', 'new_batch', 'quantity',
             'seed_tray', 'location', 'removed', 'notes', 'cell_plantings',
         ]
+        extra_kwargs = {'batch': {'required': False}}
 
     workspace_field_lookups = {
         'seeds_used': 'workspace',
@@ -293,6 +284,7 @@ class SeedTrayPlantingSerializer(BatchedSowingSerializerMixin, PostedSowingSeria
     def create(self, validated_data):
         cell_data = validated_data.pop('cell_plantings', [])
         with transaction.atomic():
+            self._resolve_batch(validated_data)
             planting = SeedTrayPlanting.objects.create(**validated_data)
             if cell_data:
                 self._save_cell_plantings(planting, cell_data)
@@ -447,10 +439,14 @@ class SpecificPlantSerializer(CurrentWorkspaceSerializerMixin, serializers.Model
     On create, automatically records the initial seed tray cell location.
     """
     locations = SpecificPlantLocationSerializer(many=True, read_only=True)
+    batch = serializers.IntegerField(
+        source='cell_planting.seed_tray_planting.batch_id',
+        read_only=True,
+    )
 
     class Meta:
         model = SpecificPlant
-        fields = ['pk', 'cell_planting', 'germinated', 'notes', 'locations']
+        fields = ['pk', 'cell_planting', 'batch', 'germinated', 'notes', 'locations']
 
     workspace_field_lookups = {
         'cell_planting': 'seed_tray_planting__workspace',
@@ -492,9 +488,14 @@ class GardenSquareTransplantSerializer(CurrentWorkspaceSerializerMixin, serializ
     """
     Serializer for GardenSquareTransplant
     """
+    batch = serializers.IntegerField(
+        source='original_planting.batch_id',
+        read_only=True,
+    )
+
     class Meta:
         model = GardenSquareTransplant
-        fields = ['pk', 'transplanted', 'original_planting', 'quantity', 'location', 'removed', 'notes']
+        fields = ['pk', 'transplanted', 'original_planting', 'batch', 'quantity', 'location', 'removed', 'notes']
 
     workspace_field_lookups = {
         'original_planting': 'workspace',

--- a/plantings/sowing.py
+++ b/plantings/sowing.py
@@ -109,6 +109,10 @@ def correct_sowing_consumption(
             'planting': 'Historical sowings without stock postings cannot be corrected.',
         })
     packet = ensure_packet_inventory_identity(seeds_used or planting.seeds_used)
+    if packet.seeds.plant_variety_id != planting.batch.variety_id:
+        raise ValidationError({
+            'seeds_used': 'The replacement packet grows a different variety from the batch.',
+        })
     corrected_quantity = quantity if quantity is not None else planting.quantity
     if corrected_quantity <= 0:
         raise ValidationError({'quantity': 'Quantity must be greater than zero.'})

--- a/plantings/test_batched_sowing.py
+++ b/plantings/test_batched_sowing.py
@@ -1,0 +1,279 @@
+"""Tests that every sowing joins exactly one compatible production batch."""
+# pylint: disable=duplicate-code
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_batch_for_packet,
+    make_garden_row,
+    make_garden_square,
+    make_production_batch,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+)
+
+from .models import (
+    GardenSquareDirectSowPlanting,
+    GardenSquareTransplant,
+    ProductionBatch,
+    SeedTrayPlanting,
+)
+
+
+class BatchedSowingRESTTests(RESTContractTestCase):
+    """Sowing writes select an active batch or create one inline."""
+
+    def setUp(self):
+        super().setUp()
+        # The current-planting summaries are session-authenticated views.
+        self.client.force_login(self.user)
+        self.packet = make_seed_packet()
+        self.variety = self.packet.seeds.plant_variety
+        self.row = make_garden_row()
+        self.square = make_garden_square()
+        self.tray = make_seed_tray()
+        self.cell = make_seed_tray_cell(tray=self.tray)
+        self.batch = make_batch_for_packet(self.packet)
+
+    def _sow_square(self, **overrides):
+        """Post one direct garden-square sowing and return the response."""
+        payload = {
+            'seeds_used': self.packet.pk,
+            'quantity': 2,
+            'location': self.square.pk,
+        }
+        payload.update(overrides)
+        return self.client.post(
+            '/plantings/directsowgardensquare/',
+            payload,
+            format='json',
+        )
+
+    def _sow_tray(self, **overrides):
+        """Post one seed-tray sowing and return the response."""
+        payload = {
+            'seeds_used': self.packet.pk,
+            'quantity': 2,
+            'seed_tray': self.tray.pk,
+            'cell_plantings': [{'cell': self.cell.pk, 'quantity': 2}],
+        }
+        payload.update(overrides)
+        return self.client.post('/plantings/seedtray/', payload, format='json')
+
+    def test_specialized_sowing_workflows_accept_an_existing_batch(self):
+        """Row, square, and tray sowings keep working with a chosen batch."""
+        requests = (
+            (
+                '/plantings/directsowgardenrow/',
+                {'location': self.row.pk},
+            ),
+            (
+                '/plantings/directsowgardensquare/',
+                {'location': self.square.pk},
+            ),
+            (
+                '/plantings/seedtray/',
+                {
+                    'seed_tray': self.tray.pk,
+                    'cell_plantings': [{'cell': self.cell.pk, 'quantity': 2}],
+                },
+            ),
+        )
+        for url, extra in requests:
+            with self.subTest(url=url):
+                response = self.client.post(
+                    url,
+                    {
+                        'seeds_used': self.packet.pk,
+                        'batch': self.batch.pk,
+                        'quantity': 2,
+                        **extra,
+                    },
+                    format='json',
+                )
+                self.assertEqual(response.status_code, 201, response.data)
+                self.assertEqual(response.data['batch'], self.batch.pk)
+
+    def test_inline_batch_creation_is_activated_with_its_sowing(self):
+        """An inline batch derives its variety and start from the sowing."""
+        response = self._sow_square(
+            planted='2026-03-05T08:00:00Z',
+            new_batch={
+                'code': 'SPRING-TOMATO',
+                'planned_start': '2026-03-01',
+                'notes': 'First succession',
+            },
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        batch = ProductionBatch.objects.get(code='SPRING-TOMATO')
+        self.assertEqual(response.data['batch'], batch.pk)
+        self.assertEqual(batch.status, ProductionBatch.Status.ACTIVE)
+        self.assertEqual(batch.variety_id, self.variety.pk)
+        self.assertEqual(
+            batch.actual_start.isoformat(),
+            '2026-03-05T08:00:00+00:00',
+        )
+        self.assertEqual(str(batch.planned_start), '2026-03-01')
+        self.assertEqual(batch.created_by, self.user)
+        self.assertEqual(batch.transitions.count(), 2)
+
+    def test_a_sowing_needs_exactly_one_batch_choice(self):
+        """Batches are never silently generated, nor chosen twice."""
+        neither = self._sow_square()
+        self.assertEqual(neither.status_code, 400)
+        self.assertIn('batch', neither.data)
+
+        both = self._sow_square(
+            batch=self.batch.pk,
+            new_batch={'code': 'SPRING-2'},
+        )
+        self.assertEqual(both.status_code, 400)
+        self.assertIn('batch', both.data)
+
+        self.assertFalse(GardenSquareDirectSowPlanting.objects.exists())
+
+    def test_a_sowing_cannot_join_an_inactive_or_mismatched_batch(self):
+        """Variety and lifecycle status both gate batch attachment."""
+        other_variety = make_production_batch()
+        mismatched = self._sow_square(batch=other_variety.pk)
+        self.assertEqual(mismatched.status_code, 400)
+        self.assertIn('different plant variety', str(mismatched.data['batch']))
+
+        planned = make_production_batch(
+            variety=self.variety,
+            status=ProductionBatch.Status.PLANNED,
+        )
+        inactive = self._sow_square(batch=planned.pk)
+        self.assertEqual(inactive.status_code, 400)
+        self.assertIn('only join an active batch', str(inactive.data['batch']))
+
+        self.assertFalse(GardenSquareDirectSowPlanting.objects.exists())
+
+    def test_a_finalized_batch_cannot_gain_more_work(self):
+        """Attachment is rejected once a batch stops producing seedlings."""
+        make_garden_square_sowing = self._sow_square(batch=self.batch.pk)
+        self.assertEqual(make_garden_square_sowing.status_code, 201)
+        sowing = GardenSquareDirectSowPlanting.objects.get(
+            pk=make_garden_square_sowing.data['pk'],
+        )
+        sowing.removed = True
+        sowing.save(update_fields=['removed'])
+        finalized = self.client.post(
+            f'/plantings/batches/{self.batch.pk}/finalize-output/',
+            {},
+            format='json',
+        )
+        self.assertEqual(finalized.status_code, 200, finalized.data)
+
+        response = self._sow_square(batch=self.batch.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('only join an active batch', str(response.data['batch']))
+        self.assertEqual(GardenSquareDirectSowPlanting.objects.count(), 1)
+
+    def test_an_inline_batch_rolls_back_with_a_rejected_sowing(self):
+        """A rejected sowing never leaves an orphaned batch behind."""
+        response = self._sow_tray(
+            new_batch={'code': 'ORPHAN'},
+            cell_plantings=[{'cell': self.cell.pk, 'quantity': 9}],
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(ProductionBatch.objects.filter(code='ORPHAN').exists())
+        self.assertFalse(SeedTrayPlanting.objects.exists())
+
+    def test_duplicate_inline_batch_codes_are_rejected(self):
+        """Inline creation obeys the same unique-code rule as the API."""
+        response = self._sow_square(new_batch={'code': self.batch.code})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(GardenSquareDirectSowPlanting.objects.count(), 0)
+
+    def test_a_sowing_cannot_move_between_batches(self):
+        """The batch a sowing joins is fixed for the life of that sowing."""
+        created = self._sow_square(batch=self.batch.pk)
+        self.assertEqual(created.status_code, 201)
+        replacement = make_batch_for_packet(self.packet)
+
+        response = self.client.patch(
+            f'/plantings/directsowgardensquare/{created.data["pk"]}/',
+            {'batch': replacement.pk},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('between batches', str(response.data['batch']))
+
+    def test_sowing_corrections_must_keep_the_batch_variety(self):
+        """A packet correction cannot silently change what a batch grows."""
+        created = self._sow_square(batch=self.batch.pk)
+        self.assertEqual(created.status_code, 201)
+        url = f'/plantings/directsowgardensquare/{created.data["pk"]}/correct-sowing/'
+        other_packet = make_seed_packet()
+
+        rejected = self.client.post(
+            url,
+            {'seeds_used': other_packet.pk, 'reason': 'Wrong packet'},
+            format='json',
+        )
+        self.assertEqual(rejected.status_code, 400)
+        self.assertIn('different variety', str(rejected.data['seeds_used']))
+
+        same_variety_packet = make_seed_packet(seeds=self.packet.seeds)
+        accepted = self.client.post(
+            url,
+            {'seeds_used': same_variety_packet.pk, 'reason': 'Wrong packet'},
+            format='json',
+        )
+        self.assertEqual(accepted.status_code, 200, accepted.data)
+
+    def test_batch_appears_in_planting_and_plant_responses(self):
+        """Existing identifiers stay, and the batch joins them."""
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=self.batch,
+            seed_tray=self.tray,
+        )
+        cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=sowing,
+            cell=self.cell,
+        )
+        plant = make_specific_plant(cell_planting=cell_planting)
+        transplant = GardenSquareTransplant.objects.create(
+            original_planting=sowing,
+            quantity=1,
+            location=self.square,
+        )
+
+        plant_response = self.client.get(f'/plantings/specificplants/{plant.pk}/')
+        self.assertEqual(plant_response.data['pk'], plant.pk)
+        self.assertEqual(plant_response.data['cell_planting'], cell_planting.pk)
+        self.assertEqual(plant_response.data['batch'], self.batch.pk)
+
+        transplant_response = self.client.get(
+            f'/plantings/transplantedgardensquare/{transplant.pk}/',
+        )
+        self.assertEqual(transplant_response.data['batch'], self.batch.pk)
+
+    def test_current_summaries_group_through_batches(self):
+        """Both display summaries name the batch without losing their shape."""
+        tray_sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=self.batch,
+            seed_tray=self.tray,
+        )
+        self._sow_square(batch=self.batch.pk)
+
+        trays = self.client.get('/plantings/seedtray/current/').json()['plantings']
+        self.assertEqual(trays[0]['pk'], tray_sowing.pk)
+        self.assertEqual(trays[0]['batch'], self.batch.pk)
+        self.assertEqual(trays[0]['batch_code'], self.batch.code)
+
+        squares = self.client.get(
+            '/plantings/garden/squares/current/',
+        ).json()['plantings']
+        self.assertEqual(squares[0]['batch'], self.batch.pk)
+        self.assertEqual(squares[0]['batch_code'], self.batch.code)

--- a/plantings/views.py
+++ b/plantings/views.py
@@ -24,7 +24,7 @@ def seedtray_current(request):
         SeedTrayPlanting.objects
         .filter(removed=False, workspace=workspace)
         .order_by('planted')
-        .select_related('seeds_used__seeds__plant_variety__plant', 'seed_tray')
+        .select_related('seeds_used__seeds__plant_variety__plant', 'seed_tray', 'batch')
         .prefetch_related('cell_plantings__cell')
     )
     garden_square_location_counts = dict(
@@ -65,6 +65,8 @@ def seedtray_current(request):
         planting_data.append({
             'pk': planting.pk,
             'seeds_used': planting.seeds_used_id,
+            'batch': planting.batch_id,
+            'batch_code': planting.batch.code,
             'plant': variety.plant.name,
             'variety': variety.name,
             'planted': planting.planted,
@@ -132,7 +134,7 @@ def gardensquare_current(request):
         GardenSquareDirectSowPlanting.objects
         .filter(removed=False, workspace=workspace)
         .order_by('planted')
-        .select_related('seeds_used__seeds__plant_variety__plant', 'location__bed__area')
+        .select_related('seeds_used__seeds__plant_variety__plant', 'location__bed__area', 'batch')
     )
     planting_data = []
     for planting in plantings:
@@ -141,6 +143,8 @@ def gardensquare_current(request):
         planting_data.append({
             'planting_pk': planting.pk,
             'seeds_used': planting.seeds_used_id,
+            'batch': planting.batch_id,
+            'batch_code': planting.batch.code,
             'plant': planting.seeds_used.seeds.plant_variety.plant.name,
             'variety': planting.seeds_used.seeds.plant_variety.name,
             'planted': planting.planted,
@@ -166,7 +170,11 @@ def gardensquare_current(request):
             has_specific_representation=Exists(specific_garden_locations),
         )
         .filter(has_specific_representation=False)
-        .select_related('original_planting__seeds_used__seeds__plant_variety__plant', 'location__bed__area')
+        .select_related(
+            'original_planting__seeds_used__seeds__plant_variety__plant',
+            'original_planting__batch',
+            'location__bed__area',
+        )
     )
     for transplanting in transplantings:
         planting = transplanting.original_planting
@@ -175,6 +183,8 @@ def gardensquare_current(request):
         planting_data.append({
             'transplanting_pk': transplanting.pk,
             'planting_pk': planting.pk,
+            'batch': planting.batch_id,
+            'batch_code': planting.batch.code,
             'transplanted': transplanting.transplanted,
             'plant': planting.seeds_used.seeds.plant_variety.plant.name,
             'variety': planting.seeds_used.seeds.plant_variety.name,
@@ -193,6 +203,7 @@ def gardensquare_current(request):
         ended__isnull=True,
     ).select_related(
         'specific_plant__cell_planting__seed_tray_planting__seeds_used__seeds__plant_variety__plant',
+        'specific_plant__cell_planting__seed_tray_planting__batch',
         'garden_square__bed__area',
     )
     for location in specific_plant_locations:
@@ -203,6 +214,8 @@ def gardensquare_current(request):
             'specific_plant_pk': location.specific_plant.pk,
             'transplanting_pk': location.pk,
             'planting_pk': planting.pk,
+            'batch': planting.batch_id,
+            'batch_code': planting.batch.code,
             'transplanted': location.started,
             'plant': variety.plant.name,
             'variety': variety.name,


### PR DESCRIPTION
Sowing creation now requires exactly one of an existing active batch or a new_batch object; batches are never silently generated. An inline batch derives its variety from the sowing packet and its actual start from the sowing time, and is created and activated in the same transaction as the sowing, so a rejected sowing leaves no orphaned batch. Attaching to a chosen batch locks it first, so work cannot land on a batch that is finalizing concurrently.

Attachment requires matching workspace and variety and an active batch, a sowing can never move between batches, and a packet correction is rejected when the replacement grows a different variety from the batch.

Plantings, specific plants, and legacy aggregate transplants now report their batch alongside their existing identifiers, and both current- planting summaries name the batch without otherwise changing shape. The batch sowing mixin lives with the other batch REST code rather than pushing plantings/rest.py past its module size limit.

## Summary by Sourcery

Ensure all sowings explicitly join a single compatible production batch, with support for inline batch creation and batch-aware reporting.

New Features:
- Allow direct sow and seed tray planting endpoints to either attach to an existing active production batch or create an inline batch in the same transaction.
- Expose production batch identifiers in specific plant and transplant API responses and in current planting summary views.

Bug Fixes:
- Prevent sowing corrections from changing a batch’s plant variety by validating replacement packets against the batch variety.

Enhancements:
- Centralize sowing batch-handling logic in a shared serializer mixin and serializer for inline batches, enforcing single-batch attachment and guarding against moves between batches.
- Extend current planting summaries to include batch metadata while preserving their existing response shape.

Tests:
- Add comprehensive REST contract tests covering batched sowing behavior, inline batch creation, validation rules, rollback semantics, and batch presence in plantings and summary views.