### PR TITLE
feat(plantings): expose harvests and the yield report

### DIFF
--- a/inventory/rest_query.py
+++ b/inventory/rest_query.py
@@ -25,19 +25,32 @@ def parse_integer(value, field):
 
 def parse_date(value, field):
     """Parse an optional ISO date query parameter."""
-    if value is None:
-        return None
-    parsed = serializers.DateField().run_validation(value)
-    if parsed is None:
-        raise ValidationError({field: 'Enter a valid date.'})
-    return parsed
+    return _parse_field(serializers.DateField(), value, field, 'Enter a valid date.')
 
 
 def parse_datetime(value, field):
     """Parse an optional ISO timestamp query parameter."""
+    return _parse_field(
+        serializers.DateTimeField(),
+        value,
+        field,
+        'Enter a valid timestamp.',
+    )
+
+
+def _parse_field(serializer_field, value, field, message):
+    """Run one field's validation, blaming the query parameter by name.
+
+    The field's own error is raised without a key, which reads as a body error
+    rather than a bad query parameter, so it is re-raised under the parameter
+    name the caller supplied.
+    """
     if value is None:
         return None
-    parsed = serializers.DateTimeField().run_validation(value)
+    try:
+        parsed = serializer_field.run_validation(value)
+    except ValidationError as exc:
+        raise ValidationError({field: exc.detail}) from exc
     if parsed is None:
-        raise ValidationError({field: 'Enter a valid timestamp.'})
+        raise ValidationError({field: message})
     return parsed

