### PR TITLE
feat(workspaces): configure the input override tolerance

### DIFF
--- a/applications/test_usage.py
+++ b/applications/test_usage.py
@@ -8,7 +8,7 @@ from django.test import SimpleTestCase
 from inventory.models import InventoryItem
 from inventory.units import UnitCode
 
-from .usage import TargetInput, UsageInputs, calculate_usage
+from .usage import TargetInput, UsageInputs, calculate_usage, override_required
 
 
 def cell(volume, weight='1', label='Cell'):
@@ -244,3 +244,53 @@ class FixedAndManualUsageTests(SimpleTestCase):
                 basis=InventoryItem.UsageBasis.MANUAL,
                 base_unit='buckets',
             ))
+
+
+class OverrideToleranceTests(SimpleTestCase):
+    """When a confirmed quantity has to be explained."""
+
+    def required(self, calculated, applied, percent='5', floor='0'):
+        """Ask whether this difference needs a reason under these bounds."""
+        return override_required(
+            None if calculated is None else Decimal(calculated),
+            Decimal(applied),
+            Decimal(percent),
+            Decimal(floor),
+        )
+
+    def test_an_exact_match_needs_no_reason(self):
+        """Using exactly what was suggested explains itself."""
+        self.assertFalse(self.required('10', '10'))
+
+    def test_a_small_percentage_difference_needs_no_reason(self):
+        """Ordinary imprecision is not worth interrupting an operator for."""
+        self.assertFalse(self.required('10', '10.4'))
+
+    def test_a_large_percentage_difference_needs_a_reason(self):
+        """A material departure from the suggestion is what the audit wants."""
+        self.assertTrue(self.required('10', '11'))
+
+    def test_a_difference_either_way_counts(self):
+        """Using notably less is as interesting as using notably more."""
+        self.assertTrue(self.required('10', '9'))
+
+    def test_the_floor_grounds_the_percentage(self):
+        """A tiny line does not demand prose over a rounding-sized drift."""
+        self.assertTrue(self.required('0.1', '0.108'))
+        self.assertFalse(self.required('0.1', '0.108', floor='0.05'))
+
+    def test_the_floor_does_not_excuse_a_large_line(self):
+        """Past the floor, the percentage governs again."""
+        self.assertTrue(self.required('20', '21.6', floor='0.05'))
+
+    def test_a_difference_exactly_on_the_floor_needs_no_reason(self):
+        """The floor is the largest difference that passes unremarked."""
+        self.assertFalse(self.required('10', '10.05', floor='0.05'))
+
+    def test_a_zero_tolerance_requires_a_reason_for_any_difference(self):
+        """A workspace can demand every departure be explained."""
+        self.assertTrue(self.required('10', '10.000000001', percent='0'))
+
+    def test_a_manual_line_never_requires_a_reason(self):
+        """There is no suggestion to have departed from."""
+        self.assertFalse(self.required(None, '10', percent='0'))

--- a/applications/usage.py
+++ b/applications/usage.py
@@ -243,6 +243,35 @@ def calculate_usage(inputs):
     return calculator(inputs)
 
 
