### PR TITLE
fix(inventory): derive usage from tray cell volume

### DIFF
--- a/frontend/js/inventory.tsx
+++ b/frontend/js/inventory.tsx
@@ -42,7 +42,7 @@ const TRACKING_LABELS: Record<InventoryTrackingMode, string> = {
 }
 
 const USAGE_LABELS: Record<InventoryUsageBasis, string> = {
-  cell_volume: 'Cell volume',
+  cell_volume: 'Tray cell volume',
   surface_area: 'Surface-area rate',
   per_unit: 'Per plant or item',
   fixed: 'Fixed quantity',
@@ -50,7 +50,6 @@ const USAGE_LABELS: Record<InventoryUsageBasis, string> = {
 }
 
 const RATE_DIMENSIONS: Partial<Record<InventoryUsageBasis, UnitDimension>> = {
-  cell_volume: 'volume',
   surface_area: 'area',
   per_unit: 'count'
 }
@@ -118,6 +117,10 @@ function InventoryItemForm({ units, onCreated }: InventoryItemFormProps) {
     setForm((current) => ({
       ...current,
       usageBasis,
+      baseUnit:
+        usageBasis === 'cell_volume' && units.find((unit) => unit.code === current.baseUnit)?.dimension !== 'volume'
+          ? (units.find((unit) => unit.dimension === 'volume')?.code ?? current.baseUnit)
+          : current.baseUnit,
       usageRateUnit: firstCompatibleUnit?.code ?? current.usageRateUnit
     }))
   }
@@ -144,6 +147,7 @@ function InventoryItemForm({ units, onCreated }: InventoryItemFormProps) {
 
   const rateDimension = RATE_DIMENSIONS[form.usageBasis]
   const rateUnits = units.filter((unit) => unit.dimension === rateDimension)
+  const baseUnits = form.usageBasis === 'cell_volume' ? units.filter((unit) => unit.dimension === 'volume') : units
 
   return (
     <Card className="mb-4">
@@ -181,7 +185,7 @@ function InventoryItemForm({ units, onCreated }: InventoryItemFormProps) {
               <Form.Group className="mb-3" controlId="inventory-item-unit">
                 <Form.Label>Base unit</Form.Label>
                 <Form.Select value={form.baseUnit} onChange={(event) => update('baseUnit', event.target.value as UnitCode)}>
-                  {units.map((unit) => (
+                  {baseUnits.map((unit) => (
                     <option key={unit.code} value={unit.code}>
                       {unit.label} ({unit.code})
                     </option>
@@ -211,6 +215,7 @@ function InventoryItemForm({ units, onCreated }: InventoryItemFormProps) {
                     </option>
                   ))}
                 </Form.Select>
+                {form.usageBasis === 'cell_volume' && <Form.Text muted>Usage comes from each selected tray&apos;s cell volume, including when tray cell sizes differ.</Form.Text>}
               </Form.Group>
             </Col>
           </Row>

--- a/inventory/migrations/0005_normalize_cell_volume_usage.py
+++ b/inventory/migrations/0005_normalize_cell_volume_usage.py
@@ -1,0 +1,35 @@
+"""Normalize cell-volume items to derive usage from tray measurements."""
+
+from django.db import migrations
+
+
+def normalize_cell_volume_usage(apps, _schema_editor):
+    """Remove obsolete rates and retain only convertible volume items."""
+    inventory_item = apps.get_model('inventory', 'InventoryItem')
+    cell_volume_items = inventory_item.objects.filter(
+        default_usage_basis='cell_volume',
+    )
+    cell_volume_items.exclude(base_unit__in=('ml', 'l')).update(
+        default_usage_basis='manual',
+        default_usage_rate=None,
+        usage_rate_unit=None,
+    )
+    cell_volume_items.filter(base_unit__in=('ml', 'l')).update(
+        default_usage_rate=None,
+        usage_rate_unit=None,
+    )
+
+
+class Migration(migrations.Migration):
+    """Discard rates that duplicated or obscured tray cell volumes."""
+
+    dependencies = [
+        ('inventory', '0004_inventoryunitreconciliation_inventoryunit_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            normalize_cell_volume_usage,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -74,7 +74,7 @@ class InventoryItem(WorkspaceOwnedModel):
         SERIALIZED = 'serialized', 'Serialized'
 
     class UsageBasis(models.TextChoices):
-        """Ways task 42 may calculate suggested consumption."""
+        """Ways input applications may calculate suggested consumption."""
 
         CELL_VOLUME = 'cell_volume', 'Cell volume'
         SURFACE_AREA = 'surface_area', 'Surface-area rate'
@@ -202,20 +202,44 @@ class InventoryItem(WorkspaceOwnedModel):
     def _validate_usage_configuration(self, errors):
         """Dispatch the selected usage basis to its configuration rules."""
         validators = {
-            self.UsageBasis.CELL_VOLUME: self._validate_rate_based_usage,
             self.UsageBasis.SURFACE_AREA: self._validate_rate_based_usage,
             self.UsageBasis.PER_UNIT: self._validate_rate_based_usage,
             self.UsageBasis.FIXED: self._validate_fixed_usage,
             self.UsageBasis.MANUAL: self._validate_manual_usage,
         }
+        if self.default_usage_basis == self.UsageBasis.CELL_VOLUME:
+            self._validate_cell_volume_usage(errors)
+            return
         validator = validators.get(self.default_usage_basis)
         if validator:
             validator(errors)
 
+    def _validate_cell_volume_usage(self, errors):
+        """Derive usage directly from tray cells in the item's volume unit."""
+        try:
+            base_unit = get_unit_definition(self.base_unit)
+        except ValidationError:
+            return
+        if base_unit.dimension != UnitDimension.VOLUME:
+            errors['base_unit'] = (
+                'Cell-volume usage requires a volume base unit.'
+            )
+        if self.default_usage_rate is not None:
+            errors['default_usage_rate'] = (
+                'Cell-volume usage derives quantity from each tray cell.'
+            )
+        if self.usage_rate_unit:
+            errors['usage_rate_unit'] = (
+                'Cell-volume usage derives quantity from each tray cell.'
+            )
+        if self.default_fixed_quantity is not None:
+            errors['default_fixed_quantity'] = (
+                'Cell-volume usage does not accept a fixed quantity.'
+            )
+
     def _validate_rate_based_usage(self, errors):
         """Require a positive rate with the correct denominator dimension."""
         rate_dimensions = {
-            self.UsageBasis.CELL_VOLUME: UnitDimension.VOLUME,
             self.UsageBasis.SURFACE_AREA: UnitDimension.AREA,
             self.UsageBasis.PER_UNIT: UnitDimension.COUNT,
         }

--- a/inventory/test_rest.py
+++ b/inventory/test_rest.py
@@ -33,8 +33,6 @@ class InventoryRestTests(APITestCase):
             'category': InventoryItem.Category.GROWING_MEDIA,
             'base_unit': UnitCode.MILLILITRE,
             'default_usage_basis': InventoryItem.UsageBasis.CELL_VOLUME,
-            'default_usage_rate': '1.000000000',
-            'usage_rate_unit': UnitCode.MILLILITRE,
         }
         payload.update(overrides)
         return self.client.post(self.item_url, payload, format='json')
@@ -66,8 +64,8 @@ class InventoryRestTests(APITestCase):
         self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(response.data['base_unit'], 'ml')
         self.assertEqual(response.data['base_unit_dimension'], 'volume')
-        self.assertEqual(response.data['default_usage_rate'], '1.000000000')
-        self.assertEqual(response.data['usage_rate_unit_dimension'], 'volume')
+        self.assertIsNone(response.data['default_usage_rate'])
+        self.assertIsNone(response.data['usage_rate_unit_dimension'])
         self.assertEqual(response.data['tracking_mode'], 'lot')
         self.assertNotIn('workspace', response.data)
 
@@ -92,6 +90,23 @@ class InventoryRestTests(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn('usage_rate_unit', response.data)
+
+    def test_cell_volume_uses_tray_measurements_without_an_item_rate(self):
+        """Cell volume is converted from each selected tray into a volume item."""
+        response = self.create_item(
+            default_usage_rate='1',
+            usage_rate_unit=UnitCode.MILLILITRE,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('default_usage_rate', response.data)
+        self.assertIn('usage_rate_unit', response.data)
+
+        response = self.create_item(
+            sku='MASS-CELL-VOLUME',
+            base_unit=UnitCode.GRAM,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('base_unit', response.data)
 
     def test_item_filters_and_inactive_selector_contract(self):
         """Catalog screens and future selectors can request precise subsets."""

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -135,10 +135,42 @@ class InventoryItemModelTests(TestCase):
         volume = self.make_item(
             sku='VOLUME-RATE',
             default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
-            default_usage_rate=Decimal('1'),
-            usage_rate_unit=UnitCode.MILLILITRE,
         )
-        self.assertEqual(volume.default_usage_rate, Decimal('1'))
+        self.assertIsNone(volume.default_usage_rate)
+        self.assertIsNone(volume.usage_rate_unit)
+
+        litre_volume = self.make_item(
+            sku='LITRE-VOLUME',
+            base_unit=UnitCode.LITRE,
+            default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+        )
+        self.assertEqual(litre_volume.base_unit, UnitCode.LITRE)
+
+        with self.assertRaises(ValidationError) as context:
+            self.make_item(
+                sku='WEIGHT-VOLUME',
+                base_unit=UnitCode.GRAM,
+                default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+            )
+        self.assertIn('base_unit', context.exception.message_dict)
+
+        with self.assertRaises(ValidationError) as context:
+            self.make_item(
+                sku='CONFIGURED-VOLUME-RATE',
+                default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+                default_usage_rate=Decimal('1'),
+                usage_rate_unit=UnitCode.MILLILITRE,
+            )
+        self.assertIn('default_usage_rate', context.exception.message_dict)
+        self.assertIn('usage_rate_unit', context.exception.message_dict)
+
+        area = self.make_item(
+            sku='AREA-RATE',
+            default_usage_basis=InventoryItem.UsageBasis.SURFACE_AREA,
+            default_usage_rate=Decimal('2'),
+            usage_rate_unit=UnitCode.SQUARE_METRE,
+        )
+        self.assertEqual(area.default_usage_rate, Decimal('2'))
 
         with self.assertRaises(ValidationError) as context:
             self.make_item(


### PR DESCRIPTION
Cell-volume usage should follow each selected tray model's physical cell size, so one catalog rate cannot represent mixed tray sizes. Require a volume base unit, remove the rate prompt, and normalize legacy configurations so future application calculations can convert summed cell volumes exactly.

## Summary by Sourcery

Derive cell-volume inventory usage directly from tray cell measurements and enforce volume-only base units, removing per-item usage rates for this mode and normalizing existing data.

Bug Fixes:
- Reject cell-volume inventory items configured with non-volume base units or with obsolete usage rate and fixed quantity fields.

Enhancements:
- Update inventory validation, REST responses, tests, and frontend forms to reflect tray-based cell volume usage, including constraining base units and clarifying UI labels and help text.
- Add a data migration to normalize existing cell-volume items by clearing legacy rates and converting incompatible configurations to manual usage.