### PR TITLE
feat(plantings): expose lifecycle history and explicit outcome actions

### DIFF
--- a/plantings/lifecycle_rest.py
+++ b/plantings/lifecycle_rest.py
@@ -1,0 +1,336 @@
+"""REST resources and explicit outcome actions for plant lifecycle events.
+
+Events are facts, so the collections are read-only and every change arrives
+through a named transition action that appends one auditable row.
+"""
+
+# pylint: disable=duplicate-code
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.shortcuts import get_object_or_404
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from workspaces.scoping import CurrentWorkspaceViewSetMixin
+
+from .lifecycle import (
+    OUTCOME_EVENTS,
+    EventType,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_bulk_outcome,
+    record_lifecycle_event,
+    reverse_lifecycle_event,
+)
+from .models import PlantLifecycleEvent, SpecificPlant
+
+
+def _model_errors(error):
+    """Translate model validation errors into DRF response details."""
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
+
+
+def _run_domain_action(function, *args, **kwargs):
+    """Invoke a lifecycle service with field-friendly API errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+def _outcome_request(event_type, values):
+    """Build the service request one validated action payload describes."""
+    return OutcomeRequest(
+        event_type=event_type,
+        occurred_at=values.get('occurred_at'),
+        reason=values['reason'],
+        reference=values['reference'],
+    )
+
+
+def _action_values(request, serializer_class):
+    """Validate one action payload and return its cleaned values."""
+    serializer = serializer_class(data=request.data)
+    serializer.is_valid(raise_exception=True)
+    return serializer.validated_data
+
+
+class ActionSerializer(serializers.Serializer):
+    """Validation-only serializer base for plant lifecycle actions."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class OutcomeSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Validate when one outcome happened and what it came from."""
+
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=True, required=False, default='')
+    reference = serializers.CharField(
+        max_length=255,
+        allow_blank=True,
+        required=False,
+        default='',
+    )
+
+
+class BulkOutcomeSerializer(OutcomeSerializer):  # pylint: disable=abstract-method
+    """Validate a selection of plants and the one outcome they share."""
+
+    plants = serializers.ListField(
+        child=serializers.IntegerField(),
+        allow_empty=False,
+    )
+    event_type = serializers.ChoiceField(
+        choices=[(event.value, event.label) for event in OUTCOME_EVENTS],
+    )
+
+
+class ReverseEventSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Validate which recorded fact was wrong and why."""
+
+    event = serializers.IntegerField()
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+    occurred_at = serializers.DateTimeField(required=False)
+
+
+class PlantLifecycleEventSerializer(serializers.ModelSerializer):
+    """Serialize one immutable lifecycle fact."""
+
+    reversed_by = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PlantLifecycleEvent
+        fields = [
+            'pk',
+            'plant',
+            'batch',
+            'event_type',
+            'occurred_at',
+            'reason',
+            'reference',
+            'created_by',
+            'reversal_of',
+            'reversed_by',
+            'created',
+        ]
+        read_only_fields = fields
+
+    def get_reversed_by(self, event):
+        """Return the correction that reversed this fact, if one did."""
+        reversal = getattr(event, 'reversal', None)
+        return None if reversal is None else reversal.pk
+
+
+class PlantLifecycleSerializerMixin:
+    """Resolve one plant's derived lifecycle state for a representation.
+
+    The state is replayed from the plant's events rather than stored, and is
+    computed once per plant so a list response reuses its prefetch. Concrete
+    serializers declare the matching `SerializerMethodField`s themselves
+    because DRF only collects declared fields from serializer bases.
+    """
+
+    #: The read-only fields a serializer using this mixin must declare.
+    LIFECYCLE_FIELDS = [
+        'lifecycle_state',
+        'sellable',
+        'final_outcome',
+        'final_outcome_at',
+    ]
+
+    def _summary(self, plant):
+        """Derive one plant's lifecycle summary at most once per response."""
+        cached = getattr(plant, '_lifecycle_summary', None)
+        if cached is None:
+            cached = plant_lifecycle_summary(plant)
+            setattr(plant, '_lifecycle_summary', cached)
+        return cached
+
+    def get_lifecycle_state(self, plant):
+        """Return the plant's current derived lifecycle state."""
+        return self._summary(plant).state
+
+    def get_sellable(self, plant):
+        """Return whether the plant may currently be offered to somebody."""
+        return self._summary(plant).sellable
+
+    def get_final_outcome(self, plant):
+        """Return the fact that resolved this plant, if one has."""
+        return self._summary(plant).final_outcome
+
+    def get_final_outcome_at(self, plant):
+        """Return when this plant was resolved, if it has been."""
+        return self._summary(plant).final_outcome_at
+
+
+class PlantOutcomeViewSetMixin:
+    """Expose one explicit action per recordable plant outcome.
+
+    Each action returns the appended event rather than the plant, so the
+    auditable row is what the caller receives.
+    """
+
+    @action(detail=True, methods=['post'])
+    def ready(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record that this plant is ready for sale or use."""
+        return self._record_outcome(request, EventType.READY)
+
+    @action(detail=True, methods=['post'])
+    def retain(self, request, pk=None):  # pylint: disable=unused-argument
+        """Keep this plant for the operation's own use, where it stands."""
+        return self._record_outcome(request, EventType.RETAINED)
+
+    @action(detail=True, methods=['post'])
+    def fail(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record that this plant did not survive."""
+        return self._record_outcome(request, EventType.FAILED)
+
+    @action(detail=True, methods=['post'])
+    def cull(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record that this plant was deliberately removed."""
+        return self._record_outcome(request, EventType.CULLED)
+
+    @action(detail=True, methods=['post'])
+    def donate(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record that this plant left the operation as a gift."""
+        return self._record_outcome(request, EventType.DONATED)
+
+    @action(detail=True, methods=['post'], url_path='finish-harvest')
+    def finish_harvest(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record the final harvest that ends this plant's cultivation."""
+        return self._record_outcome(request, EventType.HARVEST_FINISHED)
+
+    @action(detail=True, methods=['post'], url_path='reverse-event')
+    def reverse_event(self, request, pk=None):  # pylint: disable=unused-argument
+        """Correct a mistaken fact by appending its reversal."""
+        values = _action_values(request, ReverseEventSerializer)
+        plant = self.get_object()
+        event = get_object_or_404(
+            PlantLifecycleEvent,
+            pk=values['event'],
+            plant=plant,
+        )
+        correction = _run_domain_action(
+            reverse_lifecycle_event,
+            event,
+            request.user,
+            values['reason'],
+            occurred_at=values.get('occurred_at'),
+        )
+        return Response(
+            PlantLifecycleEventSerializer(correction).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=False, methods=['post'], url_path='bulk-outcome')
+    def bulk_outcome(self, request):
+        """Record one shared outcome as a separate event per selected plant."""
+        values = _action_values(request, BulkOutcomeSerializer)
+        plant_ids = self._resolve_plant_ids(values['plants'])
+        events = _run_domain_action(
+            record_bulk_outcome,
+            plant_ids,
+            request.user,
+            _outcome_request(values['event_type'], values),
+        )
+        return Response(
+            PlantLifecycleEventSerializer(events, many=True).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    def _resolve_plant_ids(self, requested):
+        """Reject a selection naming plants outside the current workspace."""
+        wanted = sorted(set(requested))
+        known = set(
+            self.get_queryset()
+            .filter(pk__in=wanted)
+            .values_list('pk', flat=True)
+        )
+        missing = [plant_id for plant_id in wanted if plant_id not in known]
+        if missing:
+            raise ValidationError({
+                'plants': f'No such plants in this workspace: {missing}.',
+            })
+        return wanted
+
+    def _record_outcome(self, request, event_type):
+        """Validate one outcome payload and append the resulting fact."""
+        values = _action_values(request, OutcomeSerializer)
+        event = _run_domain_action(
+            record_lifecycle_event,
+            self.get_object(),
+            request.user,
+            _outcome_request(event_type, values),
+        )
+        return Response(
+            PlantLifecycleEventSerializer(event).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class PlantLifecycleEventViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Read the recorded lifecycle history.
+
+    Generic update and delete endpoints are not provided: corrections append a
+    reversal through the plant's own action.
+    """
+
+    queryset = PlantLifecycleEvent.objects.select_related('reversal')
+    serializer_class = PlantLifecycleEventSerializer
+
+    def get_queryset(self):
+        """Apply the plant, batch, and event-type filters the screens use."""
+        queryset = super().get_queryset()
+        for field in ('plant', 'batch'):
+            value = self.request.query_params.get(field)
+            if value:
+                if not value.isdigit():
+                    raise ValidationError({field: f'Enter a {field} ID.'})
+                queryset = queryset.filter(**{f'{field}_id': int(value)})
+        event_type = self.request.query_params.get('event_type')
+        if event_type:
+            if event_type not in {choice.value for choice in EventType}:
+                raise ValidationError({'event_type': 'Select a valid event type.'})
+            queryset = queryset.filter(event_type=event_type)
+        return queryset
+
+
+class PlantLifecycleEventByPlantViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Read one plant's chronological lifecycle history."""
+
+    queryset = PlantLifecycleEvent.objects.select_related('reversal')
+    serializer_class = PlantLifecycleEventSerializer
+
+    def get_queryset(self):
+        """Limit the history to the named plant inside this workspace."""
+        plant = get_object_or_404(
+            SpecificPlant,
+            pk=self.kwargs['specific_plant_pk'],
+            workspace=self.get_current_workspace(),
+        )
+        return super().get_queryset().filter(plant=plant)
+
+
+def register_lifecycle_routes(router):
+    """Attach the lifecycle event resources to the planting API router."""
+    router.register(r'lifecycle-events', PlantLifecycleEventViewSet)
+    router.register(
+        r'specificplants/(?P<specific_plant_pk>[^/.]+)/lifecycle-events',
+        PlantLifecycleEventByPlantViewSet,
+        basename='specificplant-lifecycle-events',
+    )

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -15,6 +15,8 @@ from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .batch_rest import BatchedSowingSerializerMixin, InlineBatchSerializer, register_batch_routes
+from .lifecycle import record_germination_event, record_transplant_event
+from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSerializerMixin, PlantOutcomeViewSetMixin, register_lifecycle_routes
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 from .sowing import correct_sowing_consumption, post_sowing_consumption
 
@@ -433,20 +435,33 @@ class SpecificPlantMoveSerializer(CurrentWorkspaceSerializerMixin, serializers.M
         return data
 
 
-class SpecificPlantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+class SpecificPlantSerializer(PlantLifecycleSerializerMixin, CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
     """
-    Serializer for SpecificPlant — includes nested location history.
-    On create, automatically records the initial seed tray cell location.
+    Serializer for SpecificPlant — includes nested location history and the
+    lifecycle state derived from its recorded facts.
+    On create, automatically records the initial seed tray cell location
+    and the germination that started the plant's lifecycle history.
     """
     locations = SpecificPlantLocationSerializer(many=True, read_only=True)
     batch = serializers.IntegerField(
         source='cell_planting.seed_tray_planting.batch_id',
         read_only=True,
     )
+    lifecycle_state = serializers.SerializerMethodField()
+    sellable = serializers.SerializerMethodField()
+    final_outcome = serializers.SerializerMethodField()
+    final_outcome_at = serializers.SerializerMethodField()
 
     class Meta:
         model = SpecificPlant
-        fields = ['pk', 'cell_planting', 'batch', 'germinated', 'notes', 'locations']
+        fields = [
+            'pk',
+            'cell_planting',
+            'batch',
+            'germinated',
+            'notes',
+            'locations',
+        ] + PlantLifecycleSerializerMixin.LIFECYCLE_FIELDS
 
     workspace_field_lookups = {
         'cell_planting': 'seed_tray_planting__workspace',
@@ -481,7 +496,17 @@ class SpecificPlantSerializer(CurrentWorkspaceSerializerMixin, serializers.Model
                 seed_tray_cell=plant.cell_planting.cell,
                 started=plant.germinated,
             )
+            record_germination_event(plant, self.context['request'].user)
         return plant
+
+
+class SpecificPlantDetailSerializer(SpecificPlantSerializer):
+    """Add the chronological lifecycle history one plant screen needs."""
+
+    lifecycle_events = PlantLifecycleEventSerializer(many=True, read_only=True)
+
+    class Meta(SpecificPlantSerializer.Meta):
+        fields = SpecificPlantSerializer.Meta.fields + ['lifecycle_events']
 
 
 class GardenSquareTransplantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
@@ -609,18 +634,27 @@ def is_active_location_integrity_error(exc):
     return names_constraint or names_sqlite_column
 
 
-def move_specific_plant(plant, move_data):
+def move_specific_plant(plant, move_data, user=None):
     """
     Move a plant by ending its active location and creating the new one atomically.
+
+    A move into a garden square is also the moment the plant is planted out, so
+    the matching lifecycle fact is appended in the same transaction.
     """
     started = move_data.get('started') or timezone.now()
     move_payload = {**move_data, 'started': started}
+    planted_out = move_payload.get('location_type') == SpecificPlantLocation.GARDEN_SQUARE
     with transaction.atomic():
         plant = get_object_or_404(
             SpecificPlant.objects.select_for_update(),
             pk=plant.pk,
             workspace=plant.workspace,
         )
+        if planted_out:
+            try:
+                record_transplant_event(plant, user, started)
+            except DjangoValidationError as exc:
+                raise serializers.ValidationError(_model_errors(exc)) from exc
         active_location = get_single_active_location_for_update(plant)
 
         if active_location:
@@ -821,12 +855,18 @@ class GardenSquareTransplantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadO
     serializer_class = GardenSquareTransplantSerializer
 
 
-class SpecificPlantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+class SpecificPlantViewSet(PlantOutcomeViewSetMixin, CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SpecificPlant
     """
-    queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square')
+    queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square', 'lifecycle_events')
     serializer_class = SpecificPlantSerializer
+
+    def get_serializer_class(self):
+        """Use the richer serializer for a single plant."""
+        if self.action == 'retrieve':
+            return SpecificPlantDetailSerializer
+        return SpecificPlantSerializer
 
     @action(detail=True, methods=['post'])
     def move(self, request, pk=None):  # pylint: disable=unused-argument
@@ -840,6 +880,7 @@ class SpecificPlantViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
         location = move_specific_plant(
             plant,
             dict(serializer.validated_data),
+            user=request.user,
         )
         return Response(SpecificPlantLocationSerializer(location).data, status=status.HTTP_201_CREATED)
 
@@ -848,7 +889,7 @@ class SpecificPlantBySeedTrayViewSet(CurrentWorkspaceViewSetMixin, viewsets.Read
     """
     ViewSet of SpecificPlant filtered by SeedTray
     """
-    queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square')
+    queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square', 'lifecycle_events')
     serializer_class = SpecificPlantSerializer
     _parent_seed_tray = None
 
@@ -941,3 +982,4 @@ router.register(r'specificplantlocations', SpecificPlantLocationViewSet)
 router.register(r'seedtray-data/(?P<seed_tray_pk>[^/.]+)/plantings', SeedTrayPlantingViewSeedTraySet, basename='seedtray-plantings')
 router.register(r'seedtray-data/(?P<seed_tray_pk>[^/.]+)/specificplants', SpecificPlantBySeedTrayViewSet, basename='seedtray-specificplants')
 router.register(r'specificplants/(?P<specific_plant_pk>[^/.]+)/locations', SpecificPlantLocationByPlantViewSet, basename='specificplant-locations')
+register_lifecycle_routes(router)

--- a/plantings/test_lifecycle_rest.py
+++ b/plantings/test_lifecycle_rest.py
@@ -1,0 +1,395 @@
+"""Tests for the plant lifecycle REST contract and outcome actions."""
+# pylint: disable=duplicate-code
+from django.utils import timezone
+
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_garden_square,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+
+from .lifecycle import EventType, LifecycleState
+from .models import PlantLifecycleEvent, SpecificPlantLocation
+
+
+class PlantLifecycleRESTTestCase(RESTContractTestCase):
+    """Shared fixture of one tray-raised plant in a tracked location."""
+
+    def setUp(self):
+        super().setUp()
+        self.packet = make_seed_packet()
+        self.tray = make_seed_tray()
+        self.cell = make_seed_tray_cell(tray=self.tray)
+        self.tray_planting = make_seed_tray_planting(
+            seeds_used=self.packet,
+            quantity=4,
+            seed_tray=self.tray,
+        )
+        self.cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=self.tray_planting,
+            cell=self.cell,
+            quantity=4,
+        )
+        self.plant = make_specific_plant(cell_planting=self.cell_planting)
+        self.location = make_specific_plant_location(specific_plant=self.plant)
+
+    def post_outcome(self, plant_pk, outcome, payload=None):
+        """Post one named outcome action for a plant."""
+        return self.client.post(
+            f'/plantings/specificplants/{plant_pk}/{outcome}/',
+            payload or {},
+            format='json',
+        )
+
+    def get_plant(self, plant_pk):
+        """Return one plant through its detail route."""
+        response = self.client.get(f'/plantings/specificplants/{plant_pk}/')
+        self.assertEqual(response.status_code, 200)
+        return response.data
+
+
+class PlantLifecycleContractTests(PlantLifecycleRESTTestCase):
+    """The event collections follow the shared read-only REST contract."""
+
+    @property
+    def list_urls(self):
+        """Return every lifecycle collection registered with the router."""
+        return (
+            '/plantings/lifecycle-events/',
+            f'/plantings/specificplants/{self.plant.pk}/lifecycle-events/',
+        )
+
+    def test_list_routes_require_authentication(self):
+        """Anonymous requests cannot list lifecycle history."""
+        self.assert_authentication_required(self.list_urls)
+
+    def test_list_routes_return_lists(self):
+        """Authenticated lifecycle collections use the common list contract."""
+        self.assert_list_contract(self.list_urls)
+
+    def test_events_cannot_be_written_directly(self):
+        """Facts arrive through named actions, never a generic create."""
+        response = self.client.post(
+            '/plantings/lifecycle-events/',
+            {
+                'plant': self.plant.pk,
+                'event_type': EventType.FAILED,
+                'occurred_at': timezone.now(),
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 405)
+
+    def test_events_cannot_be_updated_or_deleted(self):
+        """Recorded facts have no generic update or delete endpoint."""
+        event = PlantLifecycleEvent.objects.create(
+            plant=self.plant,
+            batch=self.tray_planting.batch,
+            event_type=EventType.GERMINATED,
+            occurred_at=self.plant.germinated,
+        )
+        url = f'/plantings/lifecycle-events/{event.pk}/'
+        self.assertEqual(self.client.patch(url, {}, format='json').status_code, 405)
+        self.assertEqual(self.client.delete(url).status_code, 405)
+
+    def test_events_can_be_filtered(self):
+        """The screens can narrow history by plant, batch, and type."""
+        self.post_outcome(self.plant.pk, 'ready')
+        other = make_specific_plant()
+        response = self.client.get(
+            f'/plantings/lifecycle-events/?plant={self.plant.pk}'
+            f'&event_type={EventType.READY}',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['plant'], self.plant.pk)
+
+        response = self.client.get(f'/plantings/lifecycle-events/?plant={other.pk}')
+        self.assertEqual(response.data, [])
+
+    def test_an_invalid_filter_is_rejected(self):
+        """A malformed filter reports a field error instead of ignoring it."""
+        response = self.client.get('/plantings/lifecycle-events/?event_type=nonsense')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('event_type', response.data)
+
+
+class GerminationRecordsHistoryTests(PlantLifecycleRESTTestCase):
+    """Recording a germination starts the plant's lifecycle history."""
+
+    def test_creating_a_plant_records_its_germination(self):
+        """The existing germination action now also appends the fact."""
+        germinated = timezone.now()
+        response = self.client.post(
+            '/plantings/specificplants/',
+            {
+                'cell_planting': self.cell_planting.pk,
+                'germinated': germinated,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['lifecycle_state'], LifecycleState.GROWING)
+
+        events = PlantLifecycleEvent.objects.filter(plant_id=response.data['pk'])
+        self.assertEqual(events.count(), 1)
+        event = events.get()
+        self.assertEqual(event.event_type, EventType.GERMINATED)
+        self.assertEqual(event.occurred_at, germinated)
+        self.assertEqual(event.batch_id, self.tray_planting.batch_id)
+        self.assertEqual(event.created_by_id, self.user.pk)
+
+    def test_moving_a_plant_out_records_a_transplant(self):
+        """A move into a garden square is also a planting out."""
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            {
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': make_garden_square().pk,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertTrue(
+            PlantLifecycleEvent.objects.filter(
+                plant=self.plant,
+                event_type=EventType.TRANSPLANTED,
+            ).exists(),
+        )
+
+    def test_moving_between_cells_records_no_transplant(self):
+        """Rearranging a tray is not a planting out."""
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            {
+                'location_type': SpecificPlantLocation.SEED_TRAY_CELL,
+                'seed_tray_cell': make_seed_tray_cell(tray=self.tray, x_position=1).pk,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertFalse(
+            PlantLifecycleEvent.objects.filter(
+                plant=self.plant,
+                event_type=EventType.TRANSPLANTED,
+            ).exists(),
+        )
+
+    def test_a_resolved_plant_cannot_be_moved(self):
+        """A culled plant is not planted out afterwards."""
+        self.post_outcome(self.plant.pk, 'cull')
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/move/',
+            {
+                'location_type': SpecificPlantLocation.GARDEN_SQUARE,
+                'garden_square': make_garden_square().pk,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class PlantOutcomeActionTests(PlantLifecycleRESTTestCase):
+    """Each explicit outcome action appends one auditable event."""
+
+    def test_every_outcome_action_records_its_event(self):
+        """The named actions cover the recordable dispositions."""
+        actions = {
+            'ready': EventType.READY,
+            'retain': EventType.RETAINED,
+            'fail': EventType.FAILED,
+            'cull': EventType.CULLED,
+            'donate': EventType.DONATED,
+            'finish-harvest': EventType.HARVEST_FINISHED,
+        }
+        for outcome, event_type in actions.items():
+            with self.subTest(outcome=outcome):
+                plant = make_specific_plant()
+                response = self.post_outcome(
+                    plant.pk,
+                    outcome,
+                    {'reason': 'Recorded by test.'},
+                )
+                self.assertEqual(response.status_code, 201, response.data)
+                self.assertEqual(response.data['event_type'], event_type)
+                self.assertEqual(response.data['plant'], plant.pk)
+                self.assertEqual(response.data['reason'], 'Recorded by test.')
+
+    def test_a_plant_reports_its_derived_state(self):
+        """Derived state travels with the plant, not as a stored field."""
+        self.post_outcome(self.plant.pk, 'ready')
+        data = self.get_plant(self.plant.pk)
+        self.assertEqual(data['lifecycle_state'], LifecycleState.AVAILABLE)
+        self.assertTrue(data['sellable'])
+        self.assertIsNone(data['final_outcome'])
+
+        self.post_outcome(self.plant.pk, 'retain')
+        data = self.get_plant(self.plant.pk)
+        self.assertEqual(data['lifecycle_state'], LifecycleState.RETAINED)
+        self.assertFalse(data['sellable'])
+        self.assertEqual(data['final_outcome'], EventType.RETAINED)
+        self.assertIsNotNone(data['final_outcome_at'])
+
+    def test_a_plant_detail_lists_its_history_in_order(self):
+        """The detail view carries the chronological lifecycle history."""
+        self.post_outcome(self.plant.pk, 'ready')
+        self.post_outcome(self.plant.pk, 'cull')
+        data = self.get_plant(self.plant.pk)
+        self.assertEqual(
+            [event['event_type'] for event in data['lifecycle_events']],
+            [EventType.READY, EventType.CULLED],
+        )
+
+    def test_an_invalid_transition_returns_a_field_error(self):
+        """A rejected outcome explains itself without changing anything."""
+        self.post_outcome(self.plant.pk, 'fail')
+        response = self.post_outcome(self.plant.pk, 'ready')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('event_type', response.data)
+
+    def test_an_invalid_transition_leaves_the_location_alone(self):
+        """A refused outcome never partially closes a location."""
+        self.post_outcome(self.plant.pk, 'retain')
+        response = self.post_outcome(self.plant.pk, 'ready')
+        self.assertEqual(response.status_code, 400)
+        self.location.refresh_from_db()
+        self.assertIsNone(self.location.ended)
+
+    def test_a_final_outcome_closes_the_active_location(self):
+        """Leaving the operation ends the plant's occupancy in one step."""
+        occurred_at = timezone.now()
+        response = self.post_outcome(
+            self.plant.pk,
+            'donate',
+            {'occurred_at': occurred_at},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.location.refresh_from_db()
+        self.assertEqual(self.location.ended, occurred_at)
+
+
+class PlantEventReversalActionTests(PlantLifecycleRESTTestCase):
+    """A mistaken fact is corrected by appending its reversal."""
+
+    def test_a_failure_can_be_reversed(self):
+        """The original stays visible and the state recovers."""
+        failure = self.post_outcome(self.plant.pk, 'fail').data
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/reverse-event/',
+            {'event': failure['pk'], 'reason': 'Recorded against the wrong plant.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['event_type'], EventType.CORRECTED)
+        self.assertEqual(response.data['reversal_of'], failure['pk'])
+
+        data = self.get_plant(self.plant.pk)
+        self.assertEqual(data['lifecycle_state'], LifecycleState.GROWING)
+        self.assertIsNone(data['final_outcome'])
+        history = {event['pk']: event for event in data['lifecycle_events']}
+        self.assertIn(failure['pk'], history)
+        self.assertEqual(history[failure['pk']]['reversed_by'], response.data['pk'])
+
+    def test_a_reversal_requires_a_reason(self):
+        """Audited corrections always say why they were needed."""
+        failure = self.post_outcome(self.plant.pk, 'fail').data
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/reverse-event/',
+            {'event': failure['pk'], 'reason': ''},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('reason', response.data)
+
+    def test_an_event_from_another_plant_cannot_be_reversed(self):
+        """A correction only ever names one of its own plant's facts."""
+        other = make_specific_plant()
+        failure = self.post_outcome(other.pk, 'fail').data
+        response = self.client.post(
+            f'/plantings/specificplants/{self.plant.pk}/reverse-event/',
+            {'event': failure['pk'], 'reason': 'Wrong plant.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 404)
+
+
+class BulkPlantOutcomeActionTests(PlantLifecycleRESTTestCase):
+    """A selected list of plants yields one event per plant."""
+
+    def setUp(self):
+        super().setUp()
+        self.others = [make_specific_plant() for _ in range(2)]
+        self.plant_ids = [self.plant.pk] + [plant.pk for plant in self.others]
+
+    def _post_bulk(self, payload):
+        """Post one bulk outcome request."""
+        return self.client.post(
+            '/plantings/specificplants/bulk-outcome/',
+            payload,
+            format='json',
+        )
+
+    def test_each_selected_plant_gets_its_own_event(self):
+        """The aggregate action stays traceable plant by plant."""
+        response = self._post_bulk({
+            'plants': self.plant_ids,
+            'event_type': EventType.CULLED,
+            'reason': 'Cleared the bench.',
+        })
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(len(response.data), len(self.plant_ids))
+        self.assertEqual(
+            sorted(event['plant'] for event in response.data),
+            sorted(self.plant_ids),
+        )
+        for event in response.data:
+            self.assertEqual(event['event_type'], EventType.CULLED)
+
+    def test_an_invalid_member_rejects_the_whole_selection(self):
+        """A partial application would leave an unexplainable audit trail."""
+        self.post_outcome(self.others[0].pk, 'fail')
+        response = self._post_bulk({
+            'plants': self.plant_ids,
+            'event_type': EventType.CULLED,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('plants', response.data)
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(
+                plant=self.plant,
+                event_type=EventType.CULLED,
+            ).count(),
+            0,
+        )
+
+    def test_an_unknown_plant_is_rejected(self):
+        """A selection naming a plant we cannot see records nothing."""
+        response = self._post_bulk({
+            'plants': self.plant_ids + [0],
+            'event_type': EventType.CULLED,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('plants', response.data)
+
+    def test_an_empty_selection_is_rejected(self):
+        """Recording an outcome for nothing is a mistake, not a no-op."""
+        response = self._post_bulk({
+            'plants': [],
+            'event_type': EventType.CULLED,
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_non_outcome_event_type_is_rejected(self):
+        """Germination and corrections are not bulk-recordable outcomes."""
+        response = self._post_bulk({
+            'plants': self.plant_ids,
+            'event_type': EventType.GERMINATED,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('event_type', response.data)

--- a/workspaces/test_isolation.py
+++ b/workspaces/test_isolation.py
@@ -10,6 +10,7 @@ from plantings.models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
     GardenSquareTransplant,
+    PlantLifecycleEvent,
     ProductionBatch,
     SeedTrayCellPlanting,
     SeedTrayPlanting,
@@ -156,6 +157,13 @@ class ResourceIsolationTests(APITestCase):
             location_type=SpecificPlantLocation.SEED_TRAY_CELL,
             seed_tray_cell=self.cell,
         )
+        self.lifecycle_event = PlantLifecycleEvent.objects.create(
+            workspace=self.other,
+            plant=self.specific_plant,
+            batch=self.batch,
+            event_type=PlantLifecycleEvent.EventType.GERMINATED,
+            occurred_at=self.specific_plant.germinated,
+        )
         self.transplant = GardenSquareTransplant.objects.create(
             workspace=self.other,
             original_planting=self.tray_sowing,
@@ -298,6 +306,7 @@ class ResourceIsolationTests(APITestCase):
             ('/plantings/transplantedgardensquare/', self.transplant.pk),
             ('/plantings/specificplants/', self.specific_plant.pk),
             ('/plantings/specificplantlocations/', self.location.pk),
+            ('/plantings/lifecycle-events/', self.lifecycle_event.pk),
         )
         for url, record_pk in resources:
             with self.subTest(url=url):
@@ -311,6 +320,7 @@ class ResourceIsolationTests(APITestCase):
             f'/plantings/seedtray-data/{self.tray.pk}/plantings/',
             f'/plantings/seedtray-data/{self.tray.pk}/specificplants/',
             f'/plantings/specificplants/{self.specific_plant.pk}/locations/',
+            f'/plantings/specificplants/{self.specific_plant.pk}/lifecycle-events/',
         )
         for url in nested_urls:
             with self.subTest(url=url):
@@ -404,6 +414,12 @@ class ResourceIsolationTests(APITestCase):
             (
                 f'/plantings/specificplantlocations/{self.location.pk}/end/',
                 {},
+            ),
+            (f'/plantings/specificplants/{self.specific_plant.pk}/ready/', {}),
+            (f'/plantings/specificplants/{self.specific_plant.pk}/fail/', {}),
+            (
+                f'/plantings/specificplants/{self.specific_plant.pk}/reverse-event/',
+                {'event': self.lifecycle_event.pk, 'reason': 'Wrong plant.'},
             ),
         )
         for url, payload in requests:


### PR DESCRIPTION
Events are facts, so the collections are read-only and every change arrives through a named action that appends one auditable row: ready, retain, fail, cull, donate, finish-harvest, reverse-event, and a bulk outcome that creates and returns one event per selected plant rather than one aggregate record.

Germination and planting out now append their facts from the existing germination and move actions, inside the transactions that already hold the locks they depend on. Specific plants report their derived lifecycle state, sellable state, and final-outcome metadata, with the full history on detail.

## Summary by Sourcery

Introduce explicit, auditable plant lifecycle events and expose lifecycle state and history through the plantings API.

New Features:
- Expose read-only lifecycle event collections at top level and per plant, with filtering by plant, batch, and event type.
- Add explicit outcome actions on plants (ready, retain, fail, cull, donate, finish-harvest, reverse-event, and bulk-outcome) that append lifecycle events and derive plant state metadata.
- Include derived lifecycle state, sellable flag, final outcome, and lifecycle history in SpecificPlant API responses.

Enhancements:
- Record germination and transplant events automatically when plants are created or planted out, keeping event recording within existing transactions.
- Enforce workspace scoping and validation for lifecycle operations, including bulk outcomes and reversals, and extend REST contract tests to cover the new resources and actions.

Tests:
- Add a dedicated test suite for lifecycle REST endpoints and actions, and extend workspace isolation tests to cover lifecycle event routes and mutations.