### PR TITLE
feat(applications): calculate suggested input usage

### DIFF
--- a/applications/test_usage.py
+++ b/applications/test_usage.py
@@ -1,0 +1,246 @@
+"""Tests for suggesting how much of an input a set of targets consumes."""
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+
+from inventory.models import InventoryItem
+from inventory.units import UnitCode
+
+from .usage import TargetInput, UsageInputs, calculate_usage
+
+
+def cell(volume, weight='1', label='Cell'):
+    """Build one tray-cell target of a known volume."""
+    return TargetInput(
+        target_type='seed_tray_cell',
+        weight=Decimal(weight),
+        cell_volume_ml=volume,
+        label=label,
+    )
+
+
+def ground(area_m2, weight='1', target_type='garden_square'):
+    """Build one measured piece of garden geometry."""
+    return TargetInput(
+        target_type=target_type,
+        weight=Decimal(weight),
+        area_m2=Decimal(area_m2),
+        label='Square',
+    )
+
+
+def plant(weight='1'):
+    """Build one plant target."""
+    return TargetInput(target_type='specific_plant', weight=Decimal(weight), label='Plant')
+
+
+class CellVolumeUsageTests(SimpleTestCase):
+    """Filling tray cells with growing media."""
+
+    def calculate(self, targets, base_unit=UnitCode.LITRE, fill_factor=None):
+        """Run a cell-volume calculation over the given cells."""
+        return calculate_usage(UsageInputs(
+            basis=InventoryItem.UsageBasis.CELL_VOLUME,
+            base_unit=base_unit,
+            fill_factor=fill_factor,
+            targets=tuple(targets),
+        ))
+
+    def test_cells_of_one_size_sum(self):
+        """Twenty-four 40 ml cells hold 960 ml, which is 0.96 litres."""
+        result = self.calculate([cell(40) for _ in range(24)])
+        self.assertEqual(result.calculated_base_quantity, Decimal('0.960000000'))
+        self.assertEqual(result.basis_quantity, Decimal('960.000000000'))
+        self.assertEqual(result.basis_unit, UnitCode.MILLILITRE)
+        self.assertEqual(result.target_count, 24)
+
+    def test_cells_of_different_sizes_sum(self):
+        """Mixed tray models simply add, because each cell carries its volume."""
+        result = self.calculate([cell(40), cell(40), cell(100), cell(15)])
+        self.assertEqual(result.basis_quantity, Decimal('195.000000000'))
+        self.assertEqual(result.calculated_base_quantity, Decimal('0.195000000'))
+
+    def test_a_fill_factor_scales_the_volume(self):
+        """Filling cells to 85 per cent uses 85 per cent of their volume."""
+        result = self.calculate([cell(40) for _ in range(24)], fill_factor=Decimal('0.85'))
+        self.assertEqual(result.calculated_base_quantity, Decimal('0.816000000'))
+
+    def test_a_partial_weight_scales_one_cell(self):
+        """A half-filled cell contributes half its volume."""
+        result = self.calculate([cell(40), cell(40, weight='0.5')])
+        self.assertEqual(result.basis_quantity, Decimal('60.000000000'))
+
+    def test_a_millilitre_item_needs_no_conversion(self):
+        """An item measured in millilitres reports the summed volume directly."""
+        result = self.calculate([cell(40)], base_unit=UnitCode.MILLILITRE)
+        self.assertEqual(result.calculated_base_quantity, Decimal('40.000000000'))
+
+    def test_a_zero_fill_factor_is_refused(self):
+        """Filling cells to nothing is not an application."""
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([cell(40)], fill_factor=Decimal('0'))
+        self.assertIn('fill_factor', caught.exception.message_dict)
+
+    def test_cells_are_required(self):
+        """A cell-volume line has nothing to measure without cells."""
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([])
+        self.assertIn('targets', caught.exception.message_dict)
+
+    def test_a_cell_without_a_recorded_volume_is_refused(self):
+        """A tray model with no cell volume cannot silently contribute zero."""
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([cell(None)])
+        self.assertIn('targets', caught.exception.message_dict)
+
+    def test_the_formula_shows_its_working(self):
+        """An operator can see where the suggestion came from."""
+        result = self.calculate([cell(40) for _ in range(24)], fill_factor=Decimal('0.85'))
+        self.assertEqual(
+            result.formula,
+            '24 cells totalling 960 ml, filled to 0.85 = 0.816 l',
+        )
+
+
+class SurfaceAreaUsageTests(SimpleTestCase):
+    """Treating ground by its normalized area."""
+
+    def calculate(self, targets, rate='2', rate_unit=UnitCode.SQUARE_METRE):
+        """Run a surface-area calculation over the given geometry."""
+        return calculate_usage(UsageInputs(
+            basis=InventoryItem.UsageBasis.SURFACE_AREA,
+            base_unit=UnitCode.GRAM,
+            rate=Decimal(rate),
+            rate_unit=rate_unit,
+            targets=tuple(targets),
+        ))
+
+    def test_area_times_rate(self):
+        """Six square metres at 2 g per m2 needs 12 g."""
+        result = self.calculate([ground('4'), ground('2')])
+        self.assertEqual(result.calculated_base_quantity, Decimal('12.000000000'))
+        self.assertEqual(result.basis_quantity, Decimal('6.000000000'))
+
+    def test_a_weight_scales_one_place(self):
+        """Treating half a bed uses half its area."""
+        result = self.calculate([ground('4', weight='0.5')])
+        self.assertEqual(result.basis_quantity, Decimal('2.000000000'))
+
+    def test_every_geometry_level_can_be_treated(self):
+        """Areas, beds, rows, and squares all measure the same way."""
+        levels = ('garden_area', 'garden_bed', 'garden_row', 'garden_square')
+        for level in levels:
+            with self.subTest(level=level):
+                result = self.calculate([ground('3', target_type=level)])
+                self.assertEqual(result.calculated_base_quantity, Decimal('6.000000000'))
+
+    def test_a_rate_in_the_wrong_dimension_is_refused(self):
+        """A treatment cannot be dosed per litre of ground."""
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([ground('4')], rate_unit=UnitCode.LITRE)
+        self.assertIn('configured_rate_unit', caught.exception.message_dict)
+
+    def test_a_missing_rate_is_refused(self):
+        """Without a rate there is nothing to multiply the area by."""
+        with self.assertRaises(ValidationError) as caught:
+            calculate_usage(UsageInputs(
+                basis=InventoryItem.UsageBasis.SURFACE_AREA,
+                base_unit=UnitCode.GRAM,
+                targets=(ground('4'),),
+            ))
+        self.assertIn('configured_rate', caught.exception.message_dict)
+
+    def test_ground_without_a_measured_area_is_refused(self):
+        """Unconfirmed geometry never reaches the calculation as a zero."""
+        unmeasured = TargetInput(target_type='garden_square', label='Square A1')
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([unmeasured])
+        self.assertIn('targets', caught.exception.message_dict)
+
+
+class PerUnitUsageTests(SimpleTestCase):
+    """Applying a rate once per plant or item."""
+
+    def calculate(self, targets, rate='1', rate_unit=UnitCode.EACH):
+        """Run a per-unit calculation over the given targets."""
+        return calculate_usage(UsageInputs(
+            basis=InventoryItem.UsageBasis.PER_UNIT,
+            base_unit=UnitCode.EACH,
+            rate=Decimal(rate),
+            rate_unit=rate_unit,
+            targets=tuple(targets),
+        ))
+
+    def test_one_label_per_plant(self):
+        """Twelve plants need twelve labels."""
+        result = self.calculate([plant() for _ in range(12)])
+        self.assertEqual(result.calculated_base_quantity, Decimal('12.000000000'))
+        self.assertEqual(result.target_count, 12)
+
+    def test_a_rate_above_one_multiplies(self):
+        """Two labels per plant doubles the count."""
+        result = self.calculate([plant() for _ in range(12)], rate='2')
+        self.assertEqual(result.calculated_base_quantity, Decimal('24.000000000'))
+
+    def test_a_count_rate_in_the_wrong_dimension_is_refused(self):
+        """Labels are not dosed per square metre."""
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([plant()], rate_unit=UnitCode.SQUARE_METRE)
+        self.assertIn('configured_rate_unit', caught.exception.message_dict)
+
+    def test_targets_are_required(self):
+        """Nothing to label means nothing to suggest."""
+        with self.assertRaises(ValidationError) as caught:
+            self.calculate([])
+        self.assertIn('targets', caught.exception.message_dict)
+
+
+class FixedAndManualUsageTests(SimpleTestCase):
+    """Bases that do not scale with what was targeted."""
+
+    def test_a_fixed_quantity_ignores_the_target_count(self):
+        """One dose is one dose however many plants received it."""
+        result = calculate_usage(UsageInputs(
+            basis=InventoryItem.UsageBasis.FIXED,
+            base_unit=UnitCode.LITRE,
+            fixed_quantity=Decimal('2.5'),
+            targets=tuple(plant() for _ in range(7)),
+        ))
+        self.assertEqual(result.calculated_base_quantity, Decimal('2.500000000'))
+        self.assertEqual(result.target_count, 7)
+        self.assertIsNone(result.basis_quantity)
+
+    def test_a_fixed_basis_needs_a_quantity(self):
+        """A fixed usage with no configured amount suggests nothing usable."""
+        with self.assertRaises(ValidationError) as caught:
+            calculate_usage(UsageInputs(
+                basis=InventoryItem.UsageBasis.FIXED,
+                base_unit=UnitCode.LITRE,
+            ))
+        self.assertIn('configured_fixed_quantity', caught.exception.message_dict)
+
+    def test_manual_usage_suggests_nothing(self):
+        """No formula applies, so the operator supplies the amount."""
+        result = calculate_usage(UsageInputs(
+            basis=InventoryItem.UsageBasis.MANUAL,
+            base_unit=UnitCode.LITRE,
+            targets=(plant(),),
+        ))
+        self.assertIsNone(result.calculated_base_quantity)
+        self.assertEqual(result.formula, 'Manual entry')
+
+    def test_an_unknown_basis_is_refused(self):
+        """Only the supported bases can produce a suggestion."""
+        with self.assertRaises(ValidationError) as caught:
+            calculate_usage(UsageInputs(basis='vibes', base_unit=UnitCode.LITRE))
+        self.assertIn('usage_basis', caught.exception.message_dict)
+
+    def test_an_unknown_base_unit_is_refused(self):
+        """A quantity is meaningless in a unit the registry does not define."""
+        with self.assertRaises(ValidationError):
+            calculate_usage(UsageInputs(
+                basis=InventoryItem.UsageBasis.MANUAL,
+                base_unit='buckets',
+            ))

