### PR TITLE
feat(plantings): derive plant lifecycle state from recorded facts

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -1,0 +1,385 @@
+"""Append-only lifecycle history and derived state for individual plants.
+
+Current state is replayed from `PlantLifecycleEvent` rows every time it is
+asked for, so the APIs and the batch reports share one derivation and no stored
+status can drift away from the recorded facts.
+"""
+
+# pylint: disable=duplicate-code
+
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+from django.db import models, transaction
+from django.utils import timezone
+
+from .models import PlantLifecycleEvent, SpecificPlant, SpecificPlantLocation
+
+
+EventType = PlantLifecycleEvent.EventType
+
+
+class LifecycleState(models.TextChoices):
+    """The derived condition of one individual plant.
+
+    These values deliberately echo the outcome event that produces them; the
+    two vocabularies are never mixed inside one lookup.
+    """
+
+    GROWING = 'growing', 'Growing'
+    AVAILABLE = 'available', 'Available'
+    RETAINED = 'retained', 'Retained'
+    DONATED = 'donated', 'Donated'
+    FAILED = 'failed', 'Failed'
+    CULLED = 'culled', 'Culled'
+    HARVESTED = 'harvested', 'Harvested'
+
+
+#: The state each fact leaves behind. `transplanted` and `corrected` are absent
+#: because they record something that happened without changing the condition.
+STATE_AFTER = {
+    EventType.GERMINATED: LifecycleState.GROWING,
+    EventType.READY: LifecycleState.AVAILABLE,
+    EventType.RETAINED: LifecycleState.RETAINED,
+    EventType.DONATED: LifecycleState.DONATED,
+    EventType.FAILED: LifecycleState.FAILED,
+    EventType.CULLED: LifecycleState.CULLED,
+    EventType.HARVEST_FINISHED: LifecycleState.HARVESTED,
+}
+
+#: The states each fact may be recorded from. `germinated` is absent because it
+#: is only valid for a plant with no history at all.
+ALLOWED_FROM = {
+    EventType.READY: {LifecycleState.GROWING},
+    EventType.TRANSPLANTED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.RETAINED,
+    },
+    EventType.RETAINED: {LifecycleState.GROWING, LifecycleState.AVAILABLE},
+    EventType.FAILED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.RETAINED,
+    },
+    EventType.CULLED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.RETAINED,
+    },
+    EventType.DONATED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.RETAINED,
+    },
+    EventType.HARVEST_FINISHED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.RETAINED,
+    },
+}
+
+#: States that resolve a plant. Retained is final for availability without
+#: ending biological growth, so failure or harvest may still follow it.
+FINAL_STATES = {
+    LifecycleState.RETAINED,
+    LifecycleState.DONATED,
+    LifecycleState.FAILED,
+    LifecycleState.CULLED,
+    LifecycleState.HARVESTED,
+}
+
+#: States in which a plant is offerable to somebody else.
+SELLABLE_STATES = {LifecycleState.AVAILABLE}
+
+#: Facts that end a plant's presence in a physical location. A retained plant
+#: keeps growing where it is, so it is not listed.
+CLOSES_LOCATION = {
+    EventType.DONATED,
+    EventType.FAILED,
+    EventType.CULLED,
+    EventType.HARVEST_FINISHED,
+}
+
+#: Facts an operator may record directly against a plant.
+OUTCOME_EVENTS = (
+    EventType.READY,
+    EventType.RETAINED,
+    EventType.FAILED,
+    EventType.CULLED,
+    EventType.DONATED,
+    EventType.HARVEST_FINISHED,
+)
+
+
+class LifecycleSummary(NamedTuple):
+    """One plant's derived condition and final-outcome metadata."""
+
+    state: str
+    sellable: bool
+    final_outcome: object = None
+    final_outcome_at: object = None
+
+
+class OutcomeRequest(NamedTuple):
+    """Caller intent for one recorded lifecycle fact."""
+
+    event_type: str
+    occurred_at: object = None
+    reason: str = ''
+    reference: str = ''
+
+    def at(self, default):
+        """Return this request with a concrete time for the whole action."""
+        if self.occurred_at is not None:
+            return self
+        return OutcomeRequest(
+            event_type=self.event_type,
+            occurred_at=default,
+            reason=self.reason,
+            reference=self.reference,
+        )
+
+
+def is_final(state):
+    """Return whether a derived state resolves the plant."""
+    return state in FINAL_STATES
+
+
+def derive_state(events):
+    """Replay one plant's facts into its current summary.
+
+    Reversed events and the corrections that reverse them are both skipped, so
+    a correction restores whatever the surviving facts imply.
+    """
+    corrected_ids = {
+        event.reversal_of_id
+        for event in events
+        if event.reversal_of_id is not None
+    }
+    state = LifecycleState.GROWING
+    outcome = None
+    outcome_at = None
+    for event in sorted(events, key=lambda event: (event.occurred_at, event.pk)):
+        if event.pk in corrected_ids:
+            continue
+        next_state = STATE_AFTER.get(event.event_type)
+        if next_state is None:
+            continue
+        state = next_state
+        if is_final(state):
+            outcome, outcome_at = event.event_type, event.occurred_at
+        else:
+            outcome, outcome_at = None, None
+    return LifecycleSummary(
+        state=state,
+        sellable=state in SELLABLE_STATES,
+        final_outcome=outcome,
+        final_outcome_at=outcome_at,
+    )
+
+
+def plant_lifecycle_summary(plant):
+    """Return one plant's summary, reusing prefetched events when present."""
+    return derive_state(list(plant.lifecycle_events.all()))
+
+
+def lifecycle_summaries(plant_ids):
+    """Return a summary per plant id, reading every event in one query."""
+    grouped = {plant_id: [] for plant_id in plant_ids}
+    events = PlantLifecycleEvent.objects.filter(plant_id__in=list(grouped))
+    for event in events:
+        grouped[event.plant_id].append(event)
+    return {
+        plant_id: derive_state(plant_events)
+        for plant_id, plant_events in grouped.items()
+    }
+
+
+def _lock_plant(plant):
+    """Reload one plant under a row lock, serialising its transitions."""
+    return SpecificPlant.objects.select_for_update().get(pk=plant.pk)
+
+
+def _plant_events(plant):
+    """Return every recorded fact for one plant."""
+    return list(PlantLifecycleEvent.objects.filter(plant=plant))
+
+
+def _plant_batch(plant):
+    """Return the batch that raised this plant."""
+    return plant.cell_planting.seed_tray_planting.batch
+
+
+def _require_reason(reason):
+    """Reject an audit-critical action without a stated reason."""
+    if not reason or not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+
+
+def _require_transition(state, event_type):
+    """Reject a fact that the plant's current condition does not permit."""
+    if state not in ALLOWED_FROM.get(event_type, set()):
+        raise ValidationError({
+            'event_type': (
+                f'A {LifecycleState(state).label.lower()} plant cannot be '
+                f'recorded as {EventType(event_type).label.lower()}.'
+            ),
+        })
+
+
+def _require_chronology(events, occurred_at):
+    """Keep the history append-only in time as well as in storage."""
+    latest = max((event.occurred_at for event in events), default=None)
+    if latest is not None and occurred_at < latest:
+        raise ValidationError({
+            'occurred_at': 'Events must be recorded in the order they happened.',
+        })
+
+
+def _validate_outcome(plant, event_type, occurred_at):
+    """Check one plant admits a fact before anything is written."""
+    events = _plant_events(plant)
+    _require_chronology(events, occurred_at)
+    _require_transition(derive_state(events).state, event_type)
+
+
+def _close_active_location(plant, when):
+    """End the open location a departing or finished plant leaves behind."""
+    locations = list(
+        SpecificPlantLocation.objects
+        .select_for_update()
+        .filter(specific_plant=plant, ended__isnull=True)
+    )
+    if len(locations) > 1:
+        raise ValidationError({
+            'detail': 'The plant has multiple active locations.',
+        })
+    if not locations:
+        return None
+    location = locations[0]
+    if when < location.started:
+        raise ValidationError({
+            'occurred_at': 'An outcome cannot predate the current location.',
+        })
+    location.ended = when
+    location.save(update_fields=['ended'])
+    return location
+
+
+def _create_event(plant, user, request, reversal_of=None):
+    """Append one immutable fact, denormalising the batch that raised it."""
+    return PlantLifecycleEvent.objects.create(
+        workspace=plant.workspace,
+        plant=plant,
+        batch=_plant_batch(plant),
+        event_type=request.event_type,
+        occurred_at=request.occurred_at,
+        reason=request.reason,
+        reference=request.reference,
+        reversal_of=reversal_of,
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+
+
+def _apply_outcome(plant, user, request):
+    """Close a location where required and append the outcome fact."""
+    if request.event_type in CLOSES_LOCATION:
+        _close_active_location(plant, request.occurred_at)
+    return _create_event(plant, user, request)
+
+
+@transaction.atomic
+def record_lifecycle_event(plant, user, request):
+    """Record one validated fact about a plant and close its location if final."""
+    plant = _lock_plant(plant)
+    request = request.at(timezone.now())
+    _validate_outcome(plant, request.event_type, request.occurred_at)
+    return _apply_outcome(plant, user, request)
+
+
+def record_germination_event(plant, user):
+    """Record the germination that created this plant.
+
+    Called from inside the transaction that creates the plant, which already
+    holds the locks the fact depends on.
+    """
+    return _create_event(
+        plant,
+        user,
+        OutcomeRequest(EventType.GERMINATED, occurred_at=plant.germinated),
+    )
+
+
+def record_transplant_event(plant, user, occurred_at):
+    """Record that a move planted this plant out.
+
+    Called from inside `move_specific_plant`, which already locks the plant.
+    """
+    _validate_outcome(plant, EventType.TRANSPLANTED, occurred_at)
+    return _create_event(
+        plant,
+        user,
+        OutcomeRequest(EventType.TRANSPLANTED, occurred_at=occurred_at),
+    )
+
+
+@transaction.atomic
+def reverse_lifecycle_event(event, user, reason, occurred_at=None):
+    """Correct a mistaken fact by appending its reversal.
+
+    The original stays visible; the plant's state is re-derived from the facts
+    that survive. A closed location is not reopened, because where a plant has
+    been remains true — record the replacement location instead.
+    """
+    _require_reason(reason)
+    plant = _lock_plant(event.plant)
+    event = PlantLifecycleEvent.objects.get(pk=event.pk)
+    if event.event_type == EventType.CORRECTED:
+        raise ValidationError({'event': 'A correction cannot itself be corrected.'})
+    if event.event_type == EventType.GERMINATED:
+        raise ValidationError({
+            'event': 'Germination created this plant and cannot be reversed.',
+        })
+    if hasattr(event, 'reversal'):
+        raise ValidationError({'event': 'That event has already been corrected.'})
+    occurred_at = occurred_at or timezone.now()
+    _require_chronology(_plant_events(plant), occurred_at)
+    return _create_event(
+        plant,
+        user,
+        OutcomeRequest(EventType.CORRECTED, occurred_at=occurred_at, reason=reason),
+        reversal_of=event,
+    )
+
+
+@transaction.atomic
+def record_bulk_outcome(plant_ids, user, request):
+    """Record the same outcome for a selection as one event per plant.
+
+    Every plant is validated before anything is written, so an invalid
+    selection reports each offending plant without half-applying the batch.
+    """
+    wanted = sorted(set(plant_ids))
+    if not wanted:
+        raise ValidationError({'plants': 'Select at least one plant.'})
+    plants = list(
+        SpecificPlant.objects
+        .select_for_update()
+        .filter(pk__in=wanted)
+        .order_by('pk')
+    )
+    if len(plants) != len(wanted):
+        raise ValidationError({'plants': 'One or more plants are unavailable.'})
+
+    request = request.at(timezone.now())
+    errors = []
+    for plant in plants:
+        try:
+            _validate_outcome(plant, request.event_type, request.occurred_at)
+        except ValidationError as exc:
+            errors.append(f'Plant {plant.pk}: {" ".join(exc.messages)}')
+    if errors:
+        raise ValidationError({'plants': errors})
+
+    return [_apply_outcome(plant, user, request) for plant in plants]

--- a/plantings/migrations/0023_backfill_plant_lifecycle_events.py
+++ b/plantings/migrations/0023_backfill_plant_lifecycle_events.py
@@ -1,0 +1,84 @@
+"""Give every existing plant the lifecycle facts already recorded elsewhere.
+
+Only germination and planting out are trustworthy in the historical data. A
+`removed` flag or an ended location says a planting activity finished, not that
+a plant was sold, failed, or harvested, so no final outcome is invented here:
+those plants stay active until an operator records what became of them.
+"""
+
+from django.db import migrations
+
+
+GERMINATED = 'germinated'
+TRANSPLANTED = 'transplanted'
+GARDEN_SQUARE = 'garden_square'
+
+
+def _plant_origins(SpecificPlant):
+    """Map each plant to the workspace, batch, and time that produced it."""
+    return {
+        plant_id: (workspace_id, batch_id, germinated)
+        for plant_id, workspace_id, batch_id, germinated in SpecificPlant.objects.values_list(
+            'pk',
+            'workspace_id',
+            'cell_planting__seed_tray_planting__batch_id',
+            'germinated',
+        )
+    }
+
+
+def backfill_lifecycle_events(apps, _schema_editor):
+    """Record one germination per plant and one transplant per planting out."""
+    SpecificPlant = apps.get_model('plantings', 'SpecificPlant')
+    SpecificPlantLocation = apps.get_model('plantings', 'SpecificPlantLocation')
+    PlantLifecycleEvent = apps.get_model('plantings', 'PlantLifecycleEvent')
+
+    origins = _plant_origins(SpecificPlant)
+    events = [
+        PlantLifecycleEvent(
+            workspace_id=workspace_id,
+            plant_id=plant_id,
+            batch_id=batch_id,
+            event_type=GERMINATED,
+            occurred_at=germinated,
+            reason='Backfilled from the recorded germination.',
+        )
+        for plant_id, (workspace_id, batch_id, germinated) in sorted(origins.items())
+    ]
+
+    planted_out = SpecificPlantLocation.objects.filter(
+        location_type=GARDEN_SQUARE,
+    ).order_by('specific_plant_id', 'started', 'pk')
+    for plant_id, started in planted_out.values_list('specific_plant_id', 'started'):
+        if plant_id not in origins:
+            continue
+        workspace_id, batch_id, germinated = origins[plant_id]
+        events.append(PlantLifecycleEvent(
+            workspace_id=workspace_id,
+            plant_id=plant_id,
+            batch_id=batch_id,
+            event_type=TRANSPLANTED,
+            # Clamp so a location that predates its own germination cannot make
+            # the replayed history run backwards.
+            occurred_at=max(started, germinated),
+            reason='Backfilled from the recorded location history.',
+        ))
+
+    PlantLifecycleEvent.objects.bulk_create(events)
+
+
+def remove_lifecycle_events(apps, _schema_editor):
+    """Drop the backfilled history so the migration can be unapplied."""
+    PlantLifecycleEvent = apps.get_model('plantings', 'PlantLifecycleEvent')
+    PlantLifecycleEvent.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plantings', '0022_plantlifecycleevent'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_lifecycle_events, remove_lifecycle_events),
+    ]

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -1,0 +1,520 @@
+"""Tests for the append-only plant lifecycle services."""
+# pylint: disable=duplicate-code
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+from django.utils import timezone
+
+from tests.factories import (
+    make_garden_square,
+    make_plant_lifecycle_event,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace
+
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_bulk_outcome,
+    record_germination_event,
+    record_lifecycle_event,
+    record_transplant_event,
+    reverse_lifecycle_event,
+)
+from .models import PlantLifecycleEvent, SpecificPlant, SpecificPlantLocation
+
+
+#: Facts that resolve a plant, paired with the state each one derives to.
+FINAL_OUTCOMES = (
+    (EventType.RETAINED, LifecycleState.RETAINED),
+    (EventType.DONATED, LifecycleState.DONATED),
+    (EventType.FAILED, LifecycleState.FAILED),
+    (EventType.CULLED, LifecycleState.CULLED),
+    (EventType.HARVEST_FINISHED, LifecycleState.HARVESTED),
+)
+
+
+class LifecycleStateDerivationTests(TestCase):
+    """Current state is replayed from the recorded facts."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='deriver')
+        self.plant = make_specific_plant()
+        record_germination_event(self.plant, self.user)
+
+    def test_a_germinated_plant_is_growing_and_not_sellable(self):
+        """Germination starts a plant active but not yet offerable."""
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+        self.assertFalse(summary.sellable)
+        self.assertIsNone(summary.final_outcome)
+        self.assertIsNone(summary.final_outcome_at)
+
+    def test_a_plant_with_no_history_at_all_is_growing(self):
+        """A plant predating any recorded fact is not treated as resolved."""
+        summary = plant_lifecycle_summary(make_specific_plant())
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+        self.assertIsNone(summary.final_outcome)
+
+    def test_ready_makes_a_plant_available_and_sellable(self):
+        """A ready plant is the one state that may be offered to somebody."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.AVAILABLE)
+        self.assertTrue(summary.sellable)
+
+    def test_transplanting_records_a_fact_without_changing_state(self):
+        """Where a plant lives is separate from its commercial disposition."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        record_transplant_event(self.plant, self.user, timezone.now())
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.AVAILABLE)
+
+    def test_each_final_outcome_derives_its_state_and_metadata(self):
+        """Every resolving fact reports itself as the final outcome."""
+        for event_type, expected_state in FINAL_OUTCOMES:
+            with self.subTest(event_type=event_type):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                occurred_at = timezone.now()
+                record_lifecycle_event(
+                    plant,
+                    self.user,
+                    OutcomeRequest(event_type, occurred_at=occurred_at),
+                )
+                summary = plant_lifecycle_summary(plant)
+                self.assertEqual(summary.state, expected_state)
+                self.assertEqual(summary.final_outcome, event_type)
+                self.assertEqual(summary.final_outcome_at, occurred_at)
+                self.assertFalse(summary.sellable)
+
+
+class LifecycleTransitionTests(TestCase):
+    """Only the permitted transitions are accepted."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='transitioner')
+        self.plant = make_specific_plant()
+        record_germination_event(self.plant, self.user)
+
+    def test_germination_cannot_be_recorded_twice(self):
+        """A plant already has history, so it cannot germinate again."""
+        with self.assertRaises(ValidationError):
+            record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.GERMINATED))
+
+    def test_ready_is_rejected_from_a_resolved_plant(self):
+        """A failed plant cannot become available again without a correction."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        self.assertIn('event_type', caught.exception.message_dict)
+
+    def test_every_final_outcome_is_rejected_from_a_resolved_plant(self):
+        """A resolved plant cannot pick up a second competing outcome."""
+        for event_type, _ in FINAL_OUTCOMES:
+            with self.subTest(event_type=event_type):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.CULLED))
+                with self.assertRaises(ValidationError):
+                    record_lifecycle_event(plant, self.user, OutcomeRequest(event_type))
+
+    def test_a_retained_plant_may_still_fail_or_be_harvested(self):
+        """Retention ends availability without ending biological growth."""
+        for event_type in (EventType.FAILED, EventType.HARVEST_FINISHED):
+            with self.subTest(event_type=event_type):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.RETAINED))
+                record_lifecycle_event(plant, self.user, OutcomeRequest(event_type))
+                self.assertEqual(
+                    plant_lifecycle_summary(plant).final_outcome,
+                    event_type,
+                )
+
+    def test_a_retained_plant_cannot_be_marked_ready(self):
+        """Retention is final for availability."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.RETAINED))
+        with self.assertRaises(ValidationError):
+            record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+
+    def test_a_resolved_plant_cannot_be_transplanted(self):
+        """A culled plant is not moved anywhere else."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.CULLED))
+        with self.assertRaises(ValidationError):
+            record_transplant_event(self.plant, self.user, timezone.now())
+
+    def test_events_cannot_be_recorded_out_of_order(self):
+        """History is append-only in time as well as in storage."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(
+                self.plant,
+                self.user,
+                OutcomeRequest(
+                    EventType.FAILED,
+                    occurred_at=timezone.now() - timedelta(days=7),
+                ),
+            )
+        self.assertIn('occurred_at', caught.exception.message_dict)
+
+
+class LifecycleLocationClosureTests(TestCase):
+    """Outcomes close a physical location only where they should."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='closer')
+        self.plant = make_specific_plant()
+        record_germination_event(self.plant, self.user)
+        self.location = make_specific_plant_location(specific_plant=self.plant)
+
+    def _active_location(self):
+        """Return the plant's open location, if it still has one."""
+        return SpecificPlantLocation.objects.filter(
+            specific_plant=self.plant,
+            ended__isnull=True,
+        ).first()
+
+    def test_departing_and_ending_outcomes_close_the_location(self):
+        """Leaving the operation or dying ends the plant's occupancy."""
+        closing = (
+            EventType.DONATED,
+            EventType.FAILED,
+            EventType.CULLED,
+            EventType.HARVEST_FINISHED,
+        )
+        for event_type in closing:
+            with self.subTest(event_type=event_type):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                location = make_specific_plant_location(specific_plant=plant)
+                occurred_at = timezone.now()
+                record_lifecycle_event(
+                    plant,
+                    self.user,
+                    OutcomeRequest(event_type, occurred_at=occurred_at),
+                )
+                location.refresh_from_db()
+                self.assertEqual(location.ended, occurred_at)
+
+    def test_a_retained_plant_keeps_its_location(self):
+        """Retention removes a plant from sale, not from the ground."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.RETAINED))
+        self.location.refresh_from_db()
+        self.assertIsNone(self.location.ended)
+        self.assertIsNotNone(self._active_location())
+
+    def test_marking_a_plant_ready_keeps_its_location(self):
+        """Readiness is a commercial fact, not a physical one."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        self.location.refresh_from_db()
+        self.assertIsNone(self.location.ended)
+
+    def test_an_outcome_cannot_predate_the_current_location(self):
+        """A closure that ends before it started is refused outright."""
+        self.location.started = timezone.now()
+        self.location.save(update_fields=['started'])
+        with self.assertRaises(ValidationError):
+            record_lifecycle_event(
+                self.plant,
+                self.user,
+                OutcomeRequest(
+                    EventType.FAILED,
+                    occurred_at=self.location.started - timedelta(hours=1),
+                ),
+            )
+        self.location.refresh_from_db()
+        self.assertIsNone(self.location.ended)
+
+    def test_a_rejected_outcome_leaves_the_location_untouched(self):
+        """An invalid transition never half-closes a location."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.RETAINED))
+        with self.assertRaises(ValidationError):
+            record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        self.location.refresh_from_db()
+        self.assertIsNone(self.location.ended)
+
+    def test_an_outcome_without_a_location_is_still_recorded(self):
+        """A plant with no tracked location can still be resolved."""
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.FAILED))
+        self.assertEqual(
+            plant_lifecycle_summary(plant).final_outcome,
+            EventType.FAILED,
+        )
+
+
+class LifecycleCorrectionTests(TestCase):
+    """Corrections append a reversal instead of rewriting history."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='corrector')
+        self.plant = make_specific_plant()
+        record_germination_event(self.plant, self.user)
+        self.location = make_specific_plant_location(specific_plant=self.plant)
+
+    def test_reversing_a_failure_reopens_the_plant_and_keeps_the_fact(self):
+        """The mistaken event stays visible while the state recovers."""
+        failure = record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        correction = reverse_lifecycle_event(failure, self.user, 'Wrong plant.')
+
+        self.assertEqual(correction.reversal_of_id, failure.pk)
+        self.assertTrue(
+            PlantLifecycleEvent.objects.filter(pk=failure.pk).exists(),
+        )
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+        self.assertIsNone(summary.final_outcome)
+
+    def test_a_replacement_location_can_follow_a_reversed_failure(self):
+        """The closed location stays closed; a new interval is appended."""
+        failure = record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        reverse_lifecycle_event(failure, self.user, 'Wrong plant.')
+        self.location.refresh_from_db()
+        self.assertIsNotNone(self.location.ended)
+
+        replacement = SpecificPlantLocation.objects.create(
+            specific_plant=self.plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=make_garden_square(),
+            started=self.location.ended,
+        )
+        self.assertIsNone(replacement.ended)
+
+    def test_a_reversed_plant_accepts_a_valid_replacement_outcome(self):
+        """After a correction the plant can be resolved properly."""
+        failure = record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        reverse_lifecycle_event(failure, self.user, 'Wrong plant.')
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.CULLED))
+        self.assertEqual(
+            plant_lifecycle_summary(self.plant).final_outcome,
+            EventType.CULLED,
+        )
+
+    def test_a_correction_requires_a_reason(self):
+        """Audited corrections always say why they were needed."""
+        failure = record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        with self.assertRaises(ValidationError) as caught:
+            reverse_lifecycle_event(failure, self.user, '   ')
+        self.assertIn('reason', caught.exception.message_dict)
+
+    def test_an_event_cannot_be_corrected_twice(self):
+        """One fact has at most one reversal."""
+        failure = record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        reverse_lifecycle_event(failure, self.user, 'Wrong plant.')
+        with self.assertRaises(ValidationError):
+            reverse_lifecycle_event(failure, self.user, 'Again.')
+
+    def test_a_correction_cannot_itself_be_corrected(self):
+        """Corrections are undone by recording the truth, not by nesting."""
+        failure = record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.FAILED))
+        correction = reverse_lifecycle_event(failure, self.user, 'Wrong plant.')
+        with self.assertRaises(ValidationError):
+            reverse_lifecycle_event(correction, self.user, 'Undo the undo.')
+
+    def test_germination_cannot_be_reversed(self):
+        """The fact that created the plant is not correctable."""
+        germination = PlantLifecycleEvent.objects.get(
+            plant=self.plant,
+            event_type=EventType.GERMINATED,
+        )
+        with self.assertRaises(ValidationError):
+            reverse_lifecycle_event(germination, self.user, 'Never happened.')
+
+
+class LifecycleImmutabilityTests(TestCase):
+    """Recorded facts are never overwritten or deleted."""
+
+    def setUp(self):
+        super().setUp()
+        self.event = make_plant_lifecycle_event()
+
+    def test_an_event_cannot_be_saved_again(self):
+        """Editing a fact is refused by the model itself."""
+        self.event.reason = 'Rewritten.'
+        with self.assertRaises(ValidationError):
+            self.event.save()
+
+    def test_an_event_cannot_be_deleted(self):
+        """Deleting a fact is refused by the model itself."""
+        with self.assertRaises(ValidationError):
+            self.event.delete()
+
+    def test_an_event_must_match_its_plant_batch(self):
+        """The denormalised batch cannot disagree with the plant's own."""
+        other_plant = make_specific_plant()
+        with self.assertRaises(ValidationError) as caught:
+            make_plant_lifecycle_event(
+                plant=other_plant,
+                batch=self.event.batch,
+            )
+        self.assertIn('batch', caught.exception.message_dict)
+
+
+class BulkOutcomeTests(TestCase):
+    """A selection produces one traceable event per plant."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='bulk')
+        self.plants = []
+        for _ in range(3):
+            plant = make_specific_plant()
+            record_germination_event(plant, self.user)
+            make_specific_plant_location(specific_plant=plant)
+            self.plants.append(plant)
+
+    def test_each_plant_receives_its_own_event(self):
+        """The aggregate action stays auditable plant by plant."""
+        plant_ids = [plant.pk for plant in self.plants]
+        events = record_bulk_outcome(
+            plant_ids,
+            self.user,
+            OutcomeRequest(EventType.CULLED, reason='Frost damage.'),
+        )
+
+        self.assertEqual(len(events), len(plant_ids))
+        self.assertEqual(
+            sorted(event.plant_id for event in events),
+            sorted(plant_ids),
+        )
+        for event in events:
+            self.assertEqual(event.event_type, EventType.CULLED)
+            self.assertEqual(event.reason, 'Frost damage.')
+
+    def test_each_plant_location_is_closed(self):
+        """Bulk outcomes honour the same location rules as single ones."""
+        record_bulk_outcome(
+            [plant.pk for plant in self.plants],
+            self.user,
+            OutcomeRequest(EventType.CULLED),
+        )
+        self.assertFalse(
+            SpecificPlantLocation.objects.filter(
+                specific_plant__in=self.plants,
+                ended__isnull=True,
+            ).exists(),
+        )
+
+    def test_one_invalid_plant_rejects_the_whole_selection(self):
+        """A partial application would leave an unexplainable audit trail."""
+        record_lifecycle_event(self.plants[0], self.user, OutcomeRequest(EventType.FAILED))
+        with self.assertRaises(ValidationError) as caught:
+            record_bulk_outcome(
+                [plant.pk for plant in self.plants],
+                self.user,
+                OutcomeRequest(EventType.CULLED),
+            )
+
+        self.assertIn('plants', caught.exception.message_dict)
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(
+                plant__in=self.plants[1:],
+                event_type=EventType.CULLED,
+            ).count(),
+            0,
+        )
+
+    def test_an_unknown_plant_is_rejected(self):
+        """A selection naming a missing plant records nothing."""
+        with self.assertRaises(ValidationError):
+            record_bulk_outcome([0], self.user, OutcomeRequest(EventType.CULLED))
+
+    def test_an_empty_selection_is_rejected(self):
+        """Recording an outcome for nothing is a mistake, not a no-op."""
+        with self.assertRaises(ValidationError):
+            record_bulk_outcome([], self.user, OutcomeRequest(EventType.CULLED))
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentPlantOutcomeTests(TransactionTestCase):
+    """A locked plant admits only one final outcome at a time."""
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='plant-racer')
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        make_specific_plant_location(specific_plant=plant)
+        self.plant_pk = plant.pk
+
+    def _record(self, event_type):
+        """Attempt one outcome from an independent connection."""
+        close_old_connections()
+        plant = SpecificPlant.objects.get(pk=self.plant_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            record_lifecycle_event(plant, user, OutcomeRequest(event_type))
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'recorded'
+        close_old_connections()
+        return result
+
+    def test_only_one_concurrent_outcome_commits(self):
+        """The loser is rejected instead of resolving the plant twice."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._record, EventType.FAILED),
+                    pool.submit(self._record, EventType.CULLED),
+                ]
+            )
+
+        self.assertEqual(results, ['recorded', 'rejected'])
+        outcomes = PlantLifecycleEvent.objects.filter(
+            plant_id=self.plant_pk,
+            event_type__in=[EventType.FAILED, EventType.CULLED],
+        )
+        self.assertEqual(outcomes.count(), 1)
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                specific_plant_id=self.plant_pk,
+                ended__isnull=True,
+            ).count(),
+            0,
+        )
+
+    def test_only_one_concurrent_reservation_of_readiness_commits(self):
+        """Racing the same transition twice still appends one fact."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._record, EventType.READY),
+                    pool.submit(self._record, EventType.READY),
+                ]
+            )
+
+        self.assertEqual(results, ['recorded', 'rejected'])
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(
+                plant_id=self.plant_pk,
+                event_type=EventType.READY,
+            ).count(),
+            1,
+        )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -10,6 +10,7 @@ from inventory.models import InventoryLocation, InventoryUnit, StockLot, StockMo
 from plantings.models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
+    PlantLifecycleEvent,
     ProductionBatch,
     ProductionBatchTransition,
     SeedTrayCellPlanting,
@@ -339,6 +340,20 @@ def make_specific_plant(**overrides):
         values['cell_planting'] = make_seed_tray_cell_planting()
     values.update(overrides)
     return SpecificPlant.objects.create(**values)
+
+
+def make_plant_lifecycle_event(**overrides):
+    """Create one lifecycle fact, defaulting to the germination of a plant."""
+    values = dict(overrides)
+    plant = values.pop('plant', None) or make_specific_plant()
+    defaults = {
+        'plant': plant,
+        'batch': plant.cell_planting.seed_tray_planting.batch,
+        'event_type': PlantLifecycleEvent.EventType.GERMINATED,
+        'occurred_at': plant.germinated,
+    }
+    defaults.update(values)
+    return PlantLifecycleEvent.objects.create(**defaults)
 
 
 def make_specific_plant_location(**overrides):


### PR DESCRIPTION
Add the transactional services that append lifecycle facts and replay them into a current state. State is derived on every read rather than stored, so the APIs and the batch reports share one derivation and no status field can drift away from the history.

Outcomes that remove a plant from the operation or end it biologically close its active location in the same transaction; a retained plant keeps its location, because retention ends availability without ending growth. Every transition locks the plant first, so concurrent outcomes cannot both commit.

The backfill records only what is already on file: one germination per plant and one planting out per garden-square interval. A `removed` flag or an ended location says a planting activity finished, not what became of a plant, so no final outcome is invented for existing data.

Commercial events (reserved, sold, returned) wait for tasks 44 and 45, which introduce the orders they would reference.

## Summary by Sourcery

Introduce append-only plant lifecycle services that derive per-plant state from recorded events, enforce valid transitions, and support bulk and concurrent outcomes, with backfilled historical germination and transplant facts.

New Features:
- Add lifecycle derivation APIs that compute a plant’s current state, sellability, and final outcome from immutable event history.
- Introduce services to record germination, transplant, single-plant outcomes, bulk outcomes, and audited corrections to lifecycle events.
- Provide bulk lifecycle state summaries for sets of plants based on their recorded events.

Enhancements:
- Enforce lifecycle transition rules, temporal ordering of events, and location closure behaviour so physical and commercial states remain consistent.
- Ensure lifecycle events are append-only by preventing updates and deletions and validating batch consistency for each recorded fact.
- Add transactional locking around outcome recording so concurrent lifecycle changes cannot double-resolve the same plant.

Tests:
- Add comprehensive unit and transactional tests covering lifecycle state derivation, allowed transitions, location closure, corrections, immutability, bulk outcomes, and concurrency locking.

Chores:
- Backfill existing plants with derived lifecycle event records for germination and planting out using a data migration, without inventing final outcomes.