### PR TITLE
feat(garden): expose the geometry confirmation

### DIFF
--- a/garden/geometry.py
+++ b/garden/geometry.py
@@ -47,6 +47,16 @@ def owning_area(geometry):
     )
 
 
+def latest_confirmation(confirmations):
+    """Return the newest of an already-loaded set of confirmations.
+
+    Sorting in Python rather than the database lets a caller that prefetched an
+    area's confirmations reuse them instead of issuing one query per area.
+    """
+    rows = sorted(confirmations, key=lambda row: (row.confirmed_at, row.pk))
+    return rows[-1] if rows else None
+
+
 def area_confirmation(area):
     """Return the newest confirmation for one area, or None while unconfirmed."""
     return area.geometry_confirmations.order_by('-confirmed_at', '-pk').first()
@@ -57,8 +67,8 @@ def is_confirmed(area):
     return area_confirmation(area) is not None
 
 
-def metres_per_grid_step(area):
-    """Return the physical length of one grid step for one area."""
+def require_confirmation(area):
+    """Return one area's governing confirmation, refusing to guess without it."""
     confirmation = area_confirmation(area)
     if confirmation is None:
         raise ValidationError({
@@ -67,15 +77,30 @@ def metres_per_grid_step(area):
                 f'"{area.name}" before measuring it.'
             ),
         })
+    return confirmation
+
+
+def metres_per_step(confirmation):
+    """Return the physical length of one grid step for one confirmation."""
     return confirmation.cell_length * LENGTH_UNIT_METRES[confirmation.length_unit]
 
 
-def square_metres(geometry):
-    """Return one piece of geometry's normalized area in square metres.
+def metres_per_grid_step(area):
+    """Return the physical length of one grid step for one area."""
+    return metres_per_step(require_confirmation(area))
+
+
+def measure(confirmation, geometry):
+    """Return normalized area from an already-resolved confirmation.
 
     The scale is squared because ``size_x`` and ``size_y`` are both counts of
     the same grid step, so an area is steps squared times metres squared.
     """
-    step = metres_per_grid_step(owning_area(geometry))
+    step = metres_per_step(confirmation)
     total = Decimal(geometry.size_x) * Decimal(geometry.size_y) * step * step
     return total.quantize(AREA_QUANTUM)
+
+
+def square_metres(geometry):
+    """Return one piece of geometry's normalized area in square metres."""
+    return measure(require_confirmation(owning_area(geometry)), geometry)

--- a/garden/rest.py
+++ b/garden/rest.py
@@ -1,20 +1,112 @@
 """
 Rest for Gardens
 """
-from rest_framework import routers, serializers, viewsets
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from rest_framework import routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
 
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
-from .models import GardenArea, GardenBed, GardenRow, GardenSquare
+from .geometry import latest_confirmation, measure
+from .models import (
+    GardenArea,
+    GardenBed,
+    GardenGeometryConfirmation,
+    GardenRow,
+    GardenSquare,
+)
+
+
+#: Distinguishes "not derived yet" from a legitimately unconfirmed area, so a
+#: cached None is not recomputed for every field of the same response.
+_UNRESOLVED = object()
+
+
+def _model_errors(error):
+    """Translate a Django validation error into DRF's field-error shape."""
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+class GardenGeometryConfirmationSerializer(serializers.ModelSerializer):
+    """
+    Serializer for one recorded statement of an area's physical scale
+    """
+    class Meta:
+        model = GardenGeometryConfirmation
+        fields = ['pk', 'area', 'length_unit', 'cell_length', 'notes', 'confirmed_at']
+        read_only_fields = ['pk', 'area', 'confirmed_at']
+
+
+class ConfirmGeometrySerializer(serializers.Serializer):
+    """
+    Operator statement of what one grid step measures
+    """
+    length_unit = serializers.ChoiceField(
+        choices=GardenGeometryConfirmation.LengthUnit.choices,
+    )
+    cell_length = serializers.DecimalField(max_digits=12, decimal_places=6)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
 
 
 class GardenAreaSerializer(serializers.ModelSerializer):
     """
     Serializer Garden Area
     """
+    geometry_confirmed = serializers.SerializerMethodField()
+    length_unit = serializers.SerializerMethodField()
+    cell_length = serializers.SerializerMethodField()
+    square_metres = serializers.SerializerMethodField()
+
     class Meta:
         model = GardenArea
