### PR TITLE
fix(frontend): keep seed add controls on page

### DIFF
--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -151,9 +151,9 @@ function SeedSuppliersTable() {
         <tr>
           <td>
             Name{' '}
-            <a href="#" onClick={() => setShowSupplierAdd(true)}>
+            <Button variant="link" className="p-0 align-baseline" aria-label="Add supplier" onClick={() => setShowSupplierAdd(true)}>
               +
-            </a>
+            </Button>
           </td>
           <td>Website</td>
           <td>Notes</td>
@@ -375,9 +375,9 @@ function SeedTable() {
           <td>Inventory unit</td>
           <td>Notes</td>
           <td>
-            <a href="#" onClick={() => setShowSeedAdd(true)}>
+            <Button variant="link" className="p-0 align-baseline" aria-label="Add seed" onClick={() => setShowSeedAdd(true)}>
               +
-            </a>
+            </Button>
           </td>
         </tr>
       </thead>


### PR DESCRIPTION
The supplier and seed add links targeted the empty hash, so their default browser navigation replaced the active hash route after opening the form. Use semantic buttons to retain the current route while exposing the add action to assistive technology.

## Summary by Sourcery

Enhancements:
- Use semantic button components for seed and supplier add actions instead of anchor links targeting an empty hash.