--- a/applications/usage.py
+++ b/applications/usage.py
@@ -1,0 +1,260 @@
+"""Suggest how much of an input a set of targets should consume.
+
+These functions are pure: they take already-measured targets and an item's
+configured usage, and return a quantity in the item's base unit. Nothing here
+reads the database, so the same inputs always produce the same suggestion and
+a posted document can be recalculated from its stored snapshot years later.
+
+A suggestion is only ever a proposal. The operator confirms what was actually
+used, and that confirmed amount is the inventory fact.
+"""
+
+from decimal import Decimal
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+
+from inventory.ledger import quantize_quantity
+from inventory.models import InventoryItem
+from inventory.units import UnitCode, UnitDimension, convert_standard_quantity, get_unit_definition
+
+
+#: Dimension each rate-based usage divides by, matching the rules
+#: `InventoryItem._validate_rate_based_usage` already enforces on the catalog.
+RATE_DIMENSIONS = {
+    InventoryItem.UsageBasis.SURFACE_AREA: UnitDimension.AREA,
+    InventoryItem.UsageBasis.PER_UNIT: UnitDimension.COUNT,
+}
+
+#: Target types that carry a measured volume, area, or count respectively.
+VOLUME_TARGETS = frozenset({'seed_tray_cell'})
+AREA_TARGETS = frozenset({'garden_area', 'garden_bed', 'garden_row', 'garden_square'})
+COUNT_TARGETS = frozenset({'specific_plant', 'inventory_unit', 'batch'})
+
+
+class TargetInput(NamedTuple):
+    """One measured thing an input was applied to."""
+
+    target_type: str
+    weight: Decimal = Decimal('1')
+    cell_volume_ml: object = None
+    area_m2: object = None
+    label: str = ''
+
+
+class UsageInputs(NamedTuple):
+    """Everything the suggestion depends on, all of it snapshotted."""
+
+    basis: str
+    base_unit: str
+    rate: object = None
+    rate_unit: str = ''
+    fixed_quantity: object = None
+    fill_factor: object = None
+    targets: tuple = ()
+
+
+class UsageCalculation(NamedTuple):
+    """A suggested quantity and the working that produced it."""
+
+    basis: str
+    basis_quantity: object
+    basis_unit: str
+    target_count: int
+    calculated_base_quantity: object
+    base_unit: str
+    formula: str
+
+
+def _require(condition, field, message):
+    """Raise a field error unless a precondition holds."""
+    if not condition:
+        raise ValidationError({field: message})
+
+
+def _weighted(targets, attribute):
+    """Total one measured attribute across targets, scaled by each weight."""
+    total = Decimal('0')
+    for target in targets:
+        value = getattr(target, attribute)
+        _require(
+            value is not None,
+            'targets',
+            f'{target.label or target.target_type} has no recorded '
+            f'{attribute.replace("_", " ")}.',
+        )
+        total += Decimal(value) * Decimal(target.weight)
+    return total
+
+
+def _selected(targets, allowed, field_message):
+    """Return the targets this basis measures, requiring at least one."""
+    chosen = tuple(target for target in targets if target.target_type in allowed)
+    _require(chosen, 'targets', field_message)
+    return chosen
+
+
+def _rate(inputs):
+    """Return the configured rate and its unit, requiring both."""
+    _require(inputs.rate is not None, 'configured_rate', 'This usage basis requires a rate.')
+    _require(inputs.rate_unit, 'configured_rate_unit', 'This usage basis requires a rate unit.')
+    _require(
+        Decimal(inputs.rate) > 0,
+        'configured_rate',
+        'The rate must be greater than zero.',
+    )
+    dimension = get_unit_definition(inputs.rate_unit).dimension
+    _require(
+        dimension == RATE_DIMENSIONS[inputs.basis],
+        'configured_rate_unit',
+        'The rate unit has an incompatible dimension.',
+    )
+    return Decimal(inputs.rate), inputs.rate_unit
+
+
+def _cell_volume_usage(inputs):
+    """Total the volume of every selected cell and fill it to the given depth.
+
+    There is no item rate here. A cell-volume item's catalog entry records no
+    rate at all, because the quantity is the physical volume of the cells that
+    were filled; cells of different sizes simply sum. Anything not going into a
+    cell, such as spillage, is recorded separately as waste.
+    """
+    targets = _selected(
+        inputs.targets,
+        VOLUME_TARGETS,
+        'Select the tray cells this input filled.',
+    )
+    fill_factor = Decimal(inputs.fill_factor if inputs.fill_factor is not None else 1)
+    _require(
+        fill_factor > 0,
+        'fill_factor',
+        'The fill factor must be greater than zero.',
+    )
+    millilitres = _weighted(targets, 'cell_volume_ml') * fill_factor
+    calculated = convert_standard_quantity(
+        millilitres,
+        UnitCode.MILLILITRE,
+        inputs.base_unit,
+    )
+    formula = (
+        f'{len(targets)} cells totalling '
+        f'{_trim(_weighted(targets, "cell_volume_ml"))} ml, filled to '
+        f'{_trim(fill_factor)} = {_trim(quantize_quantity(calculated))} '
+        f'{inputs.base_unit}'
+    )
+    return _result(inputs, millilitres, UnitCode.MILLILITRE, len(targets), calculated, formula)
+
+
+def _surface_area_usage(inputs):
+    """Apply a rate over the normalized area of every selected place."""
+    targets = _selected(
+        inputs.targets,
+        AREA_TARGETS,
+        'Select the ground this input covered.',
+    )
+    rate, rate_unit = _rate(inputs)
+    area = _weighted(targets, 'area_m2')
+    in_rate_unit = convert_standard_quantity(area, UnitCode.SQUARE_METRE, rate_unit)
+    calculated = in_rate_unit * rate
+    formula = (
+        f'{_trim(area)} m2 at {_trim(rate)} {inputs.base_unit} per '
+        f'{rate_unit} = {_trim(quantize_quantity(calculated))} {inputs.base_unit}'
+    )
+    return _result(inputs, area, UnitCode.SQUARE_METRE, len(targets), calculated, formula)
+
+
+def _per_unit_usage(inputs):
+    """Apply a rate once per selected plant or item."""
+    targets = _selected(
+        inputs.targets,
+        COUNT_TARGETS,
+        'Select the plants or items this input was applied to.',
+    )
+    rate, rate_unit = _rate(inputs)
+    count = sum((Decimal(target.weight) for target in targets), Decimal('0'))
+    calculated = count * rate
+    formula = (
+        f'{_trim(count)} x {_trim(rate)} {inputs.base_unit} per {rate_unit} '
+        f'= {_trim(quantize_quantity(calculated))} {inputs.base_unit}'
+    )
+    return _result(inputs, count, rate_unit, len(targets), calculated, formula)
+
+
+def _fixed_usage(inputs):
+    """Use the item's fixed quantity regardless of how much was targeted.
+
+    Targets are still recorded, because the point of the document is knowing
+    what the input went on even when the amount does not depend on it.
+    """
+    _require(
+        inputs.fixed_quantity is not None,
+        'configured_fixed_quantity',
+        'Fixed usage requires a default quantity.',
+    )
+    calculated = Decimal(inputs.fixed_quantity)
+    _require(
+        calculated > 0,
+        'configured_fixed_quantity',
+        'The fixed quantity must be greater than zero.',
+    )
+    formula = f'Fixed {_trim(calculated)} {inputs.base_unit}'
+    return _result(inputs, None, '', len(inputs.targets), calculated, formula)
+
+
+def _manual_usage(inputs):
+    """Suggest nothing, because no formula applies to this item."""
+    return _result(inputs, None, '', len(inputs.targets), None, 'Manual entry')
+
+
+def _result(inputs, basis_quantity, basis_unit, target_count, calculated, formula):
+    """Assemble one calculation, quantizing the suggestion for the ledger."""
+    return UsageCalculation(
+        basis=inputs.basis,
+        basis_quantity=None if basis_quantity is None else quantize_quantity(basis_quantity),
+        basis_unit=basis_unit,
+        target_count=target_count,
+        calculated_base_quantity=None if calculated is None else quantize_quantity(calculated),
+        base_unit=inputs.base_unit,
+        formula=formula,
+    )
+
+
+def _trim(value):
+    """Render a decimal without the trailing zeros a fixed column carries."""
+    text = f'{Decimal(value):f}'
+    return text.rstrip('0').rstrip('.') if '.' in text else text
+
+
+CALCULATORS = {
+    InventoryItem.UsageBasis.CELL_VOLUME: _cell_volume_usage,
+    InventoryItem.UsageBasis.SURFACE_AREA: _surface_area_usage,
+    InventoryItem.UsageBasis.PER_UNIT: _per_unit_usage,
+    InventoryItem.UsageBasis.FIXED: _fixed_usage,
+    InventoryItem.UsageBasis.MANUAL: _manual_usage,
+}
+
+
+def calculate_usage(inputs):
+    """Return the suggested consumption for one basis and set of targets."""
+    calculator = CALCULATORS.get(inputs.basis)
+    _require(calculator is not None, 'usage_basis', 'Select a supported usage basis.')
+    get_unit_definition(inputs.base_unit)
+    return calculator(inputs)
+
+
+def item_usage_inputs(item, targets, basis=None, fill_factor=None):
+    """Build calculation inputs from an item's configured usage.
+
+    Reading the catalog happens here, once, so the caller can store what it
+    read and recalculate from the stored copy afterwards.
+    """
+    return UsageInputs(
+        basis=basis or item.default_usage_basis,
+        base_unit=item.base_unit,
+        rate=item.default_usage_rate,
+        rate_unit=item.usage_rate_unit or '',
+        fixed_quantity=item.default_fixed_quantity,
+        fill_factor=fill_factor,
+        targets=tuple(targets),
+    )


