### PR TITLE
feat(frontend): record input applications from where the work happens

### DIFF
--- a/frontend/js/api/garden.ts
+++ b/frontend/js/api/garden.ts
@@ -1,5 +1,5 @@
-import { GardenArea, GardenBed, GardenRow, GardenSquare } from '../types/garden'
-import { fetchAsJson } from '../utils'
+import { ConfirmGardenGeometry, GardenArea, GardenBed, GardenRow, GardenSquare } from '../types/garden'
+import { csrfPost, fetchAsJson } from '../utils'
 
 async function getGardenAreas(signal?: AbortSignal): Promise<Array<GardenArea>> {
   return fetchAsJson<Array<GardenArea>>('/garden/areas/', signal)
@@ -17,4 +17,8 @@ async function getGardenSquares(signal?: AbortSignal): Promise<Array<GardenSquar
   return fetchAsJson<Array<GardenSquare>>('/garden/squares/', signal)
 }
 
-export { getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares }
+async function confirmGardenGeometry(areaPk: number, data: ConfirmGardenGeometry): Promise<Response> {
+  return csrfPost(`/garden/areas/${areaPk}/confirm-geometry/`, data)
+}
+
+export { confirmGardenGeometry, getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares }

--- a/frontend/js/api/inventory.ts
+++ b/frontend/js/api/inventory.ts
@@ -1,8 +1,21 @@
-import { InventoryItem, InventoryItemCreate, InventoryItemFilters, InventoryLocation, InventoryUnit, ItemUnitConversion, ItemUnitConversionCreate } from '../types/inventory'
+import {
+  InventoryBalance,
+  InventoryItem,
+  InventoryItemCreate,
+  InventoryItemFilters,
+  InventoryLocation,
+  InventoryUnit,
+  ItemUnitConversion,
+  ItemUnitConversionCreate
+} from '../types/inventory'
 import { csrfPatch, csrfPost, fetchAsJson } from '../utils'
 
 const ITEMS_URL = '/inventory/items/'
 const CONVERSIONS_URL = '/inventory/conversions/'
