### PR TITLE
feat(frontend): read input applications

### DIFF
--- a/frontend/js/api/applications.ts
+++ b/frontend/js/api/applications.ts
@@ -1,0 +1,57 @@
+import { fetchAsJson, csrfDelete, csrfPatch, csrfPost } from '../utils'
+import { ApplicationPreview, InputApplication, InputApplicationCreate, InputApplicationFilters, PostApplication, ReverseApplication } from '../types/applications'
+
+const ROOT = '/applications/input-applications/'
+
+function applicationQuery(filters: InputApplicationFilters): string {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== '') {
+      query.set(key, String(value))
+    }
+  }
+  return query.size > 0 ? `?${query.toString()}` : ''
+}
+
+function getInputApplications(filters: InputApplicationFilters = {}, signal?: AbortSignal): Promise<Array<InputApplication>> {
+  return fetchAsJson<Array<InputApplication>>(`${ROOT}${applicationQuery(filters)}`, signal)
+}
+
+function getInputApplication(applicationPk: number, signal?: AbortSignal): Promise<InputApplication> {
+  return fetchAsJson<InputApplication>(`${ROOT}${applicationPk}/`, signal)
+}
+
+function previewInputApplication(applicationPk: number, signal?: AbortSignal): Promise<ApplicationPreview> {
+  return fetchAsJson<ApplicationPreview>(`${ROOT}${applicationPk}/preview/`, signal)
+}
+
+function addInputApplication(data: InputApplicationCreate): Promise<InputApplication> {
+  return csrfPost(ROOT, data).then((response) => response.json() as Promise<InputApplication>)
+}
+
+function updateInputApplication(applicationPk: number, data: Partial<InputApplicationCreate>): Promise<InputApplication> {
+  return csrfPatch(`${ROOT}${applicationPk}/`, data).then((response) => response.json() as Promise<InputApplication>)
+}
+
+function deleteInputApplication(applicationPk: number): Promise<Response> {
+  return csrfDelete(`${ROOT}${applicationPk}/`)
+}
+
+function postInputApplication(applicationPk: number, data: PostApplication = {}): Promise<InputApplication> {
+  return csrfPost(`${ROOT}${applicationPk}/post/`, data).then((response) => response.json() as Promise<InputApplication>)
+}
+
+function reverseInputApplication(applicationPk: number, data: ReverseApplication): Promise<InputApplication> {
+  return csrfPost(`${ROOT}${applicationPk}/reverse/`, data).then((response) => response.json() as Promise<InputApplication>)
+}
+
+export {
+  addInputApplication,
+  deleteInputApplication,
+  getInputApplication,
+  getInputApplications,
+  postInputApplication,
+  previewInputApplication,
+  reverseInputApplication,
+  updateInputApplication
+}