+def override_required(calculated, applied, tolerance_percent, tolerance_floor):
+    """Return whether the gap between suggestion and fact must be explained.
+
+    Both bounds have to be exceeded. The percentage alone would demand prose
+    for a third of a millilitre on a small line, and the floor alone would let
+    a large line drift by a wide margin unremarked, so each one grounds the
+    other.
+
+    A manual line has no suggestion to differ from, so nothing is required.
+    """
+    if calculated is None:
+        return False
+    difference = abs(Decimal(applied) - Decimal(calculated))
+    if difference <= Decimal(tolerance_floor):
+        return False
+    allowed = Decimal(calculated) * Decimal(tolerance_percent) / Decimal('100')
+    return difference > allowed
+
+
+def workspace_override_required(workspace, calculated, applied):
+    """Apply one workspace's configured override tolerance."""
+    return override_required(
+        calculated,
+        applied,
+        workspace.override_tolerance_percent,
+        workspace.override_tolerance_floor,
+    )
+
+
 def item_usage_inputs(item, targets, basis=None, fill_factor=None):
     """Build calculation inputs from an item's configured usage.
 

--- a/frontend/js/types/workspace.ts
+++ b/frontend/js/types/workspace.ts
@@ -8,10 +8,15 @@ interface Workspace {
   default_tax_rate: string
   timezone: string
   measurement_system: MeasurementSystem
+  override_tolerance_percent: string
+  override_tolerance_floor: string
   created: string
   updated: string
 }
 
-type WorkspaceUpdate = Pick<Workspace, 'name' | 'mode' | 'currency_code' | 'default_tax_rate' | 'timezone' | 'measurement_system'>
+type WorkspaceUpdate = Pick<
+  Workspace,
+  'name' | 'mode' | 'currency_code' | 'default_tax_rate' | 'timezone' | 'measurement_system' | 'override_tolerance_percent' | 'override_tolerance_floor'
+>
 
 export { MeasurementSystem, Workspace, WorkspaceMode, WorkspaceUpdate }

--- a/frontend/js/workspace.tsx
+++ b/frontend/js/workspace.tsx
@@ -32,7 +32,9 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
     currency_code: workspace.currency_code,
     default_tax_rate: workspace.default_tax_rate,
     timezone: workspace.timezone,
-    measurement_system: workspace.measurement_system
+    measurement_system: workspace.measurement_system,
+    override_tolerance_percent: workspace.override_tolerance_percent,
+    override_tolerance_floor: workspace.override_tolerance_floor
   })
   const mutation = useMutation({
     mutationFn: updateWorkspace,
@@ -46,7 +48,9 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
       currency_code: workspace.currency_code,
       default_tax_rate: workspace.default_tax_rate,
       timezone: workspace.timezone,
-      measurement_system: workspace.measurement_system
+      measurement_system: workspace.measurement_system,
+      override_tolerance_percent: workspace.override_tolerance_percent,
+      override_tolerance_floor: workspace.override_tolerance_floor
     })
   }, [workspace])
 
@@ -117,6 +121,33 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
             <option value="metric">Metric</option>
             <option value="imperial">Imperial</option>
           </Form.Select>
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-override-percent">
+          <Form.Label>Input override tolerance (%)</Form.Label>
+          <Form.Control
+            type="number"
+            min="0"
+            max="100"
+            step="0.0001"
+            value={form.override_tolerance_percent}
+            onChange={(event) => updateField('override_tolerance_percent', event.target.value)}
+            aria-describedby="workspace-override-percent-help"
+          />
+          <Form.Text id="workspace-override-percent-help">How far a confirmed input quantity may differ from the calculated suggestion before a reason is required.</Form.Text>
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-override-floor">
+          <Form.Label>Input override floor</Form.Label>
+          <Form.Control
+            type="number"
+            min="0"
+            step="0.000000001"
+            value={form.override_tolerance_floor}
+            onChange={(event) => updateField('override_tolerance_floor', event.target.value)}
+            aria-describedby="workspace-override-floor-help"
+          />
+          <Form.Text id="workspace-override-floor-help">
+            Smallest difference, in an item&apos;s own unit, that can require a reason. Zero disables it, so the percentage alone applies.
+          </Form.Text>
         </Form.Group>
         <Button type="submit" disabled={mutation.isPending}>
           {mutation.isPending ? 'Saving…' : 'Save settings'}

--- a/workspaces/migrations/0002_workspace_override_tolerance_floor_and_more.py
+++ b/workspaces/migrations/0002_workspace_override_tolerance_floor_and_more.py
@@ -1,0 +1,63 @@
+"""Configure when an input application override needs explaining.
+
+Existing workspaces take a five per cent tolerance and no floor, which asks for
+a reason whenever a confirmed quantity differs materially from the calculated
+suggestion and never for a rounding-sized drift on a large line. Raising the
+floor suppresses the small-line case too.
+"""
+
+import django.core.validators
+from decimal import Decimal
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("workspaces", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="workspace",
+            name="override_tolerance_floor",
+            field=models.DecimalField(
+                decimal_places=9,
+                default=Decimal("0"),
+                help_text="Smallest difference in an item base unit that can require a reason, so a rounding-sized drift never does. Zero disables it.",
+                max_digits=24,
+                validators=[django.core.validators.MinValueValidator(Decimal("0"))],
+            ),
+        ),
+        migrations.AddField(
+            model_name="workspace",
+            name="override_tolerance_percent",
+            field=models.DecimalField(
+                decimal_places=4,
+                default=Decimal("5"),
+                help_text="How far a confirmed input quantity may differ from the calculated suggestion, as a percentage, before a reason is required.",
+                max_digits=7,
+                validators=[
+                    django.core.validators.MinValueValidator(Decimal("0")),
+                    django.core.validators.MaxValueValidator(Decimal("100")),
+                ],
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="workspace",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    ("override_tolerance_percent__gte", 0),
+                    ("override_tolerance_percent__lte", 100),
+                ),
+                name="workspace_override_percent_range",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="workspace",
+            constraint=models.CheckConstraint(
+                condition=models.Q(("override_tolerance_floor__gte", 0)),
+                name="workspace_override_floor_nonnegative",
+            ),
+        ),
+    ]

--- a/workspaces/models.py
+++ b/workspaces/models.py
@@ -9,6 +9,14 @@ from django.core.validators import MaxValueValidator, MinValueValidator, RegexVa
 from django.db import models
 
 
+#: Ledger quantity precision, restated here rather than imported. Inventory
+#: depends on this module for workspace ownership, so importing its constants
+#: back would close a cycle. `inventory.models` is the definition of record and
+#: a test keeps the two in step.
+QUANTITY_MAX_DIGITS = 24
+QUANTITY_DECIMAL_PLACES = 9
+
+
 def validate_iana_timezone(value):
     """Require a timezone name understood by the system IANA database."""
     try:
@@ -68,16 +76,62 @@ class Workspace(models.Model):
         choices=MeasurementSystem.choices,
         default=MeasurementSystem.METRIC,
     )
+    override_tolerance_percent = models.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        default=Decimal('5'),
+        validators=[
+            MinValueValidator(Decimal('0')),
+            MaxValueValidator(Decimal('100')),
+        ],
+        help_text=(
+            'How far a confirmed input quantity may differ from the calculated '
+            'suggestion, as a percentage, before a reason is required.'
+        ),
+    )
+    override_tolerance_floor = models.DecimalField(
+        max_digits=QUANTITY_MAX_DIGITS,
+        decimal_places=QUANTITY_DECIMAL_PLACES,
+        default=Decimal('0'),
+        validators=[MinValueValidator(Decimal('0'))],
+        help_text=(
+            'Smallest difference in an item base unit that can require a '
+            'reason, so a rounding-sized drift never does. Zero disables it.'
+        ),
+    )
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(override_tolerance_percent__gte=0, override_tolerance_percent__lte=100),
+                name='workspace_override_percent_range',
+            ),
+            models.CheckConstraint(
+                condition=models.Q(override_tolerance_floor__gte=0),
+                name='workspace_override_floor_nonnegative',
+            ),
+        ]
 
     def __str__(self):
         return self.name
 
 
 def get_default_workspace_id():
-    """Return the configured workspace ID for direct ORM-created records."""
-    return get_current_workspace().pk
+    """Return the configured workspace ID for direct ORM-created records.
+
+    Only the primary key is touched, never the whole row. Migrations across
+    every app carry this as a column default and evaluate it while the schema
+    is mid-flight, so selecting all of Workspace would fail as soon as one
+    migration adds a column that the database has not reached yet.
+    """
+    workspace_id = settings.CURRENT_WORKSPACE_ID
+    if not Workspace.objects.filter(pk=workspace_id).exists():
+        raise ImproperlyConfigured(
+            f'CURRENT_WORKSPACE_ID={workspace_id} does not identify a workspace.'
+        )
+    return workspace_id
 
 
 def get_current_workspace():

--- a/workspaces/rest.py
+++ b/workspaces/rest.py
@@ -18,6 +18,8 @@ class WorkspaceSerializer(serializers.ModelSerializer):
             'default_tax_rate',
             'timezone',
             'measurement_system',
+            'override_tolerance_percent',
+            'override_tolerance_floor',
             'created',
             'updated',
         ]

--- a/workspaces/tests.py
+++ b/workspaces/tests.py
@@ -15,7 +15,21 @@ from supplies.models import Supplier
 
 from .admin import WorkspaceAdmin
 from .current import get_current_workspace
-from .models import Workspace
+from .models import QUANTITY_DECIMAL_PLACES, QUANTITY_MAX_DIGITS, Workspace
+
+
+class LedgerPrecisionTests(TestCase):
+    """The restated quantity precision must track its definition of record."""
+
+    def test_quantity_precision_matches_inventory(self):
+        """Inventory cannot be imported here without closing a cycle."""
+        from inventory import models as inventory_models  # pylint: disable=import-outside-toplevel
+
+        self.assertEqual(QUANTITY_MAX_DIGITS, inventory_models.QUANTITY_MAX_DIGITS)
+        self.assertEqual(
+            QUANTITY_DECIMAL_PLACES,
+            inventory_models.QUANTITY_DECIMAL_PLACES,
+        )
 
 
 class CurrentWorkspaceTests(TestCase):
@@ -106,6 +120,41 @@ class WorkspaceEndpointTests(APITestCase):
         self.assertEqual(response.data['default_tax_rate'], '0.0000')
         self.assertEqual(response.data['timezone'], 'UTC')
         self.assertEqual(response.data['measurement_system'], 'metric')
+        self.assertEqual(response.data['override_tolerance_percent'], '5.0000')
+        self.assertEqual(response.data['override_tolerance_floor'], '0.000000000')
+
+    def test_patch_updates_the_override_tolerance(self):
+        """A deployment sets how far a confirmed input may drift unexplained."""
+        response = self.client.patch(
+            self.url,
+            {
+                'override_tolerance_percent': '2.5000',
+                'override_tolerance_floor': '0.050000000',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        workspace = Workspace.objects.get(pk=1)
+        self.assertEqual(workspace.override_tolerance_percent, Decimal('2.5'))
+        self.assertEqual(workspace.override_tolerance_floor, Decimal('0.05'))
+
+    def test_patch_validates_the_override_tolerance(self):
+        """A percentage outside nought to a hundred, or a negative floor."""
+        response = self.client.patch(
+            self.url,
+            {
+                'override_tolerance_percent': '101',
+                'override_tolerance_floor': '-1',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            set(response.data),
+            {'override_tolerance_percent', 'override_tolerance_floor'},
+        )
 
     def test_patch_updates_editable_settings(self):
         """Authenticated users share the ability to update the profile."""


### PR DESCRIPTION
An input application suggests a quantity and the operator confirms what was actually used. A material gap between the two is what an audit wants explained, but "material" is a deployment's judgement, not a constant.

Add two settings and the policy that reads them. A reason is required only when the difference exceeds both the percentage and the floor, so each bound grounds the other: the percentage alone would demand prose over a third of a millilitre on a small line, and the floor alone would let a large line drift unremarked. The floor defaults to zero, leaving the percentage in sole charge until a deployment decides otherwise.

Also stop `get_default_workspace_id` loading the whole workspace row. Migrations in every app carry it as a column default and evaluate it while the schema is mid-flight, so adding any column to Workspace broke the migration graph before the column existed. It only ever needed the primary key.

## Summary by Sourcery

Add configurable workspace-level tolerances for when input quantity overrides require explanation, and harden workspace ID resolution used in migrations.

New Features:
- Introduce workspace settings for input override tolerance as a percentage and an absolute floor, exposed via the API and frontend workspace settings.
- Provide logic to determine when an input quantity override requires a justification, based on the configured tolerance bounds.

Bug Fixes:
- Ensure the default workspace ID helper only validates the primary key instead of loading the full workspace row, avoiding migration failures when the schema is in flux.

Enhancements:
- Restate and test ledger quantity precision constants in the workspaces app to align with the inventory definition of record.

Tests:
- Add unit and API tests covering override tolerance behaviour, validation, defaults, and ledger precision consistency.
- Extend frontend types and behaviour tests implicitly via usage of the new workspace override fields in settings.