### PR TITLE
feat(applications): post and reverse input applications

### DIFF
--- a/applications/services.py
+++ b/applications/services.py
@@ -1,0 +1,615 @@
+"""Transactional services for drafting, posting, and reversing applications.
+
+A draft is assembled and checked against stock; posting is what decrements
+inventory. The two are separate because a calculation only ever proposes a
+quantity, and an operator confirms what was actually used, often well after
+the draft was built.
+
+Posting revalidates everything against the state it holds locks on, and refuses
+a document whose stock or contents moved since the client last looked. That is
+what stops two people spending the same last litre of a lot.
+"""
+
+# pylint: disable=duplicate-code
+
+import hashlib
+from decimal import Decimal
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from garden.geometry import square_metres
+from inventory.ledger import (
+    MovementRequest,
+    lock_lots,
+    normalize_quantity,
+    physical_balance,
+    post_stock_movement,
+    quantize_quantity,
+    reverse_application_movements,
+)
+from inventory.models import InventoryItem, StockMovement
+from plantings.batches import batch_specific_plants, lock_batch
+from plantings.lifecycle import is_final, lifecycle_summaries
+from plantings.models import ProductionBatch, SpecificPlant
+from seedtrays.models import SeedTrayCell
+
+from .models import InputApplication, InputApplicationLine, InputApplicationTarget
+from .usage import TargetInput, UsageInputs, calculate_usage, workspace_override_required
+
+
+#: Batch states that can still receive an input. `planned` has grown nothing
+#: yet and `cancelled` has declared it produced nothing at all, so neither can
+#: truthfully consume stock.
+APPLICABLE_STATUSES = {
+    ProductionBatch.Status.ACTIVE,
+    ProductionBatch.Status.OUTPUT_FINALIZED,
+    ProductionBatch.Status.COMPLETED,
+}
+
+TargetType = InputApplicationTarget.TargetType
+
+
+class TargetRequest(NamedTuple):
+    """Caller intent for one thing an input was applied to."""
+
+    target_type: str
+    target: object
+    weight: object = Decimal('1')
+
+
+class LineRequest(NamedTuple):
+    """Caller intent for one item drawn from one exact lot."""
+
+    item: object
+    lot: object
+    applied_quantity: object
+    unit_code: object = None
+    unit_conversion: object = None
+    usage_basis: str = ''
+    fill_factor: object = None
+    waste_quantity: object = Decimal('0')
+    waste_reason: str = ''
+    override_reason: str = ''
+    notes: str = ''
+    targets: tuple = ()
+
+
+class ApplicationRequest(NamedTuple):
+    """Caller intent for one whole document."""
+
+    applied_at: object
+    source_location: object
+    batch: object = None
+    notes: str = ''
+    lines: tuple = ()
+
+
+class TargetSnapshot(NamedTuple):
+    """One target with whatever it measured at the moment it was read."""
+
+    target_type: str
+    target: object = None
+    weight: object = Decimal('1')
+    cell_volume_ml: object = None
+    area_m2: object = None
+    label: str = ''
+
+    def as_usage_input(self):
+        """Return the pure-calculation view of this target."""
+        return TargetInput(
+            target_type=self.target_type,
+            weight=Decimal(self.weight),
+            cell_volume_ml=self.cell_volume_ml,
+            area_m2=self.area_m2,
+            label=self.label,
+        )
+
+
+def _require_reason(reason):
+    """Reject an audit-critical action without a stated reason."""
+    if not reason or not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+
+
+def measure_target(request):
+    """Freeze what one target measures right now.
+
+    Reading happens once, here, so everything downstream works from the frozen
+    copy and a later edit to a tray model or an area's confirmed scale cannot
+    change what an application already recorded.
+    """
+    target = request.target
+    snapshot = TargetSnapshot(
+        target_type=request.target_type,
+        target=target,
+        weight=Decimal(request.weight),
+        label=str(target)[:255],
+    )
+    if request.target_type == TargetType.SEED_TRAY_CELL:
+        volume = target.tray.model.cell_size_ml
+        if not volume:
+            raise ValidationError({
+                'targets': f'Tray model {target.tray.model} has no recorded cell volume.',
+            })
+        return snapshot._replace(cell_volume_ml=volume)
+    if request.target_type in {
+        TargetType.GARDEN_AREA,
+        TargetType.GARDEN_BED,
+        TargetType.GARDEN_ROW,
+        TargetType.GARDEN_SQUARE,
+    }:
+        try:
+            return snapshot._replace(area_m2=square_metres(target))
+        except ValidationError as exc:
+            # Re-key onto this app's field so every target problem an operator
+            # can hit arrives under `targets`, whichever layer noticed it.
+            raise ValidationError({'targets': exc.messages}) from exc
+    return snapshot
+
+
+def stored_snapshot(row):
+    """Rebuild a snapshot from a saved target row without remeasuring it."""
+    return TargetSnapshot(
+        target_type=row.target_type,
+        target=row.target,
+        weight=row.weight,
+        cell_volume_ml=row.cell_volume_ml,
+        area_m2=row.area_m2,
+        label=row.label,
+    )
+
+
+def _line_usage(item, basis, fill_factor, snapshots):
+    """Calculate one line's suggestion from its snapshotted targets."""
+    return calculate_usage(UsageInputs(
+        basis=basis or item.default_usage_basis,
+        base_unit=item.base_unit,
+        rate=item.default_usage_rate,
+        rate_unit=item.usage_rate_unit or '',
+        fixed_quantity=item.default_fixed_quantity,
+        fill_factor=fill_factor,
+        targets=tuple(snapshot.as_usage_input() for snapshot in snapshots),
+    ))
+
+
+def _stored_line_usage(line):
+    """Recalculate one saved line entirely from its own frozen columns.
+
+    Nothing here reads the catalog. That is the whole point: a posted document
+    must produce the same number after an item's rate has been edited.
+    """
+    return calculate_usage(UsageInputs(
+        basis=line.usage_basis,
+        base_unit=line.base_unit,
+        rate=line.configured_rate,
+        rate_unit=line.configured_rate_unit,
+        fixed_quantity=line.configured_fixed_quantity,
+        fill_factor=line.fill_factor,
+        targets=tuple(
+            stored_snapshot(row).as_usage_input() for row in line.targets.all()
+        ),
+    ))
+
+
+def _validate_batch(batch, applied_at):
+    """Require a batch that can still truthfully consume stock."""
+    if batch is None:
+        return
+    if batch.status not in APPLICABLE_STATUSES:
+        raise ValidationError({
+            'batch': (
+                f'A {batch.get_status_display().lower()} batch cannot receive '
+                'an input application.'
+            ),
+        })
+    if batch.actual_start is not None and applied_at < batch.actual_start:
+        raise ValidationError({
+            'applied_at': 'An application cannot predate the start of its batch.',
+        })
+
+
+def _plant_ids(application):
+    """Return every plant this document targets, in primary-key order."""
+    return sorted(
+        InputApplicationTarget.objects
+        .filter(line__application=application, specific_plant__isnull=False)
+        .values_list('specific_plant_id', flat=True)
+    )
+
+
+def _validate_plants(application, plant_ids):
+    """Require living plants that came from the document's own batch."""
+    if not plant_ids:
+        return
+    summaries = lifecycle_summaries(plant_ids)
+    finished = sorted(
+        plant_id for plant_id, summary in summaries.items()
+        if is_final(summary.state)
+    )
+    if finished:
+        raise ValidationError({
+            'targets': f'These plants had already finished: {finished}.',
+        })
+    if application.batch_id is None:
+        return
+    known = set(
+        batch_specific_plants(application.batch)
+        .filter(pk__in=plant_ids)
+        .values_list('pk', flat=True)
+    )
+    missing = [plant_id for plant_id in plant_ids if plant_id not in known]
+    if missing:
+        raise ValidationError({
+            'targets': (
+                f'These plants did not come from batch '
+                f'{application.batch.code}: {missing}.'
+            ),
+        })
+
+
+def _validate_line_amounts(workspace, line, calculation):
+    """Require waste and override reasons wherever the audit needs them."""
+    if line.waste_base_quantity > 0 and not line.waste_reason.strip():
+        raise ValidationError({
+            'lines': f'Line {line.pk}: a reason is required for recorded waste.',
+        })
+    required = workspace_override_required(
+        workspace,
+        calculation.calculated_base_quantity,
+        line.applied_base_quantity,
+    )
+    if required and not line.override_reason.strip():
+        raise ValidationError({
+            'lines': (
+                f'Line {line.pk}: give a reason for applying '
+                f'{line.applied_base_quantity} {line.base_unit} instead of the '
+                f'calculated {calculation.calculated_base_quantity}.'
+            ),
+        })
+
+
+def availability_digest(rows):
+    """Summarize the stock a preview reported, so posting can detect drift.
+
+    Each row is `(lot_id, location_id, balance)`. The balance is formatted the
+    way the balances endpoint formats it, so a client that read availability
+    from either place derives the same digest.
+    """
+    canonical = '\n'.join(
+        f'{lot_id}:{location_id}:{quantize_quantity(balance):.9f}'
+        for lot_id, location_id, balance in sorted(rows)
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def application_availability(application):
+    """Return the digest inputs for every lot this document draws on."""
+    seen = {}
+    for line in application.lines.all():
+        key = (line.lot_id, application.source_location_id)
+        if key not in seen:
+            seen[key] = physical_balance(line.lot, application.source_location)
+    return [(lot_id, location_id, balance) for (lot_id, location_id), balance in seen.items()]
+
+
+def application_state(application):
+    """Describe a draft: its calculations, its stock, and what may drift.
+
+    This is what a preview returns and what posting revalidates against, so the
+    two can never disagree about what the operator was shown.
+    """
+    workspace = application.workspace
+    rows = application_availability(application)
+    balances = {(lot_id, location_id): balance for lot_id, location_id, balance in rows}
+    drawn = {}
+    lines = []
+    for line in application.lines.all():
+        calculation = _stored_line_usage(line)
+        key = (line.lot_id, application.source_location_id)
+        available = balances[key]
+        drawn[key] = drawn.get(key, Decimal('0')) + line.applied_base_quantity + line.waste_base_quantity
+        lines.append({
+            'pk': line.pk,
+            'item': line.item_id,
+            'lot': line.lot_id,
+            'usage_basis': line.usage_basis,
+            'basis_quantity': calculation.basis_quantity,
+            'basis_unit': calculation.basis_unit,
+            'target_count': calculation.target_count,
+            'formula': calculation.formula,
+            'calculated_base_quantity': calculation.calculated_base_quantity,
+            'applied_base_quantity': line.applied_base_quantity,
+            'waste_base_quantity': line.waste_base_quantity,
+            'base_unit': line.base_unit,
+            'available_base_quantity': available,
+            'available_after_base_quantity': available - drawn[key],
+            'override_required': workspace_override_required(
+                workspace,
+                calculation.calculated_base_quantity,
+                line.applied_base_quantity,
+            ),
+            'short': drawn[key] > available,
+        })
+    return {
+        'revision': application.revision,
+        'availability_digest': availability_digest(rows),
+        'target_summary': target_summary(application),
+        'lines': lines,
+    }
+
+
+def target_summary(application):
+    """Render one readable sentence naming what this document went on."""
+    counts = {}
+    for line in application.lines.all():
+        for row in line.targets.all():
+            counts[row.target_type] = counts.get(row.target_type, 0) + 1
+    if not counts:
+        return ''
+    labels = dict(TargetType.choices)
+    parts = [
+        f'{count} {labels[target_type].lower()}{"s" if count != 1 else ""}'
+        for target_type, count in sorted(counts.items())
+    ]
+    return '; '.join(parts)
+
+
+@transaction.atomic
+def create_application_draft(workspace, user, request):
+    """Assemble a draft, freezing every measurement it will calculate from."""
+    if not request.lines:
+        raise ValidationError({'lines': 'Add at least one application line.'})
+    application = InputApplication(
+        workspace=workspace,
+        applied_at=request.applied_at,
+        source_location=request.source_location,
+        batch=request.batch,
+        notes=request.notes,
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+    application.save()
+    for line_request in request.lines:
+        _create_line(application, line_request)
+    InputApplication.objects.filter(pk=application.pk).update(
+        target_summary=target_summary(application),
+    )
+    application.refresh_from_db()
+    return application
+
+
+def _create_line(application, request):
+    """Create one line, its frozen catalog snapshot, and its targets."""
+    item = request.item
+    basis = request.usage_basis or item.default_usage_basis
+    snapshots = [measure_target(target) for target in request.targets]
+    calculation = _line_usage(item, basis, request.fill_factor, snapshots)
+    line = InputApplicationLine(
+        application=application,
+        item=item,
+        lot=request.lot,
+        usage_basis=basis,
+        base_unit=item.base_unit,
+        configured_rate=item.default_usage_rate,
+        configured_rate_unit=item.usage_rate_unit or '',
+        configured_fixed_quantity=item.default_fixed_quantity,
+        fill_factor=request.fill_factor,
+        formula_basis_quantity=calculation.basis_quantity,
+        formula_basis_unit=calculation.basis_unit,
+        calculated_base_quantity=calculation.calculated_base_quantity,
+        applied_quantity=Decimal(request.applied_quantity),
+        unit_code=request.unit_code,
+        unit_conversion=request.unit_conversion,
+        applied_base_quantity=normalize_quantity(
+            item,
+            request.applied_quantity,
+            unit_code=request.unit_code,
+            unit_conversion=request.unit_conversion,
+        ),
+        waste_quantity=Decimal(request.waste_quantity),
+        waste_base_quantity=normalize_quantity(
+            item,
+            request.waste_quantity,
+            unit_code=request.unit_code,
+            unit_conversion=request.unit_conversion,
+            allow_zero=True,
+        ),
+        waste_reason=request.waste_reason,
+        override_reason=request.override_reason,
+        notes=request.notes,
+    )
+    line.save()
+    for snapshot in snapshots:
+        InputApplicationTarget.objects.create(
+            line=line,
+            target_type=snapshot.target_type,
+            weight=snapshot.weight,
+            cell_volume_ml=snapshot.cell_volume_ml,
+            area_m2=snapshot.area_m2,
+            label=snapshot.label,
+            **{snapshot.target_type: snapshot.target},
+        )
+    return line
+
+
+@transaction.atomic
+def post_application(application, user, revision=None, digest=None):
+    """Decrement stock for a confirmed draft under every relevant lock.
+
+    Locks are taken as plants, then the batch, then lots. That order is
+    load-bearing: `plantings.harvests.record_harvest` documents and
+    `plantings.test_harvest_concurrency` proves that a plant must be locked
+    before its batch, because writing a plant fact takes a key-share lock on
+    the batch row. Sowing establishes batch before lot. Extending the same
+    chain rather than inventing one is what keeps this compatible with both.
+
+    Every lock names `of=('self',)`. The batch is nullable, so selecting it
+    alongside builds an outer join, and PostgreSQL refuses to lock across the
+    nullable side of one. Only this document's own row needs holding anyway.
+    """
+    application = InputApplication.objects.select_for_update(of=('self',)).select_related(
+        'workspace',
+        'batch',
+        'source_location',
+    ).get(pk=application.pk)
+    if application.status != InputApplication.Status.DRAFT:
+        raise ValidationError({'status': 'Only draft applications can be posted.'})
+
+    plant_ids = _plant_ids(application)
+    if plant_ids:
+        list(SpecificPlant.objects.select_for_update().filter(pk__in=plant_ids).order_by('pk'))
+    batch = lock_batch(application.batch) if application.batch_id else None
+    lines = list(application.lines.select_related('item', 'lot').prefetch_related('targets'))
+    if not lines:
+        raise ValidationError({'lines': 'Add at least one application line.'})
+    lock_lots(application.workspace, [line.lot_id for line in lines])
+
+    _validate_batch(batch, application.applied_at)
+    _validate_plants(application, plant_ids)
+    _require_current(application, lines, revision, digest)
+
+    movements = []
+    for line in lines:
+        movements.extend(_post_line(application, line, user))
+    posted_at = timezone.now()
+    InputApplication.objects.filter(pk=application.pk).update(
+        status=InputApplication.Status.POSTED,
+        posted_at=posted_at,
+        target_summary=target_summary(application),
+        updated=posted_at,
+    )
+    application.refresh_from_db()
+    return application, movements
+
+
+def _require_current(application, lines, revision, digest):
+    """Refuse a document whose contents or stock moved since the client looked.
+
+    Both halves matter. The revision catches somebody editing the draft in
+    another tab, and the digest catches somebody else spending the stock this
+    document was about to draw on. Neither is checked until the locks are held,
+    so a passing check stays true through to the write.
+    """
+    if revision is not None and application.revision != revision:
+        raise ValidationError({
+            'revision': 'This draft changed after the preview. Preview it again.',
+        })
+    for line in lines:
+        calculation = _stored_line_usage(line)
+        _validate_line_amounts(application.workspace, line, calculation)
+    if digest is not None and availability_digest(application_availability(application)) != digest:
+        raise ValidationError({
+            'availability_digest': (
+                'Stock changed after the preview. Preview it again.'
+            ),
+        })
+
+
+def _post_line(application, line, user):
+    """Consume one line's confirmed quantity, and its waste when there is any."""
+    if line.item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+        raise ValidationError({
+            'lines': f'Line {line.pk}: serialized stock moves through unit actions.',
+        })
+    movements = [_post_movement(
+        application,
+        line,
+        user,
+        StockMovement.MovementType.CONSUMPTION,
+        line.applied_base_quantity,
+        line.override_reason,
+    )]
+    line.consumption_movement = movements[0]
+    if line.waste_base_quantity > 0:
+        movements.append(_post_movement(
+            application,
+            line,
+            user,
+            StockMovement.MovementType.WASTE,
+            line.waste_base_quantity,
+            line.waste_reason,
+        ))
+        line.waste_movement = movements[1]
+    InputApplicationLine.objects.filter(pk=line.pk).update(
+        consumption_movement=line.consumption_movement,
+        waste_movement=line.waste_movement,
+    )
+    line.item.mark_stock_history_started(application.applied_at)
+    return movements
+
+
+def _post_movement(application, line, user, movement_type, quantity, reason):
+    """Append one ledger row for this line."""
+    return post_stock_movement(
+        application.workspace,
+        user,
+        MovementRequest(
+            lot=line.lot,
+            movement_type=movement_type,
+            quantity=quantity,
+            source=application.source_location,
+            occurred_at=application.applied_at,
+            reason=reason,
+            reference=f'application:{application.pk} line:{line.pk}',
+        ),
+    )
+
+
+def _posted_movement_filter(application):
+    """Match every movement this document's lines posted, of either kind."""
+    return Q(application_consumption__application=application) | Q(application_waste__application=application)
+
+
+@transaction.atomic
+def reverse_application(application, user, reason):
+    """Put back everything one application took, keeping the document on file.
+
+    The calculation, the targets, and the movements all stay readable. A
+    corrected application is a new document, so the mistake and its correction
+    are both visible rather than one overwriting the other.
+    """
+    _require_reason(reason)
+    application = InputApplication.objects.select_for_update(of=('self',)).select_related(
+        'workspace',
+    ).get(pk=application.pk)
+    if application.status != InputApplication.Status.POSTED:
+        raise ValidationError({'status': 'Only posted applications can be reversed.'})
+    movements = list(
+        StockMovement.objects.select_for_update(of=('self',))
+        .select_related('lot__item', 'workspace', 'source', 'destination')
+        .filter(_posted_movement_filter(application))
+        .order_by('pk')
+    )
+    reverse_application_movements(application.workspace, movements, user, reason)
+    reversed_at = timezone.now()
+    InputApplication.objects.filter(pk=application.pk).update(
+        status=InputApplication.Status.REVERSED,
+        reversed_at=reversed_at,
+        reverse_reason=reason.strip(),
+        reversed_by=user if user is not None and user.is_authenticated else None,
+        updated=reversed_at,
+    )
+    application.refresh_from_db()
+    return application
+
+
+def application_targets(application):
+    """Return every target row this document recorded, newest line first."""
+    return InputApplicationTarget.objects.filter(
+        line__application=application,
+    ).select_related('line')
+
+
+def cells_for_tray(tray):
+    """Return one target request per cell of a tray, for the whole-tray path.
+
+    The shortcut still stores individual cells, so a document always names
+    exactly which ones were filled even when the operator picked the tray.
+    """
+    return [
+        TargetRequest(target_type=TargetType.SEED_TRAY_CELL, target=cell)
+        for cell in SeedTrayCell.objects.filter(tray=tray).order_by('y_position', 'x_position')
+    ]

--- a/applications/test_services.py
+++ b/applications/test_services.py
@@ -1,0 +1,566 @@
+"""Drafting, posting, and reversing input applications."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from garden.models import GardenGeometryConfirmation
+from inventory.ledger import physical_balance
+from inventory.models import InventoryItem, StockMovement
+from inventory.units import UnitCode
+from plantings.lifecycle import EventType, OutcomeRequest, record_bulk_outcome
+from plantings.models import ProductionBatch
+from tests.factories import (
+    make_garden_bed,
+    make_garden_geometry_confirmation,
+    make_garden_square,
+    make_inventory_item,
+    make_inventory_location,
+    make_production_batch,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_model,
+    make_specific_plant,
+    make_stock_lot,
+)
+from workspaces.models import Workspace
+
+from .models import InputApplication, InputApplicationTarget
+from .services import (
+    ApplicationRequest,
+    LineRequest,
+    TargetRequest,
+    application_state,
+    cells_for_tray,
+    create_application_draft,
+    post_application,
+    reverse_application,
+)
+
+TargetType = InputApplicationTarget.TargetType
+
+
+class ApplicationServiceMixin:
+    """Stock, a batch, and helpers for building one document."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = Workspace.objects.get(pk=1)
+        self.location = make_inventory_location()
+        self.media = make_inventory_item(
+            base_unit=UnitCode.LITRE,
+            default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+        )
+        self.lot = make_stock_lot(item=self.media, location=self.location, quantity='50')
+        self.batch = make_production_batch()
+
+    def draft(self, lines, **overrides):
+        """Create a draft from the given line requests."""
+        values = {
+            'applied_at': timezone.now(),
+            'source_location': self.location,
+            'batch': self.batch,
+            'lines': tuple(lines),
+        }
+        values.update(overrides)
+        return create_application_draft(self.workspace, None, ApplicationRequest(**values))
+
+    def media_line(self, targets, **overrides):
+        """Build a cell-volume media line over the given targets."""
+        values = {
+            'item': self.media,
+            'lot': self.lot,
+            'applied_quantity': Decimal('0.96'),
+            'unit_code': UnitCode.LITRE,
+            'targets': tuple(targets),
+        }
+        values.update(overrides)
+        return LineRequest(**values)
+
+    def tray_cells(self, count=24, cell_size_ml=40):
+        """Create one tray and `count` cells of a known volume."""
+        model = make_seed_tray_model(cell_size_ml=cell_size_ml, x_cells=count, y_cells=1)
+        tray = make_seed_tray(model=model)
+        return [make_seed_tray_cell(tray=tray, x_position=index) for index in range(count)]
+
+    def cell_targets(self, cells):
+        """Turn cells into target requests."""
+        return [TargetRequest(TargetType.SEED_TRAY_CELL, cell) for cell in cells]
+
+
+class DraftApplicationTests(ApplicationServiceMixin, TestCase):
+    """Assembling a draft freezes every measurement it calculates from."""
+
+    def test_a_draft_records_the_calculation(self):
+        """Twenty-four 40 ml cells suggest 0.96 litres of media."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        line = application.lines.get()
+
+        self.assertEqual(application.status, InputApplication.Status.DRAFT)
+        self.assertEqual(line.calculated_base_quantity, Decimal('0.960000000'))
+        self.assertEqual(line.formula_basis_quantity, Decimal('960.000000000'))
+        self.assertEqual(line.formula_basis_unit, UnitCode.MILLILITRE)
+        self.assertEqual(line.base_unit, UnitCode.LITRE)
+
+    def test_a_draft_freezes_each_cell_volume(self):
+        """Every target carries the volume it measured, not a live lookup."""
+        cells = self.tray_cells(count=2)
+        application = self.draft([self.media_line(self.cell_targets(cells))])
+
+        volumes = list(
+            InputApplicationTarget.objects
+            .filter(line__application=application)
+            .values_list('cell_volume_ml', flat=True)
+        )
+        self.assertEqual(volumes, [40, 40])
+
+    def test_a_draft_makes_no_stock_movement(self):
+        """Nothing leaves the shelf until the document is posted."""
+        targets = self.cell_targets(self.tray_cells())
+        before = StockMovement.objects.count()
+        self.draft([self.media_line(targets)])
+        self.assertEqual(StockMovement.objects.count(), before)
+
+    def test_a_whole_tray_still_names_its_cells(self):
+        """The shortcut records which cells were filled, not just the tray."""
+        cells = self.tray_cells(count=6)
+        application = self.draft([self.media_line(cells_for_tray(cells[0].tray))])
+
+        self.assertEqual(application.lines.get().targets.count(), 6)
+
+    def test_a_draft_summarizes_its_targets(self):
+        """The header says what the document went on without opening it."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells(count=3)))])
+        self.assertEqual(application.target_summary, '3 tray cells')
+
+    def test_a_document_needs_a_line(self):
+        """An application that consumes nothing is not an application."""
+        with self.assertRaises(ValidationError) as caught:
+            self.draft([])
+        self.assertIn('lines', caught.exception.message_dict)
+
+    def test_a_tray_model_without_a_cell_volume_is_refused(self):
+        """A missing volume cannot silently become zero litres of media."""
+        cells = self.tray_cells(count=2, cell_size_ml=0)
+        with self.assertRaises(ValidationError) as caught:
+            self.draft([self.media_line(self.cell_targets(cells))])
+        self.assertIn('targets', caught.exception.message_dict)
+
+
+class PostApplicationTests(ApplicationServiceMixin, TestCase):
+    """Posting turns a confirmed draft into ledger movements."""
+
+    def test_posting_consumes_the_confirmed_quantity(self):
+        """The operator's number is the inventory fact, not the suggestion."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        application, movements = post_application(application, None)
+
+        self.assertEqual(application.status, InputApplication.Status.POSTED)
+        self.assertIsNotNone(application.posted_at)
+        self.assertEqual(len(movements), 1)
+        self.assertEqual(movements[0].movement_type, StockMovement.MovementType.CONSUMPTION)
+        self.assertEqual(movements[0].quantity, Decimal('0.960000000'))
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('49.04'))
+
+    def test_waste_posts_a_second_linked_movement(self):
+        """Spillage is recorded as its own fact against the same lot."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            waste_quantity=Decimal('0.04'),
+            waste_reason='Spilled while filling',
+        )])
+        application, movements = post_application(application, None)
+
+        self.assertEqual(len(movements), 2)
+        self.assertEqual(movements[1].movement_type, StockMovement.MovementType.WASTE)
+        self.assertEqual(movements[1].quantity, Decimal('0.040000000'))
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('49'))
+
+        line = application.lines.get()
+        self.assertEqual(line.consumption_movement, movements[0])
+        self.assertEqual(line.waste_movement, movements[1])
+
+    def test_waste_without_a_reason_is_refused(self):
+        """Discarded stock has to say why it was discarded."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            waste_quantity=Decimal('0.04'),
+        )])
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+        self.assertIn('lines', caught.exception.message_dict)
+
+    def test_a_material_override_needs_a_reason(self):
+        """Using notably more than suggested is what the audit wants explained."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            applied_quantity=Decimal('1.5'),
+        )])
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+        self.assertIn('lines', caught.exception.message_dict)
+
+    def test_an_explained_override_keeps_both_numbers(self):
+        """The suggestion and the fact stay visible side by side."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            applied_quantity=Decimal('1.5'),
+            override_reason='Cells were overfilled to settle the mix',
+        )])
+        application, _ = post_application(application, None)
+
+        line = application.lines.get()
+        self.assertEqual(line.calculated_base_quantity, Decimal('0.960000000'))
+        self.assertEqual(line.applied_base_quantity, Decimal('1.500000000'))
+        self.assertEqual(line.override_reason, 'Cells were overfilled to settle the mix')
+
+    def test_a_small_difference_needs_no_reason(self):
+        """Ordinary imprecision does not interrupt the operator."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            applied_quantity=Decimal('0.98'),
+        )])
+        application, _ = post_application(application, None)
+        self.assertEqual(application.status, InputApplication.Status.POSTED)
+
+    def test_posting_more_than_the_lot_holds_is_refused(self):
+        """A lot cannot issue stock it does not have."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            applied_quantity=Decimal('80'),
+            override_reason='Testing the balance guard',
+        )])
+        with self.assertRaises(ValidationError):
+            post_application(application, None)
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('50'))
+
+    def test_a_document_cannot_be_posted_twice(self):
+        """Double posting would consume the stock a second time."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        application, _ = post_application(application, None)
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+        self.assertIn('status', caught.exception.message_dict)
+
+    def test_a_cancelled_batch_cannot_receive_an_input(self):
+        """A batch that declared it produced nothing cannot consume stock."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        ProductionBatch.objects.filter(pk=application.batch_id).update(
+            status=ProductionBatch.Status.CANCELLED,
+        )
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+        self.assertIn('batch', caught.exception.message_dict)
+
+
+class PlantTargetTests(ApplicationServiceMixin, TestCase):
+    """Applying an input to individual plants."""
+
+    def setUp(self):
+        super().setUp()
+        self.cell_planting = make_seed_tray_cell_planting()
+        self.batch = self.cell_planting.seed_tray_planting.batch
+        self.labels = make_inventory_item(
+            base_unit=UnitCode.EACH,
+            category=InventoryItem.Category.LABEL,
+            default_usage_basis=InventoryItem.UsageBasis.PER_UNIT,
+            default_usage_rate=Decimal('1'),
+            usage_rate_unit=UnitCode.EACH,
+        )
+        self.label_lot = make_stock_lot(
+            item=self.labels,
+            location=self.location,
+            quantity='500',
+        )
+
+    def label_line(self, plants, **overrides):
+        """Build a per-unit label line over the given plants."""
+        values = {
+            'item': self.labels,
+            'lot': self.label_lot,
+            'applied_quantity': Decimal(len(plants)),
+            'unit_code': UnitCode.EACH,
+            'targets': tuple(
+                TargetRequest(TargetType.SPECIFIC_PLANT, plant) for plant in plants
+            ),
+        }
+        values.update(overrides)
+        return LineRequest(**values)
+
+    def batch_plants(self, count):
+        """Create plants that came from this document's batch."""
+        return [
+            make_specific_plant(cell_planting=self.cell_planting)
+            for _ in range(count)
+        ]
+
+    def test_one_label_per_plant(self):
+        """Twelve plants consume twelve labels."""
+        application = self.draft([self.label_line(self.batch_plants(12))])
+        application, movements = post_application(application, None)
+
+        self.assertEqual(movements[0].quantity, Decimal('12.000000000'))
+        self.assertEqual(application.lines.get().calculated_base_quantity, Decimal('12.000000000'))
+
+    def test_a_plant_outside_the_batch_is_refused(self):
+        """A document cannot attribute an input to somebody else's crop."""
+        stranger = make_specific_plant()
+        application = self.draft([self.label_line(self.batch_plants(2) + [stranger])])
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+        self.assertIn('targets', caught.exception.message_dict)
+
+    def test_a_finished_plant_cannot_receive_an_input(self):
+        """A culled plant is not there to be labelled."""
+        plants = self.batch_plants(2)
+        application = self.draft([self.label_line(plants)])
+        record_bulk_outcome(
+            [plants[0].pk],
+            None,
+            OutcomeRequest(
+                EventType.CULLED,
+                occurred_at=timezone.now(),
+                reason='Damaged',
+            ),
+        )
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+        self.assertIn('targets', caught.exception.message_dict)
+
+
+class SurfaceAreaTargetTests(ApplicationServiceMixin, TestCase):
+    """Applying a treatment over measured ground."""
+
+    def setUp(self):
+        super().setUp()
+        self.treatment = make_inventory_item(
+            base_unit=UnitCode.GRAM,
+            category=InventoryItem.Category.FERTILIZER_TREATMENT,
+            default_usage_basis=InventoryItem.UsageBasis.SURFACE_AREA,
+            default_usage_rate=Decimal('2'),
+            usage_rate_unit=UnitCode.SQUARE_METRE,
+        )
+        self.treatment_lot = make_stock_lot(
+            item=self.treatment,
+            location=self.location,
+            quantity='5000',
+        )
+        self.bed = make_garden_bed()
+
+    def treatment_line(self, square, quantity, **overrides):
+        """Build a surface-area treatment line over one square."""
+        values = {
+            'item': self.treatment,
+            'lot': self.treatment_lot,
+            'applied_quantity': Decimal(quantity),
+            'unit_code': UnitCode.GRAM,
+            'targets': (TargetRequest(TargetType.GARDEN_SQUARE, square),),
+        }
+        values.update(overrides)
+        return LineRequest(**values)
+
+    def test_unconfirmed_geometry_is_refused(self):
+        """An integer of unknown unit never becomes an area silently."""
+        square = make_garden_square(bed=self.bed, size_x=300, size_y=300)
+        with self.assertRaises(ValidationError) as caught:
+            self.draft([self.treatment_line(square, '18')], batch=None)
+        self.assertIn('targets', caught.exception.message_dict)
+
+    def test_confirmed_geometry_measures_the_dose(self):
+        """A 300 x 300 mm square is 0.09 m2, so 2 g per m2 is 0.18 g."""
+        make_garden_geometry_confirmation(
+            area=self.bed.area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.MILLIMETRE,
+            cell_length=Decimal('1'),
+        )
+        square = make_garden_square(bed=self.bed, size_x=300, size_y=300)
+        application = self.draft([self.treatment_line(square, '0.18')], batch=None)
+
+        line = application.lines.get()
+        self.assertEqual(line.calculated_base_quantity, Decimal('0.180000000'))
+        self.assertEqual(line.targets.get().area_m2, Decimal('0.090000'))
+
+    def test_a_document_needs_no_batch(self):
+        """A garden with no production batch can still record an input."""
+        make_garden_geometry_confirmation(
+            area=self.bed.area,
+            length_unit=GardenGeometryConfirmation.LengthUnit.METRE,
+            cell_length=Decimal('1'),
+        )
+        square = make_garden_square(bed=self.bed, size_x=2, size_y=2)
+        application = self.draft([self.treatment_line(square, '8')], batch=None)
+        application, movements = post_application(application, None)
+
+        self.assertIsNone(application.batch)
+        self.assertEqual(movements[0].quantity, Decimal('8.000000000'))
+
+
+class SnapshotDurabilityTests(ApplicationServiceMixin, TestCase):
+    """A posted document cannot be rewritten by a later configuration edit."""
+
+    def test_editing_the_tray_model_leaves_the_document_alone(self):
+        """The frozen cell volumes are what the calculation replays from."""
+        cells = self.tray_cells()
+        application = self.draft([self.media_line(self.cell_targets(cells))])
+        application, movements = post_application(application, None)
+
+        model = cells[0].tray.model
+        model.cell_size_ml = 999
+        model.save()
+
+        line = application.lines.get()
+        line.refresh_from_db()
+        movements[0].refresh_from_db()
+        self.assertEqual(line.calculated_base_quantity, Decimal('0.960000000'))
+        self.assertEqual(line.formula_basis_quantity, Decimal('960.000000000'))
+        self.assertEqual(movements[0].quantity, Decimal('0.960000000'))
+        self.assertEqual(application_state(application)['lines'][0]['calculated_base_quantity'], Decimal('0.960000000'))
+
+    def test_editing_the_item_rate_leaves_the_document_alone(self):
+        """A recalculation reads the line's own columns, never the catalog."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        application, _ = post_application(application, None)
+
+        self.media.refresh_from_db()
+        self.media.default_usage_basis = InventoryItem.UsageBasis.MANUAL
+        self.media.save()
+
+        state = application_state(application)
+        self.assertEqual(state['lines'][0]['calculated_base_quantity'], Decimal('0.960000000'))
+
+
+class ReverseApplicationTests(ApplicationServiceMixin, TestCase):
+    """Reversal restores stock and keeps the document readable."""
+
+    def posted(self, **overrides):
+        """Post one media application with optional waste."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            **overrides,
+        )])
+        return post_application(application, None)[0]
+
+    def test_reversal_restores_the_balance(self):
+        """Everything the document took goes back."""
+        application = self.posted()
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('49.04'))
+
+        application = reverse_application(application, None, 'Applied to the wrong tray')
+
+        self.assertEqual(application.status, InputApplication.Status.REVERSED)
+        self.assertEqual(application.reverse_reason, 'Applied to the wrong tray')
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('50'))
+
+    def test_reversal_restores_waste_too(self):
+        """Both movements a line posted are put back together."""
+        application = self.posted(
+            waste_quantity=Decimal('0.04'),
+            waste_reason='Spilled while filling',
+        )
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('49'))
+
+        reverse_application(application, None, 'Wrong lot')
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('50'))
+
+    def test_reversal_keeps_the_calculation_and_targets(self):
+        """The record of what was intended survives the correction."""
+        application = self.posted()
+        application = reverse_application(application, None, 'Wrong tray')
+
+        line = application.lines.get()
+        self.assertEqual(line.calculated_base_quantity, Decimal('0.960000000'))
+        self.assertEqual(line.targets.count(), 24)
+
+    def test_a_reason_is_required(self):
+        """A correction that explains nothing is not an audit trail."""
+        application = self.posted()
+        with self.assertRaises(ValidationError) as caught:
+            reverse_application(application, None, '   ')
+        self.assertIn('reason', caught.exception.message_dict)
+
+    def test_a_document_cannot_be_reversed_twice(self):
+        """The stock would otherwise come back a second time."""
+        application = self.posted()
+        application = reverse_application(application, None, 'Wrong tray')
+        with self.assertRaises(ValidationError) as caught:
+            reverse_application(application, None, 'Again')
+        self.assertIn('status', caught.exception.message_dict)
+
+    def test_a_draft_cannot_be_reversed(self):
+        """There is nothing to put back until it posted."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        with self.assertRaises(ValidationError) as caught:
+            reverse_application(application, None, 'Never mind')
+        self.assertIn('status', caught.exception.message_dict)
+
+
+class ApplicationStateTests(ApplicationServiceMixin, TestCase):
+    """What a preview reports and what posting revalidates against."""
+
+    def test_state_reports_availability_before_and_after(self):
+        """An operator sees what the lot holds and what it will hold."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        state = application_state(application)
+
+        line = state['lines'][0]
+        self.assertEqual(line['available_base_quantity'], Decimal('50'))
+        self.assertEqual(line['available_after_base_quantity'], Decimal('49.04'))
+        self.assertFalse(line['short'])
+        self.assertFalse(line['override_required'])
+
+    def test_state_flags_a_line_the_lot_cannot_cover(self):
+        """The shortfall is visible before anything is attempted."""
+        application = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells()),
+            applied_quantity=Decimal('80'),
+            override_reason='Deliberately too much',
+        )])
+        self.assertTrue(application_state(application)['lines'][0]['short'])
+
+    def test_a_stale_revision_is_refused(self):
+        """A draft edited in another tab invalidates what the client saw."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        state = application_state(application)
+        InputApplication.objects.filter(pk=application.pk).update(revision=state['revision'] + 1)
+
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None, revision=state['revision'])
+        self.assertIn('revision', caught.exception.message_dict)
+
+    def test_a_stale_availability_digest_is_refused(self):
+        """Stock spent elsewhere since the preview invalidates it."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        state = application_state(application)
+
+        other = self.draft([self.media_line(
+            self.cell_targets(self.tray_cells(count=2)),
+            applied_quantity=Decimal('0.08'),
+        )])
+        post_application(other, None)
+
+        with self.assertRaises(ValidationError) as caught:
+            post_application(
+                application,
+                None,
+                revision=state['revision'],
+                digest=state['availability_digest'],
+            )
+        self.assertIn('availability_digest', caught.exception.message_dict)
+
+    def test_a_current_digest_posts(self):
+        """Nothing moved, so what the operator confirmed still holds."""
+        application = self.draft([self.media_line(self.cell_targets(self.tray_cells()))])
+        state = application_state(application)
+
+        application, _ = post_application(
+            application,
+            None,
+            revision=state['revision'],
+            digest=state['availability_digest'],
+        )
+        self.assertEqual(application.status, InputApplication.Status.POSTED)