--- a/plantings/harvest_rest.py
+++ b/plantings/harvest_rest.py
@@ -1,0 +1,383 @@
+"""REST resources for recording, reversing, and reporting harvests.
+
+A harvest is posted when it is created, so the collection offers no update or
+delete: a mistake is corrected through the explicit reverse action, which keeps
+the original record visible while excluding it from every total.
+"""
+
+# pylint: disable=duplicate-code
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils import timezone
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from garden.models import GardenRow, GardenSquare
+from inventory.models import (
+    POSITIVE_DECIMAL,
+    QUANTITY_DECIMAL_PLACES,
+    QUANTITY_MAX_DIGITS,
+)
+from inventory.rest_query import parse_date, parse_integer
+from workspaces.models import get_current_workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+)
+
+from .harvests import (
+    HarvestRequest,
+    harvest_finished_plant_ids,
+    record_harvest,
+    reverse_harvest,
+)
+from .models import HARVEST_UNIT_CHOICES, Harvest, ProductionBatch, SpecificPlant
+from .yields import (
+    GroupBy,
+    harvest_report,
+    local_day_bounds,
+    workspace_zone,
+)
+
+
+def _model_errors(error):
+    """Translate model validation errors into DRF response details."""
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
+
+
+def _run_domain_action(function, *args, **kwargs):
+    """Invoke a harvest service with field-friendly API errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+class ActionSerializer(serializers.Serializer):
+    """Validation-only serializer base for harvest actions."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class ReverseHarvestSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Validate why a recorded harvest should stop counting."""
+
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
+class HarvestSerializer(serializers.ModelSerializer):
+    """Serialize one posted or reversed harvest."""
+
+    batch_code = serializers.CharField(source='batch.code', read_only=True)
+    variety = serializers.IntegerField(source='batch.variety_id', read_only=True)
+    variety_name = serializers.CharField(source='batch.variety.name', read_only=True)
+    plant_name = serializers.CharField(source='batch.variety.plant.name', read_only=True)
+    location_label = serializers.SerializerMethodField()
+    plants = serializers.SerializerMethodField()
+    finished_plants = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Harvest
+        fields = [
+            'pk',
+            'batch',
+            'batch_code',
+            'variety',
+            'variety_name',
+            'plant_name',
+            'harvested_at',
+            'quantity',
+            'unit_code',
+            'garden_square',
+            'garden_row',
+            'location_label',
+            'quality_rating',
+            'grade',
+            'notes',
+            'status',
+            'posted_at',
+            'reversed_at',
+            'reverse_reason',
+            'created_by',
+            'reversed_by',
+            'created',
+            'plants',
+            'finished_plants',
+        ]
+        read_only_fields = fields
+
+    def get_location_label(self, harvest):
+        """Return where this harvest was taken, if anywhere was recorded."""
+        location = harvest.garden_square or harvest.garden_row
+        return None if location is None else str(location)
+
+    def get_plants(self, harvest):
+        """Return the individual plants this harvest is attributed to."""
+        return sorted(
+            allocation.plant_id
+            for allocation in harvest.plant_allocations.all()
+        )
+
+    def get_finished_plants(self, harvest):
+        """Return the plants this harvest ended, if it ended any."""
+        return harvest_finished_plant_ids(harvest)
+
+
+class HarvestCreateSerializer(
+    CurrentWorkspaceSerializerMixin,
+    ActionSerializer,
+):  # pylint: disable=abstract-method
+    """Validate one harvest before the service posts it.
+
+    Not a model serializer: the record is written by the domain service inside
+    one transaction and is immutable afterwards, so there is nothing for a
+    generic create-and-update contract to do.
+    """
+
+    batch = serializers.PrimaryKeyRelatedField(queryset=ProductionBatch.objects.all())
+    harvested_at = serializers.DateTimeField()
+    quantity = serializers.DecimalField(
+        max_digits=QUANTITY_MAX_DIGITS,
+        decimal_places=QUANTITY_DECIMAL_PLACES,
+        min_value=POSITIVE_DECIMAL,
+    )
+    unit_code = serializers.ChoiceField(choices=HARVEST_UNIT_CHOICES)
+    garden_square = serializers.PrimaryKeyRelatedField(
+        queryset=GardenSquare.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    garden_row = serializers.PrimaryKeyRelatedField(
+        queryset=GardenRow.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    quality_rating = serializers.IntegerField(
+        min_value=1,
+        max_value=5,
+        required=False,
+        allow_null=True,
+    )
+    grade = serializers.ChoiceField(
+        choices=Harvest.Grade.choices,
+        required=False,
+        default=Harvest.Grade.UNGRADED,
+    )
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    plants = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        default=list,
+    )
+    finish_plants = serializers.BooleanField(required=False, default=False)
+    finish_reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default='',
+    )
+
+    workspace_field_lookups = {
+        'batch': 'workspace',
+        'garden_square': 'workspace',
+        'garden_row': 'workspace',
+    }
+
+    def validate_harvested_at(self, value):
+        """Reject a crop picked before it existed.
+
+        Kept out of the model so backfills and fixtures stay free to write a
+        record with whatever timestamp the history actually holds.
+        """
+        if value > timezone.now():
+            raise serializers.ValidationError(
+                'A harvest cannot be recorded in the future.',
+            )
+        return value
+
+    def validate(self, attrs):
+        """Reject a payload no harvest could describe."""
+        if attrs.get('garden_square') and attrs.get('garden_row'):
+            raise serializers.ValidationError({
+                'garden_row': 'Record a garden square or a garden row, not both.',
+            })
+        if attrs['finish_plants'] and not attrs['plants']:
+            raise serializers.ValidationError({
+                'plants': 'Select the plants this harvest finished.',
+            })
+        return attrs
+
+    def _resolve_plant_ids(self, requested):
+        """Reject a selection naming plants outside the current workspace."""
+        wanted = sorted(set(requested))
+        known = set(
+            SpecificPlant.objects
+            .filter(workspace=get_current_workspace(), pk__in=wanted)
+            .values_list('pk', flat=True)
+        )
+        missing = [plant_id for plant_id in wanted if plant_id not in known]
+        if missing:
+            raise serializers.ValidationError({
+                'plants': f'No such plants in this workspace: {missing}.',
+            })
+        return wanted
+
+    def create(self, validated_data):
+        """Post the harvest the validated payload describes."""
+        return _run_domain_action(
+            record_harvest,
+            get_current_workspace(),
+            self.context['request'].user,
+            HarvestRequest(
+                batch=validated_data['batch'],
+                harvested_at=validated_data['harvested_at'],
+                quantity=validated_data['quantity'],
+                unit_code=validated_data['unit_code'],
+                garden_square=validated_data.get('garden_square'),
+                garden_row=validated_data.get('garden_row'),
+                quality_rating=validated_data.get('quality_rating'),
+                grade=validated_data['grade'],
+                notes=validated_data['notes'],
+                plant_ids=self._resolve_plant_ids(validated_data['plants']),
+                finish_plants=validated_data['finish_plants'],
+                finish_reason=validated_data['finish_reason'],
+            ),
+        )[0]
+
+    def to_representation(self, instance):
+        """Answer a create with the same contract a read returns."""
+        return HarvestSerializer(instance, context=self.context).data
+
+
+class HarvestViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Record and read harvests.
+
+    PUT, PATCH, and DELETE are not provided: a harvest is posted when it is
+    created, and the reverse action is the only way to stop one counting.
+    """
+
+    queryset = Harvest.objects.select_related(
+        'batch__variety__plant',
+        'garden_square',
+        'garden_row',
+    ).prefetch_related('plant_allocations')
+    serializer_class = HarvestSerializer
+    http_method_names = ['get', 'post', 'head', 'options']
+    bind_workspace_on_create = False
+
+    def get_serializer_class(self):
+        """Validate a create through the action contract, not the read one."""
+        if self.action == 'create':
+            return HarvestCreateSerializer
+        return HarvestSerializer
+
+    def get_queryset(self):
+        """Apply the crop, place, status, and period filters the screens use."""
+        queryset = super().get_queryset()
+        for field, lookup in (
+            ('batch', 'batch_id'),
+            ('variety', 'batch__variety_id'),
+            ('garden_square', 'garden_square_id'),
+            ('garden_row', 'garden_row_id'),
+        ):
+            value = parse_integer(self.request.query_params.get(field), field)
+            if value is not None:
+                queryset = queryset.filter(**{lookup: value})
+        plant = parse_integer(self.request.query_params.get('plant'), 'plant')
+        if plant is not None:
+            queryset = queryset.filter(plant_allocations__plant_id=plant).distinct()
+        harvest_status = self.request.query_params.get('status')
+        if harvest_status:
+            if harvest_status not in {choice.value for choice in Harvest.Status}:
+                raise ValidationError({'status': 'Select a valid harvest status.'})
+            queryset = queryset.filter(status=harvest_status)
+        return _filter_period(queryset, self.request.query_params)
+
+    def perform_destroy(self, instance):
+        """Refuse deletion even if a future route were to offer it."""
+        raise serializers.ValidationError({
+            'detail': 'Posted harvests cannot be deleted; reverse them instead.',
+        })
+
+    @action(detail=True, methods=['post'])
+    def reverse(self, request, pk=None):  # pylint: disable=unused-argument
+        """Stop a mistaken harvest counting without erasing the record."""
+        serializer = ReverseHarvestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        harvest = _run_domain_action(
+            reverse_harvest,
+            self.get_object(),
+            request.user,
+            serializer.validated_data['reason'],
+        )
+        return Response(
+            HarvestSerializer(harvest, context={'request': request}).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+def _filter_period(queryset, params):
+    """Narrow a harvest queryset to one inclusive range of local days.
+
+    The bounds come from the reporting module so the list and the report cut
+    days at the same instants and cannot drift apart.
+    """
+    start, end = local_day_bounds(
+        workspace_zone(get_current_workspace()),
+        parse_date(params.get('harvested_from'), 'harvested_from'),
+        parse_date(params.get('harvested_to'), 'harvested_to'),
+    )
+    if start is not None:
+        queryset = queryset.filter(harvested_at__gte=start)
+    if end is not None:
+        queryset = queryset.filter(harvested_at__lt=end)
+    return queryset
+
+
+class HarvestReportView(APIView):
+    """Report yield grouped by one dimension over an optional period.
+
+    A separate view rather than a collection action: the response describes
+    groups of harvests rather than harvests, and its filter vocabulary is not
+    the collection's.
+    """
+
+    http_method_names = ['get', 'head', 'options']
+
+    def get(self, request):
+        """Return one row per group in the requested grouping."""
+        group_by = request.query_params.get('group_by', GroupBy.BATCH)
+        if group_by not in {choice.value for choice in GroupBy}:
+            raise ValidationError({'group_by': 'Select a valid grouping.'})
+        params = request.query_params
+        return Response(harvest_report(get_current_workspace(), {
+            'group_by': group_by,
+            'batch': parse_integer(params.get('batch'), 'batch'),
+            'variety': parse_integer(params.get('variety'), 'variety'),
+            'garden_square': parse_integer(
+                params.get('garden_square'),
+                'garden_square',
+            ),
+            'garden_row': parse_integer(params.get('garden_row'), 'garden_row'),
+            'harvested_from': parse_date(
+                params.get('harvested_from'),
+                'harvested_from',
+            ),
+            'harvested_to': parse_date(params.get('harvested_to'), 'harvested_to'),
+        }))
+
+
+def register_harvest_routes(router):
+    """Attach the harvest resources to the planting API router."""
+    router.register(r'harvests', HarvestViewSet)

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -15,6 +15,7 @@ from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .batch_rest import BatchedSowingSerializerMixin, InlineBatchSerializer, register_batch_routes
+from .harvest_rest import register_harvest_routes
 from .lifecycle import record_germination_event, record_transplant_event
 from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSerializerMixin, PlantOutcomeViewSetMixin, register_lifecycle_routes
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
@@ -983,3 +984,4 @@ router.register(r'seedtray-data/(?P<seed_tray_pk>[^/.]+)/plantings', SeedTrayPla
 router.register(r'seedtray-data/(?P<seed_tray_pk>[^/.]+)/specificplants', SpecificPlantBySeedTrayViewSet, basename='seedtray-specificplants')
 router.register(r'specificplants/(?P<specific_plant_pk>[^/.]+)/locations', SpecificPlantLocationByPlantViewSet, basename='specificplant-locations')
 register_lifecycle_routes(router)
+register_harvest_routes(router)

--- a/plantings/test_harvest_rest.py
+++ b/plantings/test_harvest_rest.py
@@ -1,0 +1,459 @@
+"""Tests for the harvest REST contract and the yield report endpoint."""
+# pylint: disable=duplicate-code
+from datetime import timedelta
+from decimal import Decimal
+
+from django.utils import timezone
+
+from inventory.units import UnitCode
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_garden_row,
+    make_garden_square,
+    make_harvest,
+    make_plant,
+    make_plant_family,
+    make_plant_variety,
+    make_production_batch,
+    make_seed_tray_cell_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace
+
+from .lifecycle import record_germination_event
+from .models import Harvest, PlantLifecycleEvent
+
+
+class HarvestRESTTestCase(RESTContractTestCase):
+    """Shared fixtures and helpers for the harvest API tests."""
+
+    url = '/plantings/harvests/'
+    report_url = '/plantings/harvest-report/'
+
+    def setUp(self):
+        super().setUp()
+        self.batch = make_production_batch()
+        self.square = make_garden_square()
+
+    def payload(self, **overrides):
+        """Build a valid create payload for the fixture batch."""
+        values = {
+            'batch': self.batch.pk,
+            'harvested_at': timezone.now().isoformat(),
+            'quantity': '1.500000000',
+            'unit_code': UnitCode.KILOGRAM,
+        }
+        values.update(overrides)
+        return values
+
+    def create(self, **overrides):
+        """Post one harvest and assert it was accepted."""
+        response = self.client.post(self.url, self.payload(**overrides), format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+
+class HarvestContractTests(HarvestRESTTestCase):
+    """The collection follows the common contract and refuses edits."""
+
+    def test_list_route_requires_authentication_and_returns_a_list(self):
+        """Harvests follow the common authenticated collection contract."""
+        self.assert_authentication_required([self.url, self.report_url])
+        self.assert_list_contract([self.url])
+
+    def test_create_and_retrieve_round_trip(self):
+        """A created harvest reads back through its detail route."""
+        self.assert_create_retrieve(
+            self.url,
+            self.payload(),
+            expected_fields={
+                'batch': self.batch.pk,
+                'quantity': '1.500000000',
+                'unit_code': UnitCode.KILOGRAM,
+            },
+        )
+
+    def test_a_created_harvest_is_already_posted(self):
+        """There is no draft step; recording a harvest counts it."""
+        created = self.create()
+        self.assertEqual(created['status'], Harvest.Status.POSTED)
+        self.assertIsNotNone(created['posted_at'])
+        self.assertIsNone(created['reversed_at'])
+        self.assertEqual(created['plants'], [])
+        self.assertEqual(created['finished_plants'], [])
+
+    def test_the_quantity_is_a_string_with_a_stable_unit_code(self):
+        """Decimal yield never round-trips through a float."""
+        created = self.create(quantity='0.125000000', unit_code=UnitCode.LITRE)
+        self.assertIsInstance(created['quantity'], str)
+        self.assertEqual(Decimal(created['quantity']), Decimal('0.125'))
+        self.assertEqual(created['unit_code'], UnitCode.LITRE)
+
+    def test_a_posted_harvest_cannot_be_edited_or_deleted(self):
+        """Generic writes are not offered; a correction reverses instead."""
+        created = self.create()
+        detail = f'{self.url}{created["pk"]}/'
+        for method, kwargs in (
+            ('put', {'data': self.payload(), 'format': 'json'}),
+            ('patch', {'data': {'notes': 'edited'}, 'format': 'json'}),
+            ('delete', {}),
+        ):
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(detail, **kwargs)
+                self.assertEqual(response.status_code, 405, response.data)
+
+    def test_the_location_label_names_where_a_harvest_came_from(self):
+        """A square or a row reads back with a human label."""
+        created = self.create(garden_square=self.square.pk)
+        self.assertEqual(created['garden_square'], self.square.pk)
+        self.assertEqual(created['location_label'], str(self.square))
+
+
+class HarvestValidationTests(HarvestRESTTestCase):
+    """Invalid harvests are refused with field-level errors."""
+
+    def _reject(self, expected_field, **overrides):
+        """Post an invalid payload and assert which field was blamed."""
+        response = self.client.post(self.url, self.payload(**overrides), format='json')
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn(expected_field, response.data)
+        return response.data
+
+    def test_zero_and_negative_quantities_are_rejected(self):
+        """A harvest that measured nothing or less is not an observation."""
+        for quantity in ('0', '-5'):
+            with self.subTest(quantity=quantity):
+                self._reject('quantity', quantity=quantity)
+
+    def test_input_and_area_units_are_rejected(self):
+        """Only count, mass, and volume describe a crop that came out."""
+        for unit in (UnitCode.SEED, UnitCode.SEED_CLUSTER, UnitCode.SQUARE_METRE):
+            with self.subTest(unit=unit):
+                self._reject('unit_code', unit_code=unit)
+
+    def test_a_future_harvest_is_rejected(self):
+        """A crop cannot be picked before it exists."""
+        ahead = (timezone.now() + timedelta(days=1)).isoformat()
+        self._reject('harvested_at', harvested_at=ahead)
+
+    def test_a_square_and_a_row_cannot_both_be_recorded(self):
+        """One harvest came from one place."""
+        self._reject(
+            'garden_row',
+            garden_square=self.square.pk,
+            garden_row=make_garden_row().pk,
+        )
+
+    def test_finishing_without_a_selection_is_rejected(self):
+        """There is nothing to finish when no plant was named."""
+        self._reject('plants', finish_plants=True)
+
+    def test_a_planned_batch_cannot_be_harvested(self):
+        """Nothing has been sown yet, so nothing can have come out."""
+        from .models import ProductionBatch  # pylint: disable=import-outside-toplevel
+        batch = make_production_batch(status=ProductionBatch.Status.PLANNED)
+        self._reject('batch', batch=batch.pk)
+
+
+class HarvestWorkspaceScopingTests(HarvestRESTTestCase):
+    """References outside this workspace are field errors, not 404s."""
+
+    def setUp(self):
+        super().setUp()
+        self.other = Workspace.objects.create(name='Other workspace')
+
+    def _foreign_batch(self):
+        """Create an active batch belonging to the other workspace."""
+        family = make_plant_family(workspace=self.other)
+        plant = make_plant(workspace=self.other, family=family)
+        variety = make_plant_variety(workspace=self.other, plant=plant)
+        return make_production_batch(workspace=self.other, variety=variety)
+
+    def test_a_foreign_batch_is_a_field_error(self):
+        """Scoping is enforced by narrowing the field, not by hiding the row."""
+        response = self.client.post(
+            self.url,
+            self.payload(batch=self._foreign_batch().pk),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('batch', response.data)
+
+    def test_a_foreign_square_or_row_is_a_field_error(self):
+        """A growing location is scoped like every other reference."""
+        for field, value in (
+            ('garden_square', make_garden_square(workspace=self.other).pk),
+            ('garden_row', make_garden_row(workspace=self.other).pk),
+        ):
+            with self.subTest(field=field):
+                response = self.client.post(
+                    self.url,
+                    self.payload(**{field: value}),
+                    format='json',
+                )
+                self.assertEqual(response.status_code, 400, response.data)
+                self.assertIn(field, response.data)
+
+    def test_foreign_harvests_are_hidden_from_the_list_and_detail(self):
+        """Another workspace's yield is not this workspace's business."""
+        foreign = make_harvest(
+            workspace=self.other,
+            batch=self._foreign_batch(),
+        )
+        listed = self.client.get(self.url)
+        self.assertEqual([row['pk'] for row in listed.data], [])
+        detail = self.client.get(f'{self.url}{foreign.pk}/')
+        self.assertEqual(detail.status_code, 404)
+
+
+class HarvestPlantSelectionRESTTests(HarvestRESTTestCase):
+    """Attribution and final harvests are validated at the API boundary."""
+
+    def setUp(self):
+        super().setUp()
+        cell_planting = make_seed_tray_cell_planting()
+        self.batch = cell_planting.seed_tray_planting.batch
+        self.plant = make_specific_plant(cell_planting=cell_planting)
+        record_germination_event(self.plant, self.user)
+        make_specific_plant_location(specific_plant=self.plant)
+
+    def test_unknown_plant_ids_are_listed_rather_than_hidden(self):
+        """A caller is told which IDs were wrong instead of getting a 404."""
+        response = self.client.post(
+            self.url,
+            self.payload(plants=[999999], unit_code=UnitCode.EACH, quantity='2'),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('plants', response.data)
+        self.assertIn('999999', str(response.data['plants']))
+
+    def test_plants_from_another_batch_are_rejected(self):
+        """A harvest cannot be attributed to a crop it did not come from."""
+        stranger = make_specific_plant()
+        response = self.client.post(
+            self.url,
+            self.payload(plants=[stranger.pk], unit_code=UnitCode.EACH, quantity='2'),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('plants', response.data)
+
+    def test_a_harvest_can_leave_its_plants_growing(self):
+        """Most crops are picked repeatedly, so picking ends nothing by default."""
+        created = self.create(
+            plants=[self.plant.pk],
+            unit_code=UnitCode.EACH,
+            quantity='3',
+        )
+        self.assertEqual(created['plants'], [self.plant.pk])
+        self.assertEqual(created['finished_plants'], [])
+        self.assertFalse(
+            PlantLifecycleEvent.objects.filter(
+                plant=self.plant,
+                event_type=PlantLifecycleEvent.EventType.HARVEST_FINISHED,
+            ).exists()
+        )
+
+    def test_a_final_harvest_reports_the_plants_it_ended(self):
+        """The response says whether the harvest resolved anything."""
+        created = self.create(
+            plants=[self.plant.pk],
+            unit_code=UnitCode.EACH,
+            quantity='3',
+            finish_plants=True,
+            finish_reason='Pulled at the end of the season.',
+        )
+        self.assertEqual(created['finished_plants'], [self.plant.pk])
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(
+                plant=self.plant,
+                event_type=PlantLifecycleEvent.EventType.HARVEST_FINISHED,
+                reference=f'harvest:{created["pk"]}',
+            ).count(),
+            1,
+        )
+
+    def test_finishing_an_already_finished_plant_reports_the_plant(self):
+        """The error names the plant that could not accept the outcome."""
+        self.create(
+            plants=[self.plant.pk],
+            unit_code=UnitCode.EACH,
+            quantity='3',
+            finish_plants=True,
+        )
+        response = self.client.post(
+            self.url,
+            self.payload(
+                plants=[self.plant.pk],
+                unit_code=UnitCode.EACH,
+                quantity='1',
+                finish_plants=True,
+            ),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('plants', response.data)
+        self.assertIn(str(self.plant.pk), str(response.data['plants']))
+        self.assertEqual(Harvest.objects.count(), 1)
+
+
+class HarvestReversalRESTTests(HarvestRESTTestCase):
+    """Reversal is the only way a posted harvest stops counting."""
+
+    def setUp(self):
+        super().setUp()
+        self.harvest_pk = self.create()['pk']
+
+    def _reverse(self, **payload):
+        """Post the reverse action for the fixture harvest."""
+        return self.client.post(
+            f'{self.url}{self.harvest_pk}/reverse/',
+            payload,
+            format='json',
+        )
+
+    def test_reversing_keeps_the_record_and_drops_it_from_the_report(self):
+        """The audit trail survives while the totals forget it."""
+        response = self._reverse(reason='Weighed the wrong crate.')
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['status'], Harvest.Status.REVERSED)
+        self.assertEqual(response.data['reverse_reason'], 'Weighed the wrong crate.')
+
+        listed = self.client.get(self.url)
+        self.assertEqual([row['pk'] for row in listed.data], [self.harvest_pk])
+
+        report = self.client.get(self.report_url, {'group_by': 'batch'})
+        self.assertEqual(report.data, [])
+
+    def test_a_reversal_requires_a_reason(self):
+        """An unexplained correction is not an audit record."""
+        for reason in ('', '   '):
+            with self.subTest(reason=repr(reason)):
+                response = self._reverse(reason=reason)
+                self.assertEqual(response.status_code, 400, response.data)
+                self.assertIn('reason', response.data)
+
+    def test_a_harvest_cannot_be_reversed_twice(self):
+        """One correction is enough."""
+        self._reverse(reason='Weighed the wrong crate.')
+        response = self._reverse(reason='Again.')
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('status', response.data)
+
+
+class HarvestFilterTests(HarvestRESTTestCase):
+    """The collection narrows by crop, place, status, and period."""
+
+    def setUp(self):
+        super().setUp()
+        self.other_batch = make_production_batch()
+        self.here = self.create(garden_square=self.square.pk)['pk']
+        self.elsewhere = self.create(batch=self.other_batch.pk)['pk']
+
+    def _pks(self, **params):
+        """Return the harvest IDs one filtered list returns."""
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 200, response.data)
+        return [row['pk'] for row in response.data]
+
+    def test_filtering_by_batch_variety_and_square(self):
+        """Each filter narrows to the harvests that match it."""
+        self.assertEqual(self._pks(batch=self.batch.pk), [self.here])
+        self.assertEqual(
+            self._pks(variety=self.other_batch.variety_id),
+            [self.elsewhere],
+        )
+        self.assertEqual(self._pks(garden_square=self.square.pk), [self.here])
+
+    def test_filtering_by_status(self):
+        """A reversed harvest is still listable on its own."""
+        self.client.post(
+            f'{self.url}{self.here}/reverse/',
+            {'reason': 'Mistake.'},
+            format='json',
+        )
+        self.assertEqual(self._pks(status='reversed'), [self.here])
+        self.assertEqual(self._pks(status='posted'), [self.elsewhere])
+
+    def test_filtering_by_an_inclusive_local_day_range(self):
+        """The from and to bounds both name whole local days."""
+        today = timezone.localdate().isoformat()
+        self.assertEqual(
+            sorted(self._pks(harvested_from=today, harvested_to=today)),
+            sorted([self.here, self.elsewhere]),
+        )
+        past = (timezone.localdate() - timedelta(days=400)).isoformat()
+        self.assertEqual(self._pks(harvested_from=past, harvested_to=past), [])
+
+    def test_malformed_filters_are_rejected(self):
+        """A typo is reported rather than silently ignored."""
+        for params, field in (
+            ({'batch': 'abc'}, 'batch'),
+            ({'plant': 'abc'}, 'plant'),
+            ({'status': 'draft'}, 'status'),
+            ({'harvested_from': 'yesterday'}, 'harvested_from'),
+        ):
+            with self.subTest(params=params):
+                response = self.client.get(self.url, params)
+                self.assertEqual(response.status_code, 400, response.data)
+                self.assertIn(field, response.data)
+
+
+class HarvestReportRESTTests(HarvestRESTTestCase):
+    """The report groups yield without ever combining unlike dimensions."""
+
+    def setUp(self):
+        super().setUp()
+        self.create(garden_square=self.square.pk, quantity='1.5')
+        self.create(garden_square=self.square.pk, quantity='250', unit_code=UnitCode.GRAM)
+        self.create(quantity='12', unit_code=UnitCode.EACH)
+
+    def _rows(self, **params):
+        """Run the report and assert it was accepted."""
+        response = self.client.get(self.report_url, params)
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+    def test_weight_harvests_total_by_variety(self):
+        """Kilograms and grams combine exactly into one mass total."""
+        rows = self._rows(group_by='variety')
+        self.assertEqual(len(rows), 1)
+        totals = {
+            entry['conversion_family']: entry for entry in rows[0]['totals']
+        }
+        self.assertEqual(Decimal(totals['metric_mass']['quantity']), Decimal('1750'))
+        self.assertEqual(Decimal(totals['each']['quantity']), Decimal('12'))
+
+    def test_totals_group_by_square_and_leave_unlocated_yield_apart(self):
+        """A harvest with no square is not attributed to one."""
+        rows = {row['key']: row for row in self._rows(group_by='garden_square')}
+        self.assertEqual(
+            Decimal(rows[self.square.pk]['totals'][0]['quantity']),
+            Decimal('1750'),
+        )
+        self.assertEqual(rows[None]['harvest_count'], 1)
+
+    def test_a_date_range_narrows_the_report(self):
+        """A season is expressed as a range rather than guessed."""
+        today = timezone.localdate().isoformat()
+        self.assertEqual(len(self._rows(group_by='batch', harvested_from=today)), 1)
+        past = (timezone.localdate() - timedelta(days=400)).isoformat()
+        self.assertEqual(self._rows(group_by='batch', harvested_to=past), [])
+
+    def test_lineage_counts_are_reported_without_a_ratio(self):
+        """Seeds, plants, and harvests stay three separate numbers."""
+        row = self._rows(group_by='batch')[0]
+        self.assertIn('seeds_sown', row)
+        self.assertIn('plants_observed', row)
+        self.assertIn('plants_harvest_finished', row)
+        for key in row:
+            self.assertNotIn('ratio', key)
+            self.assertNotIn('per_', key)
+
+    def test_an_unknown_grouping_is_rejected(self):
+        """A typo is reported rather than silently defaulted."""
+        response = self.client.get(self.report_url, {'group_by': 'weather'})
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('group_by', response.data)

--- a/plantings/test_rest.py
+++ b/plantings/test_rest.py
@@ -54,6 +54,7 @@ class PlantingRESTContractTests(RESTContractTestCase):
             '/plantings/transplantedgardensquare/',
             '/plantings/specificplants/',
             '/plantings/specificplantlocations/',
+            '/plantings/harvests/',
             f'/plantings/seedtray-data/{self.tray.pk}/plantings/',
             f'/plantings/seedtray-data/{self.tray.pk}/specificplants/',
             f'/plantings/specificplants/{self.specific_plant.pk}/locations/',

--- a/plantings/urls.py
+++ b/plantings/urls.py
@@ -3,10 +3,12 @@ URL Router for plantings
 """
 from django.urls import path, include
 
