### PR TITLE
feat(applications): expose input applications over REST

### DIFF
--- a/applications/rest.py
+++ b/applications/rest.py
@@ -1,0 +1,484 @@
+"""REST surface for drafting, previewing, posting, and reversing applications."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from rest_framework import routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
+from inventory.ledger import quantize_quantity
+from inventory.models import (
+    InventoryItem,
+    InventoryLocation,
+    InventoryUnit,
+    ItemUnitConversion,
+    StockLot,
+)
+from inventory.rest_query import parse_datetime, parse_integer
+from plantings.models import ProductionBatch, SpecificPlant
+from seedtrays.models import SeedTray, SeedTrayCell
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
+from .models import InputApplication, InputApplicationLine, InputApplicationTarget
+from .services import (
+    ApplicationRequest,
+    LineRequest,
+    TargetRequest,
+    application_state,
+    cells_for_tray,
+    create_application_draft,
+    post_application,
+    reverse_application,
+    update_application_draft,
+)
+
+TargetType = InputApplicationTarget.TargetType
+
+#: How each target type is reached, and the lookup that keeps it in workspace.
+#: A tray cell is not workspace owned in its own right, so it is scoped through
+#: the tray that holds it.
+TARGET_SOURCES = {
+    TargetType.BATCH: (ProductionBatch, 'workspace'),
+    TargetType.SEED_TRAY_CELL: (SeedTrayCell, 'tray__workspace'),
+    TargetType.SPECIFIC_PLANT: (SpecificPlant, 'workspace'),
+    TargetType.INVENTORY_UNIT: (InventoryUnit, 'workspace'),
+    TargetType.GARDEN_AREA: (GardenArea, 'workspace'),
+    TargetType.GARDEN_BED: (GardenBed, 'workspace'),
+    TargetType.GARDEN_ROW: (GardenRow, 'workspace'),
+    TargetType.GARDEN_SQUARE: (GardenSquare, 'workspace'),
+}
+
+
+def _model_errors(error):
+    """Translate a Django validation error into DRF's field-error shape."""
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _run_domain_action(function, *args, **kwargs):
+    """Run a domain service, surfacing its errors as DRF field errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+def _decimal(value):
+    """Render a ledger decimal as the fixed-precision string clients expect."""
+    return None if value is None else f'{quantize_quantity(value):.9f}'
+
+
+class ActionSerializer(serializers.Serializer):
+    """Base for payloads that drive a service rather than a model."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class ReasonSerializer(ActionSerializer):
+    """A required explanation for an audited action."""
+
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
+class PostApplicationSerializer(ActionSerializer):
+    """What a client echoes back to prove nothing moved since it looked."""
+
+    revision = serializers.IntegerField(required=False)
+    availability_digest = serializers.CharField(required=False)
+
+
+class InputApplicationTargetSerializer(serializers.ModelSerializer):
+    """One frozen target of a posted or draft line."""
+
+    target = serializers.SerializerMethodField()
+
+    class Meta:
+        model = InputApplicationTarget
+        fields = [
+            'pk',
+            'target_type',
+            'target',
+            'label',
+            'weight',
+            'cell_volume_ml',
+            'area_m2',
+        ]
+        read_only_fields = fields
+
+    def get_target(self, row):
+        """Return the primary key of whichever thing this row points at."""
+        return row.target_id
+
+
+class InputApplicationLineSerializer(serializers.ModelSerializer):
+    """One item drawn from one exact lot, with its calculation snapshot."""
+
+    targets = InputApplicationTargetSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = InputApplicationLine
+        fields = [
+            'pk',
+            'item',
+            'lot',
+            'usage_basis',
+            'base_unit',
+            'configured_rate',
+            'configured_rate_unit',
+            'configured_fixed_quantity',
+            'fill_factor',
+            'formula_basis_quantity',
+            'formula_basis_unit',
+            'calculated_base_quantity',
+            'applied_quantity',
+            'unit_code',
+            'unit_conversion',
+            'applied_base_quantity',
+            'waste_quantity',
+            'waste_base_quantity',
+            'waste_reason',
+            'override_reason',
+            'notes',
+            'consumption_movement',
+            'waste_movement',
+            'targets',
+        ]
+        read_only_fields = fields
+
+
+class InputApplicationSerializer(serializers.ModelSerializer):
+    """The full readable record of one document."""
+
+    lines = InputApplicationLineSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = InputApplication
+        fields = [
+            'pk',
+            'status',
+            'batch',
+            'applied_at',
+            'source_location',
+            'notes',
+            'target_summary',
+            'revision',
+            'created_by',
+            'posted_at',
+            'reversed_at',
+            'reverse_reason',
+            'reversed_by',
+            'created',
+            'updated',
+            'lines',
+        ]
+        read_only_fields = fields
+
+
+class ApplicationTargetInputSerializer(ActionSerializer):
+    """One target a caller selected, named by type and primary key."""
+
+    target_type = serializers.ChoiceField(choices=TargetType.choices)
+    target = serializers.IntegerField()
+    weight = serializers.DecimalField(
+        max_digits=12,
+        decimal_places=6,
+        required=False,
+        default=None,
+    )
+
+
+class ApplicationLineInputSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):
+    """One line a caller wants on the draft.
+
+    This is not a model serializer. The service measures every target and
+    freezes the item's configuration onto the line, so handing it raw
+    selections keeps one place responsible for what a document records.
+    """
+
+    item = serializers.PrimaryKeyRelatedField(queryset=InventoryItem.objects.all())
+    lot = serializers.PrimaryKeyRelatedField(queryset=StockLot.objects.all())
+    applied_quantity = serializers.DecimalField(max_digits=24, decimal_places=9)
+    unit_code = serializers.CharField(required=False, allow_null=True, default=None)
+    unit_conversion = serializers.PrimaryKeyRelatedField(
+        queryset=ItemUnitConversion.objects.all(),
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    usage_basis = serializers.CharField(required=False, allow_blank=True, default='')
+    fill_factor = serializers.DecimalField(
+        max_digits=12,
+        decimal_places=6,
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    waste_quantity = serializers.DecimalField(
+        max_digits=24,
+        decimal_places=9,
+        required=False,
+        default=0,
+    )
+    waste_reason = serializers.CharField(required=False, allow_blank=True, default='')
+    override_reason = serializers.CharField(required=False, allow_blank=True, default='')
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    targets = ApplicationTargetInputSerializer(many=True, required=False, default=list)
+    tray = serializers.IntegerField(required=False, allow_null=True, default=None)
+
+    workspace_field_lookups = {
+        'item': 'workspace',
+        'lot': 'workspace',
+        'unit_conversion': 'workspace',
+    }
+
+
+class ApplicationDraftSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):
+    """The payload that creates or replaces a draft."""
+
+    applied_at = serializers.DateTimeField()
+    source_location = serializers.PrimaryKeyRelatedField(
+        queryset=InventoryLocation.objects.all(),
+    )
+    batch = serializers.PrimaryKeyRelatedField(
+        queryset=ProductionBatch.objects.all(),
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    lines = ApplicationLineInputSerializer(many=True)
+
+    workspace_field_lookups = {
+        'source_location': 'workspace',
+        'batch': 'workspace',
+    }
+
+
+def _resolve_target(workspace, values):
+    """Turn one selected primary key into the object it names."""
+    target_type = values['target_type']
+    model, lookup = TARGET_SOURCES[target_type]
+    try:
+        target = model.objects.get(**{lookup: workspace}, pk=values['target'])
+    except model.DoesNotExist as exc:
+        raise ValidationError({
+            'targets': f'No {target_type} with id {values["target"]} in this workspace.',
+        }) from exc
+    weight = values.get('weight')
+    return TargetRequest(
+        target_type=target_type,
+        target=target,
+        weight=1 if weight is None else weight,
+    )
+
+
+def _resolve_tray_cells(workspace, tray_pk):
+    """Expand a whole-tray selection into one target per cell."""
+    try:
+        tray = SeedTray.objects.get(workspace=workspace, pk=tray_pk)
+    except SeedTray.DoesNotExist as exc:
+        raise ValidationError({
+            'tray': f'No tray with id {tray_pk} in this workspace.',
+        }) from exc
+    cells = cells_for_tray(tray)
+    if not cells:
+        raise ValidationError({'tray': 'That tray has no cells recorded.'})
+    return cells
+
+
+def _build_lines(workspace, line_values):
+    """Turn validated line payloads into the service's line requests.
+
+    Every optional key is read with a fallback because a partial update skips
+    serializer defaults, so an absent field means "leave it alone" rather than
+    an error.
+    """
+    lines = []
+    for line in line_values:
+        targets = [
+            _resolve_target(workspace, target)
+            for target in line.get('targets') or []
+        ]
+        tray = line.get('tray')
+        if tray is not None:
+            targets.extend(_resolve_tray_cells(workspace, tray))
+        lines.append(LineRequest(
+            item=line['item'],
+            lot=line['lot'],
+            applied_quantity=line['applied_quantity'],
+            unit_code=line.get('unit_code'),
+            unit_conversion=line.get('unit_conversion'),
+            usage_basis=line.get('usage_basis') or '',
+            fill_factor=line.get('fill_factor'),
+            waste_quantity=line.get('waste_quantity') or Decimal('0'),
+            waste_reason=line.get('waste_reason') or '',
+            override_reason=line.get('override_reason') or '',
+            notes=line.get('notes') or '',
+            targets=tuple(targets),
+        ))
+    return tuple(lines)
+
+
+def _build_request(workspace, values):
+    """Turn a validated create payload into the service's request object."""
+    return ApplicationRequest(
+        applied_at=values['applied_at'],
+        source_location=values['source_location'],
+        batch=values['batch'],
+        notes=values['notes'],
+        lines=_build_lines(workspace, values['lines']),
+    )
+
+
+def _state_response(application):
+    """Render a document's calculations and stock as fixed-precision strings."""
+    state = application_state(application)
+    return {
+        'revision': state['revision'],
+        'availability_digest': state['availability_digest'],
+        'target_summary': state['target_summary'],
+        'lines': [
+            {
+                **line,
+                'basis_quantity': _decimal(line['basis_quantity']),
+                'calculated_base_quantity': _decimal(line['calculated_base_quantity']),
+                'applied_base_quantity': _decimal(line['applied_base_quantity']),
+                'waste_base_quantity': _decimal(line['waste_base_quantity']),
+                'available_base_quantity': _decimal(line['available_base_quantity']),
+                'available_after_base_quantity': _decimal(
+                    line['available_after_base_quantity'],
+                ),
+            }
+            for line in state['lines']
+        ],
+    }
+
+
+class InputApplicationViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+    """Draft, preview, post, and reverse input applications."""
+
+    queryset = InputApplication.objects.select_related(
+        'batch',
+        'source_location',
+    ).prefetch_related('lines__targets', 'lines__item', 'lines__lot')
+    serializer_class = InputApplicationSerializer
+    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
+    bind_workspace_on_create = False
+
+    def get_queryset(self):
+        """Filter documents by status, batch, item, and applied period."""
+        queryset = super().get_queryset()
+        query = self.request.query_params
+        if 'status' in query:
+            queryset = queryset.filter(status=query['status'])
+        batch = parse_integer(query.get('batch'), 'batch')
+        if batch is not None:
+            queryset = queryset.filter(batch_id=batch)
+        item = parse_integer(query.get('item'), 'item')
+        if item is not None:
+            queryset = queryset.filter(lines__item_id=item).distinct()
+        applied_from = parse_datetime(query.get('applied_from'), 'applied_from')
+        if applied_from is not None:
+            queryset = queryset.filter(applied_at__gte=applied_from)
+        applied_to = parse_datetime(query.get('applied_to'), 'applied_to')
+        if applied_to is not None:
+            queryset = queryset.filter(applied_at__lte=applied_to)
+        return queryset
+
+    def create(self, request, *args, **kwargs):
+        """Assemble a draft, freezing what its calculation depends on."""
+        values = ApplicationDraftSerializer(data=request.data, context={'request': request})
+        values.is_valid(raise_exception=True)
+        workspace = self.get_current_workspace()
+        application = _run_domain_action(
+            create_application_draft,
+            workspace,
+            request.user,
+            _build_request(workspace, values.validated_data),
+        )
+        return Response(
+            self.get_serializer(application).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    def update(self, request, *args, **kwargs):
+        """Edit a draft, replacing its lines only when they are supplied.
+
+        Any edit moves the revision, so a preview taken before it stops being
+        something the client can post against.
+        """
+        application = self.get_object()
+        values = ApplicationDraftSerializer(
+            data=request.data,
+            context={'request': request},
+            partial=kwargs.pop('partial', False),
+        )
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        workspace = self.get_current_workspace()
+        replace_lines = 'lines' in data
+        application = _run_domain_action(
+            update_application_draft,
+            application,
+            ApplicationRequest(
+                applied_at=data.get('applied_at', application.applied_at),
+                source_location=data.get('source_location', application.source_location),
+                batch=data.get('batch', application.batch),
+                notes=data.get('notes', application.notes),
+                lines=_build_lines(workspace, data['lines']) if replace_lines else (),
+            ),
+            replace_lines,
+        )
+        return Response(self.get_serializer(application).data)
+
+    def perform_destroy(self, instance):
+        """Refuse to delete anything that already moved stock."""
+        try:
+            instance.delete()
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_errors(exc)) from exc
+
+    @action(detail=True, methods=['get'])
+    def preview(self, request, pk=None):  # pylint: disable=unused-argument
+        """Report the calculations and stock without writing anything."""
+        return Response(_run_domain_action(_state_response, self.get_object()))
+
+    @action(detail=True, methods=['post'])
+    def post(self, request, pk=None):  # pylint: disable=unused-argument
+        """Confirm the draft and decrement the exact lots it names."""
+        values = PostApplicationSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        application, _ = _run_domain_action(
+            post_application,
+            self.get_object(),
+            request.user,
+            values.validated_data.get('revision'),
+            values.validated_data.get('availability_digest'),
+        )
+        return Response(self.get_serializer(application).data)
+
+    @action(detail=True, methods=['post'])
+    def reverse(self, request, pk=None):  # pylint: disable=unused-argument
+        """Put back everything a posted application took."""
+        values = ReasonSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        application = _run_domain_action(
+            reverse_application,
+            self.get_object(),
+            request.user,
+            values.validated_data['reason'],
+        )
+        return Response(self.get_serializer(application).data)
+
+
+router = routers.DefaultRouter()
+router.register(r'input-applications', InputApplicationViewSet)

--- a/applications/services.py
+++ b/applications/services.py
@@ -381,12 +381,46 @@ def create_application_draft(workspace, user, request):
     return application
 
 
+@transaction.atomic
+def update_application_draft(application, request, replace_lines=True):
+    """Edit a draft, bumping the revision a client has to echo back.
+
+    Every change moves the revision, including one that leaves the numbers
+    alone, because the point is to invalidate what another tab was shown
+    rather than to describe how much changed.
+    """
+    application = InputApplication.objects.select_for_update().get(pk=application.pk)
+    if application.status != InputApplication.Status.DRAFT:
+        raise ValidationError({'status': 'Only draft applications can be edited.'})
+    application.applied_at = request.applied_at
+    application.source_location = request.source_location
+    application.batch = request.batch
+    application.notes = request.notes
+    application.save()
+    if replace_lines:
+        if not request.lines:
+            raise ValidationError({'lines': 'Add at least one application line.'})
+        application.lines.all().delete()
+        for line_request in request.lines:
+            _create_line(application, line_request)
+    InputApplication.objects.filter(pk=application.pk).update(
+        revision=application.revision + 1,
+        target_summary=target_summary(application),
+    )
+    application.refresh_from_db()
+    return application
+
+
 def _create_line(application, request):
     """Create one line, its frozen catalog snapshot, and its targets."""
     item = request.item
     basis = request.usage_basis or item.default_usage_basis
     snapshots = [measure_target(target) for target in request.targets]
     calculation = _line_usage(item, basis, request.fill_factor, snapshots)
+    # The ledger refuses anything but a Decimal or string, to keep a float from
+    # ever reaching a quantity column. Convert once here so no caller has to.
+    applied_quantity = Decimal(request.applied_quantity)
+    waste_quantity = Decimal(request.waste_quantity)
     line = InputApplicationLine(
         application=application,
         item=item,
@@ -400,19 +434,19 @@ def _create_line(application, request):
         formula_basis_quantity=calculation.basis_quantity,
         formula_basis_unit=calculation.basis_unit,
         calculated_base_quantity=calculation.calculated_base_quantity,
-        applied_quantity=Decimal(request.applied_quantity),
+        applied_quantity=applied_quantity,
         unit_code=request.unit_code,
         unit_conversion=request.unit_conversion,
         applied_base_quantity=normalize_quantity(
             item,
-            request.applied_quantity,
+            applied_quantity,
             unit_code=request.unit_code,
             unit_conversion=request.unit_conversion,
         ),
-        waste_quantity=Decimal(request.waste_quantity),
+        waste_quantity=waste_quantity,
         waste_base_quantity=normalize_quantity(
             item,
-            request.waste_quantity,
+            waste_quantity,
             unit_code=request.unit_code,
             unit_conversion=request.unit_conversion,
             allow_zero=True,

--- a/applications/test_rest.py
+++ b/applications/test_rest.py
@@ -1,0 +1,345 @@
+"""REST contract for drafting, previewing, posting, and reversing."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.utils import timezone
+
+from inventory.ledger import physical_balance
+from inventory.models import InventoryItem, StockMovement
+from inventory.units import UnitCode
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_inventory_item,
+    make_inventory_location,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_model,
+    make_stock_lot,
+)
+from workspaces.models import Workspace
+
+from .models import InputApplication, InputApplicationTarget
+
+TargetType = InputApplicationTarget.TargetType
+URL = '/applications/input-applications/'
+
+
+class ApplicationRESTTestCase(RESTContractTestCase):
+    """Stock and a tray shared by the REST cases."""
+
+    def setUp(self):
+        super().setUp()
+        self.location = make_inventory_location()
+        self.media = make_inventory_item(
+            base_unit=UnitCode.LITRE,
+            default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+        )
+        self.lot = make_stock_lot(item=self.media, location=self.location, quantity='50')
+        model = make_seed_tray_model(cell_size_ml=40, x_cells=24, y_cells=1)
+        self.tray = make_seed_tray(model=model)
+        self.cells = [
+            make_seed_tray_cell(tray=self.tray, x_position=index)
+            for index in range(24)
+        ]
+
+    def payload(self, **overrides):
+        """Build a draft payload filling every cell of the tray."""
+        line = {
+            'item': self.media.pk,
+            'lot': self.lot.pk,
+            'applied_quantity': '0.960000000',
+            'unit_code': UnitCode.LITRE,
+            'targets': [
+                {'target_type': TargetType.SEED_TRAY_CELL, 'target': cell.pk}
+                for cell in self.cells
+            ],
+        }
+        line.update(overrides.pop('line', {}))
+        values = {
+            'applied_at': timezone.now().isoformat(),
+            'source_location': self.location.pk,
+            'lines': [line],
+        }
+        values.update(overrides)
+        return values
+
+    def create_draft(self, **overrides):
+        """Create one draft and return its response data."""
+        response = self.client.post(URL, self.payload(**overrides), format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+
+class ApplicationContractTests(ApplicationRESTTestCase):
+    """The collection follows the shared REST conventions."""
+
+    def test_the_list_route_requires_authentication(self):
+        """Anonymous callers cannot read what a workspace applied."""
+        self.assert_authentication_required((URL,))
+
+    def test_the_list_route_returns_a_list(self):
+        """The collection uses the common unpaginated list contract."""
+        self.assert_list_contract((URL,))
+
+    def test_a_draft_reports_its_calculation(self):
+        """Creating a draft returns the suggestion it computed."""
+        data = self.create_draft()
+
+        self.assertEqual(data['status'], 'draft')
+        self.assertEqual(data['target_summary'], '24 tray cells')
+        line = data['lines'][0]
+        self.assertEqual(line['calculated_base_quantity'], '0.960000000')
+        self.assertEqual(line['formula_basis_quantity'], '960.000000000')
+        self.assertEqual(len(line['targets']), 24)
+
+    def test_a_whole_tray_expands_to_its_cells(self):
+        """The shortcut still records exactly which cells were filled."""
+        data = self.create_draft(line={'targets': [], 'tray': self.tray.pk})
+
+        self.assertEqual(len(data['lines'][0]['targets']), 24)
+        self.assertEqual(data['lines'][0]['calculated_base_quantity'], '0.960000000')
+
+    def test_a_draft_can_be_retrieved(self):
+        """A stored draft reads back the same way it was created."""
+        created = self.create_draft()
+        response = self.client.get(f'{URL}{created["pk"]}/')
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['pk'], created['pk'])
+
+    def test_a_draft_can_be_deleted(self):
+        """An abandoned draft leaves nothing behind."""
+        created = self.create_draft()
+        response = self.client.delete(f'{URL}{created["pk"]}/')
+
+        self.assertEqual(response.status_code, 204, response.data)
+        self.assertFalse(InputApplication.objects.filter(pk=created['pk']).exists())
+
+
+class ApplicationPreviewTests(ApplicationRESTTestCase):
+    """Preview reports what would happen without doing it."""
+
+    def test_preview_writes_nothing(self):
+        """Looking at a document never moves stock."""
+        created = self.create_draft()
+        before = StockMovement.objects.count()
+
+        response = self.client.get(f'{URL}{created["pk"]}/preview/')
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(StockMovement.objects.count(), before)
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('50'))
+
+    def test_preview_reports_availability_and_the_formula(self):
+        """An operator sees the working and the effect before confirming."""
+        created = self.create_draft()
+        response = self.client.get(f'{URL}{created["pk"]}/preview/')
+
+        line = response.data['lines'][0]
+        self.assertEqual(line['available_base_quantity'], '50.000000000')
+        self.assertEqual(line['available_after_base_quantity'], '49.040000000')
+        self.assertEqual(line['calculated_base_quantity'], '0.960000000')
+        self.assertIn('24 cells totalling 960 ml', line['formula'])
+        self.assertFalse(line['override_required'])
+        self.assertIn('availability_digest', response.data)
+
+    def test_preview_flags_a_required_override(self):
+        """The form knows to ask for a reason before the post is attempted."""
+        created = self.create_draft(line={'applied_quantity': '1.500000000'})
+        response = self.client.get(f'{URL}{created["pk"]}/preview/')
+
+        self.assertTrue(response.data['lines'][0]['override_required'])
+
+
+class ApplicationPostTests(ApplicationRESTTestCase):
+    """Posting decrements the exact lot the document names."""
+
+    def test_posting_consumes_the_confirmed_quantity(self):
+        """The confirmed amount is what leaves the shelf."""
+        created = self.create_draft()
+        response = self.client.post(f'{URL}{created["pk"]}/post/', {}, format='json')
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['status'], 'posted')
+        self.assertIsNotNone(response.data['lines'][0]['consumption_movement'])
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('49.04'))
+
+    def test_posting_with_a_current_digest_succeeds(self):
+        """What the operator was shown still holds, so it posts."""
+        created = self.create_draft()
+        state = self.client.get(f'{URL}{created["pk"]}/preview/').data
+
+        response = self.client.post(
+            f'{URL}{created["pk"]}/post/',
+            {
+                'revision': state['revision'],
+                'availability_digest': state['availability_digest'],
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_posting_with_a_stale_digest_is_refused(self):
+        """Stock spent elsewhere invalidates what the operator confirmed."""
+        created = self.create_draft()
+        state = self.client.get(f'{URL}{created["pk"]}/preview/').data
+
+        other = self.create_draft(line={'applied_quantity': '1.000000000'})
+        self.client.post(f'{URL}{other["pk"]}/post/', {}, format='json')
+
+        response = self.client.post(
+            f'{URL}{created["pk"]}/post/',
+            {
+                'revision': state['revision'],
+                'availability_digest': state['availability_digest'],
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('availability_digest', response.data)
+
+    def test_editing_a_draft_moves_its_revision(self):
+        """An edit in another tab invalidates a preview taken before it."""
+        created = self.create_draft()
+        state = self.client.get(f'{URL}{created["pk"]}/preview/').data
+
+        edited = self.client.patch(
+            f'{URL}{created["pk"]}/',
+            self.payload(notes='Reconsidered'),
+            format='json',
+        )
+        self.assertEqual(edited.status_code, 200, edited.data)
+        self.assertEqual(edited.data['revision'], state['revision'] + 1)
+
+        response = self.client.post(
+            f'{URL}{created["pk"]}/post/',
+            {'revision': state['revision']},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('revision', response.data)
+
+    def test_a_material_override_without_a_reason_is_refused(self):
+        """The audit wants a departure from the suggestion explained."""
+        created = self.create_draft(line={'applied_quantity': '1.500000000'})
+        response = self.client.post(f'{URL}{created["pk"]}/post/', {}, format='json')
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('lines', response.data)
+
+    def test_a_posted_document_cannot_be_edited_or_deleted(self):
+        """What moved stock stays exactly as it was recorded."""
+        created = self.create_draft()
+        self.client.post(f'{URL}{created["pk"]}/post/', {}, format='json')
+
+        patched = self.client.patch(
+            f'{URL}{created["pk"]}/',
+            self.payload(notes='Too late'),
+            format='json',
+        )
+        self.assertEqual(patched.status_code, 400, patched.data)
+
+        deleted = self.client.delete(f'{URL}{created["pk"]}/')
+        self.assertEqual(deleted.status_code, 400, deleted.data)
+
+
+class ApplicationReverseTests(ApplicationRESTTestCase):
+    """Reversal restores stock and keeps the document readable."""
+
+    def posted(self):
+        """Create and post one draft."""
+        created = self.create_draft()
+        self.client.post(f'{URL}{created["pk"]}/post/', {}, format='json')
+        return created
+
+    def test_reversal_restores_the_balance(self):
+        """Everything the document took goes back."""
+        created = self.posted()
+        response = self.client.post(
+            f'{URL}{created["pk"]}/reverse/',
+            {'reason': 'Applied to the wrong tray'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['status'], 'reversed')
+        self.assertEqual(response.data['reverse_reason'], 'Applied to the wrong tray')
+        self.assertEqual(physical_balance(self.lot, self.location), Decimal('50'))
+
+    def test_reversal_requires_a_reason(self):
+        """A correction that explains nothing is not an audit trail."""
+        created = self.posted()
+        response = self.client.post(
+            f'{URL}{created["pk"]}/reverse/',
+            {'reason': ''},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('reason', response.data)
+
+    def test_a_draft_cannot_be_reversed(self):
+        """There is nothing to put back until it posted."""
+        created = self.create_draft()
+        response = self.client.post(
+            f'{URL}{created["pk"]}/reverse/',
+            {'reason': 'Never mind'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+
+
+class ApplicationFilterTests(ApplicationRESTTestCase):
+    """Narrowing the collection to what an operator is looking for."""
+
+    def test_status_and_item_filters(self):
+        """Documents narrow by status and by the item they consumed."""
+        draft = self.create_draft()
+        posted = self.create_draft()
+        self.client.post(f'{URL}{posted["pk"]}/post/', {}, format='json')
+
+        drafts = self.client.get(URL, {'status': 'draft'})
+        self.assertEqual([row['pk'] for row in drafts.data], [draft['pk']])
+
+        by_item = self.client.get(URL, {'item': self.media.pk})
+        self.assertEqual(len(by_item.data), 2)
+
+        other_item = self.client.get(URL, {'item': make_inventory_item().pk})
+        self.assertEqual(len(other_item.data), 0)
+
+    def test_an_unparseable_filter_is_refused(self):
+        """A malformed filter is a client error, not an empty page."""
+        response = self.client.get(URL, {'batch': 'soon'})
+        self.assertEqual(response.status_code, 400, response.data)
+
+
+class ApplicationIsolationTests(ApplicationRESTTestCase):
+    """Another workspace's records are neither listed nor accepted."""
+
+    def test_another_workspace_lot_is_refused(self):
+        """A document cannot consume stock it does not own."""
+        other = Workspace.objects.create(name='Other workspace')
+        item = make_inventory_item(workspace=other)
+        location = make_inventory_location(workspace=other)
+        lot = make_stock_lot(item=item, location=location)
+
+        response = self.client.post(
+            URL,
+            self.payload(line={'item': item.pk, 'lot': lot.pk}),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_another_workspace_document_is_not_listed(self):
+        """The collection shows only this workspace's applications."""
+        other = Workspace.objects.create(name='Other workspace')
+        InputApplication.objects.create(
+            workspace=other,
+            applied_at=timezone.now(),
+            source_location=make_inventory_location(workspace=other),
+        )
+        self.create_draft()
+
+        response = self.client.get(URL)
+        self.assertEqual(len(response.data), 1)

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -1,0 +1,9 @@
+"""URLs for the input application documents."""
+
+from django.urls import include, path
+
+from .rest import router
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/gp/urls.py
+++ b/gp/urls.py
@@ -30,4 +30,5 @@ urlpatterns = [
     path("supplies/", include('supplies.urls')),
     path("inventory/", include('inventory.urls')),
     path("seedtrays/", include('seedtrays.urls')),
+    path("applications/", include('applications.urls')),
 ]


### PR DESCRIPTION
Draft, preview, post, and reverse. Preview is a GET because it writes nothing: it reports each line's formula, its suggestion, the lot balance before and after, and whether the confirmed amount needs a reason, so a form can ask for one before the post is attempted rather than after it fails.

Posting accepts the revision and availability digest a preview reported. Both are optional, so a simple client can post without them, but a form that shows an operator numbers should echo back what it showed.

Editing a draft replaces its lines only when they are supplied, matching how receipts and stocktakes behave, and moves the revision either way. The point of the revision is to invalidate what another tab was shown, not to describe how much changed.

A line may name a tray instead of listing cells. That expands server side to one target per cell, so the stored document always says exactly which cells were filled even when the operator picked the whole tray.

Verified against PostgreSQL 18 as well as SQLite, after the nullable-join lock failure showed that passing locally proves less than it looks.

## Summary by Sourcery

Expose input application drafting, previewing, posting, and reversal over a REST API with workspace scoping and optimistic concurrency, and wire it into the main URL routing.

New Features:
- Provide REST endpoints for creating, updating, previewing, posting, listing, and reversing input applications, including tray and target handling.
- Support optimistic posting of input applications using revision and availability digests, plus override and reversal reasons for auditability.

Enhancements:
- Allow editing existing application drafts via a service that bumps document revision and optionally replaces lines.
- Normalize quantity handling in application line creation by centralizing Decimal conversion of applied and waste quantities.

Tests:
- Add comprehensive REST contract tests covering drafting, previewing, posting, reversing, filtering, workspace isolation, and tray expansion for input applications.