### PR TITLE
feat(frontend): add production batch list and detail screens

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -1,5 +1,11 @@
-import { fetchAsJson, csrfPost } from '../utils'
+import { fetchAsJson, csrfPatch, csrfPost } from '../utils'
 import {
+  BatchAction,
+  ProductionBatch,
+  ProductionBatchCreate,
+  ProductionBatchDetail,
+  ProductionBatchStatus,
+  ProductionBatchUpdate,
   GardenRowDirectPlanting,
   GardenSquareDirectPlanting,
   SeedTrayPlanting,
@@ -15,6 +21,47 @@ import {
   SpecificPlantMove,
   SowingCorrection
 } from '../types/plantings'
+
+interface ProductionBatchFilters {
+  status?: ProductionBatchStatus | ''
+  variety?: number
+  code?: string
+  needsRepair?: boolean
+}
+
+function getProductionBatches(filters: ProductionBatchFilters = {}, signal?: AbortSignal): Promise<Array<ProductionBatch>> {
+  const query = new URLSearchParams()
+  if (filters.status) {
+    query.set('status', filters.status)
+  }
+  if (filters.variety !== undefined) {
+    query.set('variety', String(filters.variety))
+  }
+  if (filters.code) {
+    query.set('code', filters.code)
+  }
+  if (filters.needsRepair) {
+    query.set('needs_repair', 'true')
+  }
+  const suffix = query.size > 0 ? `?${query.toString()}` : ''
+  return fetchAsJson<Array<ProductionBatch>>(`/plantings/batches/${suffix}`, signal)
+}
+
+function getProductionBatch(batchPk: number, signal?: AbortSignal): Promise<ProductionBatchDetail> {
+  return fetchAsJson<ProductionBatchDetail>(`/plantings/batches/${batchPk}/`, signal)
+}
+
+function addProductionBatch(data: ProductionBatchCreate): Promise<ProductionBatch> {
+  return csrfPost('/plantings/batches/', data).then((response) => response.json() as Promise<ProductionBatch>)
+}
+
+function updateProductionBatch(batchPk: number, data: ProductionBatchUpdate): Promise<ProductionBatch> {
+  return csrfPatch(`/plantings/batches/${batchPk}/`, data).then((response) => response.json() as Promise<ProductionBatch>)
+}
+
+function postProductionBatchAction(batchPk: number, batchAction: string, data: BatchAction = {}): Promise<ProductionBatchDetail> {
+  return csrfPost(`/plantings/batches/${batchPk}/${batchAction}/`, data).then((response) => response.json() as Promise<ProductionBatchDetail>)
+}
 
 function getPlantingDirectSowGardenRows(signal?: AbortSignal): Promise<Array<GardenRowDirectPlanting>> {
   return fetchAsJson<Array<GardenRowDirectPlanting>>('/plantings/directsowgardenrow/', signal)
@@ -103,6 +150,12 @@ function moveSpecificPlant(plantPk: number, data: SpecificPlantMove): Promise<Re
 }
 
 export {
+  ProductionBatchFilters,
+  getProductionBatches,
+  getProductionBatch,
+  addProductionBatch,
+  updateProductionBatch,
+  postProductionBatchAction,
   getPlantingDirectSowGardenRows,
   addPlantingDirectSowGardenRow,
   getPlantingDirectSowGardenSquares,

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -18,6 +18,7 @@ import { SeedTrayDetails } from './seedtray/seedtray_details.js'
 import { getWorkspace } from './api/workspace.js'
 import { WorkspaceModeRoute, WorkspaceSettings } from './workspace.js'
 import { InventoryCatalog } from './inventory.js'
+import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/batches.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -28,6 +29,17 @@ function SeedTrayDetailsRoute() {
   }
 
   return <SeedTrayDetails seedTrayPk={seedTrayPk} />
+}
+
+function ProductionBatchDetailRoute() {
+  const { batchId } = useParams()
+  const batchPk = Number(batchId)
+
+  if (!batchId || !Number.isInteger(batchPk) || batchPk <= 0) {
+    return <div>Batch not found.</div>
+  }
+
+  return <ProductionBatchDetailView batchPk={batchPk} />
 }
 
 function FrontEndPage() {
@@ -62,6 +74,8 @@ function FrontEndPage() {
         <Route path="/seedtrays/models" element={<SeedTrayModelsTable />} />
         <Route path="/seedtrays" element={<SeedTraysTable />} />
         <Route path="/seedtrays/:trayId" element={<SeedTrayDetailsRoute />} />
+        <Route path="/plantings/batches" element={<ProductionBatchTable />} />
+        <Route path="/plantings/batches/:batchId" element={<ProductionBatchDetailRoute />} />
         <Route path="/plantings/seedtrays" element={<SeedTrayPlantingTable />} />
         <Route path="/plantings/garden-squares" element={<GardenSquarePlantingTable />} />
         <Route path="/inventory" element={<InventoryCatalog />} />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -51,6 +51,9 @@ function GPTopBar({ workspace }: GPTopBarProps) {
             </NavDropdown.Item>
           </NavDropdown>
           <NavDropdown title="Planting" active={plantingActive}>
+            <NavDropdown.Item as={NavLink} to="/plantings/batches">
+              Batches
+            </NavDropdown.Item>
             <NavDropdown.Item as={NavLink} to="/plantings/seedtrays">
               Seed Trays
             </NavDropdown.Item>

--- a/frontend/js/plantings/batches.tsx
+++ b/frontend/js/plantings/batches.tsx
@@ -1,0 +1,547 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+import { Link } from 'react-router'
+
+import { addProductionBatch, getProductionBatch, getProductionBatches, postProductionBatchAction, updateProductionBatch } from '../api/plantings'
+import { getPlantVarieties } from '../api/plants'
+import { queryKeys } from '../query'
+import { formatDate, formatDateTime } from '../utils'
+import { ProductionBatch, ProductionBatchDetail, ProductionBatchStatus } from '../types/plantings'
+
+const STATUS_LABELS: Record<ProductionBatchStatus, string> = {
+  planned: 'Planned',
+  active: 'Active',
+  output_finalized: 'Output finalized',
+  completed: 'Completed',
+  cancelled: 'Cancelled'
+}
+
+const STATUS_VARIANTS: Record<ProductionBatchStatus, string> = {
+  planned: 'secondary',
+  active: 'success',
+  output_finalized: 'info',
+  completed: 'primary',
+  cancelled: 'dark'
+}
+
+function BatchStatusBadge({ status }: { status: ProductionBatchStatus }) {
+  return <Badge bg={STATUS_VARIANTS[status]}>{STATUS_LABELS[status]}</Badge>
+}
+
+interface NewBatchFormProps {
+  done: () => void
+}
+
+function NewBatchForm({ done }: NewBatchFormProps) {
+  const queryClient = useQueryClient()
+  const [code, setCode] = React.useState('')
+  const [variety, setVariety] = React.useState<number>()
+  const [plannedStart, setPlannedStart] = React.useState('')
+  const [notes, setNotes] = React.useState('')
+  const { data: varieties = [] } = useQuery({
+    queryKey: queryKeys.plants.varieties,
+    queryFn: ({ signal }) => getPlantVarieties(signal)
+  })
+  const mutation = useMutation({
+    mutationFn: addProductionBatch,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.plantings.batchesAll })
+      done()
+    }
+  })
+
+  function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (variety === undefined) {
+      return
+    }
+    mutation.mutate({
+      code,
+      variety,
+      planned_start: plannedStart || null,
+      notes
+    })
+  }
+
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>New batch</Card.Title>
+        <Form onSubmit={submit}>
+          <Row className="g-2 align-items-end">
+            <Col md={3}>
+              <Form.Group controlId="batch-code">
+                <Form.Label>Batch code</Form.Label>
+                <Form.Control required maxLength={64} value={code} onChange={(event) => setCode(event.target.value)} />
+              </Form.Group>
+            </Col>
+            <Col md={3}>
+              <Form.Group controlId="batch-variety">
+                <Form.Label>Variety</Form.Label>
+                <Form.Select required value={variety ?? ''} onChange={(event) => setVariety(event.target.value ? Number(event.target.value) : undefined)}>
+                  <option value="">Choose a variety…</option>
+                  {varieties.map((option) => (
+                    <option key={option.pk} value={option.pk}>
+                      {option.name}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={3}>
+              <Form.Group controlId="batch-planned-start">
+                <Form.Label>Planned start</Form.Label>
+                <Form.Control type="date" value={plannedStart} onChange={(event) => setPlannedStart(event.target.value)} />
+              </Form.Group>
+            </Col>
+            <Col md={3}>
+              <Form.Group controlId="batch-notes">
+                <Form.Label>Notes</Form.Label>
+                <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+              </Form.Group>
+            </Col>
+          </Row>
+          <div className="mt-3">
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Creating…' : 'Create batch'}
+            </Button>
+            <Button className="ms-2" variant="outline-secondary" onClick={done}>
+              Cancel
+            </Button>
+          </div>
+        </Form>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function ProductionBatchTable() {
+  const [showAdd, setShowAdd] = React.useState(false)
+  const [status, setStatus] = React.useState<ProductionBatchStatus | ''>('')
+  const [code, setCode] = React.useState('')
+  const [needsRepair, setNeedsRepair] = React.useState(false)
+  const { data: batches = [], isPending } = useQuery({
+    queryKey: queryKeys.plantings.batches(status, '', code, needsRepair),
+    queryFn: ({ signal }) => getProductionBatches({ status, code, needsRepair }, signal)
+  })
+
+  return (
+    <main className="container py-3">
+      <h1>Production batches</h1>
+      <p>A batch is the shared cultivation identity for one tracked crop: its sowings, plants, and lifecycle.</p>
+      <div className="mb-3">
+        <Button onClick={() => setShowAdd(true)} disabled={showAdd}>
+          Add batch
+        </Button>
+      </div>
+      {showAdd && <NewBatchForm done={() => setShowAdd(false)} />}
+      <Row className="g-2 mb-3">
+        <Col md={3}>
+          <Form.Select aria-label="Filter by status" value={status} onChange={(event) => setStatus(event.target.value as ProductionBatchStatus | '')}>
+            <option value="">All statuses</option>
+            {Object.entries(STATUS_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={3}>
+          <Form.Control placeholder="Search codes" value={code} onChange={(event) => setCode(event.target.value)} />
+        </Col>
+        <Col md={3} className="d-flex align-items-center">
+          <Form.Check id="batch-needs-repair" label="Needs repair" checked={needsRepair} onChange={(event) => setNeedsRepair(event.target.checked)} />
+        </Col>
+      </Row>
+      {isPending ? (
+        <div>Loading batches…</div>
+      ) : (
+        <Table responsive>
+          <thead>
+            <tr>
+              <th>Code</th>
+              <th>Crop</th>
+              <th>Status</th>
+              <th>Started</th>
+              <th>Sowings</th>
+              <th>Seeds / clusters sown</th>
+              <th>Plants observed</th>
+              <th>Currently placed</th>
+              <th>Final outcomes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {batches.map((batch) => (
+              <tr key={batch.pk}>
+                <td>
+                  <Link to={`/plantings/batches/${batch.pk}`}>{batch.code}</Link>
+                  {batch.repair_state === 'needs_repair' && (
+                    <Badge className="ms-2" bg="warning" text="dark">
+                      Needs repair
+                    </Badge>
+                  )}
+                </td>
+                <td>
+                  {batch.plant_name} - {batch.variety_name}
+                </td>
+                <td>
+                  <BatchStatusBadge status={batch.status} />
+                </td>
+                <td>{batch.actual_start ? formatDate(batch.actual_start) : formatDate(batch.planned_start ?? '')}</td>
+                <td>{batch.sowing_count}</td>
+                <td>{batch.seeds_sown}</td>
+                <td>{batch.plants_observed}</td>
+                <td>{batch.plants_with_active_location}</td>
+                <td>{batch.final_outcomes}</td>
+              </tr>
+            ))}
+            {batches.length === 0 && (
+              <tr>
+                <td colSpan={9}>No batches match these filters.</td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      )}
+    </main>
+  )
+}
+
+interface BatchActionsProps {
+  batch: ProductionBatchDetail
+}
+
+function BatchActions({ batch }: BatchActionsProps) {
+  const queryClient = useQueryClient()
+  const [reason, setReason] = React.useState('')
+  const [error, setError] = React.useState<string>()
+  const mutation = useMutation({
+    mutationFn: ({ batchAction, data }: { batchAction: string; data: { reason?: string } }) => postProductionBatchAction(batch.pk, batchAction, data),
+    onSuccess: () => {
+      setReason('')
+      setError(undefined)
+      return Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.batch(batch.pk) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.batchesAll })
+      ])
+    },
+    onError: (caught: unknown) => setError(caught instanceof Error ? caught.message : String(caught))
+  })
+
+  function run(batchAction: string) {
+    setError(undefined)
+    mutation.mutate({ batchAction, data: { reason } })
+  }
+
+  const canActivate = batch.status === 'planned'
+  const canFinalize = batch.status === 'active'
+  const canComplete = batch.status === 'output_finalized'
+  const canCancel = batch.status === 'planned' || batch.status === 'active'
+  const canReopen = batch.status === 'output_finalized' || batch.status === 'completed' || batch.status === 'cancelled'
+
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Lifecycle</Card.Title>
+        <Form.Group className="mb-3" controlId="batch-action-reason">
+          <Form.Label>Reason</Form.Label>
+          <Form.Control value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Required to cancel or reopen" />
+        </Form.Group>
+        <div className="d-flex flex-wrap gap-2">
+          <Button disabled={!canActivate || mutation.isPending} onClick={() => run('activate')}>
+            Activate
+          </Button>
+          <Button disabled={!canFinalize || mutation.isPending} onClick={() => run('finalize-output')}>
+            Finalize output
+          </Button>
+          <Button disabled={!canComplete || mutation.isPending} onClick={() => run('complete')}>
+            Complete
+          </Button>
+          <Button variant="outline-danger" disabled={!canCancel || !reason.trim() || mutation.isPending} onClick={() => run('cancel')}>
+            Cancel batch
+          </Button>
+          <Button variant="outline-secondary" disabled={!canReopen || !reason.trim() || mutation.isPending} onClick={() => run('reopen')}>
+            Reopen
+          </Button>
+        </div>
+        {error && (
+          <Alert className="mt-3" variant="danger">
+            {error}
+          </Alert>
+        )}
+        {batch.unresolved_plants.length > 0 && batch.status === 'output_finalized' && (
+          <Alert className="mt-3" variant="warning">
+            {batch.unresolved_plants.length} observed plants have no final disposition yet, so this batch cannot complete.
+          </Alert>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
+
+function BatchSummary({ batch }: { batch: ProductionBatchDetail }) {
+  const entries: Array<[string, string | number]> = [
+    ['Status', STATUS_LABELS[batch.status]],
+    ['Planned start', batch.planned_start ? formatDate(batch.planned_start) : '—'],
+    ['Actual start', batch.actual_start ? formatDateTime(batch.actual_start) : '—'],
+    ['Output finalized', batch.output_finalized_at ? formatDateTime(batch.output_finalized_at) : '—'],
+    ['Completed', batch.completed_at ? formatDateTime(batch.completed_at) : '—'],
+    ['Cancelled', batch.cancelled_at ? formatDateTime(batch.cancelled_at) : '—'],
+    ['Seeds / clusters sown', batch.seeds_sown],
+    ['Plants observed', batch.plants_observed],
+    ['Plants with an active location', batch.plants_with_active_location],
+    ['Final outcomes', batch.final_outcomes]
+  ]
+
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Summary</Card.Title>
+        <Table size="sm" borderless>
+          <tbody>
+            {entries.map(([label, value]) => (
+              <tr key={label}>
+                <th scope="row" className="fw-normal text-muted">
+                  {label}
+                </th>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function BatchSowings({ batch }: { batch: ProductionBatchDetail }) {
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Sowings</Card.Title>
+        {batch.sowings.length === 0 && <div>No sowings have joined this batch yet.</div>}
+        {batch.sowings.map((sowing) => (
+          <div key={`${sowing.sowing_type}-${sowing.pk}`} className="mb-3">
+            <div>
+              <strong>
+                {sowing.sowing_type} #{sowing.pk}
+              </strong>{' '}
+              — {sowing.quantity} sown {formatDateTime(sowing.planted)}
+              {sowing.removed && (
+                <Badge className="ms-2" bg="secondary">
+                  Closed
+                </Badge>
+              )}
+            </div>
+            <div className="text-muted">
+              Packet #{sowing.seeds_used}
+              {sowing.seed_lot !== null && <> · lot #{sowing.seed_lot}</>}
+              {sowing.seed_tray !== null && (
+                <>
+                  {' '}
+                  · <Link to={`/seedtrays/${sowing.seed_tray}`}>tray #{sowing.seed_tray}</Link>
+                </>
+              )}
+              {sowing.location && <> · {sowing.location}</>}
+            </div>
+            {sowing.cells.length > 0 && (
+              <Table size="sm" className="mt-2">
+                <thead>
+                  <tr>
+                    <th>Cell</th>
+                    <th>Position</th>
+                    <th>Sown</th>
+                    <th>Plants observed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sowing.cells.map((cell) => (
+                    <tr key={cell.pk}>
+                      <td>#{cell.cell}</td>
+                      <td>
+                        {cell.x_position}, {cell.y_position}
+                      </td>
+                      <td>{cell.quantity}</td>
+                      <td>{cell.plants_observed}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            )}
+          </div>
+        ))}
+      </Card.Body>
+    </Card>
+  )
+}
+
+function BatchLocations({ batch }: { batch: ProductionBatchDetail }) {
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Current locations</Card.Title>
+        {batch.current_locations.length === 0 ? (
+          <div>No individual plants from this batch currently occupy a tracked location.</div>
+        ) : (
+          <Table size="sm">
+            <thead>
+              <tr>
+                <th>Plant</th>
+                <th>Location</th>
+                <th>Since</th>
+              </tr>
+            </thead>
+            <tbody>
+              {batch.current_locations.map((location) => (
+                <tr key={`${location.specific_plant}-${location.started}`}>
+                  <td>#{location.specific_plant}</td>
+                  <td>{location.label}</td>
+                  <td>{formatDateTime(location.started)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
+
+function BatchHistory({ batch }: { batch: ProductionBatchDetail }) {
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Lifecycle history</Card.Title>
+        <Table size="sm">
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>Change</th>
+              <th>Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {batch.transitions.map((transition) => (
+              <tr key={transition.pk}>
+                <td>{formatDateTime(transition.created)}</td>
+                <td>
+                  {transition.previous_status ? STATUS_LABELS[transition.previous_status] : 'Created'} → {STATUS_LABELS[transition.new_status]}
+                </td>
+                <td>{transition.reason || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  )
+}
+
+interface BatchDetailsFormProps {
+  batch: ProductionBatch
+}
+
+function BatchDetailsForm({ batch }: BatchDetailsFormProps) {
+  const queryClient = useQueryClient()
+  const [code, setCode] = React.useState(batch.code)
+  const [plannedStart, setPlannedStart] = React.useState(batch.planned_start ?? '')
+  const [notes, setNotes] = React.useState(batch.notes)
+  const mutation = useMutation({
+    mutationFn: () => updateProductionBatch(batch.pk, { code, planned_start: plannedStart || null, notes }),
+    onSuccess: () =>
+      Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.plantings.batch(batch.pk) }), queryClient.invalidateQueries({ queryKey: queryKeys.plantings.batchesAll })])
+  })
+
+  React.useEffect(() => {
+    setCode(batch.code)
+    setPlannedStart(batch.planned_start ?? '')
+    setNotes(batch.notes)
+  }, [batch])
+
+  function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    mutation.mutate()
+  }
+
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Details</Card.Title>
+        <Form onSubmit={submit}>
+          <Row className="g-2">
+            <Col md={4}>
+              <Form.Group controlId="batch-detail-code">
+                <Form.Label>Batch code</Form.Label>
+                <Form.Control required maxLength={64} value={code} onChange={(event) => setCode(event.target.value)} />
+              </Form.Group>
+            </Col>
+            <Col md={4}>
+              <Form.Group controlId="batch-detail-planned-start">
+                <Form.Label>Planned start</Form.Label>
+                <Form.Control type="date" value={plannedStart} onChange={(event) => setPlannedStart(event.target.value)} />
+              </Form.Group>
+            </Col>
+            <Col md={4}>
+              <Form.Group controlId="batch-detail-notes">
+                <Form.Label>Notes</Form.Label>
+                <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+              </Form.Group>
+            </Col>
+          </Row>
+          <Button className="mt-3" type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? 'Saving…' : 'Save details'}
+          </Button>
+          {mutation.isSuccess && <span className="ms-3 text-success">Details saved.</span>}
+        </Form>
+      </Card.Body>
+    </Card>
+  )
+}
+
+interface ProductionBatchDetailViewProps {
+  batchPk: number
+}
+
+function ProductionBatchDetailView({ batchPk }: ProductionBatchDetailViewProps) {
+  const { data: batch, isPending } = useQuery({
+    queryKey: queryKeys.plantings.batch(batchPk),
+    queryFn: ({ signal }) => getProductionBatch(batchPk, signal)
+  })
+
+  if (isPending) {
+    return <div className="container py-3">Loading batch…</div>
+  }
+  if (!batch) {
+    return <div className="container py-3">Batch not found.</div>
+  }
+
+  return (
+    <main className="container py-3">
+      <div className="d-flex align-items-center gap-3">
+        <h1 className="mb-0">{batch.code}</h1>
+        <BatchStatusBadge status={batch.status} />
+      </div>
+      <p className="text-muted">
+        {batch.plant_name} - {batch.variety_name}
+      </p>
+      <Link to="/plantings/batches">← All batches</Link>
+      {batch.repair_state === 'needs_repair' && (
+        <Alert className="mt-3" variant="warning">
+          <Alert.Heading>This migrated batch needs repair</Alert.Heading>
+          <pre className="mb-0 text-wrap">{batch.repair_details}</pre>
+        </Alert>
+      )}
+      <div className="mt-3">
+        <BatchSummary batch={batch} />
+        <BatchActions batch={batch} />
+        <BatchDetailsForm batch={batch} />
+        <BatchSowings batch={batch} />
+        <BatchLocations batch={batch} />
+        <BatchHistory batch={batch} />
+      </div>
+    </main>
+  )
+}
+
+export { ProductionBatchTable, ProductionBatchDetailView, STATUS_LABELS }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -47,6 +47,9 @@ const queryKeys = {
   },
   plantings: {
     all: ['plantings'] as const,
+    batchesAll: ['plantings', 'batches'] as const,
+    batches: (status: string, variety: number | '', code: string, needsRepair: boolean) => ['plantings', 'batches', status, variety, code, needsRepair] as const,
+    batch: (batchPk: number) => ['plantings', 'batches', 'detail', batchPk] as const,
     directGardenRows: ['plantings', 'directGardenRows'] as const,
     directGardenSquares: ['plantings', 'directGardenSquares'] as const,
     transplantedGardenSquares: ['plantings', 'transplantedGardenSquares'] as const,

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -1,7 +1,112 @@
 import { GardenSquare } from './garden'
 
+type ProductionBatchStatus = 'planned' | 'active' | 'output_finalized' | 'completed' | 'cancelled'
+
+type ProductionBatchRepairState = 'none' | 'needs_repair'
+
+interface NewBatchInline {
+  code: string
+  planned_start?: string | null
+  notes?: string
+}
+
+interface ProductionBatch {
+  pk: number
+  code: string
+  variety: number
+  variety_name: string
+  plant_name: string
+  status: ProductionBatchStatus
+  planned_start: string | null
+  actual_start: string | null
+  output_finalized_at: string | null
+  completed_at: string | null
+  cancelled_at: string | null
+  notes: string
+  created_by: number | null
+  repair_state: ProductionBatchRepairState
+  repair_details: string
+  sowing_count: number
+  seeds_sown: number
+  plants_observed: number
+  plants_with_active_location: number
+  final_outcomes: number
+  unresolved_plants: Array<number>
+  created: string
+  updated: string
+}
+
+interface ProductionBatchCreate {
+  code: string
+  variety: number
+  planned_start?: string | null
+  notes?: string
+}
+
+interface ProductionBatchUpdate {
+  code?: string
+  variety?: number
+  planned_start?: string | null
+  notes?: string
+}
+
+interface ProductionBatchTransition {
+  pk: number
+  previous_status: ProductionBatchStatus | ''
+  new_status: ProductionBatchStatus
+  created_by: number | null
+  reason: string
+  created: string
+}
+
+interface ProductionBatchCell {
+  pk: number
+  cell: number
+  x_position: number
+  y_position: number
+  quantity: number
+  plants_observed: number
+}
+
+interface ProductionBatchSowing {
+  pk: number
+  sowing_type: string
+  planted: string
+  quantity: number
+  removed: boolean
+  seeds_used: number
+  seed_lot: number | null
+  seed_tray: number | null
+  location: string | null
+  notes: string | null
+  cells: Array<ProductionBatchCell>
+  plants_observed: number
+}
+
+interface ProductionBatchLocation {
+  specific_plant: number
+  location_type: 'seed_tray_cell' | 'garden_square'
+  seed_tray_cell: number | null
+  garden_square: number | null
+  started: string
+  label: string
+}
+
+interface ProductionBatchDetail extends ProductionBatch {
+  sowings: Array<ProductionBatchSowing>
+  current_locations: Array<ProductionBatchLocation>
+  transitions: Array<ProductionBatchTransition>
+}
+
+interface BatchAction {
+  reason?: string
+  actual_start?: string
+}
+
 interface PlantingCreate {
   seeds_used: number
+  batch?: number
+  new_batch?: NewBatchInline
   quantity: number
   notes?: string
 }
@@ -23,6 +128,7 @@ interface SeedTrayPlantingCreate extends PlantingCreate {
 interface Planting {
   pk: number
   seeds_used: number
+  batch: number
   quantity: number
   removed: boolean
   notes: string
@@ -54,6 +160,8 @@ interface GardenSquareTransplanting extends Planting {
 interface SeedTrayPlantingDetails {
   pk: number
   seeds_used: number
+  batch: number
+  batch_code: string
   plant: string
   variety: string
   planted: string
@@ -78,6 +186,8 @@ interface GardenSquarePlanting {
   transplanting_pk?: number
   transplanted?: string
   planting_pk: number
+  batch: number
+  batch_code: string
   seeds_used?: number
   plant: string
   variety: string
@@ -122,6 +232,7 @@ interface SpecificPlantMove {
 interface SpecificPlant {
   pk: number
   cell_planting: number
+  batch: number
   germinated: string
   notes?: string
   locations: Array<SpecificPlantLocation>
@@ -140,7 +251,19 @@ interface SowingCorrection {
 }
 
 export {
+  BatchAction,
+  NewBatchInline,
   Planting,
+  ProductionBatch,
+  ProductionBatchCell,
+  ProductionBatchCreate,
+  ProductionBatchDetail,
+  ProductionBatchLocation,
+  ProductionBatchRepairState,
+  ProductionBatchSowing,
+  ProductionBatchStatus,
+  ProductionBatchTransition,
+  ProductionBatchUpdate,
   GardenRowDirectPlanting,
   GardenSquareDirectPlanting,
   SeedTrayPlanting,


### PR DESCRIPTION
Add a Planting > Batches list that filters by status, code, and repair state and shows each batch's crop, lifecycle state, and the four output counts separately, so seeds sown is never mistaken for plants raised.

The detail screen groups everything one crop needs: its sowings with seed lots, cell allocations and germinations, where its individual plants are living now, an editable code, planned start, and notes, the lifecycle actions with a reason field that cancel and reopen require, and the full append-only transition history. Migrated batches carrying repair details surface them prominently instead of hiding them.

No price, cost, or customer data appears, so the screens read the same in Garden and Nursery mode.

## Summary by Sourcery

Introduce production batch management screens and APIs for listing and viewing detailed lifecycle information for planting batches.

New Features:
- Add production batch list view with filtering by status, code, and repair state, and display of key sowing and plant counts.
- Add production batch detail view showing sowings, cell allocations, current plant locations, lifecycle actions with reasons, and transition history.
- Allow creating and editing production batches, including inline association from plantings.

Enhancements:
- Extend planting types and query keys to associate plantings and specific plants with production batches and support batch-focused data fetching.