+
+function getInventoryBalances(item: number, signal?: AbortSignal): Promise<Array<InventoryBalance>> {
+  return fetchAsJson<Array<InventoryBalance>>(`/inventory/balances/?item=${item}`, signal)
+}
 
 function getInventoryUnits(signal?: AbortSignal): Promise<Array<InventoryUnit>> {
   return fetchAsJson<Array<InventoryUnit>>('/inventory/units/', signal)
@@ -50,6 +63,7 @@ async function setItemUnitConversionActive(pk: number, active: boolean): Promise
 export {
   createInventoryItem,
   createItemUnitConversion,
+  getInventoryBalances,
   getInventoryItems,
   getInventoryLocations,
   getInventoryUnits,

--- a/frontend/js/applications/application_form.tsx
+++ b/frontend/js/applications/application_form.tsx
@@ -1,0 +1,340 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Button, Card, Col, Form, Row } from 'react-bootstrap'
+
+import { addInputApplication, deleteInputApplication, postInputApplication, previewInputApplication, updateInputApplication } from '../api/applications'
+import { getInventoryBalances, getInventoryItems } from '../api/inventory'
+import { queryKeys } from '../query'
+import { formatMeasure, formatQuantity, localDatetimeInputValue, parseLocalDatetimeInput } from '../utils'
+import { ApplicationPreview, ApplicationTargetType, InputApplication } from '../types/applications'
+import { invalidateApplications } from './application_list'
+
+interface ApplicationTargetOption {
+  // `${target_type}:${pk}` — stable across re-renders and unique per thing.
+  key: string
+  target_type: ApplicationTargetType
+  pk: number
+  label: string
+  // Set when this thing cannot be applied to yet, such as a garden area whose
+  // physical length unit nobody has confirmed. The option stays visible so the
+  // operator can see why rather than wondering where it went.
+  blocked?: string
+}
+
+interface InputApplicationFormProps {
+  targets: Array<ApplicationTargetOption>
+  batch?: number | null
+  defaultTargetKeys?: Array<string>
+  // A whole-tray shortcut. The server expands it into one target per cell, so
+  // the stored document still names exactly which cells were filled.
+  tray?: number
+  title?: string
+  onPosted?: (application: InputApplication) => void
+}
+
+function targetKey(option: ApplicationTargetOption) {
+  return option.key
+}
+
+// The catalogue is fetched here rather than pushed in as props, because every
+// screen embedding this form would otherwise duplicate the same two queries.
+// Targets stay props: they are the one thing each caller genuinely differs on.
+function InputApplicationForm({ targets, batch = null, defaultTargetKeys, tray, title = 'Apply an input', onPosted }: InputApplicationFormProps) {
+  const queryClient = useQueryClient()
+  const [item, setItem] = React.useState<number | ''>('')
+  const [lot, setLot] = React.useState<number | ''>('')
+  const [quantity, setQuantity] = React.useState('')
+  const [waste, setWaste] = React.useState('')
+  const [wasteReason, setWasteReason] = React.useState('')
+  const [overrideReason, setOverrideReason] = React.useState('')
+  const [fillFactor, setFillFactor] = React.useState('')
+  const [appliedAt, setAppliedAt] = React.useState(localDatetimeInputValue())
+  const [selected, setSelected] = React.useState<Array<string>>(defaultTargetKeys ?? [])
+  const [draft, setDraft] = React.useState<InputApplication>()
+  const [preview, setPreview] = React.useState<ApplicationPreview>()
+  const [error, setError] = React.useState<string>()
+
+  const { data: items = [] } = useQuery({
+    queryKey: queryKeys.inventory.items('', '', '', 'active'),
+    queryFn: ({ signal }) => getInventoryItems({ active: true }, signal)
+  })
+  const { data: balances = [] } = useQuery({
+    queryKey: [...queryKeys.inventory.all, 'balances', item],
+    queryFn: ({ signal }) => getInventoryBalances(Number(item), signal),
+    enabled: item !== ''
+  })
+
+  const chosenItem = items.find((entry) => entry.pk === item)
+  const chosenBalance = balances.find((entry) => entry.lot === lot)
+  const previewLine = preview?.lines[0]
+  const overrideRequired = previewLine?.override_required ?? false
+  const selectable = targets.filter((option) => !option.blocked)
+  const blocked = targets.filter((option) => option.blocked)
+
+  function toggleTarget(key: string) {
+    setSelected((current) => (current.includes(key) ? current.filter((entry) => entry !== key) : [...current, key]))
+    discardPreview()
+  }
+
+  function discardPreview() {
+    setPreview(undefined)
+  }
+
+  function linePayload() {
+    return {
+      item: Number(item),
+      lot: Number(lot),
+      applied_quantity: quantity,
+      unit_code: chosenItem?.base_unit ?? null,
+      fill_factor: fillFactor === '' ? null : fillFactor,
+      waste_quantity: waste === '' ? '0' : waste,
+      waste_reason: wasteReason,
+      override_reason: overrideReason,
+      targets: tray
+        ? []
+        : selected.map((key) => {
+            const option = targets.find((entry) => entry.key === key)
+            return { target_type: option!.target_type, target: option!.pk }
+          }),
+      tray: tray ?? null
+    }
+  }
+
+  const checkMutation = useMutation({
+    mutationFn: async () => {
+      const applied = parseLocalDatetimeInput(appliedAt)
+      if (applied === null) {
+        throw new Error('Enter when this input was applied.')
+      }
+      const payload = {
+        applied_at: applied.toISOString(),
+        source_location: chosenBalance!.location,
+        batch,
+        lines: [linePayload()]
+      }
+      const saved = draft ? await updateInputApplication(draft.pk, payload) : await addInputApplication(payload)
+      return { saved, state: await previewInputApplication(saved.pk) }
+    },
+    onSuccess: ({ saved, state }) => {
+      setDraft(saved)
+      setPreview(state)
+      setError(undefined)
+    },
+    onError: (caught: unknown) => setError(caught instanceof Error ? caught.message : String(caught))
+  })
+
+  const postMutation = useMutation({
+    mutationFn: () =>
+      postInputApplication(draft!.pk, {
+        revision: preview!.revision,
+        availability_digest: preview!.availability_digest
+      }),
+    onSuccess: async (application) => {
+      await invalidateApplications(queryClient)
+      reset()
+      onPosted?.(application)
+    },
+    onError: (caught: unknown) => setError(caught instanceof Error ? caught.message : String(caught))
+  })
+
+  const discardMutation = useMutation({
+    mutationFn: () => deleteInputApplication(draft!.pk),
+    onSuccess: () => {
+      reset()
+      return invalidateApplications(queryClient)
+    }
+  })
+
+  function reset() {
+    setDraft(undefined)
+    setPreview(undefined)
+    setQuantity('')
+    setWaste('')
+    setWasteReason('')
+    setOverrideReason('')
+    setSelected(defaultTargetKeys ?? [])
+    setError(undefined)
+  }
+
+  const readyToCheck = item !== '' && lot !== '' && quantity.trim() !== '' && (tray !== undefined || selected.length > 0)
+  const readyToPost = preview !== undefined && !checkMutation.isPending && (!overrideRequired || overrideReason.trim() !== '')
+
+  return (
+    <Card className="mb-4">
+      <Card.Body>
+        <Card.Title>{title}</Card.Title>
+        <Row className="g-2">
+          <Col md={4}>
+            <Form.Group className="mb-3" controlId="application-item">
+              <Form.Label>Item</Form.Label>
+              <Form.Select
+                value={item}
+                onChange={(event) => {
+                  setItem(event.target.value === '' ? '' : Number(event.target.value))
+                  setLot('')
+                  discardPreview()
+                }}
+              >
+                <option value="">Select an item</option>
+                {items.map((entry) => (
+                  <option key={entry.pk} value={entry.pk}>
+                    {entry.name}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Col>
+          <Col md={4}>
+            <Form.Group className="mb-3" controlId="application-lot">
+              <Form.Label>Lot</Form.Label>
+              <Form.Select
+                value={lot}
+                disabled={item === ''}
+                onChange={(event) => {
+                  setLot(event.target.value === '' ? '' : Number(event.target.value))
+                  discardPreview()
+                }}
+              >
+                <option value="">Select a lot</option>
+                {balances.map((entry) => (
+                  <option key={`${entry.lot}-${entry.location}`} value={entry.lot}>
+                    {entry.lot_identifier} · {entry.location_name} · {formatMeasure(entry.available_quantity, entry.base_unit)}
+                  </option>
+                ))}
+              </Form.Select>
+              {item !== '' && balances.length === 0 && <Form.Text className="text-warning">No stock of this item is on hand.</Form.Text>}
+            </Form.Group>
+          </Col>
+          <Col md={4}>
+            <Form.Group className="mb-3" controlId="application-applied-at">
+              <Form.Label>Applied</Form.Label>
+              <Form.Control
+                type="datetime-local"
+                value={appliedAt}
+                onChange={(event) => {
+                  setAppliedAt(event.target.value)
+                  discardPreview()
+                }}
+              />
+            </Form.Group>
+          </Col>
+        </Row>
+
+        {tray === undefined && (
+          <Form.Group className="mb-3">
+            <Form.Label>Applied to</Form.Label>
+            <div className="d-flex flex-wrap gap-3">
+              {selectable.map((option) => (
+                <Form.Check
+                  key={targetKey(option)}
+                  id={`application-target-${targetKey(option)}`}
+                  type="checkbox"
+                  label={option.label}
+                  checked={selected.includes(option.key)}
+                  onChange={() => toggleTarget(option.key)}
+                />
+              ))}
+            </div>
+            {selectable.length === 0 && <Form.Text className="text-muted">Nothing here can receive an input yet.</Form.Text>}
+            {blocked.map((option) => (
+              <Form.Text key={targetKey(option)} className="d-block text-warning">
+                {option.label}: {option.blocked}
+              </Form.Text>
+            ))}
+          </Form.Group>
+        )}
+
+        <Row className="g-2">
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="application-quantity">
+              <Form.Label>Confirmed quantity{chosenItem ? ` (${chosenItem.base_unit})` : ''}</Form.Label>
+              <Form.Control
+                value={quantity}
+                inputMode="decimal"
+                placeholder="e.g. 0.96"
+                onChange={(event) => {
+                  setQuantity(event.target.value)
+                  discardPreview()
+                }}
+              />
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="application-fill-factor">
+              <Form.Label>Fill factor</Form.Label>
+              <Form.Control
+                value={fillFactor}
+                inputMode="decimal"
+                placeholder="1.0"
+                onChange={(event) => {
+                  setFillFactor(event.target.value)
+                  discardPreview()
+                }}
+              />
+              <Form.Text className="text-muted">How full each cell was packed.</Form.Text>
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="application-waste">
+              <Form.Label>Waste</Form.Label>
+              <Form.Control
+                value={waste}
+                inputMode="decimal"
+                placeholder="0"
+                onChange={(event) => {
+                  setWaste(event.target.value)
+                  discardPreview()
+                }}
+              />
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="application-waste-reason">
+              <Form.Label>Waste reason</Form.Label>
+              <Form.Control value={wasteReason} onChange={(event) => setWasteReason(event.target.value)} placeholder="Required if any waste" />
+            </Form.Group>
+          </Col>
+        </Row>
+
+        {previewLine && (
+          <Alert variant={previewLine.short ? 'danger' : 'info'}>
+            <div>{previewLine.formula}</div>
+            <div className="small">
+              Calculated {formatMeasure(previewLine.calculated_base_quantity ?? '0', previewLine.base_unit)} · applying{' '}
+              {formatMeasure(previewLine.applied_base_quantity, previewLine.base_unit)}
+            </div>
+            <div className="small">
+              Lot holds {formatQuantity(previewLine.available_base_quantity)} and would hold {formatQuantity(previewLine.available_after_base_quantity)} {previewLine.base_unit}
+            </div>
+            {previewLine.short && <div className="fw-bold">This lot does not hold enough.</div>}
+          </Alert>
+        )}
+
+        {overrideRequired && (
+          <Form.Group className="mb-3" controlId="application-override-reason">
+            <Form.Label>Why does this differ from the calculation?</Form.Label>
+            <Form.Control value={overrideReason} onChange={(event) => setOverrideReason(event.target.value)} />
+          </Form.Group>
+        )}
+
+        {error && <Alert variant="danger">{error}</Alert>}
+
+        <div className="d-flex gap-2">
+          <Button variant="outline-primary" disabled={!readyToCheck || checkMutation.isPending} onClick={() => checkMutation.mutate()}>
+            {checkMutation.isPending ? 'Checking…' : preview ? 'Re-check' : 'Check'}
+          </Button>
+          <Button disabled={!readyToPost || postMutation.isPending} onClick={() => postMutation.mutate()}>
+            {postMutation.isPending ? 'Posting…' : 'Post application'}
+          </Button>
+          {draft && (
+            <Button variant="outline-secondary" disabled={discardMutation.isPending} onClick={() => discardMutation.mutate()}>
+              Discard draft
+            </Button>
+          )}
+        </div>
+      </Card.Body>
+    </Card>
+  )
+}
+
+export { ApplicationTargetOption, InputApplicationForm }

--- a/frontend/js/applications/applications.tsx
+++ b/frontend/js/applications/applications.tsx
@@ -1,14 +1,21 @@
 import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Col, Form, Row } from 'react-bootstrap'
+import { useSearchParams } from 'react-router'
 
 import { getInputApplications } from '../api/applications'
 import { getInventoryItems } from '../api/inventory'
 import { queryKeys } from '../query'
 import { InputApplicationStatus } from '../types/applications'
 import { ApplicationTable } from './application_list'
+import { InputApplicationForm } from './application_form'
 
 function InputApplicationsView() {
+  // The seed-tray screen is a separate bundle, so it deep links here with the
+  // tray it wants rather than embedding the form and duplicating it.
+  const [searchParams] = useSearchParams()
+  const trayParam = Number(searchParams.get('tray'))
+  const tray = Number.isInteger(trayParam) && trayParam > 0 ? trayParam : undefined
   const [status, setStatus] = React.useState<InputApplicationStatus | ''>('')
   const [item, setItem] = React.useState<number | ''>('')
   const [from, setFrom] = React.useState('')
@@ -27,6 +34,7 @@ function InputApplicationsView() {
     <main className="container py-3">
       <h1>Input applications</h1>
       <p>Every input that left stock, the exact lot it came from, and what it went on.</p>
+      {tray !== undefined && <InputApplicationForm targets={[]} tray={tray} title={`Apply an input to every cell of tray ${tray}`} />}
       <Row className="g-2 mb-3">
         <Col md={3}>
           <Form.Group controlId="application-filter-status">

--- a/frontend/js/garden.tsx
+++ b/frontend/js/garden.tsx
@@ -14,6 +14,8 @@ import { GardenSquarePlanting } from './types/plantings'
 import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
 import { getHarvests, getPlantingGardenSquaresCurrent } from './api/plantings'
 import { HarvestForm, HarvestFormBatch, HarvestFormPlant } from './plantings/harvest_form'
+import { InputApplicationForm } from './applications/application_form'
+import { ConfirmGeometryForm } from './garden/geometry'
 import { HarvestTable } from './plantings/harvest_list'
 import { SelectOption } from './types/others'
 import { queryKeys } from './query'
@@ -225,6 +227,24 @@ function GardenSquareDetailsModal({ area, bed, square, plantings, onClose }: Gar
         <section className="garden-square-harvest">
           <h2 className="h5">Harvests from this square</h2>
           <SquareHarvests squarePk={square.pk} />
+        </section>
+
+        <section className="garden-square-harvest">
+          <h2 className="h5">Apply an input here</h2>
+          {!area.geometry_confirmed && <ConfirmGeometryForm area={area} />}
+          <InputApplicationForm
+            targets={[
+              {
+                key: `garden_square:${square.pk}`,
+                target_type: 'garden_square',
+                pk: square.pk,
+                label: square.name,
+                blocked: area.geometry_confirmed ? undefined : `${area.name} has no confirmed length unit`
+              }
+            ]}
+            defaultTargetKeys={[`garden_square:${square.pk}`]}
+            title="Apply an input to this square"
+          />
         </section>
       </Modal.Body>
       <Modal.Footer>

--- a/frontend/js/garden/geometry.tsx
+++ b/frontend/js/garden/geometry.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Alert, Button, Col, Form, Row } from 'react-bootstrap'
+
+import { confirmGardenGeometry } from '../api/garden'
+import { queryKeys } from '../query'
+import { GardenArea, GardenLengthUnit } from '../types/garden'
+
+const LENGTH_UNIT_LABELS: Record<GardenLengthUnit, string> = {
+  mm: 'Millimetres',
+  cm: 'Centimetres',
+  m: 'Metres',
+  in: 'Inches',
+  ft: 'Feet'
+}
+
+// Garden placements and sizes are bare integers. Until somebody says what one
+// grid step measures, nothing can turn a square into an area, so this is the
+// gate in front of every area-based calculation rather than a nicety.
+function ConfirmGeometryForm({ area }: { area: GardenArea }) {
+  const queryClient = useQueryClient()
+  const [unit, setUnit] = React.useState<GardenLengthUnit>(area.length_unit ?? 'mm')
+  const [cellLength, setCellLength] = React.useState(area.cell_length ?? '1')
+  const [error, setError] = React.useState<string>()
+  const mutation = useMutation({
+    mutationFn: () => confirmGardenGeometry(area.pk, { length_unit: unit, cell_length: cellLength }),
+    onSuccess: () => {
+      setError(undefined)
+      return queryClient.invalidateQueries({ queryKey: queryKeys.garden.all })
+    },
+    onError: (caught: unknown) => setError(caught instanceof Error ? caught.message : String(caught))
+  })
+
+  return (
+    <div>
+      {area.geometry_confirmed ? (
+        <p className="mb-2">
+          One grid step is {area.cell_length} {area.length_unit}, so this area measures {area.square_metres} m².
+        </p>
+      ) : (
+        <Alert variant="warning" className="py-2">
+          This area&apos;s measurements have no recorded unit, so nothing can work out its size. Confirm what one grid step is.
+        </Alert>
+      )}
+      <Row className="g-2 align-items-end">
+        <Col md={4}>
+          <Form.Group controlId={`geometry-cell-length-${area.pk}`}>
+            <Form.Label>One grid step is</Form.Label>
+            <Form.Control value={cellLength} inputMode="decimal" onChange={(event) => setCellLength(event.target.value)} />
+          </Form.Group>
+        </Col>
+        <Col md={4}>
+          <Form.Group controlId={`geometry-length-unit-${area.pk}`}>
+            <Form.Label>Unit</Form.Label>
+            <Form.Select value={unit} onChange={(event) => setUnit(event.target.value as GardenLengthUnit)}>
+              {Object.entries(LENGTH_UNIT_LABELS).map(([code, label]) => (
+                <option key={code} value={code}>
+                  {label}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={4}>
+          <Button disabled={cellLength.trim() === '' || mutation.isPending} onClick={() => mutation.mutate()}>
+            {mutation.isPending ? 'Saving…' : area.geometry_confirmed ? 'Correct this' : 'Confirm'}
+          </Button>
+        </Col>
+      </Row>
+      {area.geometry_confirmed && <Form.Text className="text-muted">Correcting this leaves earlier applications exactly as they were recorded.</Form.Text>}
+      {error && (
+        <Alert variant="danger" className="mt-2 mb-0 py-1 px-2">
+          {error}
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+export { ConfirmGeometryForm, LENGTH_UNIT_LABELS }

--- a/frontend/js/plantings/batches.tsx
+++ b/frontend/js/plantings/batches.tsx
@@ -9,6 +9,9 @@ import { queryKeys } from '../query'
 import { formatDate, formatDateTime } from '../utils'
 import { PlantLifecycleState, ProductionBatch, ProductionBatchDetail, ProductionBatchStatus } from '../types/plantings'
 import { HarvestForm } from './harvest_form'
+import { ApplicationTargetOption, InputApplicationForm } from '../applications/application_form'
+import { ApplicationTable } from '../applications/application_list'
+import { getInputApplications } from '../api/applications'
 import { FamilyTotals, HarvestTable } from './harvest_list'
 import { STATE_LABELS } from './lifecycle'
 
@@ -487,6 +490,33 @@ function BatchYield({ batch }: { batch: ProductionBatchDetail }) {
   )
 }
 
+function BatchInputs({ batch }: { batch: ProductionBatchDetail }) {
+  const { data: applications = [] } = useQuery({
+    queryKey: queryKeys.applications.list('', batch.pk, '', '', ''),
+    queryFn: ({ signal }) => getInputApplications({ batch: batch.pk }, signal)
+  })
+  // The batch itself is offered alongside its plants, so an input that covers
+  // the whole crop does not have to be attributed plant by plant.
+  const targets: Array<ApplicationTargetOption> = [
+    { key: `batch:${batch.pk}`, target_type: 'batch', pk: batch.pk, label: `Whole batch ${batch.code}` },
+    ...batch.current_locations.map((location) => ({
+      key: `specific_plant:${location.specific_plant}`,
+      target_type: 'specific_plant' as const,
+      pk: location.specific_plant,
+      label: `Plant ${location.specific_plant} @ ${location.label}`
+    }))
+  ]
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Inputs</Card.Title>
+        <InputApplicationForm targets={targets} batch={batch.pk} title="Apply an input to this batch" />
+        <ApplicationTable applications={applications} />
+      </Card.Body>
+    </Card>
+  )
+}
+
 function BatchHarvests({ batch }: { batch: ProductionBatchDetail }) {
   const { data: harvests = [] } = useQuery({
     queryKey: queryKeys.plantings.harvests(batch.pk, '', '', '', '', '', ''),
@@ -634,6 +664,7 @@ function ProductionBatchDetailView({ batchPk }: ProductionBatchDetailViewProps) 
         <BatchLifecycleStates batch={batch} />
         <BatchYield batch={batch} />
         <BatchHarvests batch={batch} />
+        <BatchInputs batch={batch} />
         <BatchLocations batch={batch} />
         <BatchHistory batch={batch} />
       </div>

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -628,6 +628,18 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
       <p>Notes: {seedTray.notes}</p>
       <Card className="mb-3">
         <Card.Body>
+          <Card.Title>Inputs</Card.Title>
+          <p className="mb-2">
+            Media and treatments applied to this tray are recorded against its cells. This screen is a separate bundle, so it links to the applications page rather than embedding
+            the form.
+          </p>
+          <Button href={`/#/applications?tray=${seedTray.pk}`} variant="outline-primary">
+            Apply an input to this tray
+          </Button>
+        </Card.Body>
+      </Card>
+      <Card className="mb-3">
+        <Card.Body>
           <Card.Title>Physical inventory</Card.Title>
           {seedTray.inventory.reconciliation_required && <Alert variant="warning">Opening cost and physical location require reconciliation.</Alert>}
           <dl className="row mb-2">

--- a/frontend/js/types/garden.ts
+++ b/frontend/js/types/garden.ts
@@ -1,8 +1,22 @@
+type GardenLengthUnit = 'mm' | 'cm' | 'm' | 'in' | 'ft'
+
 interface GardenArea {
   pk: number
   name: string
   size_x: number
   size_y: number
+  // Null until an operator states what one grid step measures. Nothing derives
+  // an area from the raw integers before that.
+  geometry_confirmed: boolean
+  length_unit: GardenLengthUnit | null
+  cell_length: string | null
+  square_metres: string | null
+}
+
+interface ConfirmGardenGeometry {
+  length_unit: GardenLengthUnit
+  cell_length: string
+  notes?: string
 }
 
 interface GardenBed {
@@ -36,4 +50,4 @@ interface GardenSquare {
   size_y: number
 }
 
-export { GardenArea, GardenBed, GardenRow, GardenSquare }
+export { ConfirmGardenGeometry, GardenArea, GardenBed, GardenLengthUnit, GardenRow, GardenSquare }

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -118,7 +118,24 @@ interface ItemUnitConversionCreate {
   multiplier: string
 }
 
+interface InventoryBalance {
+  lot: number
+  lot_identifier: string
+  item: number
+  item_name: string
+  location: number
+  location_name: string
+  physical_quantity: string
+  reserved_quantity: string
+  available_quantity: string
+  base_unit: UnitCode
+  base_unit_cost: string | null
+  valuation: string | null
+  low_stock: boolean
+}
+
 export {
+  InventoryBalance,
   InventoryCategory,
   InventoryItem,
   InventoryItemCreate,


### PR DESCRIPTION
Add the shared application form and wire it into the places an operator is already standing: a production batch, a garden square, and a seed tray.

The form checks before it commits. Pressing check saves a draft and previews it, showing the formula, the calculated suggestion beside the confirmed amount, and what the lot holds before and after. A reason field appears only when the difference is material by the workspace's own tolerance, and posting echoes back the revision and availability digest the preview reported, so a draft edited elsewhere or stock spent meanwhile is refused rather than silently applied.

Targets are props because they are the one thing each screen genuinely differs on; the item and stock catalogues are fetched inside the form so four callers do not repeat the same two queries.

A garden square whose area has no confirmed length unit offers the confirmation inline rather than hiding the option, since an operator who cannot apply a treatment needs to know why. Correcting a confirmation says plainly that earlier applications keep what they recorded.

The seed tray screen links to the applications page instead of embedding the form. It is a separate esbuild entry, and a link costs that bundle 0.5kb against the form's full weight.

## Summary by Sourcery

Introduce a shared input application workflow and surface it from key production views to record stock usage where work occurs.

New Features:
- Add a reusable input application form that previews calculated usage, validates stock, and posts applications against selected targets or seed trays.
- Expose input application recording from production batch, garden square, and seed tray views so operators can log inputs in context.
- Allow garden areas to have their grid geometry confirmed, enabling area-based calculations and unlocking inputs on squares tied to unconfirmed areas.

Enhancements:
- Fetch inventory item catalogues and lot balances in the input application form to centralize stock lookups and avoid duplicated queries across screens.
- Extend the applications view to support deep-linking from seed trays with a tray-wide input shortcut.