### PR DESCRIPTION
Add the pure calculation engine behind an input application: cell volume, surface area, per unit, fixed, and manual. It reads no database, so the same inputs always produce the same suggestion and a posted document can be recalculated from its stored snapshot years later.

Cell volume totals each selected cell's own volume and fills it to the given depth, with no item rate. Cells of different sizes simply sum, which is what lets one application cover mixed tray models. That follows c072ee8, which removed the rate from cell-volume items precisely because one catalog rate cannot stand for several physical cell sizes.

Every basis reports the working that produced its number, so an operator confirming an amount can see what it was derived from rather than being handed a bare quantity to trust.

A target that carries no measurement is refused rather than counted as zero. A tray model with no recorded cell volume or a garden square whose area is unconfirmed would otherwise silently shrink the suggestion.

## Summary by Sourcery

Introduce a pure usage-calculation engine for input applications that suggests quantities based on configured usage basis and measured targets.

New Features:
- Support usage suggestions for cell volume, surface area, per-unit, fixed, and manual bases independent of the database.
- Capture calculation inputs and outputs in snapshot-friendly structures for reproducible recalculation, including human-readable formulae explaining the suggestion.

Tests:
- Add unit tests covering all usage bases, validation rules, and edge cases (missing measurements, incompatible units, unknown bases).