### PR TITLE
fix(frontend): keep plant add controls on page

### DIFF
--- a/frontend/js/plants.tsx
+++ b/frontend/js/plants.tsx
@@ -97,9 +97,9 @@ class PlantFamilyRow extends React.Component<PlantFamilyRowProps> {
       <tr>
         <td>{this.props.family.name}</td>
         <td>
-          <a href="#" onClick={this.addNewPlant}>
+          <Button variant="link" className="p-0 align-baseline" aria-label="Add plant" onClick={this.addNewPlant}>
             +
-          </a>
+          </Button>
         </td>
         <td></td>
         <td></td>
@@ -261,9 +261,9 @@ class PlantRow extends React.Component<PlantRowProps> {
         <td>{this.props.familyName}</td>
         <td>{this.props.plant.name}</td>
         <td>
-          <a href="#" onClick={this.addNewPlantVariety}>
+          <Button variant="link" className="p-0 align-baseline" aria-label="Add variety" onClick={this.addNewPlantVariety}>
             +
-          </a>
+          </Button>
         </td>
         <td>{this.props.plant.spacing}</td>
         <td>{this.props.plant.inter_row_spacing}</td>
@@ -581,9 +581,9 @@ function PlantsView() {
         <tr>
           <td>
             Family{' '}
-            <a href="#" onClick={() => setShowFamilyAdd(true)}>
+            <Button variant="link" className="p-0 align-baseline" aria-label="Add family" onClick={() => setShowFamilyAdd(true)}>
               +
-            </a>
+            </Button>
           </td>
           <td>Plant</td>
           <td>Variety</td>


### PR DESCRIPTION
The family, plant, and variety add links targeted the empty hash, so their default browser navigation replaced the active hash route after opening the form, dropping the operator back to the garden view. Use semantic buttons to retain the current route while exposing the add action to assistive technology.

This repeats the fix 47af533 made for the seed and supplier controls. A sweep of the remaining screens found no further instances: every other anchor is a real external link, the menu uses NavLink throughout, and each form either calls preventDefault or relies on react-bootstrap's default type="button".

## Summary by Sourcery

Replace hash-based add links in plant management UI with semantic buttons to prevent route changes while preserving accessibility.

Bug Fixes:
- Prevent plant, family, and variety add controls from resetting the current hash route when opening add forms.

Enhancements:
- Improve accessibility of plant, family, and variety add controls by using semantic button components with appropriate labels.