### PR TITLE
feat(garden): confirm what garden geometry physically measures

### DIFF
--- a/garden/geometry.py
+++ b/garden/geometry.py
@@ -1,0 +1,81 @@
+"""Normalize garden geometry into physical area.
+
+Garden placements and sizes are dimensionless integers on a grid. Reading one
+as a length requires an operator to have said what a grid step measures, so
+every function here refuses to guess: an area without a
+:class:`~garden.models.GardenGeometryConfirmation` raises rather than assuming
+that a historical integer meant metres.
+"""
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError
+
+from .models import (
+    GardenArea,
+    GardenBed,
+    GardenGeometryConfirmation,
+    GardenRow,
+    GardenSquare,
+)
+
+
+#: Exact metre equivalents for one of each supported length unit. Inches and
+#: feet are exact by definition, so no value here is an approximation.
+LENGTH_UNIT_METRES = {
+    GardenGeometryConfirmation.LengthUnit.MILLIMETRE: Decimal('0.001'),
+    GardenGeometryConfirmation.LengthUnit.CENTIMETRE: Decimal('0.01'),
+    GardenGeometryConfirmation.LengthUnit.METRE: Decimal('1'),
+    GardenGeometryConfirmation.LengthUnit.INCH: Decimal('0.0254'),
+    GardenGeometryConfirmation.LengthUnit.FOOT: Decimal('0.3048'),
+}
+
+#: Precision of a normalized area, matching the column that stores it.
+AREA_QUANTUM = Decimal('0.000001')
+
+
+def owning_area(geometry):
+    """Return the area whose confirmed scale governs one piece of geometry."""
+    if isinstance(geometry, GardenArea):
+        return geometry
+    if isinstance(geometry, GardenBed):
+        return geometry.area
+    if isinstance(geometry, (GardenRow, GardenSquare)):
+        return geometry.bed.area
+    raise ValidationError(
+        {'target': 'That target does not describe a piece of garden geometry.'},
+    )
+
+
+def area_confirmation(area):
+    """Return the newest confirmation for one area, or None while unconfirmed."""
+    return area.geometry_confirmations.order_by('-confirmed_at', '-pk').first()
+
+
+def is_confirmed(area):
+    """Return whether an operator has stated what this area's grid step means."""
+    return area_confirmation(area) is not None
+
+
+def metres_per_grid_step(area):
+    """Return the physical length of one grid step for one area."""
+    confirmation = area_confirmation(area)
+    if confirmation is None:
+        raise ValidationError({
+            'target': (
+                f'Confirm the physical length unit of garden area '
+                f'"{area.name}" before measuring it.'
+            ),
+        })
+    return confirmation.cell_length * LENGTH_UNIT_METRES[confirmation.length_unit]
+
+
+def square_metres(geometry):
+    """Return one piece of geometry's normalized area in square metres.
+
+    The scale is squared because ``size_x`` and ``size_y`` are both counts of
+    the same grid step, so an area is steps squared times metres squared.
+    """
+    step = metres_per_grid_step(owning_area(geometry))
+    total = Decimal(geometry.size_x) * Decimal(geometry.size_y) * step * step
+    return total.quantize(AREA_QUANTUM)

