### PR TITLE
fix(plantings): read the article before a vowel-initial state

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -217,12 +217,18 @@ def _require_reason(reason):
         raise ValidationError({'reason': 'A reason is required.'})
 
 
+def _article_for(word):
+    """Return the indefinite article that reads correctly before a word."""
+    return 'An' if word[:1].lower() in 'aeiou' else 'A'
+
+
 def _require_transition(state, event_type):
     """Reject a fact that the plant's current condition does not permit."""
     if state not in ALLOWED_FROM.get(event_type, set()):
+        described = LifecycleState(state).label.lower()
         raise ValidationError({
             'event_type': (
-                f'A {LifecycleState(state).label.lower()} plant cannot be '
+                f'{_article_for(described)} {described} plant cannot be '
                 f'recorded as {EventType(event_type).label.lower()}.'
             ),
         })

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -142,6 +142,16 @@ class LifecycleTransitionTests(TestCase):
                     event_type,
                 )
 
+    def test_a_rejection_names_the_state_it_came_from(self):
+        """The message reads as a sentence for a vowel-initial state too."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        self.assertEqual(
+            caught.exception.message_dict['event_type'],
+            ['An available plant cannot be recorded as ready for sale or use.'],
+        )
+
     def test_a_retained_plant_cannot_be_marked_ready(self):
         """Retention is final for availability."""
         record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.RETAINED))


### PR DESCRIPTION
A rejected transition from the available state read "A available plant cannot be recorded as ...".

## Summary by Sourcery

Handle lifecycle rejection messages correctly for vowel-initial states so they read as grammatically correct sentences.

Bug Fixes:
- Fix lifecycle rejection message to choose the correct indefinite article for vowel-initial lifecycle states.

Tests:
- Add a regression test asserting the rejection message uses the correct article for an 'available' plant state.