### PR TITLE
fix(plantings): lock plants before the batch when harvesting

### DIFF
--- a/plantings/harvests.py
+++ b/plantings/harvests.py
@@ -21,7 +21,13 @@ from inventory.ledger import quantize_quantity
 
 from .batches import batch_specific_plants, lock_batch
 from .lifecycle import EventType, OutcomeRequest, record_bulk_outcome
-from .models import Harvest, HarvestPlant, PlantLifecycleEvent, ProductionBatch
+from .models import (
+    Harvest,
+    HarvestPlant,
+    PlantLifecycleEvent,
+    ProductionBatch,
+    SpecificPlant,
+)
 
 
 #: Batch statuses that may still yield a crop. `output_finalized` declares that
@@ -78,16 +84,21 @@ def _require_within_batch(batch, harvested_at):
 
 
 def _resolve_plants(batch, plant_ids):
-    """Return the named plants, refusing any this batch did not raise."""
+    """Return the named plants under a row lock, in primary-key order.
+
+    Membership is checked before the lock is taken because a plant's batch is
+    reached through links that never move: a sowing cannot change batches and a
+    plant cannot change cell allocations, so no concurrent write can make a
+    plant belong to a different crop while this runs.
+    """
     wanted = sorted(set(plant_ids))
     if not wanted:
         return []
-    plants = list(
+    known = set(
         batch_specific_plants(batch)
         .filter(pk__in=wanted)
-        .order_by('pk')
+        .values_list('pk', flat=True)
     )
-    known = {plant.pk for plant in plants}
     missing = [plant_id for plant_id in wanted if plant_id not in known]
     if missing:
         raise ValidationError({
@@ -95,7 +106,12 @@ def _resolve_plants(batch, plant_ids):
                 f'These plants did not come from batch {batch.code}: {missing}.'
             ),
         })
-    return plants
+    return list(
+        SpecificPlant.objects
+        .select_for_update()
+        .filter(pk__in=wanted)
+        .order_by('pk')
+    )
 
 
 def _finish_plants(harvest, plants, user, reason):
@@ -124,15 +140,16 @@ def _finish_plants(harvest, plants, user, reason):
 def record_harvest(workspace, user, request):
     """Post one harvest and, when asked, finish the plants it took.
 
-    The batch lock is always acquired before any plant lock, because
-    `record_bulk_outcome` locks the selected plants in primary-key order. No
-    other path takes a plant lock before a batch lock, so this ordering keeps
-    concurrent batch and plant work free of deadlock.
+    Plants are locked in primary-key order before the batch is locked, and that
+    ordering is load-bearing. Recording any plant outcome writes a lifecycle
+    event carrying a batch reference, so it holds the plant while the database
+    takes a key-share lock on the batch row. Taking the batch first here would
+    close the cycle and deadlock the two writers against each other.
     """
+    plants = _resolve_plants(request.batch, request.plant_ids)
     batch = lock_batch(request.batch)
     _require_harvestable(batch)
     _require_within_batch(batch, request.harvested_at)