### PR DESCRIPTION
Drafting freezes every measurement the calculation will use: each cell's volume, each place's normalized area, and the item's rate and basis. Posting recalculates from those frozen columns and never reads the catalog, so editing a tray model or an item's rate afterwards cannot change what a posted document says it used. Two tests hold that line directly.

Locks are taken as plants, then the batch, then lots. That order is load-bearing rather than arbitrary: harvests documents and its concurrency test proves that a plant must be locked before its batch, because writing a plant fact takes a key-share lock on the batch row, and sowing already establishes batch before lot. Extending the same chain keeps this compatible with both writers instead of opening a new cycle against them.

Posting refuses a document whose draft or stock moved since the client last looked, checked after the locks are held so a passing check stays true through to the write. The revision catches an edit in another tab and the availability digest catches somebody else spending the stock this document was about to draw on.

Reversal restores both the consumption and the waste together and keeps the calculation and targets readable, because a correction is a new document and the mistake should stay visible next to it.

The whole-tray shortcut expands to individual cell targets, so a document always names exactly which cells were filled even when the operator picked the tray.

## Summary by Sourcery

Introduce transactional services for drafting, posting, and reversing input applications with durable snapshots and concurrency safeguards.

New Features:
- Add application drafting service that freezes target measurements and catalog-derived usage configuration into application lines.
- Add posting service that validates batch/plant eligibility, rechecks stock and revision state, and records consumption and waste movements against lots.
- Add reversal service that restores both consumption and waste movements while keeping the original application, calculations, and targets readable.
- Provide helpers to expand whole-tray selections into individual cell targets and to summarize application targets for display.
- Expose an application state preview including per-line calculations, availability before/after posting, override requirements, and a stock digest for drift detection.

Bug Fixes:
- Prevent posting when stock balances, draft revisions, or plant/batch lifecycle state have changed since the client preview, avoiding double-spend and misattribution.
- Disallow waste recording and significant material overrides unless an audit reason is provided, tightening inventory and correction controls.

Enhancements:
- Ensure tray cell volumes, garden geometry, and item usage configuration are snapshotted so later catalog edits cannot alter posted application results.
- Enforce lock ordering across plants, batches, and lots to remain compatible with existing planting and harvest concurrency patterns.

Tests:
- Add comprehensive tests covering drafting calculations, target snapshots, posting behaviors including waste and overrides, plant and surface-area targeting rules, snapshot durability, reversal behavior, and application state/concurrency validation.