### PR TITLE
feat(plantings): report yield by crop, place, and period

### DIFF
--- a/plantings/batch_rest.py
+++ b/plantings/batch_rest.py
@@ -23,6 +23,7 @@ from .batches import (
     batch_final_outcome_count,
     batch_lifecycle_counts,
     batch_plants_with_active_location,
+    batch_posted_harvest_count,
     batch_seeds_sown,
     batch_specific_plants,
     batch_unresolved_plant_ids,
@@ -35,6 +36,7 @@ from .batches import (
     reopen_batch,
 )
 from .models import ProductionBatch, ProductionBatchTransition, SpecificPlantLocation
+from .yields import batch_harvest_finished_count, batch_harvest_totals
 
 
 def _model_errors(error):
@@ -328,6 +330,9 @@ class ProductionBatchDetailSerializer(ProductionBatchSerializer):
     sowings = serializers.SerializerMethodField()
     current_locations = serializers.SerializerMethodField()
     lifecycle_counts = serializers.SerializerMethodField()
+    harvest_count = serializers.SerializerMethodField()
+    harvest_totals = serializers.SerializerMethodField()
+    plants_harvest_finished = serializers.SerializerMethodField()
     transitions = ProductionBatchTransitionSerializer(many=True, read_only=True)
 
     class Meta(ProductionBatchSerializer.Meta):
@@ -335,12 +340,35 @@ class ProductionBatchDetailSerializer(ProductionBatchSerializer):
             'sowings',
             'current_locations',
             'lifecycle_counts',
+            'harvest_count',
+            'harvest_totals',
+            'plants_harvest_finished',
             'transitions',
         ]
 
     def get_sowings(self, batch):
         """Return each attached sowing with its lot, cells, and germinations."""
         return BatchSowingSerializer(_batch_sowings(batch), many=True).data
+
+    def get_harvest_count(self, batch):
+        """Return how many harvests still count as output from this batch."""
+        return batch_posted_harvest_count(batch)
+
+    def get_harvest_totals(self, batch):
+        """Return this batch's yield, one total per unit family.
+
+        Count, mass, and volume stay in separate entries; they are never added
+        together into a single figure.
+        """
+        return batch_harvest_totals(batch)
+
+    def get_plants_harvest_finished(self, batch):
+        """Return how many plants this batch harvested out.
+
+        Narrower than `final_outcomes`, which also counts plants that failed,
+        were culled, were donated, or were retained.
+        """
+        return batch_harvest_finished_count(batch)
 
     def get_lifecycle_counts(self, batch):
         """Return how many of this batch's plants sit in each derived state."""

--- a/plantings/test_batch_rest.py
+++ b/plantings/test_batch_rest.py
@@ -1,9 +1,13 @@
 """Tests for the production batch REST resources and lifecycle actions."""
 # pylint: disable=duplicate-code
+from decimal import Decimal
+
+from inventory.units import UnitCode
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_batch_for_packet,
     make_garden_square_sowing,
+    make_harvest,
     make_plant_variety,
     make_seed_packet,
     make_seed_tray_cell_planting,
@@ -251,6 +255,25 @@ class ProductionBatchRESTTests(RESTContractTestCase):
         self.assertEqual(len(response.data['current_locations']), 1)
         self.assertEqual(response.data['sowings'][0]['plants_observed'], 3)
         self.assertEqual(response.data['sowings'][0]['cells'][0]['quantity'], 2)
