### PR TITLE
feat(plantings): post and reverse harvests

### DIFF
--- a/plantings/batches.py
+++ b/plantings/batches.py
@@ -13,6 +13,7 @@ from .lifecycle import LifecycleState, is_final, lifecycle_summaries
 from .models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
+    Harvest,
     ProductionBatch,
     ProductionBatchTransition,
     SeedTrayPlanting,
@@ -130,6 +131,14 @@ def batch_final_outcome_count(batch):
     )
 
 
+def batch_posted_harvest_count(batch):
+    """Return how many harvests still count as output from this batch."""
+    return Harvest.objects.filter(
+        batch=batch,
+        status=Harvest.Status.POSTED,
+    ).count()
+
+
 def batch_lifecycle_counts(batch):
     """Return how many of this batch's plants sit in each derived state."""
     counts = {state.value: 0 for state in LifecycleState}
@@ -149,7 +158,7 @@ def _record_transition(batch, previous_status, user, reason=''):
     )
 
 
-def _lock_batch(batch):
+def lock_batch(batch):
     """Reload one batch under a row lock for a lifecycle change."""
     return ProductionBatch.objects.select_for_update().get(pk=batch.pk)
 
@@ -194,7 +203,7 @@ def create_batch(workspace, user, request):
 @transaction.atomic
 def activate_batch(batch, user, actual_start=None, reason=''):
     """Start a planned batch at a supplied or current time."""
-    batch = _lock_batch(batch)
+    batch = lock_batch(batch)
     _require_status(batch, {ProductionBatch.Status.PLANNED}, 'be activated')
     previous_status = batch.status
     batch.status = ProductionBatch.Status.ACTIVE
@@ -219,7 +228,7 @@ def create_and_activate_batch(workspace, user, request, actual_start=None):
 @transaction.atomic
 def finalize_batch_output(batch, user, reason=''):
     """Declare that no further seedlings will come from this batch."""