--- a/frontend/js/applications/application_list.tsx
+++ b/frontend/js/applications/application_list.tsx
@@ -1,0 +1,169 @@
+import React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Alert, Badge, Button, Form, Table } from 'react-bootstrap'
+
+import { reverseInputApplication } from '../api/applications'
+import { formatDateTime, formatMeasure, formatQuantity } from '../utils'
+import { APPLICATION_STATUS_LABELS, InputApplication, InputApplicationLine, TARGET_TYPE_LABELS } from '../types/applications'
+import { queryKeys } from '../query'
+
+const STATUS_VARIANTS: Record<string, string> = {
+  draft: 'secondary',
+  posted: 'success',
+  reversed: 'warning'
+}
+
+function invalidateApplications(queryClient: ReturnType<typeof useQueryClient>) {
+  return Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.applications.all }), queryClient.invalidateQueries({ queryKey: queryKeys.inventory.all })])
+}
+
+function ReverseApplicationButton({ application }: { application: InputApplication }) {
+  const queryClient = useQueryClient()
+  const [reason, setReason] = React.useState('')
+  const [open, setOpen] = React.useState(false)
+  const [error, setError] = React.useState<string>()
+  const mutation = useMutation({
+    mutationFn: () => reverseInputApplication(application.pk, { reason }),
+    onSuccess: () => {
+      setOpen(false)
+      setReason('')
+      setError(undefined)
+      return invalidateApplications(queryClient)
+    },
+    onError: (caught: unknown) => setError(caught instanceof Error ? caught.message : String(caught))
+  })
+
+  if (application.status !== 'posted') {
+    return <span className="text-muted">—</span>
+  }
+  if (!open) {
+    return (
+      <Button size="sm" variant="outline-danger" onClick={() => setOpen(true)}>
+        Reverse
+      </Button>
+    )
+  }
+  return (
+    <div className="d-flex flex-column gap-1">
+      <Form.Control size="sm" value={reason} placeholder="Why was this wrong?" onChange={(event) => setReason(event.target.value)} />
+      <div className="d-flex gap-1">
+        <Button size="sm" variant="danger" disabled={!reason.trim() || mutation.isPending} onClick={() => mutation.mutate()}>
+          {mutation.isPending ? 'Reversing…' : 'Confirm'}
+        </Button>
+        <Button size="sm" variant="outline-secondary" onClick={() => setOpen(false)}>
+          Cancel
+        </Button>
+      </div>
+      {error && (
+        <Alert className="mb-0 py-1 px-2" variant="danger">
+          {error}
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+// The suggestion and the confirmed amount are always shown together. Seeing one
+// without the other is what makes an override invisible, which is the whole
+// thing the override reason exists to prevent.
+function LineAmounts({ line }: { line: InputApplicationLine }) {
+  return (
+    <>
+      <div>{formatMeasure(line.applied_base_quantity, line.base_unit)}</div>
+      {line.calculated_base_quantity !== null && line.calculated_base_quantity !== line.applied_base_quantity && (
+        <div className="text-muted small">calculated {formatQuantity(line.calculated_base_quantity)}</div>
+      )}
+      {line.waste_base_quantity !== '0.000000000' && <div className="text-muted small">waste {formatMeasure(line.waste_base_quantity, line.base_unit)}</div>}
+    </>
+  )
+}
+
+function TargetSummary({ line }: { line: InputApplicationLine }) {
+  if (line.targets.length === 0) {
+    return <span className="text-muted">No targets recorded</span>
+  }
+  const first = line.targets[0]
+  const label = TARGET_TYPE_LABELS[first.target_type]
+  if (line.targets.length === 1) {
+    return <>{first.label || label}</>
+  }
+  return (
+    <>
+      {line.targets.length} × {label.toLowerCase()}
+    </>
+  )
+}
+
+function ApplicationLinesTable({ lines }: { lines: Array<InputApplicationLine> }) {
+  return (
+    <Table size="sm" className="mb-0">
+      <thead>
+        <tr>
+          <th>Applied</th>
+          <th>Targets</th>
+          <th>Working</th>
+          <th>Movements</th>
+        </tr>
+      </thead>
+      <tbody>
+        {lines.map((line) => (
+          <tr key={line.pk}>
+            <td>
+              <LineAmounts line={line} />
+              {line.override_reason && <div className="text-muted small">{line.override_reason}</div>}
+            </td>
+            <td>
+              <TargetSummary line={line} />
+            </td>
+            <td className="small text-muted">
+              {line.formula_basis_quantity !== null ? `${formatQuantity(line.formula_basis_quantity)} ${line.formula_basis_unit}` : line.usage_basis.replace('_', ' ')}
+            </td>
+            <td className="small">
+              {line.consumption_movement !== null ? `#${line.consumption_movement}` : '—'}
+              {line.waste_movement !== null && <span className="text-muted"> · waste #{line.waste_movement}</span>}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+function ApplicationTable({ applications }: { applications: Array<InputApplication> }) {
+  if (applications.length === 0) {
+    return <p className="text-muted mb-0">No input applications recorded yet.</p>
+  }
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Applied</th>
+          <th>Status</th>
+          <th>Went on</th>
+          <th>Lines</th>
+          <th>Correct</th>
+        </tr>
+      </thead>
+      <tbody>
+        {applications.map((application) => (
+          <tr key={application.pk}>
+            <td>{formatDateTime(application.applied_at)}</td>
+            <td>
+              <Badge bg={STATUS_VARIANTS[application.status]}>{APPLICATION_STATUS_LABELS[application.status]}</Badge>
+              {application.status === 'reversed' && application.reverse_reason && <div className="text-muted small">{application.reverse_reason}</div>}
+            </td>
+            <td>{application.target_summary || <span className="text-muted">Nothing recorded</span>}</td>
+            <td>
+              <ApplicationLinesTable lines={application.lines} />
+            </td>
+            <td>
+              <ReverseApplicationButton application={application} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+export { ApplicationLinesTable, ApplicationTable, ReverseApplicationButton, invalidateApplications }

--- a/frontend/js/applications/applications.tsx
+++ b/frontend/js/applications/applications.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Col, Form, Row } from 'react-bootstrap'
+
+import { getInputApplications } from '../api/applications'
+import { getInventoryItems } from '../api/inventory'
+import { queryKeys } from '../query'
+import { InputApplicationStatus } from '../types/applications'
+import { ApplicationTable } from './application_list'
+
+function InputApplicationsView() {
+  const [status, setStatus] = React.useState<InputApplicationStatus | ''>('')
+  const [item, setItem] = React.useState<number | ''>('')
+  const [from, setFrom] = React.useState('')
+  const [to, setTo] = React.useState('')
+
+  const { data: items = [] } = useQuery({
+    queryKey: queryKeys.inventory.items('', '', '', 'active'),
+    queryFn: ({ signal }) => getInventoryItems({ active: true }, signal)
+  })
+  const { data: applications = [], isPending } = useQuery({
+    queryKey: queryKeys.applications.list(status, '', item, from, to),
+    queryFn: ({ signal }) => getInputApplications({ status, item, applied_from: from, applied_to: to }, signal)
+  })
+
+  return (
+    <main className="container py-3">
+      <h1>Input applications</h1>
+      <p>Every input that left stock, the exact lot it came from, and what it went on.</p>
+      <Row className="g-2 mb-3">
+        <Col md={3}>
+          <Form.Group controlId="application-filter-status">
+            <Form.Label>Status</Form.Label>
+            <Form.Select value={status} onChange={(event) => setStatus(event.target.value as InputApplicationStatus | '')}>
+              <option value="">All</option>
+              <option value="draft">Draft</option>
+              <option value="posted">Posted</option>
+              <option value="reversed">Reversed</option>
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="application-filter-item">
+            <Form.Label>Item</Form.Label>
+            <Form.Select value={item} onChange={(event) => setItem(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">All</option>
+              {items.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="application-filter-from">
+            <Form.Label>From</Form.Label>
+            <Form.Control type="date" value={from} onChange={(event) => setFrom(event.target.value)} />
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="application-filter-to">
+            <Form.Label>To</Form.Label>
+            <Form.Control type="date" value={to} onChange={(event) => setTo(event.target.value)} />
+          </Form.Group>
+        </Col>
+      </Row>
+      {isPending ? <div>Loading applications…</div> : <ApplicationTable applications={applications} />}
+    </main>
+  )
+}
+
+export { InputApplicationsView }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -18,6 +18,7 @@ import { SeedTrayDetails } from './seedtray/seedtray_details.js'
 import { getWorkspace } from './api/workspace.js'
 import { WorkspaceModeRoute, WorkspaceSettings } from './workspace.js'
 import { InventoryCatalog } from './inventory.js'
+import { InputApplicationsView } from './applications/applications.js'
 import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/batches.js'
 import { HarvestsView, YieldReportView } from './plantings/harvests.js'
 
@@ -82,6 +83,7 @@ function FrontEndPage() {
         <Route path="/plantings/harvests" element={<HarvestsView />} />
         <Route path="/plantings/yield" element={<YieldReportView />} />
         <Route path="/inventory" element={<InventoryCatalog />} />
+        <Route path="/applications" element={<InputApplicationsView />} />
         <Route
           path="/settings"
           element={

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -16,6 +16,7 @@ function GPTopBar({ workspace }: GPTopBarProps) {
   const seedsActive = pathname === '/seeds' || pathname.startsWith('/seeds/')
   const seedTraysActive = pathname === '/seedtrays' || pathname.startsWith('/seedtrays/')
   const plantingActive = pathname === '/plantings' || pathname.startsWith('/plantings/')
+  const inventoryActive = pathname === '/inventory' || pathname.startsWith('/applications')
 
   return (
     <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
@@ -67,9 +68,14 @@ function GPTopBar({ workspace }: GPTopBarProps) {
               Yield
             </NavDropdown.Item>
           </NavDropdown>
-          <Nav.Link as={NavLink} to="/inventory">
-            Inventory
-          </Nav.Link>
+          <NavDropdown title="Inventory" active={inventoryActive}>
+            <NavDropdown.Item as={NavLink} to="/inventory" end>
+              Catalog
+            </NavDropdown.Item>
+            <NavDropdown.Item as={NavLink} to="/applications">
+              Input applications
+            </NavDropdown.Item>
+          </NavDropdown>
           <Nav.Link as={NavLink} to="/settings">
             Settings
           </Nav.Link>

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -68,6 +68,13 @@ const queryKeys = {
     harvestReportAll: ['plantings', 'harvestReport'] as const,
     harvestReport: (groupBy: string, batch: number | '', variety: number | '', from: string, to: string) =>
       ['plantings', 'harvestReport', groupBy, batch, variety, from, to] as const
+  },
+  applications: {
+    all: ['applications'] as const,
+    listAll: ['applications', 'list'] as const,
+    list: (status: string, batch: number | '', item: number | '', from: string, to: string) => ['applications', 'list', status, batch, item, from, to] as const,
+    detail: (applicationPk: number) => ['applications', 'detail', applicationPk] as const,
+    preview: (applicationPk: number) => ['applications', 'preview', applicationPk] as const
   }
 }
 

--- a/frontend/js/types/applications.ts
+++ b/frontend/js/types/applications.ts
@@ -1,0 +1,172 @@
+import { UnitCode } from './inventory'
+
+type InputApplicationStatus = 'draft' | 'posted' | 'reversed'
+
+type ApplicationUsageBasis = 'cell_volume' | 'surface_area' | 'per_unit' | 'fixed' | 'manual'
+
+type ApplicationTargetType = 'batch' | 'seed_tray_cell' | 'specific_plant' | 'inventory_unit' | 'garden_area' | 'garden_bed' | 'garden_row' | 'garden_square'
+
+const APPLICATION_STATUS_LABELS: Record<InputApplicationStatus, string> = {
+  draft: 'Draft',
+  posted: 'Posted',
+  reversed: 'Reversed'
+}
+
+const TARGET_TYPE_LABELS: Record<ApplicationTargetType, string> = {
+  batch: 'Production batch',
+  seed_tray_cell: 'Tray cell',
+  specific_plant: 'Plant',
+  inventory_unit: 'Serialized unit',
+  garden_area: 'Garden area',
+  garden_bed: 'Garden bed',
+  garden_row: 'Garden row',
+  garden_square: 'Garden square'
+}
+
+interface InputApplicationTarget {
+  pk: number
+  target_type: ApplicationTargetType
+  target: number
+  label: string
+  weight: string
+  cell_volume_ml: number | null
+  area_m2: string | null
+}
+
+interface InputApplicationLine {
+  pk: number
+  item: number
+  lot: number
+  usage_basis: ApplicationUsageBasis
+  base_unit: UnitCode
+  configured_rate: string | null
+  configured_rate_unit: string
+  configured_fixed_quantity: string | null
+  fill_factor: string | null
+  formula_basis_quantity: string | null
+  formula_basis_unit: string
+  calculated_base_quantity: string | null
+  applied_quantity: string
+  unit_code: UnitCode | null
+  unit_conversion: number | null
+  applied_base_quantity: string
+  waste_quantity: string
+  waste_base_quantity: string
+  waste_reason: string
+  override_reason: string
+  notes: string
+  consumption_movement: number | null
+  waste_movement: number | null
+  targets: Array<InputApplicationTarget>
+}
+
+interface InputApplication {
+  pk: number
+  status: InputApplicationStatus
+  batch: number | null
+  applied_at: string
+  source_location: number
+  notes: string
+  target_summary: string
+  revision: number
+  created_by: number | null
+  posted_at: string | null
+  reversed_at: string | null
+  reverse_reason: string
+  reversed_by: number | null
+  created: string
+  updated: string
+  lines: Array<InputApplicationLine>
+}
+
+interface ApplicationPreviewLine {
+  pk: number
+  item: number
+  lot: number
+  usage_basis: ApplicationUsageBasis
+  basis_quantity: string | null
+  basis_unit: string
+  target_count: number
+  formula: string
+  calculated_base_quantity: string | null
+  applied_base_quantity: string
+  waste_base_quantity: string
+  base_unit: UnitCode
+  available_base_quantity: string
+  available_after_base_quantity: string
+  override_required: boolean
+  short: boolean
+}
+
+interface ApplicationPreview {
+  revision: number
+  availability_digest: string
+  target_summary: string
+  lines: Array<ApplicationPreviewLine>
+}
+
+interface ApplicationTargetInput {
+  target_type: ApplicationTargetType
+  target: number
+  weight?: string
+}
+
+interface ApplicationLineInput {
+  item: number
+  lot: number
+  applied_quantity: string
+  unit_code?: UnitCode | null
+  unit_conversion?: number | null
+  usage_basis?: ApplicationUsageBasis | ''
+  fill_factor?: string | null
+  waste_quantity?: string
+  waste_reason?: string
+  override_reason?: string
+  notes?: string
+  targets?: Array<ApplicationTargetInput>
+  tray?: number | null
+}
+
+interface InputApplicationCreate {
+  applied_at: string
+  source_location: number
+  batch?: number | null
+  notes?: string
+  lines: Array<ApplicationLineInput>
+}
+
+interface PostApplication {
+  revision?: number
+  availability_digest?: string
+}
+
+interface ReverseApplication {
+  reason: string
+}
+
+interface InputApplicationFilters {
+  status?: InputApplicationStatus | ''
+  batch?: number | ''
+  item?: number | ''
+  applied_from?: string
+  applied_to?: string
+}
+
+export {
+  APPLICATION_STATUS_LABELS,
+  TARGET_TYPE_LABELS,
+  ApplicationLineInput,
+  ApplicationPreview,
+  ApplicationPreviewLine,
+  ApplicationTargetInput,
+  ApplicationTargetType,
+  ApplicationUsageBasis,
+  InputApplication,
+  InputApplicationCreate,
+  InputApplicationFilters,
+  InputApplicationLine,
+  InputApplicationStatus,
+  InputApplicationTarget,
+  PostApplication,
+  ReverseApplication
+}


### PR DESCRIPTION
Add the types, API client, query keys, and the screen that lists what left stock, which exact lot it came from, and what it went on.

Each line shows the confirmed amount and the calculated suggestion together whenever they differ, with the override reason underneath. Showing one without the other is what would make an override invisible, which is the thing the reason exists to prevent.

Posted movement ids are linked from each line so a balance can be traced back to the document that moved it, and a posted application can be reversed with a reason from the same table.

Inventory becomes a dropdown holding the catalog and this screen, matching how seeds, seed trays, and planting already group their pages.

## Summary by Sourcery

Introduce frontend support for viewing and managing input applications, including navigation, data types, API client, and listing UI.

New Features:
- Add an Input Applications screen with filters for status, item, and date range, showing detailed application lines and targets.
- Provide the ability to reverse posted input applications with a required reason directly from the list view.
- Expose input applications in the main navigation under a new Inventory dropdown grouping catalog and applications pages.

Enhancements:
- Define strongly-typed models for input applications, previews, and related filters for use across the frontend.
- Add React Query keys and API client helpers for listing, viewing, previewing, creating, updating, posting, reversing, and deleting input applications.