-    plants = _resolve_plants(batch, request.plant_ids)
     harvest = Harvest(
         workspace=workspace,
         batch=batch,

--- a/plantings/test_harvest_concurrency.py
+++ b/plantings/test_harvest_concurrency.py
@@ -1,0 +1,197 @@
+"""Concurrency proofs for the locks harvest recording relies on.
+
+`record_harvest` takes the batch lock before `record_bulk_outcome` takes the
+plant locks, and no other path takes a plant lock before a batch lock. These
+tests exercise both halves of that ordering under real row locks, so they need
+a database that honours `SELECT ... FOR UPDATE`.
+"""
+# pylint: disable=duplicate-code
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.utils import timezone
+
+from inventory.units import UnitCode
+from tests.factories import (
+    make_production_batch,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace
+
+from .batches import cancel_batch
+from .harvests import HarvestRequest, record_harvest
+from .lifecycle import (
+    EventType,
+    OutcomeRequest,
+    record_germination_event,
+    record_lifecycle_event,
+)
+from .models import Harvest, PlantLifecycleEvent, ProductionBatch, SpecificPlant
+
+
+class HarvestConcurrencyTestCase(TransactionTestCase):
+    """Shared fixture teardown for the harvest race tests."""
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentFinalHarvestTests(HarvestConcurrencyTestCase):
+    """A final harvest cannot resolve a plant somebody else is resolving.
+
+    Two harvests of one batch already serialise on the batch lock, so this races
+    a final harvest against a plant-level outcome instead. That path takes the
+    plant lock without ever touching the batch, which makes the plant lock
+    inside `record_bulk_outcome` the only thing keeping one plant from ending
+    twice. The idempotency reference cannot catch it: the two writers use
+    different event types and different references.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='harvest-racer')
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        make_specific_plant_location(specific_plant=plant)
+        self.plant_pk = plant.pk
+        self.batch_pk = plant.cell_planting.seed_tray_planting.batch_id
+
+    def _finish_harvest(self):
+        """Attempt a final harvest from an independent connection."""
+        close_old_connections()
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            record_harvest(batch.workspace, user, HarvestRequest(
+                batch=batch,
+                harvested_at=timezone.now(),
+                quantity=Decimal('1'),
+                unit_code=UnitCode.EACH,
+                plant_ids=(self.plant_pk,),
+                finish_plants=True,
+            ))
+        except ValidationError:
+            result = 'harvest rejected'
+        else:
+            result = 'harvested'
+        close_old_connections()
+        return result
+
+    def _fail_plant(self):
+        """Attempt to record the plant as failed from another connection."""
+        close_old_connections()
+        plant = SpecificPlant.objects.get(pk=self.plant_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            record_lifecycle_event(plant, user, OutcomeRequest(EventType.FAILED))
+        except ValidationError:
+            result = 'failure rejected'
+        else:
+            result = 'failed'
+        close_old_connections()
+        return result
+
+    def test_a_plant_is_resolved_by_exactly_one_writer(self):
+        """Whichever wins, the plant ends with a single final outcome."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._finish_harvest),
+                    pool.submit(self._fail_plant),
+                ]
+            )
+
+        outcomes = PlantLifecycleEvent.objects.filter(
+            plant_id=self.plant_pk,
+            event_type__in=(
+                PlantLifecycleEvent.EventType.HARVEST_FINISHED,
+                PlantLifecycleEvent.EventType.FAILED,
+            ),
+        )
+        self.assertEqual(outcomes.count(), 1)
+        if outcomes.get().event_type == PlantLifecycleEvent.EventType.FAILED:
+            self.assertEqual(results, ['failed', 'harvest rejected'])
+            self.assertFalse(Harvest.objects.exists())
+        else:
+            self.assertEqual(results, ['failure rejected', 'harvested'])
+            self.assertEqual(Harvest.objects.count(), 1)
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentHarvestAndCancelTests(HarvestConcurrencyTestCase):
+    """Cancelling a batch and harvesting it serialise on the same lock."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='cancel-racer')
+        self.batch_pk = make_production_batch().pk
+
+    def _record(self):
+        """Attempt an aggregate harvest from an independent connection."""
+        close_old_connections()
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            record_harvest(batch.workspace, user, HarvestRequest(
+                batch=batch,
+                harvested_at=timezone.now(),
+                quantity=Decimal('4'),
+                unit_code=UnitCode.KILOGRAM,
+            ))
+        except ValidationError:
+            result = 'harvest rejected'
+        else:
+            result = 'harvested'
+        close_old_connections()
+        return result
+
+    def _cancel(self):
+        """Attempt to cancel the batch from an independent connection."""
+        close_old_connections()
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            cancel_batch(batch, user, 'Abandoned.')
+        except ValidationError:
+            result = 'cancel rejected'
+        else:
+            result = 'cancelled'
+        close_old_connections()
+        return result
+
+    def test_a_batch_is_never_both_cancelled_and_harvested(self):
+        """Whichever wins, the other is refused rather than half-applied."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._record),
+                    pool.submit(self._cancel),
+                ]
+            )
+
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        harvested = Harvest.objects.filter(
+            batch=batch,
+            status=Harvest.Status.POSTED,
+        ).exists()
+        if batch.status == ProductionBatch.Status.CANCELLED:
+            self.assertEqual(results, ['cancelled', 'harvest rejected'])
+            self.assertFalse(harvested)
+        else:
+            self.assertEqual(results, ['cancel rejected', 'harvested'])
+            self.assertTrue(harvested)


### PR DESCRIPTION
Add the concurrency proofs for harvest recording, and fix the deadlock the first of them found.

`record_harvest` took the batch lock and then, through `record_bulk_outcome`, the plant locks. Recording any plant outcome does the reverse implicitly: it holds the plant while inserting a lifecycle event whose batch reference makes the database take a key-share lock on the batch row. A final harvest running alongside any plant-level outcome on the same batch closed that cycle and deadlocked both writers. Plants are now locked in primary-key order first and the batch second, which is an order nothing else contradicts.

Two races are covered. A final harvest against a plant-level outcome proves a plant is resolved by exactly one writer; without the plant lock it deadlocks every run. Cancelling a batch against harvesting it proves the two serialise on the batch lock, so a batch is never both cancelled and harvested.

## Summary by Sourcery

Prevent deadlocks and ensure consistent outcomes when recording harvests by enforcing a strict lock ordering between plants and batches and adding concurrency tests.

Bug Fixes:
- Change harvest recording to lock plants in primary-key order before locking the batch to avoid deadlocks between plant- and batch-level operations.

Tests:
- Add transactional concurrency tests proving a plant can only receive a single final outcome when raced between a final harvest and a plant-level failure.
- Add transactional concurrency tests proving cancelling a batch and harvesting it are mutually exclusive and serialize correctly on the batch lock.
- Introduce a shared transactional test base that restores required Workspace seed data after teardown for harvest concurrency tests.