+
+    def test_batch_detail_reports_yield_beside_its_lineage_counts(self):
+        """The batch screen shows what came out without a second request."""
+        batch = make_batch_for_packet(self.packet)
+        make_harvest(batch=batch, quantity=Decimal('1.5'), unit_code=UnitCode.KILOGRAM)
+        make_harvest(batch=batch, quantity=Decimal('250'), unit_code=UnitCode.GRAM)
+        make_harvest(batch=batch, quantity=Decimal('12'), unit_code=UnitCode.EACH)
+
+        response = self.client.get(f'{self.url}{batch.pk}/')
+
+        self.assertEqual(response.data['harvest_count'], 3)
+        totals = {
+            entry['conversion_family']: entry
+            for entry in response.data['harvest_totals']
+        }
+        self.assertEqual(Decimal(totals['metric_mass']['quantity']), Decimal('1750'))
+        self.assertEqual(totals['metric_mass']['unit_code'], UnitCode.GRAM)
+        self.assertEqual(Decimal(totals['each']['quantity']), Decimal('12'))
+        self.assertEqual(response.data['plants_harvest_finished'], 0)
 
     def test_batches_are_filterable_by_status_variety_and_repair_state(self):
         """The batch screens can narrow a long list without extra endpoints."""

--- a/plantings/test_yields.py
+++ b/plantings/test_yields.py
@@ -1,0 +1,344 @@
+"""Tests for yield aggregation across recorded harvests."""
+# pylint: disable=duplicate-code
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from inventory.units import UnitCode
+from tests.factories import (
+    make_garden_row,
+    make_garden_square,
+    make_harvest,
+    make_production_batch,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_specific_plant,
+)
+from workspaces.models import get_current_workspace
+
+from .harvests import HarvestRequest, record_harvest, reverse_harvest
+from .lifecycle import record_germination_event
+from .models import Harvest, HarvestPlant
+from .yields import (
+    GroupBy,
+    NO_LOCATION_LABEL,
+    batch_harvest_finished_count,
+    batch_harvest_totals,
+    harvest_report,
+)
+
+
+def _report(group_by, **filters):
+    """Run a report over the current workspace with one grouping."""
+    return harvest_report(
+        get_current_workspace(),
+        {'group_by': group_by, **filters},
+    )
+
+
+def _total(row, family):
+    """Return one family's total from a report row, or None if absent."""
+    for entry in row['totals']:
+        if entry['conversion_family'] == family:
+            return entry
+    return None
+
+
+class UnitFamilyTotalTests(TestCase):
+    """Compatible units combine exactly; incompatible ones never do."""
+
+    def setUp(self):
+        super().setUp()
+        self.batch = make_production_batch()
+
+    def test_grams_and_kilograms_total_exactly_in_grams(self):
+        """Converting into a family's reference unit cannot lose precision."""
+        make_harvest(batch=self.batch, quantity=Decimal('1.5'), unit_code=UnitCode.KILOGRAM)
+        make_harvest(batch=self.batch, quantity=Decimal('250'), unit_code=UnitCode.GRAM)
+        mass = _total(_report(GroupBy.BATCH)[0], 'metric_mass')
+        self.assertEqual(mass['unit_code'], UnitCode.GRAM)
+        self.assertEqual(Decimal(mass['quantity']), Decimal('1750'))
+
+    def test_millilitres_and_litres_total_exactly_in_millilitres(self):
+        """Volume behaves the same way mass does."""
+        make_harvest(batch=self.batch, quantity=Decimal('2'), unit_code=UnitCode.LITRE)
+        make_harvest(batch=self.batch, quantity=Decimal('125'), unit_code=UnitCode.MILLILITRE)
+        volume = _total(_report(GroupBy.BATCH)[0], 'metric_volume')
+        self.assertEqual(volume['unit_code'], UnitCode.MILLILITRE)
+        self.assertEqual(Decimal(volume['quantity']), Decimal('2125'))
+
+    def test_count_and_weight_stay_in_separate_totals(self):
+        """Forty fruit plus twelve kilograms is not a number."""
+        make_harvest(batch=self.batch, quantity=Decimal('40'), unit_code=UnitCode.EACH)
+        make_harvest(batch=self.batch, quantity=Decimal('12'), unit_code=UnitCode.KILOGRAM)
+        row = _report(GroupBy.BATCH)[0]
+        self.assertEqual(len(row['totals']), 2)
+        self.assertEqual(Decimal(_total(row, 'each')['quantity']), Decimal('40'))
+        self.assertEqual(Decimal(_total(row, 'metric_mass')['quantity']), Decimal('12000'))
+        self.assertEqual(row['harvest_count'], 2)
+
+    def test_a_batch_total_matches_the_report(self):
+        """The batch screen and the report share one derivation."""
+        make_harvest(batch=self.batch, quantity=Decimal('3'), unit_code=UnitCode.KILOGRAM)
+        self.assertEqual(batch_harvest_totals(self.batch), _report(GroupBy.BATCH)[0]['totals'])
+
+    def test_a_reversed_harvest_is_excluded_from_totals(self):
+        """A retracted harvest stops counting the moment it is reversed."""
+        user = get_user_model().objects.create_user(username='yield-reverser')
+        make_harvest(batch=self.batch, quantity=Decimal('1'), unit_code=UnitCode.KILOGRAM)
+        drop = make_harvest(batch=self.batch, quantity=Decimal('9'), unit_code=UnitCode.KILOGRAM)
+        reverse_harvest(drop, user, 'Weighed the wrong crate.')
+        row = _report(GroupBy.BATCH)[0]
+        self.assertEqual(Decimal(_total(row, 'metric_mass')['quantity']), Decimal('1000'))
+        self.assertEqual(row['harvest_count'], 1)
+        self.assertEqual(Harvest.objects.count(), 2)
+
+
+class GroupingTests(TestCase):
+    """Every supported dimension groups the same harvests differently."""
+
+    def setUp(self):
+        super().setUp()
+        self.square = make_garden_square()
+        self.row = make_garden_row()
+        self.batch = make_production_batch()
+        self.other_batch = make_production_batch()
+        make_harvest(
+            batch=self.batch,
+            garden_square=self.square,
+            quantity=Decimal('1'),
+            unit_code=UnitCode.KILOGRAM,
+        )
+        make_harvest(
+            batch=self.other_batch,
+            garden_row=self.row,
+            quantity=Decimal('2'),
+            unit_code=UnitCode.KILOGRAM,
+        )
+        make_harvest(batch=self.batch, quantity=Decimal('4'), unit_code=UnitCode.KILOGRAM)
+
+    def test_grouping_by_batch_separates_the_crops(self):
+        """Each batch reports only what it produced."""
+        rows = {row['key']: row for row in _report(GroupBy.BATCH)}
+        self.assertEqual(
+            Decimal(_total(rows[self.batch.pk], 'metric_mass')['quantity']),
+            Decimal('5000'),
+        )
+        self.assertEqual(
+            Decimal(_total(rows[self.other_batch.pk], 'metric_mass')['quantity']),
+            Decimal('2000'),
+        )
+
+    def test_grouping_by_variety_labels_the_crop(self):
+        """A variety row names the plant and the variety it belongs to."""
+        rows = _report(GroupBy.VARIETY)
+        self.assertEqual(len(rows), 2)
+        labels = {row['label'] for row in rows}
+        self.assertIn(
+            f'{self.batch.variety.plant.name} — {self.batch.variety.name}',
+            labels,
+        )
+
+    def test_grouping_by_square_collects_unlocated_harvests_separately(self):
+        """A harvest with no location is not attributed to somewhere it wasn't."""
+        rows = {row['key']: row for row in _report(GroupBy.GARDEN_SQUARE)}
+        self.assertEqual(
+            Decimal(_total(rows[self.square.pk], 'metric_mass')['quantity']),
+            Decimal('1000'),
+        )
+        self.assertEqual(rows[None]['label'], NO_LOCATION_LABEL)
+        self.assertEqual(rows[None]['harvest_count'], 2)
+
+    def test_grouping_by_row_reports_the_row_that_grew_it(self):
+        """Direct-sown rows are a growing location like squares are."""
+        rows = {row['key']: row for row in _report(GroupBy.GARDEN_ROW)}
+        self.assertEqual(
+            Decimal(_total(rows[self.row.pk], 'metric_mass')['quantity']),
+            Decimal('2000'),
+        )
+
+    def test_grouping_by_year_buckets_the_calendar(self):
+        """A season is a date range; the calendar axis inside it is by period."""
+        rows = _report(GroupBy.YEAR)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['key'], f'{timezone.localdate().year:04d}')
+        self.assertEqual(rows[0]['harvest_count'], 3)
+
+    def test_a_date_range_narrows_the_report(self):
+        """The from and to bounds are both inclusive local days."""
+        today = timezone.localdate()
+        rows = _report(GroupBy.BATCH, harvested_from=today, harvested_to=today)
+        self.assertEqual(sum(row['harvest_count'] for row in rows), 3)
+        past = today - timedelta(days=400)
+        self.assertEqual(
+            _report(GroupBy.BATCH, harvested_from=past, harvested_to=past),
+            [],
+        )
+
+
+class PlantAttributionTests(TestCase):
+    """A per-plant report never triples or invents a shared measurement."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='attributor')
+        cell_planting = make_seed_tray_cell_planting()
+        self.batch = cell_planting.seed_tray_planting.batch
+        self.plants = [
+            make_specific_plant(cell_planting=cell_planting) for _ in range(3)
+        ]
+        for plant in self.plants:
+            record_germination_event(plant, self.user)
+
+    def _record(self, quantity, plants):
+        """Post one count harvest attributed to the given plants."""
+        return record_harvest(self.batch.workspace, self.user, HarvestRequest(
+            batch=self.batch,
+            harvested_at=timezone.now(),
+            quantity=quantity,
+            unit_code=UnitCode.EACH,
+            plant_ids=tuple(plant.pk for plant in plants),
+        ))
+
+    def test_a_solely_attributed_harvest_is_that_plant_s_own_yield(self):
+        """One plant, one measurement, one total."""
+        self._record(Decimal('5'), [self.plants[0]])
+        rows = {row['key']: row for row in _report(GroupBy.PLANT)}
+        row = rows[self.plants[0].pk]
+        self.assertEqual(Decimal(_total(row, 'each')['quantity']), Decimal('5'))
+        self.assertEqual(row['shared_totals'], [])
+
+    def test_a_shared_harvest_is_reported_beside_the_total_not_inside_it(self):
+        """Three plants sharing one crate did not each grow the whole crate."""
+        self._record(Decimal('9'), self.plants)
+        rows = {row['key']: row for row in _report(GroupBy.PLANT)}
+        for plant in self.plants:
+            row = rows[plant.pk]
+            self.assertEqual(row['totals'], [])
+            self.assertEqual(len(row['shared_totals']), 1)
+            self.assertEqual(
+                Decimal(row['shared_totals'][0]['quantity']),
+                Decimal('9'),
+            )
+
+    def test_other_groupings_never_report_shared_totals(self):
+        """The split only means anything when the grouping is a plant."""
+        self._record(Decimal('9'), self.plants)
+        for group_by in (GroupBy.BATCH, GroupBy.VARIETY, GroupBy.MONTH):
+            with self.subTest(group_by=group_by):
+                self.assertEqual(_report(group_by)[0]['shared_totals'], [])
+
+    def test_a_shared_harvest_is_counted_once_per_batch(self):
+        """Attribution must not multiply the crop the batch actually produced."""
+        self._record(Decimal('9'), self.plants)
+        self.assertEqual(HarvestPlant.objects.count(), 3)
+        row = _report(GroupBy.BATCH)[0]
+        self.assertEqual(Decimal(_total(row, 'each')['quantity']), Decimal('9'))
+        self.assertEqual(row['harvest_count'], 1)
+
+
+class LineageCountTests(TestCase):
+    """Seed, plant, and harvest counts are reported as separate integers."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='counter')
+        sowing = make_seed_tray_planting(quantity=40)
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=sowing)
+        self.batch = sowing.batch
+        self.plants = [
+            make_specific_plant(cell_planting=cell_planting) for _ in range(4)
+        ]
+        for plant in self.plants:
+            record_germination_event(plant, self.user)
+        record_harvest(self.batch.workspace, self.user, HarvestRequest(
+            batch=self.batch,
+            harvested_at=timezone.now(),
+            quantity=Decimal('3'),
+            unit_code=UnitCode.EACH,
+            plant_ids=(self.plants[0].pk, self.plants[1].pk),
+            finish_plants=True,
+        ))
+
+    def test_the_three_counts_are_reported_independently(self):
+        """Sowing, germination, and harvest are three separate outcomes."""
+        row = _report(GroupBy.BATCH)[0]
+        self.assertEqual(row['seeds_sown'], 40)
+        self.assertEqual(row['plants_observed'], 4)
+        self.assertEqual(row['plants_harvest_finished'], 2)
+
+    def test_no_ratio_of_unlike_things_is_reported(self):
+        """Seeds sown divided by weight picked is not a rate of anything."""
+        row = _report(GroupBy.BATCH)[0]
+        for key in row:
+            self.assertNotIn('ratio', key)
+            self.assertNotIn('rate', key)
+            self.assertNotIn('per_', key)
+
+    def test_lineage_is_absent_where_it_is_undefined(self):
+        """A square, a row, or a month may hold several crops at once."""
+        for group_by in (GroupBy.GARDEN_SQUARE, GroupBy.GARDEN_ROW,
+                         GroupBy.MONTH, GroupBy.YEAR, GroupBy.PLANT):
+            with self.subTest(group_by=group_by):
+                row = _report(group_by)[0]
+                self.assertIsNone(row['seeds_sown'])
+                self.assertIsNone(row['plants_observed'])
+                self.assertIsNone(row['plants_harvest_finished'])
+
+    def test_the_finished_count_matches_the_batch_helper(self):
+        """The report and the batch screen share one derivation."""
+        self.assertEqual(batch_harvest_finished_count(self.batch), 2)
+
+
+class LocalCalendarTests(TestCase):
+    """Buckets and day bounds are cut in the workspace's own timezone."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.timezone = 'Pacific/Auckland'
+        self.workspace.save()
+        self.zone = ZoneInfo('Pacific/Auckland')
+        self.batch = make_production_batch()
+
+    def _at(self, local):
+        """Post a one-kilogram harvest at one local wall-clock time."""
+        make_harvest(
+            batch=self.batch,
+            harvested_at=local.replace(tzinfo=self.zone),
+            quantity=Decimal('1'),
+            unit_code=UnitCode.KILOGRAM,
+        )
+
+    def test_a_late_evening_harvest_buckets_into_its_local_month(self):
+        """23:30 on the last of the month is not the next month in UTC terms."""
+        self._at(datetime(2026, 4, 30, 23, 30))
+        rows = _report(GroupBy.MONTH)
+        self.assertEqual([row['key'] for row in rows], ['2026-04'])
+
+    def test_a_late_evening_harvest_falls_inside_its_local_day(self):
+        """An inclusive to-bound covers the whole local day it names."""
+        self._at(datetime(2026, 4, 30, 23, 30))
+        rows = _report(
+            GroupBy.BATCH,
+            harvested_from=date(2026, 4, 30),
+            harvested_to=date(2026, 4, 30),
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['harvest_count'], 1)
+
+    def test_the_next_local_day_is_excluded(self):
+        """The bound is a local day, not a rounded UTC instant."""
+        self._at(datetime(2026, 5, 1, 0, 30))
+        self.assertEqual(
+            _report(
+                GroupBy.BATCH,
+                harvested_from=date(2026, 4, 30),
+                harvested_to=date(2026, 4, 30),
+            ),
+            [],
+        )

--- a/plantings/yields.py
+++ b/plantings/yields.py
@@ -1,0 +1,281 @@
+"""Yield aggregation over recorded harvests.
+
+Totals are grouped by one dimension at a time and reported per unit family.
+Count, mass, and volume are never added together: a report that combined
+forty fruit with twelve kilograms would be arithmetic without a meaning, so
+each family gets its own total expressed in that family's reference unit.
+
+"Season" is deliberately not a grouping. Which months make a season depends on
+the hemisphere and on the crop, so guessing one would invent information the
+records do not hold. A caller expresses a season as a `harvested_from` and
+`harvested_to` range, and the month and year groupings supply the calendar
+axis inside it.
+
+Seed, plant, and harvest counts are likewise reported as separate integers.
+Seeds sown divided by kilograms picked is not a yield ratio, and this module
+never produces one.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import datetime, time, timedelta
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.db import models
+
+from inventory.ledger import quantize_quantity
+from inventory.units import convert_standard_quantity, get_unit_definition
+
+from .batches import batch_seeds_sown, batch_specific_plants
+from .lifecycle import LifecycleState, lifecycle_summaries
+from .models import Harvest
+
+
+class GroupBy(models.TextChoices):
+    """The dimensions a yield report may be grouped by."""
+
+    PLANT = 'plant', 'Plant'
+    VARIETY = 'variety', 'Variety'
+    BATCH = 'batch', 'Batch'
+    GARDEN_SQUARE = 'garden_square', 'Garden square'
+    GARDEN_ROW = 'garden_row', 'Garden row'
+    MONTH = 'month', 'Month'
+    YEAR = 'year', 'Year'
+
+
+#: Groupings whose rows describe one crop, and so can carry the seed and plant
+#: counts that lineage is defined for. A square, a row, or a calendar bucket may
+#: hold several crops at once, so reporting a seed count against one would
+#: attribute another crop's sowing to it. An individual plant has no lineage
+#: worth reporting either: it came from one seed and is one plant, so the
+#: counts would be trivia rather than information.
+LINEAGE_GROUPINGS = {GroupBy.BATCH, GroupBy.VARIETY}
+
+#: The label a row carries when its harvest recorded no growing location.
+NO_LOCATION_LABEL = 'No location recorded'
+
+
+def _reference_unit(unit_code):
+    """Return the unit one family totals in, and the family's identity."""
+    definition = get_unit_definition(unit_code)
+    return definition.conversion_family, definition.reference_unit
+
+
+def _family_total(harvests):
+    """Total compatible harvests, keeping incompatible dimensions apart.
+
+    Converting into a family's reference unit is exact: the target multiplier
+    is always one, so the conversion is a multiplication and no division
+    rounding can occur.
+    """
+    families = {}
+    for harvest in harvests:
+        family, reference = _reference_unit(harvest.unit_code)
+        bucket = families.setdefault(family, {
+            'conversion_family': family,
+            'dimension': get_unit_definition(reference).dimension,
+            'unit_code': reference,
+            'total': Decimal('0'),
+            'harvest_count': 0,
+        })
+        bucket['total'] += convert_standard_quantity(
+            harvest.quantity,
+            harvest.unit_code,
+            reference,
+        )
+        bucket['harvest_count'] += 1
+    return [
+        {
+            'conversion_family': bucket['conversion_family'],
+            'dimension': bucket['dimension'],
+            'unit_code': bucket['unit_code'],
+            'quantity': f'{quantize_quantity(bucket["total"]):.9f}',
+            'harvest_count': bucket['harvest_count'],
+        }
+        for _family, bucket in sorted(families.items())
+    ]
+
+
+def batch_harvest_totals(batch):
+    """Return one batch's posted yield, one total per unit family."""
+    return _family_total(
+        Harvest.objects.filter(batch=batch, status=Harvest.Status.POSTED),
+    )
+
+
+def batch_harvest_finished_count(batch):
+    """Return how many of this batch's plants were harvested out.
+
+    Narrower than the batch's final-outcome count, which also counts plants
+    that failed, were culled, were donated, or were retained.
+    """
+    summaries = lifecycle_summaries(
+        batch_specific_plants(batch).order_by('pk').values_list('pk', flat=True),
+    )
+    return sum(
+        1
+        for summary in summaries.values()
+        if summary.state == LifecycleState.HARVESTED
+    )
+
+
+def _zone(workspace):
+    """Return the timezone a workspace's calendar buckets are cut in."""
+    return ZoneInfo(workspace.timezone)
+
+
+def _day_bounds(zone, harvested_from, harvested_to):
+    """Return the half-open aware range two inclusive local dates describe."""
+    start = None
+    end = None
+    if harvested_from is not None:
+        start = datetime.combine(harvested_from, time.min, tzinfo=zone)
+    if harvested_to is not None:
+        end = datetime.combine(harvested_to + timedelta(days=1), time.min, tzinfo=zone)
+    return start, end
+
+
+def _filtered_harvests(workspace, filters):
+    """Return the posted harvests one report covers, in one query."""
+    queryset = Harvest.objects.filter(
+        workspace=workspace,
+        status=Harvest.Status.POSTED,
+    ).select_related(
+        'batch__variety__plant',
+        'garden_square',
+        'garden_row',
+    ).prefetch_related('plant_allocations')
+    start, end = _day_bounds(
+        _zone(workspace),
+        filters.get('harvested_from'),
+        filters.get('harvested_to'),
+    )
+    if start is not None:
+        queryset = queryset.filter(harvested_at__gte=start)
+    if end is not None:
+        queryset = queryset.filter(harvested_at__lt=end)
+    for field, lookup in (
+        ('batch', 'batch_id'),
+        ('variety', 'batch__variety_id'),
+        ('garden_square', 'garden_square_id'),
+        ('garden_row', 'garden_row_id'),
+    ):
+        value = filters.get(field)
+        if value is not None:
+            queryset = queryset.filter(**{lookup: value})
+    return queryset
+
+
+def _entity_key(group_by, harvest):
+    """Return the identity and label of the group one harvest belongs to."""
+    if group_by == GroupBy.BATCH:
+        return harvest.batch_id, harvest.batch.code
+    if group_by == GroupBy.VARIETY:
+        variety = harvest.batch.variety
+        return variety.pk, f'{variety.plant.name} — {variety.name}'
+    if group_by == GroupBy.GARDEN_SQUARE:
+        square = harvest.garden_square
+        return (None, NO_LOCATION_LABEL) if square is None else (square.pk, str(square))
+    row = harvest.garden_row
+    return (None, NO_LOCATION_LABEL) if row is None else (row.pk, str(row))
+
+
+def _period_key(group_by, harvest, zone):
+    """Return the calendar bucket one harvest falls in, cut locally."""
+    local = harvest.harvested_at.astimezone(zone)
+    if group_by == GroupBy.YEAR:
+        return f'{local.year:04d}', f'{local.year:04d}'
+    return f'{local.year:04d}-{local.month:02d}', local.strftime('%B %Y')
+
+
+def _grouped_harvests(harvests, group_by, zone):
+    """Return each group's key, label, and harvests, in a stable order."""
+    groups = {}
+    for harvest in harvests:
+        if group_by in (GroupBy.MONTH, GroupBy.YEAR):
+            pairs = [_period_key(group_by, harvest, zone)]
+        elif group_by == GroupBy.PLANT:
+            pairs = [
+                (allocation.plant_id, f'Plant {allocation.plant_id}')
+                for allocation in harvest.plant_allocations.all()
+            ]
+        else:
+            pairs = [_entity_key(group_by, harvest)]
+        for key, label in pairs:
+            groups.setdefault(key, {'label': label, 'harvests': []})
+            groups[key]['harvests'].append(harvest)
+    return sorted(
+        groups.items(),
+        key=lambda item: (item[0] is None, str(item[0])),
+    )
+
+
+def _plant_totals(harvests):
+    """Split a plant's harvests into its own yield and its shared yield.
+
+    A harvest attributed to three plants measured one crop, not three. Adding it
+    to each plant would triple the yield, and dividing it would invent a split
+    nobody observed, so shared harvests are reported beside the total rather
+    than inside it.
+    """
+    own = [h for h in harvests if len(h.plant_allocations.all()) == 1]
+    shared = [h for h in harvests if len(h.plant_allocations.all()) > 1]
+    return _family_total(own), _family_total(shared)
+
+
+def _lineage_counts(group_by, batches):
+    """Return the seed, plant, and harvest counts for one group's crops.
+
+    Reported as three independent integers. A seed count divided by a picked
+    weight is not a rate of anything, so no ratio is derived from them here or
+    anywhere downstream.
+    """
+    if group_by not in LINEAGE_GROUPINGS:
+        return {
+            'seeds_sown': None,
+            'plants_observed': None,
+            'plants_harvest_finished': None,
+        }
+    return {
+        'seeds_sown': sum(batch_seeds_sown(batch) for batch in batches),
+        'plants_observed': sum(
+            batch_specific_plants(batch).count() for batch in batches
+        ),
+        'plants_harvest_finished': sum(
+            batch_harvest_finished_count(batch) for batch in batches
+        ),
+    }
+
+
+def harvest_report(workspace, filters):
+    """Return one row per group describing what that group yielded.
+
+    Aggregated in Python from a single query. Totalling in SQL would mean
+    either summing incompatible units into one meaningless number or issuing a
+    query per unit family, and the local calendar bucketing below has no
+    portable SQL equivalent.
+    """
+    group_by = filters['group_by']
+    zone = _zone(workspace)
+    harvests = list(_filtered_harvests(workspace, filters))
+    rows = []
+    for key, group in _grouped_harvests(harvests, group_by, zone):
+        members = group['harvests']
+        if group_by == GroupBy.PLANT:
+            totals, shared_totals = _plant_totals(members)
+        else:
+            totals, shared_totals = _family_total(members), []
+        batches = {harvest.batch_id: harvest.batch for harvest in members}
+        rows.append({
+            'group_by': group_by,
+            'key': key,
+            'label': group['label'],
+            'harvest_count': len(members),
+            'first_harvested_at': min(h.harvested_at for h in members),
+            'last_harvested_at': max(h.harvested_at for h in members),
+            'totals': totals,
+            'shared_totals': shared_totals,
+            **_lineage_counts(group_by, batches.values()),
+        })
+    return rows