-        fields = ['pk', 'name', 'size_x', 'size_y']
+        fields = [
+            'pk',
+            'name',
+            'size_x',
+            'size_y',
+            'geometry_confirmed',
+            'length_unit',
+            'cell_length',
+            'square_metres',
+        ]
+
+    def _confirmation(self, area):
+        """Return the governing confirmation once per serialized area."""
+        cached = getattr(area, '_geometry_confirmation', _UNRESOLVED)
+        if cached is _UNRESOLVED:
+            cached = latest_confirmation(area.geometry_confirmations.all())
+            setattr(area, '_geometry_confirmation', cached)
+        return cached
+
+    def get_geometry_confirmed(self, area):
+        """Report whether this area's integers have a stated physical meaning."""
+        return self._confirmation(area) is not None
+
+    def get_length_unit(self, area):
+        """Report the confirmed unit, or null while the area is unconfirmed."""
+        confirmation = self._confirmation(area)
+        return confirmation.length_unit if confirmation else None
+
+    def get_cell_length(self, area):
+        """Report the confirmed length of one grid step as a fixed string."""
+        confirmation = self._confirmation(area)
+        return f'{confirmation.cell_length:.6f}' if confirmation else None
+
+    def get_square_metres(self, area):
+        """Report the area's normalized extent, or null while unconfirmed."""
+        confirmation = self._confirmation(area)
+        if confirmation is None:
+            return None
+        return f'{measure(confirmation, area):.6f}'
 
 
 class GardenBedSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
@@ -54,8 +146,43 @@ class GardenAreaViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  #
     """
     ViewSet for Garden Area
     """
-    queryset = GardenArea.objects.all()
+    queryset = GardenArea.objects.prefetch_related('geometry_confirmations')
     serializer_class = GardenAreaSerializer