-    batch = _lock_batch(batch)
+    batch = lock_batch(batch)
     _require_status(batch, {ProductionBatch.Status.ACTIVE}, 'finalize its output')
     if batch_sowing_count(batch) == 0:
         raise ValidationError({
@@ -244,7 +253,7 @@ def finalize_batch_output(batch, user, reason=''):
 @transaction.atomic
 def complete_batch(batch, user, reason=''):
     """Complete a batch once every output has a final disposition."""
-    batch = _lock_batch(batch)
+    batch = lock_batch(batch)
     _require_status(batch, {ProductionBatch.Status.OUTPUT_FINALIZED}, 'be completed')
     unresolved = batch_unresolved_plant_ids(batch)
     if unresolved:
@@ -266,7 +275,7 @@ def complete_batch(batch, user, reason=''):
 def cancel_batch(batch, user, reason):
     """Abandon a batch that produced no tracked individual outputs."""
     _require_reason(reason)
-    batch = _lock_batch(batch)
+    batch = lock_batch(batch)
     _require_status(
         batch,
         {ProductionBatch.Status.PLANNED, ProductionBatch.Status.ACTIVE},
@@ -286,6 +295,14 @@ def cancel_batch(batch, user, reason):
             raise ValidationError({
                 'detail': (
                     f'{observed} observed plants came from this batch, so it '
+                    'produced output and cannot be cancelled.'
+                ),
+            })
+        harvested = batch_posted_harvest_count(batch)
+        if harvested:
+            raise ValidationError({
+                'detail': (
+                    f'{harvested} harvests came from this batch, so it '
                     'produced output and cannot be cancelled.'
                 ),
             })
@@ -310,7 +327,7 @@ def _reopen_target(batch):
 def reopen_batch(batch, user, reason):
     """Correct a lifecycle mistake by returning to the previous status."""
     _require_reason(reason)
-    batch = _lock_batch(batch)
+    batch = lock_batch(batch)
     _require_status(batch, set(REOPEN_TARGETS) | {ProductionBatch.Status.CANCELLED}, 'be reopened')
     previous_status = batch.status
     batch.status = _reopen_target(batch)
@@ -336,6 +353,6 @@ def validate_batch_for_sowing(batch, packet, workspace):
 @transaction.atomic
 def lock_batch_for_sowing(batch, packet, workspace):
     """Lock and revalidate a batch so work cannot attach after finalization."""
-    locked = _lock_batch(batch)
+    locked = lock_batch(batch)
     validate_batch_for_sowing(locked, packet, workspace)
     return locked

--- a/plantings/harvests.py
+++ b/plantings/harvests.py
@@ -1,0 +1,198 @@
+"""Transactional services for recording and reversing crop harvests.
+
+A harvest is posted the moment it is recorded, so there is no draft to assemble
+and no post step. A mistake is corrected by reversing the record, which keeps
+the original visible while excluding its quantity from every total.
+
+Harvesting is kept separate from ending a plant. Many crops are picked
+repeatedly, so recording a harvest changes no plant's lifecycle unless the
+caller explicitly says this harvest finished the plants it took.
+"""
+
+# pylint: disable=duplicate-code
+
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from inventory.ledger import quantize_quantity
+
+from .batches import batch_specific_plants, lock_batch
+from .lifecycle import EventType, OutcomeRequest, record_bulk_outcome
+from .models import Harvest, HarvestPlant, PlantLifecycleEvent, ProductionBatch
+
+
+#: Batch statuses that may still yield a crop. `output_finalized` declares that
+#: no further seedlings will come from the batch, not that no further fruit
+#: will; `planned` has sown nothing, and `cancelled` has declared it produced
+#: nothing at all.
+HARVESTABLE_STATUSES = {
+    ProductionBatch.Status.ACTIVE,
+    ProductionBatch.Status.OUTPUT_FINALIZED,
+    ProductionBatch.Status.COMPLETED,
+}
+
+
+class HarvestRequest(NamedTuple):
+    """Caller intent for one recorded harvest."""
+
+    batch: object
+    harvested_at: object
+    quantity: object
+    unit_code: str
+    garden_square: object = None
+    garden_row: object = None
+    quality_rating: object = None
+    grade: str = Harvest.Grade.UNGRADED
+    notes: str = ''
+    plant_ids: tuple = ()
+    finish_plants: bool = False
+    finish_reason: str = ''
+
+
+def _require_reason(reason):
+    """Reject an audit-critical action without a stated reason."""
+    if not reason or not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+
+
+def _require_harvestable(batch):
+    """Reject a harvest from a batch that has not grown anything yet."""
+    if batch.status not in HARVESTABLE_STATUSES:
+        raise ValidationError({
+            'batch': (
+                f'A {batch.get_status_display().lower()} batch cannot be '
+                'harvested.'
+            ),
+        })
+
+
+def _require_within_batch(batch, harvested_at):
+    """Reject a harvest taken before its batch started growing."""
+    if batch.actual_start is not None and harvested_at < batch.actual_start:
+        raise ValidationError({
+            'harvested_at': 'A harvest cannot predate the start of its batch.',
+        })
+
+
+def _resolve_plants(batch, plant_ids):
+    """Return the named plants, refusing any this batch did not raise."""
+    wanted = sorted(set(plant_ids))
+    if not wanted:
+        return []
+    plants = list(
+        batch_specific_plants(batch)
+        .filter(pk__in=wanted)
+        .order_by('pk')
+    )
+    known = {plant.pk for plant in plants}
+    missing = [plant_id for plant_id in wanted if plant_id not in known]
+    if missing:
+        raise ValidationError({
+            'plants': (
+                f'These plants did not come from batch {batch.code}: {missing}.'
+            ),
+        })
+    return plants
+
+
+def _finish_plants(harvest, plants, user, reason):
+    """End the cultivation of every plant this harvest took.
+
+    The reference ties each appended fact back to the harvest that caused it,
+    which is what lets the API report whether a harvest resolved any plants.
+    """
+    if not plants:
+        raise ValidationError({
+            'plants': 'Select the plants this harvest finished.',
+        })
+    return record_bulk_outcome(
+        [plant.pk for plant in plants],
+        user,
+        OutcomeRequest(
+            EventType.HARVEST_FINISHED,
+            occurred_at=harvest.harvested_at,
+            reason=reason,
+            reference=f'harvest:{harvest.pk}',
+        ),
+    )
+
+
+@transaction.atomic
+def record_harvest(workspace, user, request):
+    """Post one harvest and, when asked, finish the plants it took.
+
+    The batch lock is always acquired before any plant lock, because
+    `record_bulk_outcome` locks the selected plants in primary-key order. No
+    other path takes a plant lock before a batch lock, so this ordering keeps
+    concurrent batch and plant work free of deadlock.
+    """
+    batch = lock_batch(request.batch)
+    _require_harvestable(batch)
+    _require_within_batch(batch, request.harvested_at)
+    plants = _resolve_plants(batch, request.plant_ids)
+    harvest = Harvest(
+        workspace=workspace,
+        batch=batch,
+        harvested_at=request.harvested_at,
+        quantity=quantize_quantity(request.quantity),
+        unit_code=request.unit_code,
+        garden_square=request.garden_square,
+        garden_row=request.garden_row,
+        quality_rating=request.quality_rating,
+        grade=request.grade,
+        notes=request.notes,
+        status=Harvest.Status.POSTED,
+        posted_at=timezone.now(),
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+    harvest.save()
+    for plant in plants:
+        HarvestPlant.objects.create(harvest=harvest, plant=plant)
+    events = []
+    if request.finish_plants:
+        events = _finish_plants(harvest, plants, user, request.finish_reason)
+    return harvest, events
+
+
+@transaction.atomic
+def reverse_harvest(harvest, user, reason):
+    """Exclude a mistaken harvest from totals while keeping it on file.
+
+    Reversal is a status change on the original row rather than a compensating
+    negative harvest, because there is no ledger to keep in balance and a second
+    row would only be one more thing every report had to filter out.
+
+    The lifecycle events a harvest created are deliberately left alone. A
+    finished plant's location was closed when the fact was recorded, and where a
+    plant has been remains true; correcting a plant is its own decision, made
+    through that plant's `reverse-event` action.
+    """
+    _require_reason(reason)
+    harvest = Harvest.objects.select_for_update().get(pk=harvest.pk)
+    if harvest.status != Harvest.Status.POSTED:
+        raise ValidationError({'status': 'That harvest is already reversed.'})
+    Harvest.objects.filter(pk=harvest.pk, status=Harvest.Status.POSTED).update(
+        status=Harvest.Status.REVERSED,
+        reversed_at=timezone.now(),
+        reverse_reason=reason.strip(),
+        reversed_by=user if user is not None and user.is_authenticated else None,
+    )
+    harvest.refresh_from_db()
+    return harvest
+
+
+def harvest_finished_plant_ids(harvest):
+    """Return the plants this harvest resolved, if it finished any.
+
+    Derived from the recorded facts rather than stored, so a later correction to
+    one plant is reflected here without a second write.
+    """
+    return sorted(
+        PlantLifecycleEvent.objects.filter(
+            event_type=EventType.HARVEST_FINISHED,
+            reference=f'harvest:{harvest.pk}',
+        ).values_list('plant_id', flat=True)
+    )

--- a/plantings/test_harvests.py
+++ b/plantings/test_harvests.py
@@ -1,7 +1,9 @@
-"""Tests for the harvest record and its attribution to individual plants."""
+"""Tests for the harvest record and the services that post and reverse it."""
 # pylint: disable=duplicate-code
+from datetime import timedelta
 from decimal import Decimal
 
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.test import TestCase
@@ -17,11 +19,32 @@ from tests.factories import (
     make_plant_family,
     make_plant_variety,
     make_production_batch,
+    make_seed_tray_cell_planting,
     make_specific_plant,
+    make_specific_plant_location,
 )
 from workspaces.models import Workspace
 
-from .models import Harvest, HarvestPlant
+from .batches import cancel_batch
+from .harvests import (
+    HarvestRequest,
+    harvest_finished_plant_ids,
+    record_harvest,
+    reverse_harvest,
+)
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    plant_lifecycle_summary,
+    record_germination_event,
+)
+from .models import (
+    Harvest,
+    HarvestPlant,
+    PlantLifecycleEvent,
+    ProductionBatch,
+    SpecificPlantLocation,
+)
 
 
 class HarvestModelTests(TestCase):
@@ -218,3 +241,400 @@ class HarvestPlantTests(TestCase):
         with self.assertRaises(ValidationError):
             allocation.delete()
         self.assertTrue(HarvestPlant.objects.filter(pk=allocation.pk).exists())
+
+
+class RecordHarvestTests(TestCase):
+    """Posting a harvest validates the crop, the time, and the plants."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='harvester')
+        self.batch = make_production_batch()
+        self.workspace = self.batch.workspace
+
+    def _request(self, **overrides):
+        """Build a valid harvest request for this batch."""
+        values = {
+            'batch': self.batch,
+            'harvested_at': timezone.now(),
+            'quantity': Decimal('1.5'),
+            'unit_code': UnitCode.KILOGRAM,
+        }
+        values.update(overrides)
+        return HarvestRequest(**values)
+
+    def test_a_recorded_harvest_is_posted_immediately(self):
+        """Recording is posting; there is no separate document to assemble."""
+        harvest, events = record_harvest(self.workspace, self.user, self._request())
+        self.assertEqual(harvest.status, Harvest.Status.POSTED)
+        self.assertEqual(harvest.created_by, self.user)
+        self.assertEqual(events, [])
+
+    def test_the_quantity_is_quantized_before_it_is_validated(self):
+        """A value the column would round to zero fails as a field error."""
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(
+                self.workspace,
+                self.user,
+                self._request(quantity=Decimal('0.0000000004')),
+            )
+        self.assertIn('quantity', caught.exception.message_dict)
+        self.assertFalse(Harvest.objects.exists())
+
+    def test_a_planned_batch_cannot_be_harvested(self):
+        """Nothing has been sown yet, so nothing can have come out."""
+        batch = make_production_batch(status=ProductionBatch.Status.PLANNED)
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(self.workspace, self.user, self._request(batch=batch))
+        self.assertIn('batch', caught.exception.message_dict)
+
+    def test_a_cancelled_batch_cannot_be_harvested(self):
+        """A cancelled batch has declared that it produced nothing."""
+        batch = make_production_batch(
+            status=ProductionBatch.Status.CANCELLED,
+            cancelled_at=timezone.now(),
+        )
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(self.workspace, self.user, self._request(batch=batch))
+        self.assertIn('batch', caught.exception.message_dict)
+
+    def test_a_finalized_or_completed_batch_can_still_be_harvested(self):
+        """Finalizing output stops seedlings, not fruit."""
+        for status in (ProductionBatch.Status.OUTPUT_FINALIZED,
+                       ProductionBatch.Status.COMPLETED):
+            with self.subTest(status=status):
+                batch = make_production_batch(status=status)
+                harvest, _events = record_harvest(
+                    self.workspace,
+                    self.user,
+                    self._request(batch=batch),
+                )
+                self.assertEqual(harvest.batch, batch)
+
+    def test_a_harvest_cannot_predate_its_batch(self):
+        """A crop cannot be picked before it was sown."""
+        before = self.batch.actual_start - timedelta(days=1)
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(
+                self.workspace,
+                self.user,
+                self._request(harvested_at=before),
+            )
+        self.assertIn('harvested_at', caught.exception.message_dict)
+
+    def test_a_location_is_recorded_when_supplied(self):
+        """The square a crop came from is what makes a square report real."""
+        square = make_garden_square()
+        harvest, _events = record_harvest(
+            self.workspace,
+            self.user,
+            self._request(garden_square=square),
+        )
+        self.assertEqual(harvest.garden_square, square)
+
+
+class HarvestPlantSelectionTests(TestCase):
+    """Attribution names only plants the harvested batch actually raised."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='picker')
+        self.plant = make_specific_plant()
+        self.batch = self.plant.cell_planting.seed_tray_planting.batch
+        self.workspace = self.batch.workspace
+        record_germination_event(self.plant, self.user)
+
+    def _request(self, **overrides):
+        """Build a valid count-harvest request for this batch."""
+        values = {
+            'batch': self.batch,
+            'harvested_at': timezone.now(),
+            'quantity': Decimal('3'),
+            'unit_code': UnitCode.EACH,
+        }
+        values.update(overrides)
+        return HarvestRequest(**values)
+
+    def test_selected_plants_are_allocated(self):
+        """The allocation records which plants contributed the yield."""
+        harvest, _events = record_harvest(
+            self.workspace,
+            self.user,
+            self._request(plant_ids=(self.plant.pk,)),
+        )
+        self.assertEqual(
+            list(harvest.plant_allocations.values_list('plant_id', flat=True)),
+            [self.plant.pk],
+        )
+
+    def test_a_plant_from_another_batch_is_refused_by_name(self):
+        """The error says which plants did not come from this crop."""
+        stranger = make_specific_plant()
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(
+                self.workspace,
+                self.user,
+                self._request(plant_ids=(stranger.pk,)),
+            )
+        self.assertIn('plants', caught.exception.message_dict)
+        self.assertIn(str(stranger.pk), str(caught.exception))
+        self.assertFalse(Harvest.objects.exists())
+
+    def test_a_direct_sow_batch_has_no_plants_to_allocate(self):
+        """Individual plants only exist for tray sowings, never direct sowings."""
+        batch = make_production_batch()
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(
+                self.workspace,
+                self.user,
+                self._request(batch=batch, plant_ids=(self.plant.pk,)),
+            )
+        self.assertIn('plants', caught.exception.message_dict)
+
+    def test_repeated_harvests_from_the_same_plants_are_allowed(self):
+        """Many crops are picked again and again from a living plant."""
+        for _ in range(2):
+            record_harvest(
+                self.workspace,
+                self.user,
+                self._request(plant_ids=(self.plant.pk,)),
+            )
+        self.assertEqual(Harvest.objects.count(), 2)
+        self.assertEqual(
+            HarvestPlant.objects.filter(plant=self.plant).count(),
+            2,
+        )
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+
+
+class FinalHarvestTests(TestCase):
+    """A harvest ends a plant only when the caller says it did."""
+
+    def setUp(self):
+        """Lay out an explicit timeline so backdating can be tested exactly."""
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='finisher')
+        self.sown = timezone.now() - timedelta(days=60)
+        self.germinated = self.sown + timedelta(days=10)
+        cell_planting = make_seed_tray_cell_planting()
+        self.batch = cell_planting.seed_tray_planting.batch
+        ProductionBatch.objects.filter(pk=self.batch.pk).update(actual_start=self.sown)
+        self.batch.refresh_from_db()
+        self.plant = make_specific_plant(
+            cell_planting=cell_planting,
+            germinated=self.germinated,
+        )
+        self.other = make_specific_plant(
+            cell_planting=cell_planting,
+            germinated=self.germinated,
+        )
+        self.locations = {}
+        for plant in (self.plant, self.other):
+            record_germination_event(plant, self.user)
+            self.locations[plant.pk] = make_specific_plant_location(
+                specific_plant=plant,
+                started=self.germinated,
+            )
+
+    def _request(self, **overrides):
+        """Build a final-harvest request naming both plants."""
+        values = {
+            'batch': self.batch,
+            'harvested_at': timezone.now(),
+            'quantity': Decimal('2'),
+            'unit_code': UnitCode.EACH,
+            'plant_ids': (self.plant.pk, self.other.pk),
+            'finish_plants': True,
+            'finish_reason': 'Picked out at the end of the season.',
+        }
+        values.update(overrides)
+        return HarvestRequest(**values)
+
+    def test_finishing_records_one_event_per_plant(self):
+        """Each plant gets its own fact, referencing the harvest that caused it."""
+        harvest, events = record_harvest(self.batch.workspace, self.user, self._request())
+        self.assertEqual(len(events), 2)
+        for event in events:
+            self.assertEqual(event.event_type, EventType.HARVEST_FINISHED)
+            self.assertEqual(event.reference, f'harvest:{harvest.pk}')
+        self.assertEqual(
+            harvest_finished_plant_ids(harvest),
+            sorted([self.plant.pk, self.other.pk]),
+        )
+        for plant in (self.plant, self.other):
+            self.assertEqual(
+                plant_lifecycle_summary(plant).state,
+                LifecycleState.HARVESTED,
+            )
+
+    def test_finishing_closes_only_the_open_location(self):
+        """Where a plant has already been stays exactly as it was recorded."""
+        active = self.locations[self.plant.pk]
+        SpecificPlantLocation.objects.filter(pk=active.pk).update(
+            ended=self.germinated + timedelta(days=5),
+        )
+        moved = make_specific_plant_location(
+            specific_plant=self.plant,
+            started=self.germinated + timedelta(days=5),
+        )
+        history = list(
+            SpecificPlantLocation.objects
+            .filter(specific_plant=self.plant)
+            .exclude(pk=moved.pk)
+            .order_by('pk')
+            .values_list('pk', 'started', 'ended')
+        )
+        harvest, _events = record_harvest(self.batch.workspace, self.user, self._request())
+        self.assertEqual(
+            list(
+                SpecificPlantLocation.objects
+                .filter(specific_plant=self.plant)
+                .exclude(pk=moved.pk)
+                .order_by('pk')
+                .values_list('pk', 'started', 'ended')
+            ),
+            history,
+        )
+        moved.refresh_from_db()
+        self.assertEqual(moved.ended, harvest.harvested_at)
+
+    def test_finishing_without_a_selection_is_refused(self):
+        """There is nothing to finish when no plant was named."""
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(
+                self.batch.workspace,
+                self.user,
+                self._request(plant_ids=()),
+            )
+        self.assertIn('plants', caught.exception.message_dict)
+        self.assertFalse(Harvest.objects.exists())
+
+    def test_finishing_an_already_harvested_plant_rolls_the_harvest_back(self):
+        """A resolved plant cannot be resolved twice, and nothing is left behind."""
+        record_harvest(self.batch.workspace, self.user, self._request())
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(self.batch.workspace, self.user, self._request())
+        self.assertIn('plants', caught.exception.message_dict)
+        self.assertEqual(Harvest.objects.count(), 1)
+
+    def test_a_backdated_final_harvest_is_refused(self):
+        """A plant cannot be recorded as finishing before its latest fact."""
+        earlier = self.sown + timedelta(days=1)
+        with self.assertRaises(ValidationError) as caught:
+            record_harvest(
+                self.batch.workspace,
+                self.user,
+                self._request(harvested_at=earlier),
+            )
+        self.assertIn('plants', caught.exception.message_dict)
+        self.assertFalse(Harvest.objects.exists())
+
+    def test_a_backdated_harvest_without_finishing_is_allowed(self):
+        """Only the lifecycle history is append-only in time; yield is not."""
+        earlier = self.sown + timedelta(days=1)
+        harvest, events = record_harvest(
+            self.batch.workspace,
+            self.user,
+            self._request(harvested_at=earlier, finish_plants=False),
+        )
+        self.assertEqual(harvest.harvested_at, earlier)
+        self.assertEqual(events, [])
+
+
+class ReverseHarvestTests(TestCase):
+    """A reversal excludes a harvest from totals without erasing it."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='reverser')
+        self.plant = make_specific_plant()
+        self.batch = self.plant.cell_planting.seed_tray_planting.batch
+        self.workspace = self.batch.workspace
+        record_germination_event(self.plant, self.user)
+        make_specific_plant_location(specific_plant=self.plant)
+        self.harvest, self.events = record_harvest(
+            self.workspace,
+            self.user,
+            HarvestRequest(
+                batch=self.batch,
+                harvested_at=timezone.now(),
+                quantity=Decimal('4'),
+                unit_code=UnitCode.EACH,
+                plant_ids=(self.plant.pk,),
+                finish_plants=True,
+            ),
+        )
+
+    def test_reversing_stamps_the_record_and_keeps_it(self):
+        """The audit trail keeps the mistake visible rather than deleting it."""
+        reversed_harvest = reverse_harvest(self.harvest, self.user, 'Weighed twice.')
+        self.assertEqual(reversed_harvest.status, Harvest.Status.REVERSED)
+        self.assertIsNotNone(reversed_harvest.reversed_at)
+        self.assertEqual(reversed_harvest.reverse_reason, 'Weighed twice.')
+        self.assertEqual(reversed_harvest.reversed_by, self.user)
+        self.assertEqual(
+            list(reversed_harvest.plant_allocations.values_list('plant_id', flat=True)),
+            [self.plant.pk],
+        )
+
+    def test_a_reversal_requires_a_reason(self):
+        """An unexplained correction is not an audit record."""
+        for reason in ('', '   '):
+            with self.subTest(reason=repr(reason)):
+                with self.assertRaises(ValidationError) as caught:
+                    reverse_harvest(self.harvest, self.user, reason)
+                self.assertIn('reason', caught.exception.message_dict)
+
+    def test_a_harvest_cannot_be_reversed_twice(self):
+        """One correction is enough; a second would say nothing new."""
+        reverse_harvest(self.harvest, self.user, 'Weighed twice.')
+        with self.assertRaises(ValidationError) as caught:
+            reverse_harvest(self.harvest, self.user, 'Again.')
+        self.assertIn('status', caught.exception.message_dict)
+
+    def test_reversing_leaves_the_lifecycle_history_alone(self):
+        """Where a plant has been, and that it ended, both remain true."""
+        before = list(
+            PlantLifecycleEvent.objects.values_list('pk', 'event_type', 'occurred_at')
+        )
+        reverse_harvest(self.harvest, self.user, 'Weighed twice.')
+        after = list(
+            PlantLifecycleEvent.objects.values_list('pk', 'event_type', 'occurred_at')
+        )
+        self.assertEqual(before, after)
+        self.assertEqual(
+            plant_lifecycle_summary(self.plant).state,
+            LifecycleState.HARVESTED,
+        )
+
+
+class CancelHarvestedBatchTests(TestCase):
+    """A batch that yielded a crop produced output and cannot be cancelled."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='canceller')
+        self.batch = make_production_batch()
+        self.harvest, _events = record_harvest(
+            self.batch.workspace,
+            self.user,
+            HarvestRequest(
+                batch=self.batch,
+                harvested_at=timezone.now(),
+                quantity=Decimal('1'),
+                unit_code=UnitCode.KILOGRAM,
+            ),
+        )
+
+    def test_cancelling_a_harvested_batch_is_refused(self):
+        """Four kilograms of crop is output, however it was grown."""
+        with self.assertRaises(ValidationError) as caught:
+            cancel_batch(self.batch, self.user, 'Changed my mind.')
+        self.assertIn('harvests came from this batch', str(caught.exception))
+
+    def test_cancelling_succeeds_once_the_harvest_is_reversed(self):
+        """A retracted harvest no longer counts as output."""
+        reverse_harvest(self.harvest, self.user, 'Recorded against the wrong crop.')
+        batch = cancel_batch(self.batch, self.user, 'Changed my mind.')
+        self.assertEqual(batch.status, ProductionBatch.Status.CANCELLED)


### PR DESCRIPTION
Add the transactional services behind harvest recording. Posting locks the batch, refuses a crop from a batch that has not grown one, refuses a harvest predating its batch, and refuses plants the batch did not raise.

Harvesting stays separate from ending a plant. A harvest changes no lifecycle state unless the caller says it finished the plants it took, in which case one append-only `harvest_finished` fact per plant is recorded, referencing the harvest that caused it. The batch lock is always taken before any plant lock, which is the ordering every other path already follows.

Reversal is a status change on the original row rather than a compensating harvest: there is no ledger to keep in balance, and a second row would only be one more thing every report had to filter out. The lifecycle facts a harvest created are left alone, because a closed location remains true and correcting a plant is that plant's own decision.

A batch that yielded a posted harvest now refuses cancellation. Previously a direct-sow batch with no individually tracked plants could be cancelled as "produced no output" after yielding a real crop.

## Summary by Sourcery

Introduce transactional services for recording, posting, and reversing crop harvests, integrating them with batch lifecycle rules and plant lifecycle events.

New Features:
- Add a harvest recording service that immediately posts harvests with validation of batch status, timing, quantity, and associated plants.
- Allow harvests to optionally mark selected plants as finished by appending harvest-related lifecycle events.
- Introduce a harvest reversal service that excludes reversed harvests from output totals while preserving their audit trail.

Bug Fixes:
- Prevent cancellation of batches that have produced posted harvests, unless those harvests are reversed.

Enhancements:
- Expose a reusable batch row-lock helper and use it across batch lifecycle operations, and add a helper to count posted harvests per batch.
- Expand test coverage around harvest recording, plant attribution, final harvest handling, harvest reversal, and batch cancellation behavior in the presence of harvests.

Tests:
- Add comprehensive tests for recording harvests, selecting and finishing plants, reversing harvests, and cancelling harvested batches.