### PR TITLE
feat(frontend): receive general inventory through a draft editor

### DIFF
--- a/frontend/js/inventory/receipt_editor.tsx
+++ b/frontend/js/inventory/receipt_editor.tsx
@@ -1,0 +1,449 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+
+import { createStockReceipt, getItemUnitConversions, updateStockReceipt } from '../api/inventory'
+import { ApiError, formatMeasure, formatQuantity } from '../utils'
+import { InventoryItem, InventoryLocation, InventoryUnit, QuantityCertainty, StockReceipt, StockReceiptLine, StockReceiptLineWrite, UnitCode } from '../types/inventory'
+import { Supplier } from '../types/suppliers'
+import { queryKeys } from '../query'
+import { documentErrors, invalidateReceipts, lineFieldErrors, localErrorMessage } from './receipt_list'
+
+// The unit and the item conversion are one choice for the operator but two
+// mutually exclusive fields on the wire, so the option value carries which.
+type UnitChoice = `unit:${string}` | `conversion:${number}` | ''
+
+interface ReceiptLineDraft {
+  key: string
+  item: number | ''
+  quantityCertainty: QuantityCertainty
+  // Kept as the operator typed it. Parsing to a number here would reintroduce
+  // the float artifacts the 9-decimal-place string contract exists to avoid.
+  quantity: string
+  unitChoice: UnitChoice
+  supplierLotReference: string
+  expiresOn: string
+  lineCostExTax: string
+  destination: number | ''
+  // The last quantity the server normalized. Null means nobody has checked
+  // this line's arithmetic since it was last touched.
+  baseQuantity: string | null
+  baseUnit: UnitCode | null
+}
+
+function blankLine(key: string): ReceiptLineDraft {
+  return {
+    key,
+    item: '',
+    quantityCertainty: 'exact',
+    quantity: '',
+    unitChoice: '',
+    supplierLotReference: '',
+    expiresOn: '',
+    lineCostExTax: '',
+    destination: '',
+    baseQuantity: null,
+    baseUnit: null
+  }
+}
+
+function hydrateLine(line: StockReceiptLine, key: string): ReceiptLineDraft {
+  return {
+    key,
+    item: line.item,
+    quantityCertainty: line.quantity_certainty,
+    quantity: line.quantity === null ? '' : formatQuantity(line.quantity),
+    unitChoice: line.unit_conversion !== null ? `conversion:${line.unit_conversion}` : line.unit_code !== null ? `unit:${line.unit_code}` : '',
+    supplierLotReference: line.supplier_lot_reference,
+    expiresOn: line.expires_on ?? '',
+    lineCostExTax: line.line_cost_ex_tax,
+    destination: line.destination,
+    baseQuantity: line.base_quantity,
+    baseUnit: line.base_unit
+  }
+}
+
+function linePayload(line: ReceiptLineDraft): StockReceiptLineWrite {
+  const unknown = line.quantityCertainty === 'unknown'
+  const [kind, value] = line.unitChoice.split(':')
+  return {
+    item: Number(line.item),
+    supplier_lot_reference: line.supplierLotReference,
+    expires_on: line.expiresOn === '' ? null : line.expiresOn,
+    quantity: unknown ? null : line.quantity,
+    quantity_certainty: line.quantityCertainty,
+    // Both keys are always sent. The server requires exactly one to be set, and
+    // omitting the unused one would leave a stale value behind on a PATCH.
+    unit_code: kind === 'unit' ? (value as UnitCode) : null,
+    unit_conversion: kind === 'conversion' ? Number(value) : null,
+    line_cost_ex_tax: line.lineCostExTax,
+    destination: Number(line.destination)
+  }
+}
+
+function receivableLocations(locations: Array<InventoryLocation>) {
+  // Seed packet containers are system-managed, and SYSTEM-TRAY-UNKNOWN exists
+  // only so the tray migration had somewhere to put unplaced assets.
+  return locations.filter((location) => location.location_type !== 'seed_packet' && location.code !== 'SYSTEM-TRAY-UNKNOWN')
+}
+
+function receivableItems(items: Array<InventoryItem>) {
+  return items.filter((item) => item.category !== 'seed' && item.tracking_mode !== 'serialized')
+}
+
+interface LineRowProps {
+  line: ReceiptLineDraft
+  index: number
+  items: Array<InventoryItem>
+  locations: Array<InventoryLocation>
+  units: Array<InventoryUnit>
+  errors: Record<string, string>
+  removable: boolean
+  onChange: (key: string, patch: Partial<ReceiptLineDraft>, renormalize?: boolean) => void
+  onRemove: (key: string) => void
+}
+
+function LineRow({ line, index, items, locations, units, errors, removable, onChange, onRemove }: LineRowProps) {
+  const chosenItem = items.find((item) => item.pk === line.item)
+  const { data: conversions = [] } = useQuery({
+    queryKey: queryKeys.inventory.conversions(Number(line.item)),
+    queryFn: ({ signal }) => getItemUnitConversions(Number(line.item), signal),
+    enabled: line.item !== ''
+  })
+
+  // Compatibility is by conversion family, not dimension: seeds and loose
+  // countable things are both counts but cannot be converted between.
+  const family = units.find((unit) => unit.code === chosenItem?.base_unit)?.reference_unit
+  const standardUnits = family === undefined ? [] : units.filter((unit) => unit.reference_unit === family)
+  const packageUnits = conversions.filter((conversion) => conversion.active)
+  const unknown = line.quantityCertainty === 'unknown'
+
+  return (
+    <tr>
+      <td>
+        <Form.Select
+          size="sm"
+          value={line.item}
+          isInvalid={errors.item !== undefined}
+          onChange={(event) => onChange(line.key, { item: event.target.value === '' ? '' : Number(event.target.value), unitChoice: '' }, true)}
+        >
+          <option value="">Select an item</option>
+          {items.map((item) => (
+            <option key={item.pk} value={item.pk}>
+              {item.name} ({item.base_unit})
+            </option>
+          ))}
+        </Form.Select>
+        {errors.item && <Form.Text className="text-danger">{errors.item}</Form.Text>}
+      </td>
+      <td>
+        <Form.Select size="sm" value={line.quantityCertainty} onChange={(event) => onChange(line.key, { quantityCertainty: event.target.value as QuantityCertainty }, true)}>
+          <option value="exact">Exact</option>
+          <option value="estimated">Estimated</option>
+          <option value="unknown">Unknown</option>
+        </Form.Select>
+        <Form.Control
+          size="sm"
+          className="mt-1"
+          value={unknown ? '' : line.quantity}
+          disabled={unknown}
+          inputMode="decimal"
+          placeholder={unknown ? 'Not counted' : 'e.g. 2'}
+          isInvalid={errors.quantity !== undefined}
+          onChange={(event) => onChange(line.key, { quantity: event.target.value }, true)}
+        />
+        {errors.quantity && <Form.Text className="text-danger">{errors.quantity}</Form.Text>}
+      </td>
+      <td>
+        <Form.Select
+          size="sm"
+          value={line.unitChoice}
+          disabled={line.item === ''}
+          isInvalid={errors.unit_code !== undefined || errors.unit_conversion !== undefined}
+          onChange={(event) => onChange(line.key, { unitChoice: event.target.value as UnitChoice }, true)}
+        >
+          <option value="">Select a unit</option>
+          {standardUnits.map((unit) => (
+            <option key={unit.code} value={`unit:${unit.code}`}>
+              {unit.label} ({unit.code})
+            </option>
+          ))}
+          {packageUnits.map((conversion) => (
+            <option key={conversion.pk} value={`conversion:${conversion.pk}`}>
+              {conversion.label} (× {formatQuantity(conversion.multiplier)} {chosenItem?.base_unit})
+            </option>
+          ))}
+        </Form.Select>
+        {(errors.unit_code || errors.unit_conversion) && <Form.Text className="text-danger">{errors.unit_code ?? errors.unit_conversion}</Form.Text>}
+      </td>
+      <td className="small">
+        {unknown ? (
+          <span className="text-muted">Unknown — claims no balance</span>
+        ) : line.baseQuantity !== null ? (
+          formatMeasure(line.baseQuantity, line.baseUnit ?? '')
+        ) : (
+          <span className="text-muted">Save the draft to normalize</span>
+        )}
+      </td>
+      <td>
+        <Form.Select
+          size="sm"
+          value={line.destination}
+          isInvalid={errors.destination !== undefined}
+          onChange={(event) => onChange(line.key, { destination: event.target.value === '' ? '' : Number(event.target.value) })}
+        >
+          <option value="">Select a place</option>
+          {locations.map((location) => (
+            <option key={location.pk} value={location.pk}>
+              {location.name}
+            </option>
+          ))}
+        </Form.Select>
+        {errors.destination && <Form.Text className="text-danger">{errors.destination}</Form.Text>}
+      </td>
+      <td>
+        <Form.Control
+          size="sm"
+          type="number"
+          min="0"
+          step="0.0001"
+          value={line.lineCostExTax}
+          isInvalid={errors.line_cost_ex_tax !== undefined}
+          onChange={(event) => onChange(line.key, { lineCostExTax: event.target.value })}
+        />
+        {errors.line_cost_ex_tax && <Form.Text className="text-danger">{errors.line_cost_ex_tax}</Form.Text>}
+      </td>
+      <td>
+        <Form.Control
+          size="sm"
+          value={line.supplierLotReference}
+          placeholder="Supplier lot"
+          onChange={(event) => onChange(line.key, { supplierLotReference: event.target.value })}
+        />
+        <Form.Control size="sm" className="mt-1" type="date" value={line.expiresOn} onChange={(event) => onChange(line.key, { expiresOn: event.target.value })} />
+      </td>
+      <td>
+        <Button size="sm" variant="outline-danger" disabled={!removable} onClick={() => onRemove(line.key)} aria-label={`Remove line ${index + 1}`}>
+          Remove
+        </Button>
+      </td>
+    </tr>
+  )
+}
+
+interface ReceiptEditorProps {
+  receipt?: StockReceipt
+  items: Array<InventoryItem>
+  locations: Array<InventoryLocation>
+  suppliers: Array<Supplier>
+  units: Array<InventoryUnit>
+  onClosed: () => void
+}
+
+// The parent mounts this with a key derived from which draft is open, so
+// switching drafts re-initialises every field instead of syncing props in an
+// effect.
+function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }: ReceiptEditorProps) {
+  const queryClient = useQueryClient()
+  const nextKey = React.useRef(0)
+
+  function freshKey() {
+    nextKey.current += 1
+    return `new-${nextKey.current}`
+  }
+
+  const [receiptPk, setReceiptPk] = React.useState<number | null>(receipt?.pk ?? null)
+  const [supplier, setSupplier] = React.useState<number | ''>(receipt?.supplier ?? '')
+  const [receivedDate, setReceivedDate] = React.useState(receipt?.received_date ?? new Date().toISOString().slice(0, 10))
+  const [supplierReference, setSupplierReference] = React.useState(receipt?.supplier_reference ?? '')
+  const [currencyCode, setCurrencyCode] = React.useState(receipt?.currency_code ?? '')
+  const [taxRate, setTaxRate] = React.useState(receipt?.tax_rate ?? '')
+  const [taxRecoverable, setTaxRecoverable] = React.useState(receipt?.tax_recoverable ?? true)
+  const [notes, setNotes] = React.useState(receipt?.notes ?? '')
+  const [lines, setLines] = React.useState<Array<ReceiptLineDraft>>(() =>
+    receipt && receipt.lines.length > 0 ? receipt.lines.map((line) => hydrateLine(line, `saved-${line.pk}`)) : [blankLine(freshKey())]
+  )
+  const [error, setError] = React.useState<string>()
+  const [lineErrors, setLineErrors] = React.useState<Array<Record<string, string>>>([])
+  const [saved, setSaved] = React.useState(false)
+
+  const selectableItems = receivableItems(items)
+  const selectableLocations = receivableLocations(locations)
+
+  // Any edit that could change the arithmetic clears the normalization it was
+  // based on. A stale number that still looks like a number is worse than none.
+  function updateLine(key: string, patch: Partial<ReceiptLineDraft>, renormalize = false) {
+    setSaved(false)
+    setLines((current) => current.map((line) => (line.key === key ? { ...line, ...patch, ...(renormalize ? { baseQuantity: null, baseUnit: null } : {}) } : line)))
+  }
+
+  function addLine() {
+    setSaved(false)
+    setLines((current) => [...current, blankLine(freshKey())])
+  }
+
+  function removeLine(key: string) {
+    setSaved(false)
+    setLines((current) => current.filter((line) => line.key !== key))
+  }
+
+  function recordFailure(caught: unknown) {
+    setSaved(false)
+    if (caught instanceof ApiError) {
+      const document = documentErrors(caught.body)
+      setError(document.length > 0 ? document.join(' ') : caught.message)
+      setLineErrors(lineFieldErrors(caught.body))
+      return
+    }
+    setError(localErrorMessage(caught))
+    setLineErrors([])
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      const payload = {
+        supplier: Number(supplier),
+        received_date: receivedDate,
+        supplier_reference: supplierReference,
+        tax_recoverable: taxRecoverable,
+        notes,
+        // Blank means "whatever the workspace says", which the server fills in
+        // and returns, so these inputs populate themselves after the first save.
+        ...(currencyCode.trim() === '' ? {} : { currency_code: currencyCode }),
+        ...(taxRate.trim() === '' ? {} : { tax_rate: taxRate }),
+        lines: lines.map(linePayload)
+      }
+      return receiptPk === null ? createStockReceipt(payload) : updateStockReceipt(receiptPk, payload)
+    },
+    onSuccess: async (response) => {
+      setReceiptPk(response.pk)
+      setCurrencyCode(response.currency_code)
+      setTaxRate(response.tax_rate)
+      // A PATCH deletes and recreates every line, so the returned pks are all
+      // new. Identity is carried positionally instead, which the server
+      // guarantees by creating lines in the order they were submitted.
+      setLines((current) => response.lines.map((line, index) => hydrateLine(line, current[index]?.key ?? `saved-${line.pk}`)))
+      setError(undefined)
+      setLineErrors([])
+      setSaved(true)
+      await invalidateReceipts(queryClient)
+    },
+    onError: recordFailure
+  })
+
+  const complete = lines.every((line) => line.item !== '' && line.destination !== '' && line.unitChoice !== '' && line.lineCostExTax.trim() !== '')
+  const quantified = lines.every((line) => line.quantityCertainty === 'unknown' || line.quantity.trim() !== '')
+  const readyToSave = supplier !== '' && receivedDate !== '' && lines.length > 0 && complete && quantified
+
+  return (
+    <Card className="mb-4">
+      <Card.Body>
+        <Card.Title>{receiptPk === null ? 'Receive inventory' : `Edit draft receipt #${receiptPk}`}</Card.Title>
+        <Row className="g-2">
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="receipt-supplier">
+              <Form.Label>Supplier</Form.Label>
+              <Form.Select value={supplier} onChange={(event) => setSupplier(event.target.value === '' ? '' : Number(event.target.value))}>
+                <option value="">Select a supplier</option>
+                {suppliers.map((entry) => (
+                  <option key={entry.pk} value={entry.pk}>
+                    {entry.name}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Col>
+          <Col md={2}>
+            <Form.Group className="mb-3" controlId="receipt-received-date">
+              <Form.Label>Received</Form.Label>
+              <Form.Control type="date" value={receivedDate} onChange={(event) => setReceivedDate(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="receipt-supplier-reference">
+              <Form.Label>Supplier reference</Form.Label>
+              <Form.Control value={supplierReference} placeholder="Invoice or docket number" onChange={(event) => setSupplierReference(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={2}>
+            <Form.Group className="mb-3" controlId="receipt-currency">
+              <Form.Label>Currency</Form.Label>
+              <Form.Control value={currencyCode} placeholder="Workspace default" onChange={(event) => setCurrencyCode(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={2}>
+            <Form.Group className="mb-3" controlId="receipt-tax-rate">
+              <Form.Label>Tax rate %</Form.Label>
+              <Form.Control value={taxRate} inputMode="decimal" placeholder="Workspace default" onChange={(event) => setTaxRate(event.target.value)} />
+            </Form.Group>
+          </Col>
+        </Row>
+        <Row className="g-2">
+          <Col md={9}>
+            <Form.Group className="mb-3" controlId="receipt-notes">
+              <Form.Label>Notes</Form.Label>
+              <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={3} className="d-flex align-items-center">
+            <Form.Check
+              id="receipt-tax-recoverable"
+              type="checkbox"
+              label="Tax is recoverable"
+              checked={taxRecoverable}
+              onChange={(event) => setTaxRecoverable(event.target.checked)}
+            />
+          </Col>
+        </Row>
+
+        <Table size="sm" responsive>
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th>Quantity</th>
+              <th>Unit</th>
+              <th>Normalizes to</th>
+              <th>Destination</th>
+              <th>Cost ex tax</th>
+              <th>Lot reference and expiry</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((line, index) => (
+              <LineRow
+                key={line.key}
+                line={line}
+                index={index}
+                items={selectableItems}
+                locations={selectableLocations}
+                units={units}
+                errors={lineErrors[index] ?? {}}
+                removable={lines.length > 1}
+                onChange={updateLine}
+                onRemove={removeLine}
+              />
+            ))}
+          </tbody>
+        </Table>
+        <Button size="sm" variant="outline-secondary" className="mb-3" onClick={addLine}>
+          Add a line
+        </Button>
+
+        {error && <Alert variant="danger">{error}</Alert>}
+        {saved && <Alert variant="info">Saved as a draft. Nothing has moved yet — check the normalized quantities, then post it from the list below.</Alert>}
+
+        <div className="d-flex gap-2">
+          <Button disabled={!readyToSave || saveMutation.isPending} onClick={() => saveMutation.mutate()}>
+            {saveMutation.isPending ? 'Saving…' : receiptPk === null ? 'Save draft' : 'Save changes'}
+          </Button>
+          <Button variant="outline-secondary" onClick={onClosed}>
+            Close
+          </Button>
+        </div>
+      </Card.Body>
+    </Card>
+  )
+}
+
+export { ReceiptEditor }

--- a/frontend/js/inventory/receipt_list.tsx
+++ b/frontend/js/inventory/receipt_list.tsx
@@ -1,0 +1,280 @@
+import React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Alert, Badge, Button, Form, Table } from 'react-bootstrap'
+
+import { deleteStockReceipt, postStockReceipt, reverseStockReceipt } from '../api/inventory'
+import { formatMeasure } from '../utils'
+import { InventoryItem, InventoryLocation, StockReceipt, StockReceiptLine } from '../types/inventory'
+import { Supplier } from '../types/suppliers'
+import { queryKeys } from '../query'
+
+const STATUS_VARIANTS: Record<string, string> = {
+  draft: 'secondary',
+  posted: 'success',
+  reversed: 'warning'
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: 'Draft',
+  posted: 'Posted',
+  reversed: 'Reversed'
+}
+
+// One prefix covers receipts, lots, balances, and items: posting a receipt
+// creates a lot and a movement, and the first post of an item also stamps its
+// stock_history_started_at, which the catalog renders. Applications go too,
+// because their cached preview carries an availability digest that a stock
+// change invalidates. Seeds and seed trays deliberately do not: the receipt
+// API now refuses their items outright, so neither cache can have moved.
+function invalidateReceipts(queryClient: ReturnType<typeof useQueryClient>) {
+  return Promise.all([queryClient.invalidateQueries({ queryKey: queryKeys.inventory.all }), queryClient.invalidateQueries({ queryKey: queryKeys.applications.all })])
+}
+
+// Document-level failures come back as {"lines": "Add at least one receipt
+// line."} — one string for the whole document — while field failures come back
+// as one object per submitted line. Telling them apart by shape is what keeps a
+// document error from being rendered against an arbitrary row.
+function documentErrors(body: unknown): Array<string> {
+  if (typeof body !== 'object' || body === null) return []
+  return Object.entries(body as Record<string, unknown>).flatMap(([field, value]) => {
+    if (field === 'lines' && Array.isArray(value)) return []
+    const messages = Array.isArray(value) ? value : [value]
+    return messages.filter((message): message is string => typeof message === 'string')
+  })
+}
+
+// Positional, because the server returns line errors aligned with the lines the
+// client submitted. DRF spells a single message as either a string or a list of
+// one, so both are flattened to the first message.
+function lineFieldErrors(body: unknown): Array<Record<string, string>> {
+  if (typeof body !== 'object' || body === null) return []
+  const lines = (body as Record<string, unknown>).lines
+  if (!Array.isArray(lines)) return []
+  return lines.map((entry) => {
+    if (typeof entry !== 'object' || entry === null) return {}
+    return Object.fromEntries(
+      Object.entries(entry as Record<string, unknown>).map(([field, value]) => {
+        const message = Array.isArray(value) ? value[0] : value
+        return [field, typeof message === 'string' ? message : String(message)]
+      })
+    )
+  })
+}
+
+function localErrorMessage(caught: unknown) {
+  return caught instanceof Error ? caught.message : String(caught)
+}
+
+function ReverseReceiptButton({ receipt }: { receipt: StockReceipt }) {
+  const queryClient = useQueryClient()
+  const [reason, setReason] = React.useState('')
+  const [open, setOpen] = React.useState(false)
+  const [error, setError] = React.useState<string>()
+  const mutation = useMutation({
+    mutationFn: () => reverseStockReceipt(receipt.pk, reason),
+    onSuccess: () => {
+      setOpen(false)
+      setReason('')
+      setError(undefined)
+      return invalidateReceipts(queryClient)
+    },
+    onError: (caught: unknown) => setError(localErrorMessage(caught))
+  })
+
+  if (!open) {
+    return (
+      <Button size="sm" variant="outline-danger" onClick={() => setOpen(true)}>
+        Reverse
+      </Button>
+    )
+  }
+  return (
+    <div className="d-flex flex-column gap-1">
+      <Form.Control size="sm" value={reason} placeholder="Why was this wrong?" onChange={(event) => setReason(event.target.value)} />
+      <div className="d-flex gap-1">
+        <Button size="sm" variant="danger" disabled={!reason.trim() || mutation.isPending} onClick={() => mutation.mutate()}>
+          {mutation.isPending ? 'Reversing…' : 'Confirm'}
+        </Button>
+        <Button size="sm" variant="outline-secondary" onClick={() => setOpen(false)}>
+          Keep
+        </Button>
+      </div>
+      {error && (
+        <Alert className="mb-0 py-1 px-2" variant="danger">
+          {error}
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+interface DraftActionsProps {
+  receipt: StockReceipt
+  onEdit: (pk: number) => void
+  onCancelled: (pk: number) => void
+}
+
+function DraftActions({ receipt, onEdit, onCancelled }: DraftActionsProps) {
+  const queryClient = useQueryClient()
+  const [confirming, setConfirming] = React.useState(false)
+  const [error, setError] = React.useState<string>()
+
+  const postMutation = useMutation({
+    mutationFn: () => postStockReceipt(receipt.pk),
+    onSuccess: () => {
+      setError(undefined)
+      onCancelled(receipt.pk)
+      return invalidateReceipts(queryClient)
+    },
+    onError: (caught: unknown) => setError(localErrorMessage(caught))
+  })
+  const cancelMutation = useMutation({
+    mutationFn: () => deleteStockReceipt(receipt.pk),
+    onSuccess: () => {
+      setConfirming(false)
+      setError(undefined)
+      onCancelled(receipt.pk)
+      return invalidateReceipts(queryClient)
+    },
+    onError: (caught: unknown) => setError(localErrorMessage(caught))
+  })
+  const busy = postMutation.isPending || cancelMutation.isPending
+
+  return (
+    <div className="d-flex flex-column gap-1">
+      <div className="d-flex gap-1">
+        <Button size="sm" variant="outline-secondary" disabled={busy} onClick={() => onEdit(receipt.pk)}>
+          Edit
+        </Button>
+        <Button size="sm" disabled={busy || receipt.lines.length === 0} onClick={() => postMutation.mutate()}>
+          {postMutation.isPending ? 'Posting…' : 'Post receipt'}
+        </Button>
+      </div>
+      {confirming ? (
+        <div className="d-flex gap-1">
+          <Button size="sm" variant="danger" disabled={busy} onClick={() => cancelMutation.mutate()}>
+            {cancelMutation.isPending ? 'Cancelling…' : 'Confirm cancel'}
+          </Button>
+          <Button size="sm" variant="outline-secondary" onClick={() => setConfirming(false)}>
+            Keep draft
+          </Button>
+        </div>
+      ) : (
+        <Button size="sm" variant="outline-danger" disabled={busy} onClick={() => setConfirming(true)}>
+          Cancel draft
+        </Button>
+      )}
+      {error && (
+        <Alert className="mb-0 py-1 px-2" variant="danger">
+          {error}
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+// The base quantity is what the ledger will actually hold, so it is shown
+// beside the operator's own number rather than instead of it. An unknown
+// quantity says so: it will claim no balance at all when this posts.
+function LineQuantity({ line }: { line: StockReceiptLine }) {
+  if (line.quantity_certainty === 'unknown') {
+    return <span className="text-muted">Unknown — claims no balance</span>
+  }
+  return (
+    <>
+      <div>{formatMeasure(line.base_quantity, line.base_unit)}</div>
+      {line.quantity_certainty === 'estimated' && <div className="text-muted small">estimated</div>}
+    </>
+  )
+}
+
+interface ReceiptLinesTableProps {
+  receipt: StockReceipt
+  items: Array<InventoryItem>
+  locations: Array<InventoryLocation>
+}
+
+function ReceiptLinesTable({ receipt, items, locations }: ReceiptLinesTableProps) {
+  if (receipt.lines.length === 0) {
+    return <span className="text-muted">No lines yet.</span>
+  }
+  return (
+    <Table size="sm" className="mb-0">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Quantity</th>
+          <th>Destination</th>
+          <th>Cost</th>
+          <th>Lot</th>
+        </tr>
+      </thead>
+      <tbody>
+        {receipt.lines.map((line) => (
+          <tr key={line.pk}>
+            <td>{items.find((item) => item.pk === line.item)?.name ?? `#${line.item}`}</td>
+            <td>
+              <LineQuantity line={line} />
+            </td>
+            <td>{locations.find((location) => location.pk === line.destination)?.name ?? `#${line.destination}`}</td>
+            <td>
+              {line.line_cost_ex_tax} {receipt.currency_code}
+            </td>
+            <td className="small">{line.lot !== null ? `#${line.lot}` : '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+interface ReceiptTableProps {
+  receipts: Array<StockReceipt>
+  items: Array<InventoryItem>
+  locations: Array<InventoryLocation>
+  suppliers: Array<Supplier>
+  onEdit: (pk: number) => void
+  onCancelled: (pk: number) => void
+}
+
+function ReceiptTable({ receipts, items, locations, suppliers, onEdit, onCancelled }: ReceiptTableProps) {
+  if (receipts.length === 0) {
+    return <p className="text-muted mb-0">No receipts here yet.</p>
+  }
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Received</th>
+          <th>Supplier</th>
+          <th>Reference</th>
+          <th>Status</th>
+          <th>Lines</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {receipts.map((receipt) => (
+          <tr key={receipt.pk} className={receipt.status === 'draft' ? 'table-warning' : undefined}>
+            <td>{receipt.received_date}</td>
+            <td>{suppliers.find((supplier) => supplier.pk === receipt.supplier)?.name ?? `#${receipt.supplier}`}</td>
+            <td>{receipt.supplier_reference || <span className="text-muted">—</span>}</td>
+            <td>
+              <Badge bg={STATUS_VARIANTS[receipt.status]}>{STATUS_LABELS[receipt.status]}</Badge>
+            </td>
+            <td>
+              <ReceiptLinesTable receipt={receipt} items={items} locations={locations} />
+            </td>
+            <td>
+              {receipt.status === 'draft' && <DraftActions receipt={receipt} onEdit={onEdit} onCancelled={onCancelled} />}
+              {receipt.status === 'posted' && <ReverseReceiptButton receipt={receipt} />}
+              {receipt.status === 'reversed' && <span className="text-muted">—</span>}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+export { ReceiptTable, ReverseReceiptButton, documentErrors, invalidateReceipts, lineFieldErrors, localErrorMessage }

--- a/frontend/js/inventory/receipts.tsx
+++ b/frontend/js/inventory/receipts.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Button, Col, Form, Row } from 'react-bootstrap'
+
+import { getInventoryItems, getInventoryLocations, getInventoryUnits, getStockReceipts } from '../api/inventory'
+import { getSuppliers } from '../api/supplies'
+import { queryKeys } from '../query'
+import { StockReceiptStatus } from '../types/inventory'
+import { ReceiptEditor } from './receipt_editor'
+import { ReceiptTable } from './receipt_list'
+
+function InventoryReceiptsView() {
+  const [status, setStatus] = React.useState<StockReceiptStatus>('draft')
+  const [editing, setEditing] = React.useState<number | 'new' | null>(null)
+
+  const { data: units = [] } = useQuery({
+    queryKey: queryKeys.inventory.units,
+    queryFn: ({ signal }) => getInventoryUnits(signal)
+  })
+  const { data: items = [] } = useQuery({
+    queryKey: queryKeys.inventory.items('', '', '', 'active'),
+    queryFn: ({ signal }) => getInventoryItems({ active: true }, signal)
+  })
+  const { data: locations = [] } = useQuery({
+    queryKey: queryKeys.inventory.locations,
+    queryFn: ({ signal }) => getInventoryLocations(signal)
+  })
+  const { data: suppliers = [] } = useQuery({
+    queryKey: queryKeys.suppliers.all,
+    queryFn: ({ signal }) => getSuppliers(signal)
+  })
+  // Seed packet drafts are never this screen's business: they have their own
+  // editor, and the receipt API refuses to post them from here anyway.
+  const { data: receipts = [], isPending } = useQuery({
+    queryKey: queryKeys.inventory.receipts(status, 'false'),
+    queryFn: ({ signal }) => getStockReceipts({ status, seed_packet: false }, signal)
+  })
+
+  const editingReceipt = typeof editing === 'number' ? receipts.find((receipt) => receipt.pk === editing) : undefined
+
+  return (
+    <main className="container py-3">
+      <h1>Receiving</h1>
+      <p>Grow media, fertilizer, labels, packaging, and pots arriving from a supplier. Seed packets and seed trays have their own receiving screens.</p>
+
+      {editing !== null && (
+        <ReceiptEditor key={editing} receipt={editingReceipt} items={items} locations={locations} suppliers={suppliers} units={units} onClosed={() => setEditing(null)} />
+      )}
+
+      <Row className="g-2 mb-3 align-items-end">
+        <Col md={3}>
+          <Form.Group controlId="receipt-filter-status">
+            <Form.Label>Status</Form.Label>
+            <Form.Select
+              value={status}
+              onChange={(event) => {
+                // The editor reads its draft out of this list, so a filter that
+                // no longer contains it would silently turn an edit into a new
+                // receipt. Close it instead.
+                setEditing(null)
+                setStatus(event.target.value as StockReceiptStatus)
+              }}
+            >
+              <option value="draft">Draft</option>
+              <option value="posted">Posted</option>
+              <option value="reversed">Reversed</option>
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Button onClick={() => setEditing('new')} disabled={editing === 'new'}>
+            Receive inventory
+          </Button>
+        </Col>
+      </Row>
+
+      {isPending ? (
+        <div>Loading receipts…</div>
+      ) : (
+        <ReceiptTable
+          receipts={receipts}
+          items={items}
+          locations={locations}
+          suppliers={suppliers}
+          onEdit={(pk) => setEditing(pk)}
+          onCancelled={(pk) => setEditing((current) => (current === pk ? null : current))}
+        />
+      )}
+    </main>
+  )
+}
+
+export { InventoryReceiptsView }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -18,6 +18,7 @@ import { SeedTrayDetails } from './seedtray/seedtray_details.js'
 import { getWorkspace } from './api/workspace.js'
 import { WorkspaceModeRoute, WorkspaceSettings } from './workspace.js'
 import { InventoryCatalog } from './inventory.js'
+import { InventoryReceiptsView } from './inventory/receipts.js'
 import { InputApplicationsView } from './applications/applications.js'
 import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/batches.js'
 import { HarvestsView, YieldReportView } from './plantings/harvests.js'
@@ -83,6 +84,7 @@ function FrontEndPage() {
         <Route path="/plantings/harvests" element={<HarvestsView />} />
         <Route path="/plantings/yield" element={<YieldReportView />} />
         <Route path="/inventory" element={<InventoryCatalog />} />
+        <Route path="/inventory/receipts" element={<InventoryReceiptsView />} />
         <Route path="/applications" element={<InputApplicationsView />} />
         <Route
           path="/settings"

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -16,7 +16,7 @@ function GPTopBar({ workspace }: GPTopBarProps) {
   const seedsActive = pathname === '/seeds' || pathname.startsWith('/seeds/')
   const seedTraysActive = pathname === '/seedtrays' || pathname.startsWith('/seedtrays/')
   const plantingActive = pathname === '/plantings' || pathname.startsWith('/plantings/')
-  const inventoryActive = pathname === '/inventory' || pathname.startsWith('/applications')
+  const inventoryActive = pathname === '/inventory' || pathname.startsWith('/inventory/') || pathname.startsWith('/applications')
 
   return (
     <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
@@ -71,6 +71,9 @@ function GPTopBar({ workspace }: GPTopBarProps) {
           <NavDropdown title="Inventory" active={inventoryActive}>
             <NavDropdown.Item as={NavLink} to="/inventory" end>
               Catalog
+            </NavDropdown.Item>
+            <NavDropdown.Item as={NavLink} to="/inventory/receipts">
+              Receiving
             </NavDropdown.Item>
             <NavDropdown.Item as={NavLink} to="/applications">
               Input applications


### PR DESCRIPTION
Grow media, fertilizer, labels, packaging and pots could be defined in the catalog and consumed by an application, but there was no way to record them arriving. Seed packets and serialized trays already had their own receiving screens; everything else had only the API.

The editor holds an array of lines, which is new here — every other document form in this codebase writes exactly one. Lines carry a client-side key rather than their primary key, because saving replaces the whole set server-side and hands back new pks; identity is carried positionally instead, the same alignment the server uses to report which line an error belongs to.

Saving the draft is what normalizes it: the response gives each line its base quantity, which is shown beside the operator's own number so the figure the ledger will hold can be checked before anything moves. Editing the item, quantity, certainty or unit clears that figure outright, since a stale number that still looks like a number is worse than none.

Units are offered by conversion family rather than dimension, so an each-counted item is not offered seeds, and the item's own package units sit in the same dropdown as the controlled ones.

## Summary by Sourcery

Add a draft-based UI workflow for receiving general inventory items and managing stock receipts in the frontend.

New Features:
- Introduce an inventory receiving screen for non-seed, non-serialized catalog items with multi-line draft editing.
- Add a stock receipt editor that normalizes quantities via server-side draft saves and supports posting or reversing receipts.
- Expose inventory receiving via a new navigation entry and route under the inventory section.

Enhancements:
- Filter available items and locations in the receiving UI to only show receivable items and valid storage locations.
- Align inventory and application query cache invalidation with stock receipt lifecycle events to keep downstream views consistent.