### PR TITLE
feat(plantings): add the harvest record

### DIFF
--- a/plantings/migrations/0024_harvest.py
+++ b/plantings/migrations/0024_harvest.py
@@ -1,0 +1,266 @@
+"""Add the harvest record and its attribution to individual plants.
+
+There is deliberately no data migration. `removed=True` on a planting records
+that it stopped being tracked and carries no quantity, unit, or date, so it
+cannot say whether the crop was harvested, failed, or simply pulled out.
+Inventing harvests from it would fabricate yield history. Every existing
+planting already carries a production batch from the task 40 backfill, so
+historical crops become harvestable by hand as soon as this ships.
+"""
+
+import django.core.validators
+import django.db.models.deletion
+import django.utils.timezone
+import workspaces.models
+from decimal import Decimal
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("garden", "0005_workspace_ownership"),
+        ("plantings", "0023_backfill_plant_lifecycle_events"),
+        ("workspaces", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Harvest",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("harvested_at", models.DateTimeField()),
+                (
+                    "quantity",
+                    models.DecimalField(
+                        decimal_places=9,
+                        max_digits=24,
+                        validators=[
+                            django.core.validators.MinValueValidator(Decimal("1E-9"))
+                        ],
+                    ),
+                ),
+                (
+                    "unit_code",
+                    models.CharField(
+                        choices=[
+                            ("each", "Each"),
+                            ("g", "Gram"),
+                            ("kg", "Kilogram"),
+                            ("ml", "Millilitre"),
+                            ("l", "Litre"),
+                        ],
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "quality_rating",
+                    models.PositiveSmallIntegerField(
+                        blank=True,
+                        null=True,
+                        validators=[
+                            django.core.validators.MinValueValidator(1),
+                            django.core.validators.MaxValueValidator(5),
+                        ],
+                    ),
+                ),
+                (
+                    "grade",
+                    models.CharField(
+                        choices=[
+                            ("ungraded", "Ungraded"),
+                            ("premium", "Premium"),
+                            ("standard", "Standard"),
+                            ("seconds", "Seconds"),
+                        ],
+                        default="ungraded",
+                        max_length=16,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True, default="")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[("posted", "Posted"), ("reversed", "Reversed")],
+                        default="posted",
+                        editable=False,
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "posted_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, editable=False
+                    ),
+                ),
+                (
+                    "reversed_at",
+                    models.DateTimeField(blank=True, editable=False, null=True),
+                ),
+                (
+                    "reverse_reason",
+                    models.TextField(blank=True, default="", editable=False),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                (
+                    "batch",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="harvests",
+                        to="plantings.productionbatch",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        editable=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "garden_row",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="harvests",
+                        to="garden.gardenrow",
+                    ),
+                ),
+                (
+                    "garden_square",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="harvests",
+                        to="garden.gardensquare",
+                    ),
+                ),
+                (
+                    "reversed_by",
+                    models.ForeignKey(
+                        editable=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        default=workspaces.models.get_default_workspace_id,
+                        editable=False,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="workspaces.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-harvested_at", "-pk"],
+            },
+        ),
+        migrations.CreateModel(
+            name="HarvestPlant",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                (
+                    "harvest",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="plant_allocations",
+                        to="plantings.harvest",
+                    ),
+                ),
+                (
+                    "plant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="harvest_allocations",
+                        to="plantings.specificplant",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["harvest", "plant"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="harvest",
+            index=models.Index(
+                fields=["batch", "harvested_at"], name="harvest_batch_period_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="harvest",
+            index=models.Index(
+                fields=["workspace", "harvested_at"], name="harvest_period_idx"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="harvest",
+            constraint=models.CheckConstraint(
+                condition=models.Q(("quantity__gt", 0)),
+                name="harvest_quantity_positive",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="harvest",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(("garden_square__isnull", True)),
+                    models.Q(("garden_row__isnull", True)),
+                    _connector="OR",
+                ),
+                name="harvest_single_location",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="harvest",
+            constraint=models.CheckConstraint(
+                condition=models.Q(("unit_code__in", ["each", "g", "kg", "ml", "l"])),
+                name="harvest_allowed_unit",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="harvest",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(("reversed_at__isnull", True), ("status", "posted")),
+                    models.Q(("reversed_at__isnull", False), ("status", "reversed")),
+                    _connector="OR",
+                ),
+                name="harvest_reversal_stamp",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="harvestplant",
+            constraint=models.UniqueConstraint(
+                fields=("harvest", "plant"), name="harvest_plant_unique"
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -4,11 +4,17 @@ Models for Plantings
 # pylint: disable=duplicate-code
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.validators import MinValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils import timezone
 
-from inventory.models import StockMovement
+from inventory.models import (
+    POSITIVE_DECIMAL,
+    QUANTITY_DECIMAL_PLACES,
+    QUANTITY_MAX_DIGITS,
+    StockMovement,
+)
+from inventory.units import UnitCode
 from plants.models import PlantVariety
 from seeds.models import SeedPacket
 from seedtrays.models import SeedTray, SeedTrayCell
@@ -506,6 +512,228 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
 
     def delete(self, *args, **kwargs):
         raise ValidationError('Plant lifecycle events cannot be deleted.')
+
+
+#: The measurement units a crop yield may be recorded in. Seed units describe
+#: what went in rather than what came out, and an area is not a yield, so
+#: neither appears here.
+HARVEST_UNIT_CODES = (
+    UnitCode.EACH,
+    UnitCode.GRAM,
+    UnitCode.KILOGRAM,
+    UnitCode.MILLILITRE,
+    UnitCode.LITRE,
+)
+
+HARVEST_UNIT_CHOICES = [(code.value, code.label) for code in HARVEST_UNIT_CODES]
+
+
+class Harvest(WorkspaceOwnedModel):
+    """One measured crop yield taken from a production batch.
+
+    A harvest is an observation rather than a document assembled from lines, so
+    it is posted the moment it is recorded. A mistake is corrected by reversing
+    the record, which keeps it visible while excluding it from every total.
+    """
+
+    class Status(models.TextChoices):
+        """Whether this harvest still counts towards yield."""
+
+        POSTED = 'posted', 'Posted'
+        REVERSED = 'reversed', 'Reversed'
+
+    class Grade(models.TextChoices):
+        """The saleable class an operator assigned to this yield."""
+
+        UNGRADED = 'ungraded', 'Ungraded'
+        PREMIUM = 'premium', 'Premium'
+        STANDARD = 'standard', 'Standard'
+        SECONDS = 'seconds', 'Seconds'
+
+    batch = models.ForeignKey(
+        ProductionBatch,
+        on_delete=models.PROTECT,
+        related_name='harvests',
+    )
+    harvested_at = models.DateTimeField()
+    quantity = models.DecimalField(
+        max_digits=QUANTITY_MAX_DIGITS,
+        decimal_places=QUANTITY_DECIMAL_PLACES,
+        validators=[MinValueValidator(POSITIVE_DECIMAL)],
+    )
+    unit_code = models.CharField(max_length=16, choices=HARVEST_UNIT_CHOICES)
+    garden_square = models.ForeignKey(
+        GardenSquare,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name='harvests',
+    )
+    garden_row = models.ForeignKey(
+        GardenRow,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name='harvests',
+    )
+    quality_rating = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        validators=[MinValueValidator(1), MaxValueValidator(5)],
+    )
+    grade = models.CharField(
+        max_length=16,
+        choices=Grade.choices,
+        default=Grade.UNGRADED,
+    )
+    notes = models.TextField(blank=True, default='')
+    status = models.CharField(
+        max_length=16,
+        choices=Status.choices,
+        default=Status.POSTED,
+        editable=False,
+    )
+    posted_at = models.DateTimeField(default=timezone.now, editable=False)
+    reversed_at = models.DateTimeField(null=True, blank=True, editable=False)
+    reverse_reason = models.TextField(blank=True, default='', editable=False)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        editable=False,
+        related_name='+',
+    )
+    reversed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        editable=False,
+        related_name='+',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-harvested_at', '-pk']
+        indexes = [
+            models.Index(fields=['batch', 'harvested_at'], name='harvest_batch_period_idx'),
+            models.Index(fields=['workspace', 'harvested_at'], name='harvest_period_idx'),
+        ]
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(quantity__gt=0),
+                name='harvest_quantity_positive',
+            ),
+            models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(garden_square__isnull=True),
+                    models.Q(garden_row__isnull=True),
+                    _connector=models.Q.OR,
+                ),
+                name='harvest_single_location',
+            ),
+            models.CheckConstraint(
+                condition=models.Q(
+                    unit_code__in=[code.value for code in HARVEST_UNIT_CODES],
+                ),
+                name='harvest_allowed_unit',
+            ),
+            models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(status='posted', reversed_at__isnull=True),
+                    models.Q(status='reversed', reversed_at__isnull=False),
+                    _connector=models.Q.OR,
+                ),
+                name='harvest_reversal_stamp',
+            ),
+        ]
+
+    def __str__(self):
+        return f'{self.quantity} {self.unit_code} from {self.batch} on {self.harvested_at}'
+
+    def clean(self):
+        """Keep the batch, the location, and the unit inside this workspace."""
+        super().clean()
+        errors = {}
+        if self.batch_id and self.batch.workspace_id != self.workspace_id:
+            errors['batch'] = 'The batch belongs to a different workspace.'
+        if self.garden_square_id and self.garden_row_id:
+            errors['garden_row'] = 'Record a garden square or a garden row, not both.'
+        for field in ('garden_square', 'garden_row'):
+            location = getattr(self, field, None)
+            if location is not None and location.workspace_id != self.workspace_id:
+                errors[field] = 'The location belongs to a different workspace.'
+        if self.unit_code not in {code.value for code in HARVEST_UNIT_CODES}:
+            errors['unit_code'] = 'Record a harvest in each, g, kg, ml, or l.'
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        if self.pk:
+            raise ValidationError('Harvests are immutable; reverse them instead.')
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        raise ValidationError('Harvests cannot be deleted; reverse them instead.')
+
+
+class HarvestPlant(models.Model):
+    """One individual plant a harvest is attributed to.
+
+    The allocation records attribution and nothing more. A measured kilogram is
+    never split across the plants it came from, because that division was not
+    observed and inventing it would misreport every per-plant total.
+    """
+
+    harvest = models.ForeignKey(
+        Harvest,
+        on_delete=models.PROTECT,
+        related_name='plant_allocations',
+    )
+    plant = models.ForeignKey(
+        SpecificPlant,
+        on_delete=models.PROTECT,
+        related_name='harvest_allocations',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['harvest', 'plant']
+        constraints = [
+            models.UniqueConstraint(
+                fields=['harvest', 'plant'],
+                name='harvest_plant_unique',
+            ),
+        ]
+
+    def __str__(self):
+        return f'Harvest {self.harvest_id} from plant {self.plant_id}'
+
+    def clean(self):
+        """Require a plant this workspace raised in this harvest's batch."""
+        super().clean()
+        if not self.harvest_id or not self.plant_id:
+            return
+        errors = {}
+        if self.plant.workspace_id != self.harvest.workspace_id:
+            errors['plant'] = 'The plant belongs to a different workspace.'
+        elif self.plant_batch_id() != self.harvest.batch_id:
+            errors['plant'] = "The plant was not raised by this harvest's batch."
+        if errors:
+            raise ValidationError(errors)
+
+    def plant_batch_id(self):
+        """Return the batch that raised this allocation's plant."""
+        return self.plant.cell_planting.seed_tray_planting.batch_id
+
+    def save(self, *args, **kwargs):
+        if self.pk:
+            raise ValidationError('Harvest allocations are immutable.')
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        raise ValidationError('Harvest allocations cannot be deleted.')
 
 
 class GardenSquareTransplant(WorkspaceOwnedModel):

--- a/plantings/test_harvests.py
+++ b/plantings/test_harvests.py
@@ -1,0 +1,220 @@
+"""Tests for the harvest record and its attribution to individual plants."""
+# pylint: disable=duplicate-code
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from django.utils import timezone
+
+from inventory.units import UnitCode
+from tests.factories import (
+    make_garden_row,
+    make_garden_square,
+    make_harvest,
+    make_harvest_plant,
+    make_plant,
+    make_plant_family,
+    make_plant_variety,
+    make_production_batch,
+    make_specific_plant,
+)
+from workspaces.models import Workspace
+
+from .models import Harvest, HarvestPlant
+
+
+class HarvestModelTests(TestCase):
+    """A harvest is posted when recorded and never edited afterwards."""
+
+    def setUp(self):
+        super().setUp()
+        self.batch = make_production_batch()
+
+    def test_a_new_harvest_is_posted_and_stamped(self):
+        """Recording a harvest counts it immediately, with no draft step."""
+        harvest = make_harvest(batch=self.batch)
+        self.assertEqual(harvest.status, Harvest.Status.POSTED)
+        self.assertIsNotNone(harvest.posted_at)
+        self.assertIsNone(harvest.reversed_at)
+        self.assertEqual(harvest.reverse_reason, '')
+
+    def test_saving_an_existing_harvest_is_refused(self):
+        """The record is immutable, so a correction must reverse it instead."""
+        harvest = make_harvest(batch=self.batch)
+        harvest.notes = 'Edited'
+        with self.assertRaises(ValidationError) as caught:
+            harvest.save()
+        self.assertIn('immutable', str(caught.exception))
+
+    def test_deleting_a_harvest_is_refused(self):
+        """Yield history survives a mistake rather than disappearing."""
+        harvest = make_harvest(batch=self.batch)
+        with self.assertRaises(ValidationError):
+            harvest.delete()
+        self.assertTrue(Harvest.objects.filter(pk=harvest.pk).exists())
+
+    def test_a_zero_quantity_is_rejected(self):
+        """A harvest that measured nothing is not an observation."""
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(batch=self.batch, quantity=Decimal('0'))
+        self.assertIn('quantity', caught.exception.message_dict)
+
+    def test_a_negative_quantity_is_rejected(self):
+        """Yield is never negative; a mistake is reversed, not subtracted."""
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(batch=self.batch, quantity=Decimal('-1'))
+        self.assertIn('quantity', caught.exception.message_dict)
+
+    def test_a_sub_quantum_quantity_is_rejected_as_a_field_error(self):
+        """A value the column rounds to zero fails cleanly, not as a crash."""
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(batch=self.batch, quantity=Decimal('0.0000000004'))
+        self.assertIn('quantity', caught.exception.message_dict)
+
+    def test_input_and_area_units_are_rejected(self):
+        """Seed and area units describe inputs and space, never a yield."""
+        for unit in (UnitCode.SEED, UnitCode.SEED_CLUSTER, UnitCode.SQUARE_METRE):
+            with self.subTest(unit=unit):
+                with self.assertRaises(ValidationError) as caught:
+                    make_harvest(batch=self.batch, unit_code=unit)
+                self.assertIn('unit_code', caught.exception.message_dict)
+
+    def test_every_yield_unit_is_accepted(self):
+        """Count, mass, and volume all describe a real crop measurement."""
+        for unit in (UnitCode.EACH, UnitCode.GRAM, UnitCode.KILOGRAM,
+                     UnitCode.MILLILITRE, UnitCode.LITRE):
+            with self.subTest(unit=unit):
+                harvest = make_harvest(batch=self.batch, unit_code=unit)
+                self.assertEqual(harvest.unit_code, unit)
+
+    def test_a_square_and_a_row_cannot_both_be_recorded(self):
+        """One harvest came from one place, so only one location may be named."""
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(
+                batch=self.batch,
+                garden_square=make_garden_square(),
+                garden_row=make_garden_row(),
+            )
+        self.assertIn('garden_row', caught.exception.message_dict)
+
+    def test_the_database_also_refuses_two_locations(self):
+        """The single-location rule survives a write that skips validation."""
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                Harvest.objects.bulk_create([Harvest(
+                    workspace=self.batch.workspace,
+                    batch=self.batch,
+                    harvested_at=timezone.now(),
+                    quantity=Decimal('1'),
+                    unit_code=UnitCode.GRAM,
+                    garden_square=make_garden_square(),
+                    garden_row=make_garden_row(),
+                )])
+
+    def test_the_database_also_refuses_a_zero_quantity(self):
+        """The positive-quantity rule survives a write that skips validation."""
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                Harvest.objects.bulk_create([Harvest(
+                    workspace=self.batch.workspace,
+                    batch=self.batch,
+                    harvested_at=timezone.now(),
+                    quantity=Decimal('0'),
+                    unit_code=UnitCode.GRAM,
+                )])
+
+    def test_a_location_is_optional(self):
+        """An aggregate batch yield need not name where it came from."""
+        harvest = make_harvest(batch=self.batch)
+        self.assertIsNone(harvest.garden_square)
+        self.assertIsNone(harvest.garden_row)
+
+    def test_a_quality_rating_outside_one_to_five_is_rejected(self):
+        """The subjective score is a fixed scale, not an arbitrary number."""
+        for rating in (0, 6):
+            with self.subTest(rating=rating):
+                with self.assertRaises(ValidationError) as caught:
+                    make_harvest(batch=self.batch, quality_rating=rating)
+                self.assertIn('quality_rating', caught.exception.message_dict)
+
+
+class HarvestWorkspaceTests(TestCase):
+    """Every reference a harvest names belongs to its own workspace."""
+
+    def setUp(self):
+        super().setUp()
+        self.other = Workspace.objects.create(name='Other workspace')
+
+    def test_a_batch_from_another_workspace_is_rejected(self):
+        """A harvest cannot claim yield from somebody else's crop."""
+        family = make_plant_family(workspace=self.other)
+        plant = make_plant(workspace=self.other, family=family)
+        variety = make_plant_variety(workspace=self.other, plant=plant)
+        foreign = make_production_batch(workspace=self.other, variety=variety)
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(batch=foreign)
+        self.assertIn('batch', caught.exception.message_dict)
+
+    def test_a_square_from_another_workspace_is_rejected(self):
+        """The growing location is scoped like every other reference."""
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(garden_square=make_garden_square(workspace=self.other))
+        self.assertIn('garden_square', caught.exception.message_dict)
+
+    def test_a_row_from_another_workspace_is_rejected(self):
+        """A row is scoped exactly as a square is."""
+        with self.assertRaises(ValidationError) as caught:
+            make_harvest(garden_row=make_garden_row(workspace=self.other))
+        self.assertIn('garden_row', caught.exception.message_dict)
+
+
+class HarvestPlantTests(TestCase):
+    """An allocation attributes a harvest to plants that batch actually raised."""
+
+    def setUp(self):
+        super().setUp()
+        self.plant = make_specific_plant()
+        self.batch = self.plant.cell_planting.seed_tray_planting.batch
+
+    def test_a_plant_from_the_same_batch_is_accepted(self):
+        """Attribution records which of the batch's plants contributed."""
+        allocation = make_harvest_plant(plant=self.plant)
+        self.assertEqual(allocation.plant, self.plant)
+        self.assertEqual(allocation.harvest.batch, self.batch)
+
+    def test_a_plant_from_another_batch_is_rejected(self):
+        """A harvest cannot be attributed to a crop it did not come from."""
+        harvest = make_harvest(batch=make_production_batch())
+        with self.assertRaises(ValidationError) as caught:
+            HarvestPlant.objects.create(harvest=harvest, plant=self.plant)
+        self.assertIn('plant', caught.exception.message_dict)
+
+    def test_a_plant_from_another_workspace_is_rejected(self):
+        """Attribution is scoped like every other cross-model reference."""
+        other = Workspace.objects.create(name='Other workspace')
+        stranger = make_specific_plant(workspace=other)
+        harvest = make_harvest(
+            batch=stranger.cell_planting.seed_tray_planting.batch,
+        )
+        with self.assertRaises(ValidationError) as caught:
+            HarvestPlant.objects.create(harvest=harvest, plant=stranger)
+        self.assertIn('plant', caught.exception.message_dict)
+
+    def test_the_same_plant_cannot_be_allocated_twice(self):
+        """One harvest names each contributing plant once."""
+        allocation = make_harvest_plant(plant=self.plant)
+        with self.assertRaises(ValidationError):
+            HarvestPlant.objects.create(
+                harvest=allocation.harvest,
+                plant=self.plant,
+            )
+
+    def test_an_allocation_is_immutable_and_undeletable(self):
+        """Attribution is part of the record the reversal keeps visible."""
+        allocation = make_harvest_plant(plant=self.plant)
+        with self.assertRaises(ValidationError):
+            allocation.save()
+        with self.assertRaises(ValidationError):
+            allocation.delete()
+        self.assertTrue(HarvestPlant.objects.filter(pk=allocation.pk).exists())

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -7,9 +7,12 @@ from django.utils import timezone
 
 from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
 from inventory.models import InventoryLocation, InventoryUnit, StockLot, StockMovement
+from inventory.units import UnitCode
 from plantings.models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
+    Harvest,
+    HarvestPlant,
     PlantLifecycleEvent,
     ProductionBatch,
     ProductionBatchTransition,
@@ -354,6 +357,36 @@ def make_plant_lifecycle_event(**overrides):
     }
     defaults.update(values)
     return PlantLifecycleEvent.objects.create(**defaults)