+from .harvest_rest import HarvestReportView
 from .rest import router
 from . import views
 
 urlpatterns = [
+    path('harvest-report/', HarvestReportView.as_view(), name='harvest_report'),
     path('seedtray/current/', views.seedtray_current, name='current_seedtray'),
     path('seedtray/complete/', views.seedtray_complete, name='complete_seedtray'),
     path('garden/squares/current/', views.gardensquare_current, name='current_gardensquare'),

--- a/plantings/yields.py
+++ b/plantings/yields.py
@@ -120,12 +120,12 @@ def batch_harvest_finished_count(batch):
     )
 
 
-def _zone(workspace):
+def workspace_zone(workspace):
     """Return the timezone a workspace's calendar buckets are cut in."""
     return ZoneInfo(workspace.timezone)
 
 
-def _day_bounds(zone, harvested_from, harvested_to):
+def local_day_bounds(zone, harvested_from, harvested_to):
     """Return the half-open aware range two inclusive local dates describe."""
     start = None
     end = None
@@ -146,8 +146,8 @@ def _filtered_harvests(workspace, filters):
         'garden_square',
         'garden_row',
     ).prefetch_related('plant_allocations')
-    start, end = _day_bounds(
-        _zone(workspace),
+    start, end = local_day_bounds(
+        workspace_zone(workspace),
         filters.get('harvested_from'),
         filters.get('harvested_to'),
     )
@@ -257,7 +257,7 @@ def harvest_report(workspace, filters):
     portable SQL equivalent.
     """
     group_by = filters['group_by']
-    zone = _zone(workspace)
+    zone = workspace_zone(workspace)
     harvests = list(_filtered_harvests(workspace, filters))
     rows = []
     for key, group in _grouped_harvests(harvests, group_by, zone):


### PR DESCRIPTION
Add the harvest collection, its reverse action, and a yield report endpoint.

The collection offers GET and POST only. A harvest is posted when it is created, so PUT, PATCH, and DELETE would all describe an operation the record does not support; the reverse action is the one way to stop a harvest counting, and it keeps the row listable afterwards.

Creation validates through an action serializer rather than a model serializer, because the domain service writes the record in one transaction and it is immutable after that. Workspace scoping narrows the batch, square, and row querysets, so a reference from another workspace is a field error rather than a misleading 404, and unknown plant IDs are listed back to the caller for the same reason.

The report is a separate view: its rows describe groups of harvests rather than harvests, and its filter vocabulary is not the collection's. Both share one definition of a local day boundary so a date range cannot mean two things.

`parse_date` and `parse_datetime` now blame the query parameter by name, as `parse_integer` and `parse_boolean` already did. The field's own error was being raised unkeyed, which read as a body error rather than a bad parameter.

## Summary by Sourcery

Introduce a harvests REST API and yield report endpoint, aligned with workspace scoping and consistent date filtering across listings and reports.

New Features:
- Add harvest collection endpoints to record, list, and reverse harvests for plantings.
- Expose a yield report endpoint that aggregates harvests by configurable grouping and date range.

Bug Fixes:
- Ensure date and datetime query parameter parsing attributes validation errors to the correct parameter name.

Enhancements:
- Share a common local-day boundary helper between harvest listings and yield reports to keep date filtering consistent across views.
- Extend plantings routing and URL configuration to include harvest resources and their report endpoint.

Tests:
- Add comprehensive REST contract tests for harvest creation, validation, workspace scoping, plant attribution, reversal behavior, filtering, and yield reporting.