### PR TITLE
fix(frontend): keep a reversed harvest's reason readable

### DIFF
--- a/frontend/js/plantings/harvest_list.tsx
+++ b/frontend/js/plantings/harvest_list.tsx
@@ -108,14 +108,17 @@ function HarvestTable({ harvests, showCrop = true, showLocation = true }: Harves
         {harvests.map((harvest) => {
           const reversed = harvest.status === 'reversed'
           return (
-            <tr key={harvest.pk} className={reversed ? 'text-muted text-decoration-line-through' : undefined}>
+            // Only the quantity is struck through, because the quantity is what
+            // stopped counting. Striking the whole row would also strike the
+            // reason it was retracted, which no descendant style can undo.
+            <tr key={harvest.pk} className={reversed ? 'text-muted' : undefined}>
               <td>{formatDateTime(harvest.harvested_at)}</td>
               {showCrop && (
                 <td>
                   {harvest.batch_code} · {harvest.plant_name} — {harvest.variety_name}
                 </td>
               )}
-              <td>{formatMeasure(harvest.quantity, HARVEST_UNIT_LABELS[harvest.unit_code])}</td>
+              <td className={reversed ? 'text-decoration-line-through' : undefined}>{formatMeasure(harvest.quantity, HARVEST_UNIT_LABELS[harvest.unit_code])}</td>
               {showLocation && <td>{harvest.location_label ?? '—'}</td>}
               <td>{GRADE_LABELS[harvest.grade]}</td>
               <td>{harvest.quality_rating ?? '—'}</td>
@@ -125,7 +128,7 @@ function HarvestTable({ harvests, showCrop = true, showLocation = true }: Harves
               </td>
               <td>
                 {harvest.notes || '—'}
-                {reversed && harvest.reverse_reason && <div className="text-decoration-none">Reversed: {harvest.reverse_reason}</div>}
+                {reversed && harvest.reverse_reason && <div>Reversed: {harvest.reverse_reason}</div>}
               </td>
               <td className="text-nowrap">
                 <ReverseHarvestButton harvest={harvest} />


### PR DESCRIPTION
Striking through the whole row also struck the reason it was retracted, and no descendant style can undo a text decoration set on an ancestor. Only the quantity is struck now, which is also the more accurate thing to mark: the quantity is what stopped counting.

## Summary by Sourcery

Bug Fixes:
- Ensure reversal reasons remain legible by only applying line-through styling to the reversed harvest quantity instead of the entire row.