### PR TITLE
feat(plantings): resolve batch completion from recorded plant outcomes

### DIFF
--- a/plantings/batch_rest.py
+++ b/plantings/batch_rest.py
@@ -20,6 +20,8 @@ from .batches import (
     BatchRequest,
     SOWING_MODELS,
     activate_batch,
+    batch_final_outcome_count,
+    batch_lifecycle_counts,
     batch_plants_with_active_location,
     batch_seeds_sown,
     batch_specific_plants,
@@ -257,9 +259,9 @@ class ProductionBatchSerializer(
         """Return the plants currently occupying a tracked location."""
         return batch_plants_with_active_location(batch).count()
 
-    def get_final_outcomes(self, batch):  # pylint: disable=unused-argument
-        """Return recorded final dispositions, which task 41 will supply."""
-        return 0
+    def get_final_outcomes(self, batch):
+        """Return how many plants have a recorded final disposition."""
+        return batch_final_outcome_count(batch)
 
     def get_unresolved_plants(self, batch):
         """Return the plants blocking completion of this batch."""
@@ -325,18 +327,24 @@ class ProductionBatchDetailSerializer(ProductionBatchSerializer):
 
     sowings = serializers.SerializerMethodField()
     current_locations = serializers.SerializerMethodField()
+    lifecycle_counts = serializers.SerializerMethodField()
     transitions = ProductionBatchTransitionSerializer(many=True, read_only=True)
 
     class Meta(ProductionBatchSerializer.Meta):
         fields = ProductionBatchSerializer.Meta.fields + [
             'sowings',
             'current_locations',
+            'lifecycle_counts',
             'transitions',
         ]
 
     def get_sowings(self, batch):
         """Return each attached sowing with its lot, cells, and germinations."""
         return BatchSowingSerializer(_batch_sowings(batch), many=True).data
+
+    def get_lifecycle_counts(self, batch):
+        """Return how many of this batch's plants sit in each derived state."""
+        return batch_lifecycle_counts(batch)
 
     def get_current_locations(self, batch):
         """Return where this batch's individual plants are living now."""

--- a/plantings/batches.py
+++ b/plantings/batches.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.db.models import Exists, OuterRef, Sum
 from django.utils import timezone
 
+from .lifecycle import LifecycleState, is_final, lifecycle_summaries
 from .models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
@@ -100,14 +101,41 @@ def batch_plants_with_active_location(batch):
     return batch_specific_plants(batch).filter(Exists(open_location))
 
 
-def batch_unresolved_plant_ids(batch):
-    """Return plants without a final disposition, newest task 41 pending.
+def _batch_lifecycle_summaries(batch):
+    """Return the derived lifecycle summary of every plant in this batch."""
+    return lifecycle_summaries(
+        batch_specific_plants(batch).order_by('pk').values_list('pk', flat=True),
+    )
 
-    Until lifecycle outcomes exist, an observed plant is always unresolved:
-    an ended location records where a plant stopped being, not what became
-    of it.
+
+def batch_unresolved_plant_ids(batch):
+    """Return the plants whose lifecycle has recorded no final outcome.
+
+    An ended location records where a plant stopped being, not what became of
+    it, so resolution comes from the lifecycle history alone.
     """
-    return list(batch_specific_plants(batch).order_by('pk').values_list('pk', flat=True))
+    return sorted(
+        plant_id
+        for plant_id, summary in _batch_lifecycle_summaries(batch).items()
+        if not is_final(summary.state)
+    )
+
+
+def batch_final_outcome_count(batch):
+    """Return how many of this batch's plants have a recorded final outcome."""
+    return sum(
+        1
+        for summary in _batch_lifecycle_summaries(batch).values()
+        if is_final(summary.state)
+    )
+
+
+def batch_lifecycle_counts(batch):
+    """Return how many of this batch's plants sit in each derived state."""
+    counts = {state.value: 0 for state in LifecycleState}
+    for summary in _batch_lifecycle_summaries(batch).values():
+        counts[summary.state] += 1
+    return counts
 
 
 def _record_transition(batch, previous_status, user, reason=''):

--- a/plantings/test_batches.py
+++ b/plantings/test_batches.py
@@ -23,6 +23,8 @@ from workspaces.models import Workspace, get_current_workspace
 from .batches import (
     BatchRequest,
     activate_batch,
+    batch_final_outcome_count,
+    batch_lifecycle_counts,
     batch_plants_with_active_location,
     batch_seeds_sown,
     batch_unresolved_plant_ids,
@@ -33,6 +35,12 @@ from .batches import (
     finalize_batch_output,
     reopen_batch,
     validate_batch_for_sowing,
+)
+from .lifecycle import (
+    EventType,
+    OutcomeRequest,
+    record_lifecycle_event,
+    reverse_lifecycle_event,
 )
 from .models import ProductionBatch
 
@@ -330,6 +338,69 @@ class BatchLifecycleTests(TestCase):
             self.packet,
             self.workspace,
         )
+
+
+class BatchPlantResolutionTests(TestCase):
+    """Batch completion follows the plants' recorded lifecycle outcomes."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username='resolver')
+        self.packet = make_seed_packet()
+
+    def _finalized_batch_with_plants(self, count):
+        """Return an output-finalized batch and the plants it raised."""
+        batch = make_batch_for_packet(self.packet)
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            batch=batch,
+            removed=True,
+        )
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        plants = [
+            make_specific_plant(cell_planting=cell_planting)
+            for _ in range(count)
+        ]
+        finalize_batch_output(batch, self.user)
+        return batch, plants
+
+    def test_recorded_outcomes_resolve_plants_and_unblock_completion(self):
+        """Every recorded final outcome clears one plant from the blockers."""
+        batch, (failed, retained) = self._finalized_batch_with_plants(2)
+
+        record_lifecycle_event(failed, self.user, OutcomeRequest(EventType.FAILED))
+        self.assertEqual(batch_unresolved_plant_ids(batch), [retained.pk])
+        self.assertEqual(batch_final_outcome_count(batch), 1)
+
+        record_lifecycle_event(retained, self.user, OutcomeRequest(EventType.RETAINED))
+        self.assertEqual(batch_unresolved_plant_ids(batch), [])
+        self.assertEqual(batch_final_outcome_count(batch), 2)
+        self.assertEqual(
+            batch_lifecycle_counts(batch),
+            {
+                'growing': 0,
+                'available': 0,
+                'retained': 1,
+                'donated': 0,
+                'failed': 1,
+                'culled': 0,
+                'harvested': 0,
+            },
+        )
+
+        completed = complete_batch(batch, self.user)
+        self.assertEqual(completed.status, ProductionBatch.Status.COMPLETED)
+
+    def test_a_reversed_outcome_blocks_completion_again(self):
+        """Correcting a mistaken failure returns the plant to the blockers."""
+        batch, (plant,) = self._finalized_batch_with_plants(1)
+
+        failure = record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.FAILED))
+        self.assertEqual(batch_unresolved_plant_ids(batch), [])
+
+        reverse_lifecycle_event(failure, self.user, 'Recorded against the wrong plant.')
+        self.assertEqual(batch_unresolved_plant_ids(batch), [plant.pk])
+        with self.assertRaisesMessage(ValidationError, '1 observed plants'):
+            complete_batch(batch, self.user)
 
 
 @skipUnlessDBFeature('has_select_for_update')


### PR DESCRIPTION
`batch_unresolved_plant_ids` treated every observed plant as unresolved and `final_outcomes` was hardcoded to zero, both waiting on this task, so no batch that raised a plant could ever complete. Both now read the lifecycle history, and the batch detail reports how many plants sit in each state.

Reversing a mistaken outcome returns its plant to the blockers, so a correction cannot leave a batch completed on evidence that was withdrawn.

## Summary by Sourcery

Update batch completion logic to resolve plants based on recorded lifecycle outcomes and surface lifecycle state counts in batch details.

New Features:
- Expose lifecycle-derived state counts for batch plants via the batch detail serializer.

Bug Fixes:
- Ensure unresolved plants and batch completion are driven by plants’ recorded lifecycle outcomes instead of treating all observed plants as unresolved.
- Prevent batches from remaining completed when a previously recorded final outcome is reversed, returning the plant to the unresolved blockers.

Enhancements:
- Add helpers to derive unresolved plant IDs, final outcome counts, and lifecycle state distributions from lifecycle summaries for batch plants.

Tests:
- Add tests validating batch completion and unresolved plant behaviour based on lifecycle outcomes, including reversing mistaken outcomes.