### PR TITLE
feat(inventory): separate seed and serialized stock from general receipts

### DIFF
--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -153,6 +153,14 @@ class StockReceiptLineSerializer(
         destination = attrs.get('destination')
         if not item.active:
             raise ValidationError({'item': 'The item is inactive.'})
+        if item.category == InventoryItem.Category.SEED:
+            raise ValidationError({
+                'item': 'Receive seed packets through the seed receipt API.',
+            })
+        if item.tracking_mode == InventoryItem.TrackingMode.SERIALIZED:
+            raise ValidationError({
+                'item': 'Receive serialized items through their own workflow.',
+            })
         if conversion and not conversion.active:
             raise ValidationError(
                 {'unit_conversion': 'The conversion is inactive.'},
@@ -190,6 +198,7 @@ class StockReceiptSerializer(
 
     lines = StockReceiptLineSerializer(many=True, required=False)
     movement_ids = serializers.SerializerMethodField()
+    is_seed_packet_draft = serializers.SerializerMethodField()
 
     class Meta:
         model = StockReceipt
@@ -206,6 +215,7 @@ class StockReceiptSerializer(
             'created_by',
             'posted_at',
             'reversed_at',
+            'is_seed_packet_draft',
             'created',
             'updated',
             'lines',
@@ -216,6 +226,7 @@ class StockReceiptSerializer(
             'created_by',
             'posted_at',
             'reversed_at',
+            'is_seed_packet_draft',
             'created',
             'updated',
             'movement_ids',
@@ -234,6 +245,10 @@ class StockReceiptSerializer(
             .order_by('pk')
             .values_list('pk', flat=True)
         )
+
+    def get_is_seed_packet_draft(self, receipt):
+        """Name the drafts the seed workflow owns its own editor for."""
+        return hasattr(receipt, 'seed_packet_draft')
 
     def validate(self, attrs):
         """Apply workspace financial defaults to new draft documents."""
@@ -660,7 +675,11 @@ class StockReceiptViewSet(
 ):  # pylint: disable=too-many-ancestors
     """Edit draft receipts and explicitly post or reverse them."""
 
-    queryset = StockReceipt.objects.select_related('supplier', 'created_by').prefetch_related(
+    queryset = StockReceipt.objects.select_related(
+        'supplier',
+        'created_by',
+        'seed_packet_draft',
+    ).prefetch_related(
         'lines__item',
         'lines__unit_conversion',
         'lines__destination',
@@ -709,6 +728,12 @@ class StockReceiptViewSet(
             queryset = queryset.filter(received_date__gte=received_after)
         if received_before:
             queryset = queryset.filter(received_date__lte=received_before)
+        seed_packet = _parse_boolean(
+            self.request.query_params.get('seed_packet'),
+            'seed_packet',
+        )
+        if seed_packet is not None:
+            queryset = queryset.filter(seed_packet_draft__isnull=not seed_packet)
         return queryset
 
     @action(detail=True, methods=['post'])

--- a/inventory/test_ledger_rest.py
+++ b/inventory/test_ledger_rest.py
@@ -12,16 +12,18 @@ from workspaces.models import Workspace, get_current_workspace
 from .models import (
     InventoryItem,
     InventoryLocation,
+    ItemUnitConversion,
     StockLot,
     StockMovement,
     StockReceipt,
+    StockReceiptLine,
     Stocktake,
 )
 from .units import UnitCode
 
 
-class LedgerRestTests(APITestCase):
-    """Ledger APIs are scoped, explicit, normalized, and append-only."""
+class LedgerRestFixture(APITestCase):
+    """Shared ledger fixture: one workspace, supplier, item, and two places."""
 
     location_url = '/inventory/locations/'
     receipt_url = '/inventory/receipts/'
@@ -127,6 +129,10 @@ class LedgerRestTests(APITestCase):
         )
         self.assertEqual(response.status_code, 201, response.data)
         return response.data
+
+
+class LedgerRestTests(LedgerRestFixture):
+    """Ledger APIs are scoped, explicit, normalized, and append-only."""
 
     def test_authentication_is_required_for_every_collection(self):
         """No ledger or balance data is anonymously readable."""
@@ -455,3 +461,268 @@ class LedgerRestTests(APITestCase):
             ).status_code,
             405,
         )
+
+
+class StockReceiptDraftTests(LedgerRestFixture):
+    """General receipt drafts normalize, edit, post, and exclude seed stock."""
+
+    def create_draft(self, **overrides):
+        """Create one draft receipt, returning its response body."""
+        response = self.client.post(
+            self.receipt_url,
+            self.receipt_payload(**overrides),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def line_payload(self, **overrides):
+        """Return one complete line, the only shape the editor ever sends."""
+        line = self.receipt_payload()['lines'][0]
+        line.update(overrides)
+        return line
+
+    def bag_conversion(self):
+        """Return a 20 litre package unit for the fixture's growing media."""
+        return ItemUnitConversion.objects.create(
+            workspace=self.workspace,
+            item=self.item,
+            label='20 litre bag',
+            multiplier=Decimal('20000'),
+        )
+
+    def test_draft_receipt_claims_no_balance_until_posted(self):
+        """A saved draft normalizes for review while moving no stock at all."""
+        created = self.create_draft()
+        self.assertEqual(created['status'], StockReceipt.Status.DRAFT)
+        self.assertEqual(created['lines'][0]['base_quantity'], '2000.000000000')
+        self.assertEqual(created['lines'][0]['base_unit'], UnitCode.MILLILITRE)
+        self.assertEqual(StockLot.objects.count(), 0)
+        self.assertEqual(StockMovement.objects.count(), 0)
+        self.assertEqual(
+            self.client.get(self.balance_url, {'item': self.item.pk}).data,
+            [],
+        )
+
+        posted = self.client.post(
+            f"{self.receipt_url}{created['pk']}/post/",
+            {},
+            format='json',
+        )
+        self.assertEqual(posted.status_code, 200, posted.data)
+        balances = self.client.get(self.balance_url, {'item': self.item.pk})
+        self.assertEqual(len(balances.data), 1)
+        self.assertEqual(balances.data[0]['physical_quantity'], '2000.000000000')
+        self.assertEqual(balances.data[0]['valuation'], '11.5000')
+        self.assertEqual(balances.data[0]['currency_code'], 'NZD')
+
+    def test_draft_lines_are_added_removed_and_replaced_before_posting(self):
+        """Line edits replace the whole set and preserve the submitted order."""
+        created = self.create_draft()
+        submitted = [
+            self.line_payload(quantity='3.000000000'),
+            self.line_payload(
+                quantity='500.000000000',
+                unit_code=UnitCode.MILLILITRE,
+                destination=self.growing.pk,
+            ),
+        ]
+        added = self.client.patch(
+            f"{self.receipt_url}{created['pk']}/",
+            {'lines': submitted},
+            format='json',
+        )
+        self.assertEqual(added.status_code, 200, added.data)
+        self.assertEqual(
+            [line['base_quantity'] for line in added.data['lines']],
+            ['3000.000000000', '500.000000000'],
+        )
+        self.assertEqual(
+            [line['destination'] for line in added.data['lines']],
+            [self.store.pk, self.growing.pk],
+        )
+
+        removed = self.client.patch(
+            f"{self.receipt_url}{created['pk']}/",
+            {'lines': [submitted[1]]},
+            format='json',
+        )
+        self.assertEqual(removed.status_code, 200, removed.data)
+        self.assertEqual(removed.data['lines'][0]['destination'], self.growing.pk)
+        self.assertEqual(
+            StockReceiptLine.objects.filter(receipt_id=created['pk']).count(),
+            1,
+        )
+
+    def test_receipt_lines_normalize_standard_units_and_item_conversions(self):
+        """One controlled unit or one item package unit, never both or neither."""
+        conversion = self.bag_conversion()
+        packaged = self.create_draft(
+            lines=[
+                self.line_payload(
+                    quantity='2.000000000',
+                    unit_code=None,
+                    unit_conversion=conversion.pk,
+                ),
+            ],
+        )
+        self.assertEqual(
+            packaged['lines'][0]['base_quantity'],
+            '40000.000000000',
+        )
+
+        for label, line in (
+            ('both', self.line_payload(unit_conversion=conversion.pk)),
+            ('neither', self.line_payload(unit_code=None)),
+            ('incompatible', self.line_payload(unit_code=UnitCode.GRAM)),
+        ):
+            with self.subTest(units=label):
+                rejected = self.client.post(
+                    self.receipt_url,
+                    self.receipt_payload(lines=[line]),
+                    format='json',
+                )
+                self.assertEqual(rejected.status_code, 400, rejected.data)
+
+    def test_unknown_quantity_lines_move_no_stock_and_zero_is_refused(self):
+        """An unknown packet stays truthful rather than claiming a zero balance."""
+        unknown = self.create_draft(
+            lines=[
+                self.line_payload(
+                    quantity=None,
+                    quantity_certainty='unknown',
+                ),
+            ],
+        )
+        self.assertIsNone(unknown['lines'][0]['base_quantity'])
+
+        for label, line in (
+            ('numbered unknown', self.line_payload(quantity_certainty='unknown')),
+            ('zero exact', self.line_payload(quantity='0.000000000')),
+        ):
+            with self.subTest(quantity=label):
+                rejected = self.client.post(
+                    self.receipt_url,
+                    self.receipt_payload(lines=[line]),
+                    format='json',
+                )
+                self.assertEqual(rejected.status_code, 400, rejected.data)
+                self.assertIn('quantity', rejected.data['lines'][0])
+
+        posted = self.client.post(
+            f"{self.receipt_url}{unknown['pk']}/post/",
+            {},
+            format='json',
+        )
+        self.assertEqual(posted.status_code, 200, posted.data)
+        lot = StockLot.objects.get(receipt_line__receipt_id=unknown['pk'])
+        self.assertIsNone(lot.initial_base_quantity)
+        self.assertEqual(StockMovement.objects.filter(lot=lot).count(), 0)
+        self.assertEqual(posted.data['movement_ids'], [])
+
+    def test_receipt_lines_reject_inactive_items_conversions_and_locations(self):
+        """Retired catalog entries stay visible in history but unselectable."""
+        conversion = self.bag_conversion()
+        cases = (
+            ('item', self.item, self.line_payload()),
+            (
+                'unit_conversion',
+                conversion,
+                self.line_payload(unit_code=None, unit_conversion=conversion.pk),
+            ),
+            ('destination', self.store, self.line_payload()),
+        )
+        for field, record, line in cases:
+            with self.subTest(field=field):
+                type(record).objects.filter(pk=record.pk).update(active=False)
+                rejected = self.client.post(
+                    self.receipt_url,
+                    self.receipt_payload(lines=[line]),
+                    format='json',
+                )
+                type(record).objects.filter(pk=record.pk).update(active=True)
+                self.assertEqual(rejected.status_code, 400, rejected.data)
+                self.assertIn(field, rejected.data['lines'][0])
+
+    def test_posted_receipts_reject_edit_delete_and_repost(self):
+        """Corrections go through reversal rather than rewriting the document."""
+        created, _posted, _lot = self.create_and_post_receipt()
+        detail = f"{self.receipt_url}{created['pk']}/"
+        self.assertEqual(
+            self.client.patch(detail, {'notes': 'Late'}, format='json').status_code,
+            400,
+        )
+        self.assertEqual(self.client.delete(detail).status_code, 400)
+        reposted = self.client.post(f'{detail}post/', {}, format='json')
+        self.assertEqual(reposted.status_code, 400, reposted.data)
+        self.assertIn('status', reposted.data)
+
+        reversed_response = self.client.post(
+            f'{detail}reverse/',
+            {'reason': 'Delivered to the wrong nursery'},
+            format='json',
+        )
+        self.assertEqual(reversed_response.status_code, 200, reversed_response.data)
+        self.assertEqual(
+            reversed_response.data['status'],
+            StockReceipt.Status.REVERSED,
+        )
+
+    def test_general_receipt_lines_reject_seed_and_serialized_items(self):
+        """Seeds and serialized assets keep their own receiving workflows."""
+        seed = InventoryItem.objects.create(
+            workspace=self.workspace,
+            name='API carrot seed',
+            category=InventoryItem.Category.SEED,
+            base_unit=UnitCode.SEED,
+        )
+        tray = InventoryItem.objects.create(
+            workspace=self.workspace,
+            name='API 40 cell tray',
+            category=InventoryItem.Category.TRAY,
+            tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
+            base_unit=UnitCode.EACH,
+        )
+        draft = self.create_draft()
+        for label, item in (('seed', seed), ('serialized', tray)):
+            line = self.line_payload(
+                item=item.pk,
+                unit_code=item.base_unit,
+                quantity='4.000000000',
+            )
+            with self.subTest(item=label, method='post'):
+                rejected = self.client.post(
+                    self.receipt_url,
+                    self.receipt_payload(lines=[line]),
+                    format='json',
+                )
+                self.assertEqual(rejected.status_code, 400, rejected.data)
+                self.assertIn('item', rejected.data['lines'][0])
+            with self.subTest(item=label, method='patch'):
+                rejected = self.client.patch(
+                    f"{self.receipt_url}{draft['pk']}/",
+                    {'lines': [line]},
+                    format='json',
+                )
+                self.assertEqual(rejected.status_code, 400, rejected.data)
+                self.assertIn('item', rejected.data['lines'][0])
+
+    def test_general_drafts_are_flagged_and_filterable_by_seed_packet(self):
+        """The general screen can ask for the drafts it is allowed to edit."""
+        created = self.create_draft()
+        self.assertIs(created['is_seed_packet_draft'], False)
+        listed = self.client.get(
+            self.receipt_url,
+            {'status': 'draft', 'seed_packet': 'false'},
+        )
+        self.assertEqual(
+            [receipt['pk'] for receipt in listed.data],
+            [created['pk']],
+        )
+        self.assertEqual(
+            self.client.get(self.receipt_url, {'seed_packet': 'true'}).data,
+            [],
+        )
+        invalid = self.client.get(self.receipt_url, {'seed_packet': 'maybe'})
+        self.assertEqual(invalid.status_code, 400)
+        self.assertIn('seed_packet', invalid.data)

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -354,3 +354,28 @@ class SeedPacketInventoryWorkflowTests(APITestCase):
             f"/seeds/packet-receipts/{posted['pk']}/",
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_seed_drafts_are_flagged_and_refused_by_the_general_receipt_api(self):
+        """The general receiving screen can neither see nor post a seed draft."""
+        draft = self.create_draft(QuantityCertainty.EXACT, '10')
+        receipt = StockReceipt.objects.get(seed_packet_draft__pk=draft['pk'])
+        detail = f'/inventory/receipts/{receipt.pk}/'
+
+        hidden = self.client.get(
+            '/inventory/receipts/',
+            {'seed_packet': 'false'},
+        )
+        self.assertNotIn(receipt.pk, [entry['pk'] for entry in hidden.data])
+        listed = self.client.get('/inventory/receipts/', {'seed_packet': 'true'})
+        self.assertEqual([entry['pk'] for entry in listed.data], [receipt.pk])
+        self.assertIs(listed.data[0]['is_seed_packet_draft'], True)
+
+        self.assertEqual(
+            self.client.patch(detail, {'notes': 'General edit'}, format='json').status_code,
+            400,
+        )
+        self.assertEqual(self.client.delete(detail).status_code, 400)
+        self.assertEqual(
+            self.client.post(f'{detail}post/', {}, format='json').status_code,
+            400,
+        )


### PR DESCRIPTION
The general receipt API accepted any active item, so a seed-category line would post a lot with no SeedPacket behind it — stock the seed workflow could never see — and a serialized line would bypass the tray receiving path that generates each unit's asset. Both are now refused at the line serializer, which is the only door the general editor knocks on: the seeds and seedtrays apps build their lines directly through the ORM, so their own workflows are untouched.

The receipts list also returned seed packet drafts with nothing to distinguish them, leaving a general screen no way to honour the boundary the PATCH, DELETE, and post actions already enforced. It now carries a derived is_seed_packet_draft flag and a seed_packet query filter, so a caller can ask for exactly the drafts it is allowed to edit.

Covers the receipt draft contract the receiving UI depends on: no balance before posting, line add/remove/replace preserving submitted order, standard-unit and item-conversion normalization, unknown quantities that move no stock, inactive selectors, and posted-receipt immutability.

## Summary by Sourcery

Clarify the separation between general inventory receipts and seed/serialized stock workflows, and tighten the draft receipt contract used by the receiving UI.

New Features:
- Expose an is_seed_packet_draft flag on receipt representations so clients can distinguish and route seed drafts appropriately.
- Add a seed_packet query parameter on the receipts list API to filter drafts by ownership of the seed packet workflow.

Bug Fixes:
- Prevent general receipt lines from creating lots for seed items without seed packets or bypassing serialized tray asset creation by refusing seed-category and serialized items at validation.

Enhancements:
- Enforce stricter normalization and validation rules for draft receipt lines, covering unit conversions, unknown quantities, inactive references, and immutability of posted receipts.
- Expand the receipt queryset to eager-load seed packet draft relations, improving behaviour when filtering and inspecting seed-linked receipts.
- Factor shared ledger test setup into a reusable fixture class and add focused tests around general draft behaviour and seed/serialized workflow separation.

Tests:
- Add comprehensive tests for draft receipt behaviour, including balance neutrality before posting, full-line replacement semantics, unit normalization, handling of unknown quantities, inactive references, reversal-only corrections, and seed/serialized item exclusion.
- Add seeds app tests to verify that seed packet drafts are correctly flagged, filterable via the general receipts API, and protected from general editing and posting.