### PR TITLE
feat(frontend): show plant lifecycle state, history, and outcomes

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -1,6 +1,11 @@
 import { fetchAsJson, csrfPatch, csrfPost } from '../utils'
 import {
   BatchAction,
+  BulkPlantOutcome,
+  PlantLifecycleEvent,
+  PlantOutcome,
+  PlantOutcomeAction,
+  ReversePlantEvent,
   ProductionBatch,
   ProductionBatchCreate,
   ProductionBatchDetail,
@@ -17,6 +22,7 @@ import {
   SeedTrayPlantingDetails,
   SpecificPlant,
   SpecificPlantCreate,
+  SpecificPlantDetail,
   SpecificPlantLocationCreate,
   SpecificPlantMove,
   SowingCorrection
@@ -149,6 +155,26 @@ function moveSpecificPlant(plantPk: number, data: SpecificPlantMove): Promise<Re
   return csrfPost(`/plantings/specificplants/${plantPk}/move/`, data)
 }
 
+function getSpecificPlant(plantPk: number, signal?: AbortSignal): Promise<SpecificPlantDetail> {
+  return fetchAsJson<SpecificPlantDetail>(`/plantings/specificplants/${plantPk}/`, signal)
+}
+
+function getSpecificPlantLifecycleEvents(plantPk: number, signal?: AbortSignal): Promise<Array<PlantLifecycleEvent>> {
+  return fetchAsJson<Array<PlantLifecycleEvent>>(`/plantings/specificplants/${plantPk}/lifecycle-events/`, signal)
+}
+
+function postSpecificPlantOutcome(plantPk: number, outcome: PlantOutcomeAction, data: PlantOutcome = {}): Promise<PlantLifecycleEvent> {
+  return csrfPost(`/plantings/specificplants/${plantPk}/${outcome}/`, data).then((response) => response.json() as Promise<PlantLifecycleEvent>)
+}
+
+function reverseSpecificPlantEvent(plantPk: number, data: ReversePlantEvent): Promise<PlantLifecycleEvent> {
+  return csrfPost(`/plantings/specificplants/${plantPk}/reverse-event/`, data).then((response) => response.json() as Promise<PlantLifecycleEvent>)
+}
+
+function postBulkPlantOutcome(data: BulkPlantOutcome): Promise<Array<PlantLifecycleEvent>> {
+  return csrfPost('/plantings/specificplants/bulk-outcome/', data).then((response) => response.json() as Promise<Array<PlantLifecycleEvent>>)
+}
+
 export {
   ProductionBatchFilters,
   getProductionBatches,
@@ -175,5 +201,10 @@ export {
   addSpecificPlant,
   addSpecificPlantLocation,
   endSpecificPlantLocation,
-  moveSpecificPlant
+  moveSpecificPlant,
+  getSpecificPlant,
+  getSpecificPlantLifecycleEvents,
+  postSpecificPlantOutcome,
+  reverseSpecificPlantEvent,
+  postBulkPlantOutcome
 }

--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -26,7 +26,7 @@ import {
   completePlantingSeedTray,
   correctGardenSquareSowing,
   correctSeedTraySowing,
-  endSpecificPlantLocation
+  postSpecificPlantOutcome
 } from './api/plantings'
 import { getPlantVarieties } from './api/plants'
 import { getSeedPackets, getSeeds } from './api/seeds'
@@ -319,7 +319,7 @@ function SeedTrayPlantingRow({ planting, seedPackets, completePlanting, correctP
             Manage Plants
           </Link>
         )}
-        <Button onClick={() => completePlanting(planting.pk)}>Empty</Button>
+        <Button onClick={() => completePlanting(planting.pk)}>Close sowing</Button>
         <Button variant="outline-secondary" onClick={() => setCorrecting((current) => !current)}>
           Correct sowing
         </Button>
@@ -594,7 +594,7 @@ function GardenSquarePlantingRow({ planting, seedPackets, completePlanting, corr
       <td>{formatDateRange(planting.maturity_date_early, planting.maturity_date_late)}</td>
       <td>{planting.notes}</td>
       <td>
-        <Button onClick={() => completePlanting(planting)}>Harvested</Button>
+        <Button onClick={() => completePlanting(planting)}>{planting.specific_plant_pk ? 'Harvested' : 'Close sowing'}</Button>
         {directSowing && (
           <Button variant="outline-secondary" onClick={() => setCorrecting((current) => !current)}>
             Correct sowing
@@ -676,12 +676,14 @@ function GardenSquarePlantingTable() {
     mutationFn: ({ pk, data }: { pk: number; data: SowingCorrection }) => correctGardenSquareSowing(pk, data),
     onSuccess: invalidatePlantingsAndPackets
   })
-  const endLocationMutation = useMutation({
-    mutationFn: endSpecificPlantLocation,
+  const finishHarvestMutation = useMutation({
+    mutationFn: (plantPk: number) => postSpecificPlantOutcome(plantPk, 'finish-harvest'),
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.plantings.currentGardenSquares }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.specificPlantsAll })
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.specificPlantsAll }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.plantLifecycleAll }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.plantings.batchesAll })
       ])
   })
 