### PR DESCRIPTION
Add yield aggregation over posted harvests, grouped by plant, variety, batch, garden square, garden row, month, or year, and surface a batch's own totals on its detail resource.

Count, mass, and volume are never added together. Each unit family gets its own total in that family's reference unit, which makes the conversion a pure multiplication and so exact. Seeds sown, plants observed, and plants harvested out are three separate integers; no ratio is derived between a seed count and a picked weight, because that would not be a rate of anything.

Season is not a grouping. Which months make a season depends on the hemisphere and the crop, so a caller expresses one as a date range and the month and year groupings give the calendar axis inside it. Those buckets and the inclusive day bounds are cut in the workspace's own timezone, not the server's.

A per-plant report keeps a harvest shared between several plants beside the total rather than inside it. Adding a shared crate to each plant would triple the yield and dividing it would invent a split nobody measured.

## Summary by Sourcery

Add yield aggregation over posted harvests and expose batch-level harvest totals and counts alongside lineage metrics.

New Features:
- Expose harvest count, yield totals per unit family, and harvested-out plant counts on the production batch detail resource.
- Introduce a yield reporting API that aggregates posted harvests by crop, location, and calendar period, with separate totals for each unit family and support for plant-level attribution.

Tests:
- Add comprehensive tests covering unit-family aggregation precision, grouping by batch, variety, location, and period, shared plant harvest attribution, independent lineage counts, and timezone-aware calendar bucketing for yield reports.