### PR TITLE
feat(frontend): trim trailing zeros from displayed quantities

### DIFF
--- a/frontend/js/inventory.tsx
+++ b/frontend/js/inventory.tsx
@@ -23,6 +23,7 @@ import {
   UnitCode,
   UnitDimension
 } from './types/inventory'
+import { formatQuantity } from './utils'
 
 const CATEGORY_LABELS: Record<InventoryCategory, string> = {
   seed: 'Seed',
@@ -310,7 +311,7 @@ function ConversionPanel({ item }: ConversionPanelProps) {
               <tr key={conversion.pk}>
                 <td>{conversion.label}</td>
                 <td>
-                  {conversion.multiplier} {conversion.base_unit}
+                  {formatQuantity(conversion.multiplier)} {conversion.base_unit}
                 </td>
                 <td>{conversion.active ? 'Active' : 'Inactive'}</td>
                 <td>

--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -15,7 +15,7 @@ import { GardenSquareDirectPlantingCreate, GardenSquarePlanting, SeedTrayPlantin
 import { SeedTray, SeedTrayModel } from './types/seedtrays'
 import { SelectOption } from './types/others'
 import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
-import { formatDate, formatDateRange } from './utils'
+import { formatDate, formatDateRange, formatQuantity } from './utils'
 import {
   getPlantingSeedTrayCurrent,
   getPlantingGardenSquaresCurrent,
@@ -47,9 +47,9 @@ function packetVarietyPk(packetPk: number | undefined, packets: Array<SeedPacket
 function packetBalanceLabel(packet: SeedPacket): string {
   const inventory = packet.inventory
   if (!inventory || inventory.remaining_quantity === null) {
-    return `quantity unknown; ${inventory?.sown_quantity ?? '0'} sown`
+    return `quantity unknown; ${formatQuantity(inventory?.sown_quantity, '0')} sown`
   }
-  return `${inventory.remaining_quantity} ${inventory.base_unit} remaining (${inventory.quantity_certainty})`
+  return `${formatQuantity(inventory.remaining_quantity)} ${inventory.base_unit} remaining (${inventory.quantity_certainty})`
 }
 
 interface SeedTrayCellGridProps {

--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -23,6 +23,7 @@ import {
 } from './api/seeds'
 import { addSupplier, getSuppliers } from './api/supplies'
 import { queryKeys } from './query'
+import { formatQuantity } from './utils'
 
 interface NewSeedSupplierRowProps {
   done: () => void
@@ -509,7 +510,7 @@ function ReceiptDraftRow({ draft, label, onPost, onCancel }: ReceiptDraftRowProp
       <td>{draft.received_date}</td>
       <td>{draft.sow_by || '—'}</td>
       <td>
-        {draft.quantity_certainty === 'unknown' ? 'Unknown' : `${draft.quantity} ${draft.base_unit}`} ({draft.quantity_certainty})
+        {draft.quantity_certainty === 'unknown' ? 'Unknown' : `${formatQuantity(draft.quantity)} ${draft.base_unit}`} ({draft.quantity_certainty})
       </td>
       <td>{draft.line_price}</td>
       <td colSpan={2}>Draft — confirm these normalized receipt details before posting.</td>
@@ -550,17 +551,17 @@ function SeedPacketRow({ packet, label, onReconcile }: SeedPacketRowProps) {
       <td>{packet.purchase_date || '—'}</td>
       <td>{packet.sow_by || '—'}</td>
       <td>
-        {inventory?.received_quantity ?? 'Unknown'} {inventory?.base_unit} ({inventory?.quantity_certainty ?? 'unlinked'})
+        {formatQuantity(inventory?.received_quantity, 'Unknown')} {inventory?.base_unit} ({inventory?.quantity_certainty ?? 'unlinked'})
       </td>
       <td>
         {inventory?.acquisition_total ?? 'Unknown'} {inventory?.currency_code}
         {inventory?.effective_base_unit_cost && ` (${inventory.effective_base_unit_cost}/${inventory.base_unit})`}
       </td>
       <td>
-        {inventory?.sown_quantity ?? '0'} sown; {inventory?.adjustment_quantity ?? '0'} adjusted
+        {formatQuantity(inventory?.sown_quantity, '0')} sown; {formatQuantity(inventory?.adjustment_quantity, '0')} adjusted
       </td>
       <td>
-        {inventory?.remaining_quantity ?? 'Unknown'} {inventory?.base_unit}
+        {formatQuantity(inventory?.remaining_quantity, 'Unknown')} {inventory?.base_unit}
         {inventory?.warnings.map((warning) => (
           <Alert key={warning} variant="warning" className="p-1 my-1">
             {warning}

--- a/frontend/js/utils.tsx
+++ b/frontend/js/utils.tsx
@@ -224,4 +224,13 @@ function formatDateRange(start: string | null | undefined, end: string | null | 
   return `${formatDate(start ?? '')} - ${formatDate(end ?? '')}`
 }
 
-export { ApiError, csrfDelete, csrfPost, csrfPatch, fetchAsJson, localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime, formatDateRange }
+// Quantities arrive as zero-padded decimal strings ("24.000000000"). Trim the padding without
+// parsing to a number, which would reintroduce float artifacts the decimal column avoids.
+function formatQuantity(value: string | number | null | undefined, fallback = ''): string {
+  if (value === null || value === undefined || value === '') return fallback
+  const s = String(value)
+  if (!/^-?\d+(\.\d+)?$/.test(s)) return s
+  return s.includes('.') ? s.replace(/\.?0+$/, '') : s
+}
+
+export { ApiError, csrfDelete, csrfPost, csrfPatch, fetchAsJson, localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime, formatDateRange, formatQuantity }


### PR DESCRIPTION
Quantity columns are DECIMAL(24, 9) and the REST layer serialises them with explicit zero padding, so a packet of 24 seeds reached the browser as "24.000000000" and rendered raw. Nine meaningless decimal places ate horizontal space in the packet tables, the sowing packet picker, and the inventory unit-conversion table.

Add formatQuantity to utils.tsx alongside the date formatters and apply it at the render sites. The trim is lossless — trailing zeros only, no rounding — and operates on the string rather than parsing to a number, which would reintroduce the float artifacts the decimal column avoids.

Display-only: the 9-decimal wire format, the quantity inputs, and the backend are untouched.

## Summary by Sourcery

Trim superfluous trailing zeros from displayed quantity values across seed, planting, and inventory views using a shared formatter.

Enhancements:
- Introduce a reusable formatQuantity utility to render decimal quantities without trailing zero padding.
- Apply the new quantity formatter to seed packets, planting balances, and inventory unit conversions to improve readability of quantity displays.