@@ -708,8 +710,10 @@ function GardenSquarePlantingTable() {
   }
 
   async function completePlanting(planting: GardenSquarePlanting) {
-    if (planting.specific_plant_pk && planting.transplanting_pk) {
-      await endLocationMutation.mutateAsync(planting.transplanting_pk)
+    if (planting.specific_plant_pk) {
+      // An individual plant records the outcome itself; the service closes its
+      // location in the same transaction.
+      await finishHarvestMutation.mutateAsync(planting.specific_plant_pk)
     } else if (planting.transplanted && planting.transplanting_pk) {
       await completeTransplantMutation.mutateAsync(planting.transplanting_pk)
     } else {

--- a/frontend/js/plantings/batches.tsx
+++ b/frontend/js/plantings/batches.tsx
@@ -7,7 +7,8 @@ import { addProductionBatch, getProductionBatch, getProductionBatches, postProdu
 import { getPlantVarieties } from '../api/plants'
 import { queryKeys } from '../query'
 import { formatDate, formatDateTime } from '../utils'
-import { ProductionBatch, ProductionBatchDetail, ProductionBatchStatus } from '../types/plantings'
+import { PlantLifecycleState, ProductionBatch, ProductionBatchDetail, ProductionBatchStatus } from '../types/plantings'
+import { STATE_LABELS } from './lifecycle'
 
 const STATUS_LABELS: Record<ProductionBatchStatus, string> = {
   planned: 'Planned',
@@ -376,6 +377,38 @@ function BatchSowings({ batch }: { batch: ProductionBatchDetail }) {
   )
 }
 
+function BatchLifecycleStates({ batch }: { batch: ProductionBatchDetail }) {
+  const states = Object.entries(batch.lifecycle_counts).filter(([, count]) => count > 0) as Array<[PlantLifecycleState, number]>
+
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Plant lifecycle states</Card.Title>
+        {states.length === 0 ? (
+          <p className="text-muted mb-0">No individual plants have been observed from this batch.</p>
+        ) : (
+          <Table size="sm">
+            <thead>
+              <tr>
+                <th>State</th>
+                <th>Plants</th>
+              </tr>
+            </thead>
+            <tbody>
+              {states.map(([state, count]) => (
+                <tr key={state}>
+                  <td>{STATE_LABELS[state]}</td>
+                  <td>{count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
+
 function BatchLocations({ batch }: { batch: ProductionBatchDetail }) {
   return (
     <Card className="mb-3">
@@ -537,6 +570,7 @@ function ProductionBatchDetailView({ batchPk }: ProductionBatchDetailViewProps) 
         <BatchActions batch={batch} />
         <BatchDetailsForm batch={batch} />
         <BatchSowings batch={batch} />
+        <BatchLifecycleStates batch={batch} />
         <BatchLocations batch={batch} />
         <BatchHistory batch={batch} />
       </div>

--- a/frontend/js/plantings/lifecycle.tsx
+++ b/frontend/js/plantings/lifecycle.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { Badge, Button, Table } from 'react-bootstrap'
+
+import { formatDateTime } from '../utils'
+import { PlantLifecycleEvent, PlantLifecycleEventType, PlantLifecycleState, PlantOutcomeAction, SpecificPlant } from '../types/plantings'
+
+const STATE_LABELS: Record<PlantLifecycleState, string> = {
+  growing: 'Growing',
+  available: 'Available',
+  retained: 'Retained',
+  donated: 'Donated',
+  failed: 'Failed',
+  culled: 'Culled',
+  harvested: 'Harvested'
+}
+
+const STATE_VARIANTS: Record<PlantLifecycleState, string> = {
+  growing: 'secondary',
+  available: 'success',
+  retained: 'primary',
+  donated: 'info',
+  failed: 'danger',
+  culled: 'dark',
+  harvested: 'primary'
+}
+
+const EVENT_LABELS: Record<PlantLifecycleEventType, string> = {
+  germinated: 'Germinated',
+  ready: 'Ready for sale or use',
+  transplanted: 'Planted out',
+  retained: 'Retained',
+  failed: 'Failed',
+  culled: 'Culled',
+  donated: 'Donated',
+  harvest_finished: 'Harvest finished',
+  corrected: 'Corrected'
+}
+
+// Actions offered on a plant that has not yet been resolved. `ready` is only
+// meaningful while a plant is still growing, so it is filtered out below.
+const OUTCOME_ACTIONS: Array<{ action: PlantOutcomeAction; label: string; variant: string }> = [
+  { action: 'ready', label: 'Ready', variant: 'outline-success' },
+  { action: 'retain', label: 'Retain', variant: 'outline-primary' },
+  { action: 'finish-harvest', label: 'Harvested', variant: 'outline-primary' },
+  { action: 'fail', label: 'Failed', variant: 'outline-danger' },
+  { action: 'cull', label: 'Cull', variant: 'outline-danger' },
+  { action: 'donate', label: 'Donate', variant: 'outline-info' }
+]
+
+function PlantLifecycleBadge({ plant }: { plant: SpecificPlant }) {
+  return <Badge bg={STATE_VARIANTS[plant.lifecycle_state]}>{STATE_LABELS[plant.lifecycle_state]}</Badge>
+}
+
+function availableActions(plant: SpecificPlant): Array<{ action: PlantOutcomeAction; label: string; variant: string }> {
+  if (plant.final_outcome !== null) {
+    // A retained plant is finished for availability but still growing, so it
+    // can still fail or be harvested out.
+    if (plant.lifecycle_state !== 'retained') {
+      return []
+    }
+    return OUTCOME_ACTIONS.filter((entry) => entry.action === 'fail' || entry.action === 'cull' || entry.action === 'finish-harvest')
+  }
+  if (plant.lifecycle_state === 'available') {
+    return OUTCOME_ACTIONS.filter((entry) => entry.action !== 'ready')
+  }
+  return OUTCOME_ACTIONS
+}
+
+interface PlantOutcomeButtonsProps {
+  plant: SpecificPlant
+  onOutcome: (plant: SpecificPlant, outcome: PlantOutcomeAction) => void
+  disabled?: boolean
+}
+
+function PlantOutcomeButtons({ plant, onOutcome, disabled }: PlantOutcomeButtonsProps) {
+  const actions = availableActions(plant)
+  if (actions.length === 0) {
+    return <span className="text-muted">Resolved</span>
+  }
+  return (
+    <div className="d-flex flex-wrap gap-1">
+      {actions.map((entry) => (
+        <Button key={entry.action} size="sm" variant={entry.variant} disabled={disabled} onClick={() => onOutcome(plant, entry.action)}>
+          {entry.label}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+interface PlantLifecycleHistoryProps {
+  events: Array<PlantLifecycleEvent>
+  onReverse?: (event: PlantLifecycleEvent) => void
+}
+
+function PlantLifecycleHistory({ events, onReverse }: PlantLifecycleHistoryProps) {
+  if (events.length === 0) {
+    return <p className="text-muted mb-0">No lifecycle history recorded.</p>
+  }
+  return (
+    <Table size="sm" className="mb-0">
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Event</th>
+          <th>Reason</th>
+          {onReverse && <th />}
+        </tr>
+      </thead>
+      <tbody>
+        {events.map((event) => (
+          <tr key={event.pk} className={event.reversed_by === null ? undefined : 'text-muted text-decoration-line-through'}>
+            <td>{formatDateTime(event.occurred_at)}</td>
+            <td>{EVENT_LABELS[event.event_type]}</td>
+            <td>{event.reason || '—'}</td>
+            {onReverse && (
+              <td>
+                {event.reversed_by === null && event.event_type !== 'germinated' && event.event_type !== 'corrected' && (
+                  <Button size="sm" variant="outline-secondary" onClick={() => onReverse(event)}>
+                    Correct
+                  </Button>
+                )}
+              </td>
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+export { EVENT_LABELS, STATE_LABELS, PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -58,7 +58,9 @@ const queryKeys = {
     currentSeedTrays: ['plantings', 'currentSeedTrays'] as const,
     currentGardenSquares: ['plantings', 'currentGardenSquares'] as const,
     specificPlantsAll: ['plantings', 'specificPlants'] as const,
-    specificPlants: (trayPk: number) => ['plantings', 'specificPlants', trayPk] as const
+    specificPlants: (trayPk: number) => ['plantings', 'specificPlants', trayPk] as const,
+    plantLifecycleAll: ['plantings', 'plantLifecycle'] as const,
+    plantLifecycle: (plantPk: number) => ['plantings', 'plantLifecycle', plantPk] as const
   }
 }
 

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -6,8 +6,17 @@ import { SeedTray, SeedTrayCell, SeedTrayModel } from '../types/seedtrays'
 import { localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime } from '../utils'
 import { getSeedTrayModels, getSeedTrays, getSeedTrayCells, getSerializedUnitMovements, postSerializedUnitAction } from '../api/seedtrays'
 import { Alert, Button, Card, Form, Table } from 'react-bootstrap'
-import { SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
-import { getPlantingSeedTray, getSpecificPlantsBySeedTray, addSpecificPlant, moveSpecificPlant } from '../api/plantings'
+import { PlantLifecycleEvent, PlantOutcomeAction, SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
+import {
+  getPlantingSeedTray,
+  getSpecificPlantsBySeedTray,
+  getSpecificPlantLifecycleEvents,
+  addSpecificPlant,
+  moveSpecificPlant,
+  postSpecificPlantOutcome,
+  reverseSpecificPlantEvent
+} from '../api/plantings'
+import { PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons } from '../plantings/lifecycle'
 import { ApiErrorAlert } from '../api_error_alert'
 import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
@@ -139,6 +148,9 @@ const SeedTrayCellView: React.FC<SeedTrayCellViewProps> = ({
               Plant #{plant.pk}
               {loc && <span style={{ color: '#555' }}> — {locationLabel(loc)}</span>}
             </div>
+            <div style={{ marginTop: 2 }}>
+              <PlantLifecycleBadge plant={plant} />
+            </div>
             <Button size="sm" variant="outline-primary" style={{ fontSize: '0.75em', padding: '1px 4px', marginTop: 2 }} onClick={() => onOpenMove(plant)}>
               Move
             </Button>
@@ -168,6 +180,56 @@ const SeedTrayCellView: React.FC<SeedTrayCellViewProps> = ({
           </Button>
         ))}
     </td>
+  )
+}
+
+type PlantLifecycleRowProps = {
+  plant: SpecificPlant
+  locationLabel: (loc: SpecificPlantLocation) => string
+  onOutcome: (plant: SpecificPlant, outcome: PlantOutcomeAction) => void
+  onReverse: (plant: SpecificPlant, event: PlantLifecycleEvent) => void
+  busy: boolean
+}
+
+const PlantLifecycleRow: React.FC<PlantLifecycleRowProps> = ({ plant, locationLabel, onOutcome, onReverse, busy }) => {
+  const [showHistory, setShowHistory] = React.useState(false)
+  const loc = currentLocation(plant)
+  const historyQuery = useQuery({
+    queryKey: queryKeys.plantings.plantLifecycle(plant.pk),
+    queryFn: ({ signal }) => getSpecificPlantLifecycleEvents(plant.pk, signal),
+    enabled: showHistory
+  })
+
+  return (
+    <>
+      <tr>
+        <td>#{plant.pk}</td>
+        <td>
+          <PlantLifecycleBadge plant={plant} />
+        </td>
+        <td>{loc ? locationLabel(loc) : '—'}</td>
+        <td>{plant.final_outcome_at ? formatDateTime(plant.final_outcome_at) : '—'}</td>
+        <td>
+          <PlantOutcomeButtons plant={plant} onOutcome={onOutcome} disabled={busy} />
+        </td>
+        <td>
+          <Button size="sm" variant="outline-secondary" onClick={() => setShowHistory((shown) => !shown)}>
+            {showHistory ? 'Hide history' : 'History'}
+          </Button>
+        </td>
+      </tr>
+      {showHistory && (
+        <tr>
+          <td colSpan={6}>
+            {historyQuery.isPending ? (
+              <span className="text-muted">Loading history…</span>
+            ) : (
+              <PlantLifecycleHistory events={historyQuery.data ?? []} onReverse={(event) => onReverse(plant, event)} />
+            )}
+          </td>
+        </tr>
+      )}
+    </>
   )
 }
 
@@ -399,6 +461,14 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
         cache.invalidateQueries({ queryKey: queryKeys.seeds.packets.all })
       ])
   })
+  const outcomeMutation = useMutation({
+    mutationFn: ({ plantPk, outcome }: { plantPk: number; outcome: PlantOutcomeAction }) => postSpecificPlantOutcome(plantPk, outcome),
+    onSuccess: (_event, variables) => invalidatePlantLifecycle(variables.plantPk)
+  })
+  const reverseMutation = useMutation({
+    mutationFn: ({ plantPk, event, reason }: { plantPk: number; event: number; reason: string }) => reverseSpecificPlantEvent(plantPk, { event, reason }),
+    onSuccess: (_event, variables) => invalidatePlantLifecycle(variables.plantPk)
+  })
   const inventoryMutation = useMutation({
     mutationFn: ({ unit, action, data }: { unit: number; action: InventoryAction; data: object }) => postSerializedUnitAction(unit, action, data),
     onSuccess: () =>
@@ -469,6 +539,26 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
       }
     })
     setMoveForm(undefined)
+  }
+
+  function invalidatePlantLifecycle(plantPk: number) {
+    return Promise.all([
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.plantLifecycle(plantPk) }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.specificPlantsAll }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.batchesAll }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.currentSeedTrays }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.currentGardenSquares })
+    ])
+  }
+
+  async function handleRecordOutcome(plant: SpecificPlant, outcome: PlantOutcomeAction) {
+    await outcomeMutation.mutateAsync({ plantPk: plant.pk, outcome })
+  }
+
+  async function handleReverseEvent(plant: SpecificPlant, event: PlantLifecycleEvent) {
+    const reason = globalThis.prompt('Why was this recorded in error?')
+    if (!reason || !reason.trim()) return
+    await reverseMutation.mutateAsync({ plantPk: plant.pk, event: event.pk, reason })
   }
 
   function openMoveForm(plant: SpecificPlant) {
@@ -705,6 +795,39 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
             ))}
         </tbody>
       </Table>
+      <Card className="mb-3">
+        <Card.Body>
+          <Card.Title>Plants</Card.Title>
+          {specificPlants.length === 0 ? (
+            <p className="text-muted mb-0">No germinations recorded for this tray yet.</p>
+          ) : (
+            <Table size="sm" responsive>
+              <thead>
+                <tr>
+                  <th>Plant</th>
+                  <th>State</th>
+                  <th>Location</th>
+                  <th>Resolved</th>
+                  <th>Record outcome</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {specificPlants.map((plant) => (
+                  <PlantLifecycleRow
+                    key={plant.pk}
+                    plant={plant}
+                    locationLabel={locationLabel}
+                    onOutcome={handleRecordOutcome}
+                    onReverse={handleReverseEvent}
+                    busy={outcomeMutation.isPending || reverseMutation.isPending}
+                  />
+                ))}
+              </tbody>
+            </Table>
+          )}
+        </Card.Body>
+      </Card>
       {germinatingCellPlantingPk && (
         <GerminationForm
           cellPlantingPk={germinatingCellPlantingPk}

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -95,6 +95,7 @@ interface ProductionBatchLocation {
 interface ProductionBatchDetail extends ProductionBatch {
   sowings: Array<ProductionBatchSowing>
   current_locations: Array<ProductionBatchLocation>
+  lifecycle_counts: Record<PlantLifecycleState, number>
   transitions: Array<ProductionBatchTransition>
 }
 
@@ -229,6 +230,43 @@ interface SpecificPlantMove {
   notes?: string
 }
 
+type PlantLifecycleEventType = 'germinated' | 'ready' | 'transplanted' | 'retained' | 'failed' | 'culled' | 'donated' | 'harvest_finished' | 'corrected'
+
+type PlantLifecycleState = 'growing' | 'available' | 'retained' | 'donated' | 'failed' | 'culled' | 'harvested'
+
+type PlantOutcomeAction = 'ready' | 'retain' | 'fail' | 'cull' | 'donate' | 'finish-harvest'
+
+interface PlantLifecycleEvent {
+  pk: number
+  plant: number
+  batch: number
+  event_type: PlantLifecycleEventType
+  occurred_at: string
+  reason: string
+  reference: string
+  created_by: number | null
+  reversal_of: number | null
+  reversed_by: number | null
+  created: string
+}
+
+interface PlantOutcome {
+  occurred_at?: string
+  reason?: string
+  reference?: string
+}
+
+interface BulkPlantOutcome extends PlantOutcome {
+  plants: Array<number>
+  event_type: PlantLifecycleEventType
+}
+
+interface ReversePlantEvent {
+  event: number
+  reason: string
+  occurred_at?: string
+}
+
 interface SpecificPlant {
   pk: number
   cell_planting: number
@@ -236,6 +274,14 @@ interface SpecificPlant {
   germinated: string
   notes?: string
   locations: Array<SpecificPlantLocation>
+  lifecycle_state: PlantLifecycleState
+  sellable: boolean
+  final_outcome: PlantLifecycleEventType | null
+  final_outcome_at: string | null
+}
+
+interface SpecificPlantDetail extends SpecificPlant {
+  lifecycle_events: Array<PlantLifecycleEvent>
 }
 
 interface SpecificPlantCreate {
@@ -252,6 +298,13 @@ interface SowingCorrection {
 
 export {
   BatchAction,
+  BulkPlantOutcome,
+  PlantLifecycleEvent,
+  PlantLifecycleEventType,
+  PlantLifecycleState,
+  PlantOutcome,
+  PlantOutcomeAction,
+  ReversePlantEvent,
   NewBatchInline,
   Planting,
   ProductionBatch,
@@ -275,6 +328,7 @@ export {
   SeedTrayPlantingCreate,
   SpecificPlant,
   SpecificPlantCreate,
+  SpecificPlantDetail,
   SpecificPlantLocation,
   SpecificPlantLocationCreate,
   SpecificPlantMove,


### PR DESCRIPTION
Add the shared lifecycle badge, history table, and outcome buttons, and use them on the tray and garden screens so an operator can record what became of a plant instead of only ending its location. The batch detail gains the breakdown of how many plants sit in each state.

The garden square's per-plant "Harvested" button ended the plant's location without recording an outcome; it now posts the harvest itself, and the service closes the location in the same transaction. The sowing-level buttons say "Close sowing", because closing a planting activity says nothing about what became of the plants it raised.

## Summary by Sourcery

Add plant lifecycle tracking to frontend screens so operators can view per-plant state/history and record outcomes directly from seed tray and garden views, with batch-level lifecycle breakdowns.

New Features:
- Display per-plant lifecycle state badges on seed tray cells and in a new plants table on the seed tray details screen.
- Provide per-plant lifecycle history view with reversible events and outcome action buttons (ready, retain, donate, fail, cull, harvest finished).
- Expose batch-level counts of plants by lifecycle state on the production batch detail screen.

Enhancements:
- Update garden square sowing controls so individual plants record harvest outcomes directly while the service closes their locations, and sowing-level actions are labelled as closing sowings rather than harvesting.
- Extend planting APIs and query keys to support lifecycle events, outcomes, reversals, and bulk outcome operations.