### PR TITLE
feat(frontend): type the general stock receipt contract

### DIFF
--- a/frontend/js/api/inventory.ts
+++ b/frontend/js/api/inventory.ts
@@ -6,12 +6,16 @@ import {
   InventoryLocation,
   InventoryUnit,
   ItemUnitConversion,
-  ItemUnitConversionCreate
+  ItemUnitConversionCreate,
+  StockReceipt,
+  StockReceiptFilters,
+  StockReceiptWrite
 } from '../types/inventory'
-import { csrfPatch, csrfPost, fetchAsJson } from '../utils'
+import { csrfDelete, csrfPatch, csrfPost, fetchAsJson } from '../utils'
 
 const ITEMS_URL = '/inventory/items/'
 const CONVERSIONS_URL = '/inventory/conversions/'
+const RECEIPTS_URL = '/inventory/receipts/'
 
 function getInventoryBalances(item: number, signal?: AbortSignal): Promise<Array<InventoryBalance>> {
   return fetchAsJson<Array<InventoryBalance>>(`/inventory/balances/?item=${item}`, signal)
@@ -60,14 +64,55 @@ async function setItemUnitConversionActive(pk: number, active: boolean): Promise
   return response.json() as Promise<ItemUnitConversion>
 }
 
+function getStockReceipts(filters: StockReceiptFilters, signal?: AbortSignal): Promise<Array<StockReceipt>> {
+  const params = new URLSearchParams()
+  if (filters.status) params.set('status', filters.status)
+  if (filters.seed_packet !== undefined) params.set('seed_packet', String(filters.seed_packet))
+  const query = params.size ? `?${params.toString()}` : ''
+  return fetchAsJson<Array<StockReceipt>>(`${RECEIPTS_URL}${query}`, signal)
+}
+
+async function createStockReceipt(receipt: StockReceiptWrite): Promise<StockReceipt> {
+  const response = await csrfPost(RECEIPTS_URL, receipt)
+  return response.json() as Promise<StockReceipt>
+}
+
+async function updateStockReceipt(pk: number, receipt: StockReceiptWrite): Promise<StockReceipt> {
+  const response = await csrfPatch(`${RECEIPTS_URL}${pk}/`, receipt)
+  return response.json() as Promise<StockReceipt>
+}
+
+// The action reads no body and there is no revision or availability digest to
+// echo back, unlike postInputApplication: posting a receipt only adds stock, so
+// no third party's view of what is on hand can have gone stale underneath it.
+async function postStockReceipt(pk: number): Promise<StockReceipt> {
+  const response = await csrfPost(`${RECEIPTS_URL}${pk}/post/`, {})
+  return response.json() as Promise<StockReceipt>
+}
+
+async function reverseStockReceipt(pk: number, reason: string): Promise<StockReceipt> {
+  const response = await csrfPost(`${RECEIPTS_URL}${pk}/reverse/`, { reason })
+  return response.json() as Promise<StockReceipt>
+}
+
+function deleteStockReceipt(pk: number): Promise<Response> {
+  return csrfDelete(`${RECEIPTS_URL}${pk}/`)
+}
+
 export {
   createInventoryItem,
   createItemUnitConversion,
+  createStockReceipt,
+  deleteStockReceipt,
   getInventoryBalances,
   getInventoryItems,
   getInventoryLocations,
   getInventoryUnits,
   getItemUnitConversions,
+  getStockReceipts,
+  postStockReceipt,
+  reverseStockReceipt,
   setInventoryItemActive,
-  setItemUnitConversionActive
+  setItemUnitConversionActive,
+  updateStockReceipt
 }