--- a/garden/migrations/0006_gardengeometryconfirmation.py
+++ b/garden/migrations/0006_gardengeometryconfirmation.py
@@ -1,0 +1,120 @@
+"""Record what an area's grid integers physically measure.
+
+There is deliberately no data migration. Every existing area's `size_x` and
+`size_y` are bare integers whose unit was never recorded, and the deployed
+values could as easily be millimetres as metres or feet. Backfilling a guess
+would silently license area-based calculations that are wrong by three orders
+of magnitude, so existing areas start unconfirmed and an operator states the
+scale for each one.
+"""
+
+import django.core.validators
+import django.db.models.deletion
+import django.utils.timezone
+import workspaces.models
+from decimal import Decimal
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("garden", "0005_workspace_ownership"),
+        ("workspaces", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GardenGeometryConfirmation",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "length_unit",
+                    models.CharField(
+                        choices=[
+                            ("mm", "Millimetres"),
+                            ("cm", "Centimetres"),
+                            ("m", "Metres"),
+                            ("in", "Inches"),
+                            ("ft", "Feet"),
+                        ],
+                        max_length=8,
+                    ),
+                ),
+                (
+                    "cell_length",
+                    models.DecimalField(
+                        decimal_places=6,
+                        help_text="Physical length of one grid step, in the chosen unit.",
+                        max_digits=12,
+                        validators=[
+                            django.core.validators.MinValueValidator(
+                                Decimal("0.000001")
+                            )
+                        ],
+                    ),
+                ),
+                ("notes", models.TextField(blank=True, default="")),
+                (
+                    "confirmed_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, editable=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                (
+                    "area",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="geometry_confirmations",
+                        to="garden.gardenarea",
+                    ),
+                ),
+                (
+                    "confirmed_by",
+                    models.ForeignKey(
+                        editable=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "workspace",
+                    models.ForeignKey(
+                        default=workspaces.models.get_default_workspace_id,
+                        editable=False,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="workspaces.workspace",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-confirmed_at", "-pk"],
+                "indexes": [
+                    models.Index(
+                        fields=["area", "-confirmed_at"],
+                        name="garden_geometry_latest_idx",
+                    )
+                ],
+                "constraints": [
+                    models.CheckConstraint(
+                        condition=models.Q(("cell_length__gt", 0)),
+                        name="garden_geometry_positive_cell_length",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/garden/models.py
+++ b/garden/models.py
@@ -2,10 +2,22 @@
 Garden models
 """
 
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.utils import timezone
 
 from workspaces.models import WorkspaceOwnedModel
+
+
+#: Smallest grid step a confirmation can record, matching ``cell_length``'s
+#: six decimal places.
+POSITIVE_LENGTH = Decimal('0.000001')
 
 
 class GardenArea(WorkspaceOwnedModel):
@@ -26,6 +38,90 @@ class GardenArea(WorkspaceOwnedModel):
 
     def __str__(self):
         return self.name
+
+
+class GardenGeometryConfirmation(WorkspaceOwnedModel):
+    """One operator's audited statement of what an area's integers mean.
+
+    Garden geometry is a bare integer grid: an area, bed, row, and square all
+    carry ``size_x``/``size_y`` with no recorded physical scale. Nothing may
+    read those integers as a length until somebody says what one grid step
+    measures, so this record exists and areas without one stay unconfirmed.
+
+    Confirmations are append-only and the newest one wins. A mistaken unit is
+    corrected by confirming again, which leaves the original statement on file;
+    input applications freeze the square metres they calculated, so a later
+    correction never rewrites what was already applied.
+    """
+
+    class LengthUnit(models.TextChoices):
+        """Physical units a grid step may be measured in."""
+
+        MILLIMETRE = 'mm', 'Millimetres'
+        CENTIMETRE = 'cm', 'Centimetres'
+        METRE = 'm', 'Metres'
+        INCH = 'in', 'Inches'
+        FOOT = 'ft', 'Feet'
+
+    area = models.ForeignKey(
+        GardenArea,
+        on_delete=models.PROTECT,
+        related_name='geometry_confirmations',
+    )
+    length_unit = models.CharField(max_length=8, choices=LengthUnit.choices)
+    cell_length = models.DecimalField(
+        max_digits=12,
+        decimal_places=6,
+        validators=[MinValueValidator(POSITIVE_LENGTH)],
+        help_text='Physical length of one grid step, in the chosen unit.',
+    )
+    notes = models.TextField(blank=True, default='')
+    confirmed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        editable=False,
+        related_name='+',
+    )
+    confirmed_at = models.DateTimeField(default=timezone.now, editable=False)
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-confirmed_at', '-pk']
+        indexes = [
+            models.Index(
+                fields=['area', '-confirmed_at'],
+                name='garden_geometry_latest_idx',
+            ),
+        ]
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(cell_length__gt=0),
+                name='garden_geometry_positive_cell_length',
+            ),
+        ]
+
+    def __str__(self):
+        return f'{self.area}: 1 step = {self.cell_length} {self.length_unit}'
+
+    def clean(self):
+        """Keep a confirmation and the area it describes in one workspace."""
+        super().clean()
+        if self.area_id and self.area.workspace_id != self.workspace_id:
+            raise ValidationError(
+                {'area': 'The area belongs to a different workspace.'},
+            )
+
+    def save(self, *args, **kwargs):
+        if self.pk:
+            raise ValidationError(
+                'Geometry confirmations are immutable; confirm again instead.',
+            )
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        raise ValidationError('Geometry confirmations cannot be deleted.')
 
 
 class GardenBed(WorkspaceOwnedModel):

--- a/garden/test_geometry.py
+++ b/garden/test_geometry.py
@@ -1,0 +1,201 @@
+"""Tests for normalizing garden geometry into physical area."""
+
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from django.utils import timezone
+
+from tests.factories import (
+    make_garden_area,
+    make_garden_bed,
+    make_garden_geometry_confirmation,
+    make_garden_row,
+    make_garden_square,
+)
+from workspaces.models import Workspace
+
+from .geometry import (
+    area_confirmation,
+    is_confirmed,
+    metres_per_grid_step,
+    owning_area,
+    square_metres,
+)
+from .models import GardenGeometryConfirmation
+
+
+class GeometryConfirmationModelTests(TestCase):
+    """Rules that keep a confirmation an honest, append-only statement."""
+
+    def test_a_confirmation_cannot_be_edited(self):
+        """A wrong unit is corrected by confirming again, not by rewriting."""
+        confirmation = make_garden_geometry_confirmation()
+        confirmation.length_unit = GardenGeometryConfirmation.LengthUnit.METRE
+        with self.assertRaises(ValidationError):
+            confirmation.save()
+
+    def test_a_confirmation_cannot_be_deleted(self):
+        """The original statement stays on file after a correction."""
+        confirmation = make_garden_geometry_confirmation()
+        with self.assertRaises(ValidationError):
+            confirmation.delete()
+
+    def test_a_zero_grid_step_is_refused(self):
+        """A grid step of no length would make every area zero."""
+        area = make_garden_area()
+        with self.assertRaises(ValidationError):
+            make_garden_geometry_confirmation(
+                area=area,
+                cell_length=Decimal('0'),
+            )
+
+    def test_the_database_refuses_a_zero_grid_step(self):
+        """The check constraint holds even when validation is bypassed."""
+        area = make_garden_area()
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            GardenGeometryConfirmation.objects.bulk_create([
+                GardenGeometryConfirmation(
+                    area=area,
+                    length_unit=GardenGeometryConfirmation.LengthUnit.METRE,
+                    cell_length=Decimal('0'),
+                ),
+            ])
+
+    def test_an_area_from_another_workspace_is_refused(self):
+        """A confirmation cannot describe another workspace's garden."""
+        other = Workspace.objects.create(name='Other workspace')
+        area = make_garden_area(workspace=other)
+        with self.assertRaises(ValidationError):
+            make_garden_geometry_confirmation(area=area)
+
+
+class AreaConfirmationLookupTests(TestCase):
+    """Which statement governs an area, and whether one exists at all."""
+
+    def test_an_area_starts_unconfirmed(self):
+        """Existing geometry means nothing until an operator says so."""
+        area = make_garden_area()
+        self.assertIsNone(area_confirmation(area))
+        self.assertFalse(is_confirmed(area))
+
+    def test_the_newest_confirmation_wins(self):
+        """Confirming again corrects the scale without losing the original."""
+        area = make_garden_area()
+        make_garden_geometry_confirmation(
+            area=area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.FOOT,
+            cell_length=Decimal('1'),
+            confirmed_at=timezone.now() - timezone.timedelta(days=1),
+        )
+        newest = make_garden_geometry_confirmation(
+            area=area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.MILLIMETRE,
+            cell_length=Decimal('1'),
+        )
+        self.assertEqual(area_confirmation(area), newest)
+        self.assertEqual(area.geometry_confirmations.count(), 2)
+
+    def test_a_confirmation_records_who_said_so(self):
+        """An audited statement names its operator."""
+        user = get_user_model().objects.create_user(username='geometry-user')
+        confirmation = make_garden_geometry_confirmation(confirmed_by=user)
+        self.assertEqual(confirmation.confirmed_by, user)
+
+
+class OwningAreaTests(TestCase):
+    """Every piece of geometry resolves to the area that scales it."""
+
+    def test_each_geometry_type_resolves_to_its_area(self):
+        """Beds, rows, and squares all inherit their area's grid step."""
+        area = make_garden_area()
+        bed = make_garden_bed(area=area)
+        cases = {
+            'area': area,
+            'bed': bed,
+            'row': make_garden_row(bed=bed),
+            'square': make_garden_square(bed=bed),
+        }
+        for label, geometry in cases.items():
+            with self.subTest(geometry=label):
+                self.assertEqual(owning_area(geometry), area)
+
+    def test_a_non_geometry_target_is_refused(self):
+        """Only garden geometry carries a physical extent."""
+        with self.assertRaises(ValidationError):
+            owning_area(make_garden_geometry_confirmation())
+
+
+class SquareMetreTests(TestCase):
+    """Converting a confirmed grid into normalized square metres."""
+
+    def test_unconfirmed_geometry_is_refused(self):
+        """An area-based measurement never guesses what an integer meant."""
+        square = make_garden_square()
+        with self.assertRaises(ValidationError) as caught:
+            square_metres(square)
+        self.assertIn('target', caught.exception.message_dict)
+
+    def test_a_millimetre_grid_normalizes_to_square_metres(self):
+        """A 300 x 300 mm square is 0.09 m2."""
+        bed = make_garden_bed()
+        make_garden_geometry_confirmation(
+            area=bed.area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.MILLIMETRE,
+            cell_length=Decimal('1'),
+        )
+        square = make_garden_square(bed=bed, size_x=300, size_y=300)
+        self.assertEqual(square_metres(square), Decimal('0.090000'))
+
+    def test_a_multi_unit_grid_step_scales_the_area(self):
+        """A step worth 2.5 cm squares to 0.000625 m2 per grid cell."""
+        bed = make_garden_bed()
+        make_garden_geometry_confirmation(
+            area=bed.area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.CENTIMETRE,
+            cell_length=Decimal('2.5'),
+        )
+        square = make_garden_square(bed=bed, size_x=4, size_y=4)
+        self.assertEqual(square_metres(square), Decimal('0.010000'))
+
+    def test_imperial_steps_convert_exactly(self):
+        """One square foot is 0.09290304 m2, rounded to the stored precision."""
+        bed = make_garden_bed()
+        make_garden_geometry_confirmation(
+            area=bed.area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.FOOT,
+            cell_length=Decimal('1'),
+        )
+        square = make_garden_square(bed=bed, size_x=1, size_y=1)
+        self.assertEqual(square_metres(square), Decimal('0.092903'))
+
+    def test_every_geometry_level_measures(self):
+        """An area, bed, row, and square each report their own extent."""
+        area = make_garden_area(size_x=10, size_y=10)
+        make_garden_geometry_confirmation(
+            area=area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.METRE,
+            cell_length=Decimal('1'),
+        )
+        bed = make_garden_bed(area=area, size_x=4, size_y=5)
+        expected = {
+            area: Decimal('100.000000'),
+            bed: Decimal('20.000000'),
+            make_garden_row(bed=bed, size_x=4, size_y=1): Decimal('4.000000'),
+            make_garden_square(bed=bed, size_x=2, size_y=2): Decimal('4.000000'),
+        }
+        for geometry, area_m2 in expected.items():
+            with self.subTest(geometry=str(geometry)):
+                self.assertEqual(square_metres(geometry), area_m2)
+
+    def test_the_grid_step_is_reported_in_metres(self):
+        """A millimetre step is a thousandth of a metre."""
+        area = make_garden_area()
+        make_garden_geometry_confirmation(
+            area=area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.MILLIMETRE,
+            cell_length=Decimal('1'),
+        )
+        self.assertEqual(metres_per_grid_step(area), Decimal('0.001'))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,7 +5,13 @@ from itertools import count
 
 from django.utils import timezone
 
-from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
+from garden.models import (
+    GardenArea,
+    GardenBed,
+    GardenGeometryConfirmation,
+    GardenRow,
+    GardenSquare,
+)
 from inventory.models import InventoryLocation, InventoryUnit, StockLot, StockMovement
 from inventory.units import UnitCode
 from plantings.models import (
@@ -114,6 +120,18 @@ def make_garden_area(**overrides):
     }
     values.update(overrides)
     return GardenArea.objects.create(**values)
+
+
+def make_garden_geometry_confirmation(**overrides):
+    """Confirm what one area's grid step physically measures."""
+    values = {
+        'length_unit': GardenGeometryConfirmation.LengthUnit.MILLIMETRE,
+        'cell_length': Decimal('1'),
+    }
+    if 'area' not in overrides:
+        values['area'] = make_garden_area()
+    values.update(overrides)
+    return GardenGeometryConfirmation.objects.create(**values)
 
 
 def make_garden_bed(**overrides):


### PR DESCRIPTION
Garden placements and sizes are dimensionless integers on a grid, so nothing can turn a square into an area an input application could dose by. Add an append-only confirmation recording what one grid step measures, and a geometry module that normalizes any area, bed, row, or square into square metres.

An area starts unconfirmed and the migration backfills nothing. Deployed integers could as easily be millimetres as metres or feet, and a wrong guess would license area-based calculations that are off by three orders of magnitude, so every measurement refuses until an operator states the scale.

Confirmations record a unit and the length of one step, so a grid can be 1 mm or 2.5 cm per step rather than only whole units. Correcting a mistake appends a new statement and leaves the original on file; applications freeze the square metres they calculated, so a later correction cannot rewrite what was already applied.

## Summary by Sourcery

Introduce audited garden geometry confirmations and utilities to convert grid-based sizes into physical square metres.

New Features:
- Add an append-only GardenGeometryConfirmation model to record the physical scale of each garden area, including unit, grid step length, operator, and timestamp.
- Provide geometry helper functions to resolve owning areas, check confirmation status, and compute normalized square metres and metres-per-grid-step for garden geometry.
- Enable millimetre, centimetre, metre, inch, and foot units for garden grid steps so applications can dose or measure by physical area.

Enhancements:
- Enforce workspace consistency and immutability on geometry confirmations, preventing edits and deletions to keep an auditable history.
- Add database-level constraints and indexes to ensure positive grid step lengths and efficient lookup of the latest confirmation per area.

Documentation:
- Document the behavior of garden geometry confirmation and normalization in new module and migration docstrings, including the requirement that existing areas be explicitly confirmed.

Tests:
- Add factory support and a dedicated test suite covering confirmation rules, area resolution, and square-metre normalization across units and geometry types.