+
+    @action(detail=True, methods=['post'], url_path='confirm-geometry')
+    def confirm_geometry(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record what one grid step of this area physically measures.
+
+        Confirming again supersedes the previous statement without erasing it,
+        which is how a mistaken unit is corrected.
+        """
+        area = self.get_object()
+        values = ConfirmGeometrySerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        try:
+            confirmation = GardenGeometryConfirmation.objects.create(
+                workspace=area.workspace,
+                area=area,
+                confirmed_by=request.user if request.user.is_authenticated else None,
+                **values.validated_data,
+            )
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+        return Response(
+            GardenGeometryConfirmationSerializer(confirmation).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=['get'], url_path='geometry-confirmations')
+    def geometry_confirmations(self, request, pk=None):  # pylint: disable=unused-argument
+        """List every statement made about this area, newest first."""
+        area = self.get_object()
+        return Response(
+            GardenGeometryConfirmationSerializer(
+                area.geometry_confirmations.order_by('-confirmed_at', '-pk'),
+                many=True,
+            ).data,
+        )
 
 
 class GardenBedViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors

--- a/garden/test_geometry_rest.py
+++ b/garden/test_geometry_rest.py
@@ -1,0 +1,130 @@
+"""REST contract for confirming what garden geometry physically measures."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from tests.api import RESTContractTestCase
+from tests.factories import make_garden_area, make_garden_geometry_confirmation
+
+from .models import GardenGeometryConfirmation
+
+
+class ConfirmGeometryTests(RESTContractTestCase):
+    """Recording and reading an area's confirmed physical scale."""
+
+    def setUp(self):
+        super().setUp()
+        self.area = make_garden_area(size_x=2000, size_y=1000)
+        self.confirm_url = f'/garden/areas/{self.area.pk}/confirm-geometry/'
+        self.history_url = f'/garden/areas/{self.area.pk}/geometry-confirmations/'
+
+    def test_an_area_reports_itself_unconfirmed(self):
+        """Nothing claims a physical extent before an operator states one."""
+        response = self.client.get(f'/garden/areas/{self.area.pk}/')
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertFalse(response.data['geometry_confirmed'])
+        self.assertIsNone(response.data['length_unit'])
+        self.assertIsNone(response.data['cell_length'])
+        self.assertIsNone(response.data['square_metres'])
+
+    def test_confirming_reports_the_normalized_extent(self):
+        """A 2000 x 1000 mm area measures 2 m2 once its unit is confirmed."""
+        response = self.client.post(
+            self.confirm_url,
+            {'length_unit': 'mm', 'cell_length': '1'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+
+        area = self.client.get(f'/garden/areas/{self.area.pk}/')
+        self.assertTrue(area.data['geometry_confirmed'])
+        self.assertEqual(area.data['length_unit'], 'mm')
+        self.assertEqual(area.data['cell_length'], '1.000000')
+        self.assertEqual(area.data['square_metres'], '2.000000')
+
+    def test_a_confirmation_records_its_operator(self):
+        """The audited statement names whoever made it."""
+        self.client.post(
+            self.confirm_url,
+            {'length_unit': 'm', 'cell_length': '1', 'notes': 'Measured'},
+            format='json',
+        )
+        confirmation = GardenGeometryConfirmation.objects.get(area=self.area)
+        self.assertEqual(confirmation.confirmed_by, self.user)
+        self.assertEqual(confirmation.notes, 'Measured')
+
+    def test_confirming_again_supersedes_without_erasing(self):
+        """A mistaken unit is corrected by a new statement, not a rewrite."""
+        self.client.post(
+            self.confirm_url,
+            {'length_unit': 'm', 'cell_length': '1'},
+            format='json',
+        )
+        self.client.post(
+            self.confirm_url,
+            {'length_unit': 'mm', 'cell_length': '1'},
+            format='json',
+        )
+        area = self.client.get(f'/garden/areas/{self.area.pk}/')
+        self.assertEqual(area.data['length_unit'], 'mm')
+
+        history = self.client.get(self.history_url)
+        self.assertEqual(history.status_code, 200, history.data)
+        self.assertEqual([row['length_unit'] for row in history.data], ['mm', 'm'])
+
+    def test_a_zero_grid_step_is_refused(self):
+        """A step of no length would collapse every area to nothing."""
+        response = self.client.post(
+            self.confirm_url,
+            {'length_unit': 'm', 'cell_length': '0'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_an_unknown_unit_is_refused(self):
+        """Only units with an exact metre equivalent may be recorded."""
+        response = self.client.post(
+            self.confirm_url,
+            {'length_unit': 'furlong', 'cell_length': '1'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('length_unit', response.data)
+
+    def test_confirmation_requires_authentication(self):
+        """Anonymous callers cannot state what an area measures."""
+        self.client.logout()
+        response = self.client.post(
+            self.confirm_url,
+            {'length_unit': 'm', 'cell_length': '1'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 403, response.data)
+
+    def _confirmed_areas(self, count):
+        """Create `count` confirmed one-square-metre areas."""
+        for _ in range(count):
+            make_garden_geometry_confirmation(
+                area=make_garden_area(size_x=1000, size_y=1000),
+                length_unit=GardenGeometryConfirmation.LengthUnit.MILLIMETRE,
+                cell_length=Decimal('1'),
+            )
+
+    def test_listing_areas_costs_the_same_however_many_are_confirmed(self):
+        """Deriving each scale reuses one prefetch instead of a query per area.
+
+        The count is asserted at both sizes because the number itself is
+        incidental; what matters is that it does not grow with the collection.
+        """
+        self._confirmed_areas(3)
+        with self.assertNumQueries(3):
+            response = self.client.get('/garden/areas/')
+        self.assertEqual(response.status_code, 200, response.data)
+        confirmed = [row for row in response.data if row['geometry_confirmed']]
+        self.assertEqual(len(confirmed), 3)
+        self.assertEqual(confirmed[0]['square_metres'], '1.000000')
+
+        self._confirmed_areas(9)
+        with self.assertNumQueries(3):
+            self.client.get('/garden/areas/')


### PR DESCRIPTION
Add a confirm-geometry action that records what one grid step of an area measures, a geometry-confirmations action listing every statement made about it newest first, and derived read-only fields so an area reports whether it is confirmed, the unit and step it was confirmed at, and its normalized extent in square metres.

An unconfirmed area reports null for all three derived fields rather than guessing, which is what lets a client offer to confirm the scale instead of silently showing a wrong area.

The area viewset prefetches confirmations and the newest is chosen in Python, so listing a garden costs the same number of queries however many areas are confirmed. A regression test asserts that count at two collection sizes.

## Summary by Sourcery

Add geometry confirmation support for garden areas, exposing confirmation state and normalized area through the REST API while keeping listing queries constant regardless of confirmation count.

New Features:
- Expose read-only geometry confirmation fields on garden areas, including confirmation status, length unit, grid-step length, and normalized area in square metres.
- Add REST endpoints to confirm an area's physical scale and to list all geometry confirmations for an area, ordered newest first.

Enhancements:
- Optimize garden area listing by prefetching geometry confirmations and deriving the latest confirmation in Python to avoid N+1 queries.
- Refactor geometry utilities to separate confirmation resolution from measurement, enabling reuse of a resolved confirmation when computing normalized area.

Tests:
- Add REST contract tests covering geometry confirmation workflows, validation errors, authorization, and query-count regression for listing areas with varying numbers of confirmations.