--- a/frontend/js/applications/application_form.tsx
+++ b/frontend/js/applications/application_form.tsx
@@ -59,7 +59,7 @@ function InputApplicationForm({ targets, batch = null, defaultTargetKeys, tray, 
     queryFn: ({ signal }) => getInventoryItems({ active: true }, signal)
   })
   const { data: balances = [] } = useQuery({
-    queryKey: [...queryKeys.inventory.all, 'balances', item],
+    queryKey: queryKeys.inventory.balances(item),
     queryFn: ({ signal }) => getInventoryBalances(Number(item), signal),
     enabled: item !== ''
   })

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -10,7 +10,10 @@ const queryKeys = {
     units: ['inventory', 'units'] as const,
     locations: ['inventory', 'locations'] as const,
     items: (search: string, category: string, trackingMode: string, status: string) => ['inventory', 'items', search, category, trackingMode, status] as const,
-    conversions: (itemPk: number) => ['inventory', 'conversions', itemPk] as const
+    conversions: (itemPk: number) => ['inventory', 'conversions', itemPk] as const,
+    receiptsAll: ['inventory', 'receipts'] as const,
+    receipts: (status: string, seedPacket: string) => ['inventory', 'receipts', status, seedPacket] as const,
+    balances: (itemPk: number | '') => ['inventory', 'balances', itemPk] as const
   },
   garden: {
     all: ['garden'] as const,

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -76,6 +76,7 @@ interface InventoryItem {
   usage_rate_unit_dimension: UnitDimension | null
   default_fixed_quantity: string | null
   stock_history_started_at: string | null
+  reorder_level: string | null
   created: string
   updated: string
 }
@@ -131,7 +132,85 @@ interface InventoryBalance {
   base_unit: UnitCode
   base_unit_cost: string | null
   valuation: string | null
+  currency_code: string
+  expires_on: string | null
   low_stock: boolean
+}
+
+type QuantityCertainty = 'exact' | 'estimated' | 'unknown'
+type StockReceiptStatus = 'draft' | 'posted' | 'reversed'
+
+interface StockReceiptLine {
+  pk: number
+  item: number
+  supplier_lot_reference: string
+  expires_on: string | null
+  // Null only when the certainty is 'unknown'. A missing number is the honest
+  // answer for a sealed sack nobody has weighed; it is not a zero.
+  quantity: string | null
+  quantity_certainty: QuantityCertainty
+  // Exactly one of these is set: a controlled unit or one of the item's own
+  // package units.
+  unit_code: UnitCode | null
+  unit_conversion: number | null
+  base_quantity: string | null
+  base_unit: UnitCode
+  line_cost_ex_tax: string
+  destination: number
+  lot: number | null
+  created: string
+  updated: string
+}
+
+// Every field is present on every write. PATCHing `lines` replaces the whole
+// set server-side, so a partial line would be stored as a whole one.
+interface StockReceiptLineWrite {
+  item: number
+  supplier_lot_reference: string
+  expires_on: string | null
+  quantity: string | null
+  quantity_certainty: QuantityCertainty
+  unit_code: UnitCode | null
+  unit_conversion: number | null
+  line_cost_ex_tax: string
+  destination: number
+}
+
+interface StockReceipt {
+  pk: number
+  supplier: number
+  status: StockReceiptStatus
+  received_date: string
+  supplier_reference: string
+  currency_code: string
+  tax_rate: string
+  tax_recoverable: boolean
+  notes: string
+  created_by: number | null
+  posted_at: string | null
+  reversed_at: string | null
+  is_seed_packet_draft: boolean
+  created: string
+  updated: string
+  lines: Array<StockReceiptLine>
+  movement_ids: Array<number>
+}
+
+interface StockReceiptWrite {
+  supplier: number
+  received_date: string
+  supplier_reference?: string
+  // Omit these two and the server applies the workspace defaults.
+  currency_code?: string
+  tax_rate?: string
+  tax_recoverable?: boolean
+  notes?: string
+  lines: Array<StockReceiptLineWrite>
+}
+
+interface StockReceiptFilters {
+  status?: StockReceiptStatus
+  seed_packet?: boolean
 }
 
 export {
@@ -146,9 +225,16 @@ export {
   InventoryUsageBasis,
   ItemUnitConversion,
   ItemUnitConversionCreate,
+  QuantityCertainty,
   SerializedInventoryUnit,
   SerializedPhysicalState,
   SerializedStockMovement,
+  StockReceipt,
+  StockReceiptFilters,
+  StockReceiptLine,
+  StockReceiptLineWrite,
+  StockReceiptStatus,
+  StockReceiptWrite,
   UnitCode,
   UnitDimension
 }


### PR DESCRIPTION
Adds the read and write shapes for draft receipts and their lines, the six API functions behind them, and the query keys the receiving screen will read and invalidate.

The line write shape carries every field rather than making them optional, because PATCHing `lines` replaces the whole set server-side — a partial line would be stored as a whole one with the omitted fields blanked.

Two existing types were quietly wrong about what the server already sends, and the receiving screen would have inherited both: balances carry currency_code and expires_on, and items carry reorder_level.

The balances key was spelled inline in the application form as [...inventory.all, 'balances', item]; it is now the same key by name, so the two spellings cannot drift apart and leave an invalidation missing.

## Summary by Sourcery

Introduce typed stock receipt contracts and related inventory queries for frontend stock receiving.

New Features:
- Add typed models for stock receipt drafts, lines, statuses, and filters in the inventory type definitions.
- Expose stock receipt CRUD and posting/reversing API helpers in the inventory API client.
- Add React Query keys for inventory receipts and balances to support receiving workflows.

Bug Fixes:
- Align inventory item and balance types with server responses by including reorder_level, currency_code, and expires_on fields.
- Unify the inventory balances query key usage to avoid mismatched cache invalidation.

Enhancements:
- Standardize stock receipt line write shapes to require all fields, matching server-side PATCH semantics.