+
+
+def make_harvest(**overrides):
+    """Create a posted harvest, defaulting to a gram yield from a new batch."""
+    values = {
+        'quantity': Decimal('1'),
+        'unit_code': UnitCode.GRAM,
+        'notes': 'Shared test harvest',
+    }
+    if 'batch' not in overrides:
+        values['batch'] = make_production_batch()
+    if 'harvested_at' not in overrides:
+        values['harvested_at'] = timezone.now()
+    values.update(overrides)
+    return Harvest.objects.create(**values)
+
+
+def make_harvest_plant(**overrides):
+    """Attribute a harvest to one plant, building either side when absent."""
+    values = dict(overrides)
+    plant = values.pop('plant', None) or make_specific_plant()
+    defaults = {
+        'plant': plant,
+        'harvest': make_harvest(
+            batch=plant.cell_planting.seed_tray_planting.batch,
+            workspace=plant.workspace,
+        ),
+    }
+    defaults.update(values)
+    return HarvestPlant.objects.create(**defaults)
 
 
 def make_specific_plant_location(**overrides):


### PR DESCRIPTION
A garden could record what was sown and where it moved but had nowhere to record what came out of it. Add an immutable harvest measured in a count, mass, or volume unit against one production batch, optionally attributed to the individual plants that produced it and to a garden square or row.

A harvest is an observation rather than a document assembled from lines, so it is posted the moment it is recorded and corrected by reversal rather than by editing. Attribution deliberately carries no per-plant quantity: splitting a measured kilogram across the plants it came from would invent a division nobody observed.

No data migration infers harvests from `removed=True`, which records only that a planting stopped being tracked and cannot say whether the crop was harvested, failed, or was pulled out.

## Summary by Sourcery

Introduce immutable harvest records linked to production batches, including per-plant attribution and workspace-scoped validation.

New Features:
- Add a Harvest model to record crop yield quantities, units, quality, and location for a production batch.
- Add a HarvestPlant model to attribute harvests to individual plants raised by the same batch.

Enhancements:
- Enforce workspace, unit, quantity, and location constraints for harvests and allocations, including immutability and reversal semantics.
- Add factories and comprehensive tests for harvest recording, validation, and plant attribution.