### PR TITLE
Support GST-inclusive receiving prices

### DIFF
--- a/frontend/js/inventory/receipt_editor.tsx
+++ b/frontend/js/inventory/receipt_editor.tsx
@@ -47,7 +47,22 @@ function blankLine(key: string): ReceiptLineDraft {
   }
 }
 
-function hydrateLine(line: StockReceiptLine, key: string): ReceiptLineDraft {
+function displayPrice(lineCostExTax: string, includesTax: boolean, taxRate: string): string {
+  if (!includesTax || taxRate.trim() === '') return lineCostExTax
+  const rate = Number(taxRate)
+  return Number.isFinite(rate) ? (Number(lineCostExTax) * (1 + rate / 100)).toFixed(4) : lineCostExTax
+}
+
+function convertEntryPrice(value: string, fromIncludesTax: boolean, toIncludesTax: boolean, taxRate: string): string {
+  if (value.trim() === '' || fromIncludesTax === toIncludesTax || taxRate.trim() === '') return value
+  const rate = Number(taxRate)
+  if (!Number.isFinite(rate)) return value
+  const factor = 1 + rate / 100
+  const converted = fromIncludesTax ? Number(value) / factor : Number(value) * factor
+  return Number.isFinite(converted) ? converted.toFixed(4) : value
+}
+
+function hydrateLine(line: StockReceiptLine, key: string, includesTax: boolean, taxRate: string): ReceiptLineDraft {
   return {
     key,
     item: line.item,
@@ -56,7 +71,7 @@ function hydrateLine(line: StockReceiptLine, key: string): ReceiptLineDraft {
     unitChoice: line.unit_conversion !== null ? `conversion:${line.unit_conversion}` : line.unit_code !== null ? `unit:${line.unit_code}` : '',
     supplierLotReference: line.supplier_lot_reference,
     expiresOn: line.expires_on ?? '',
-    lineCostExTax: line.line_cost_ex_tax,
+    lineCostExTax: displayPrice(line.line_cost_ex_tax, includesTax, taxRate),
     destination: line.destination,
     baseQuantity: line.base_quantity,
     baseUnit: line.base_unit
@@ -258,10 +273,11 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
   const [supplierReference, setSupplierReference] = React.useState(receipt?.supplier_reference ?? '')
   const [currencyCode, setCurrencyCode] = React.useState(receipt?.currency_code ?? '')
   const [taxRate, setTaxRate] = React.useState(receipt?.tax_rate ?? '')
+  const [priceIncludesTax, setPriceIncludesTax] = React.useState(receipt?.price_includes_tax ?? false)
   const [taxRecoverable, setTaxRecoverable] = React.useState(receipt?.tax_recoverable ?? true)
   const [notes, setNotes] = React.useState(receipt?.notes ?? '')
   const [lines, setLines] = React.useState<Array<ReceiptLineDraft>>(() =>
-    receipt && receipt.lines.length > 0 ? receipt.lines.map((line) => hydrateLine(line, `saved-${line.pk}`)) : [blankLine(freshKey())]
+    receipt && receipt.lines.length > 0 ? receipt.lines.map((line) => hydrateLine(line, `saved-${line.pk}`, receipt.price_includes_tax, receipt.tax_rate)) : [blankLine(freshKey())]
   )
   const [error, setError] = React.useState<string>()
   const [lineErrors, setLineErrors] = React.useState<Array<Record<string, string>>>([])
@@ -306,6 +322,7 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
         received_date: receivedDate,
         supplier_reference: supplierReference,
         tax_recoverable: taxRecoverable,
+        price_includes_tax: priceIncludesTax,
         notes,
         // Blank means "whatever the workspace says", which the server fills in
         // and returns, so these inputs populate themselves after the first save.
@@ -319,10 +336,11 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
       setReceiptPk(response.pk)
       setCurrencyCode(response.currency_code)
       setTaxRate(response.tax_rate)
+      setPriceIncludesTax(response.price_includes_tax)
       // A PATCH deletes and recreates every line, so the returned pks are all
       // new. Identity is carried positionally instead, which the server
       // guarantees by creating lines in the order they were submitted.
-      setLines((current) => response.lines.map((line, index) => hydrateLine(line, current[index]?.key ?? `saved-${line.pk}`)))
+      setLines((current) => response.lines.map((line, index) => hydrateLine(line, current[index]?.key ?? `saved-${line.pk}`, response.price_includes_tax, response.tax_rate)))
       setError(undefined)
       setLineErrors([])
       setSaved(true)
@@ -340,7 +358,7 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
       <Card.Body>
         <Card.Title>{receiptPk === null ? 'Receive inventory' : `Edit draft receipt #${receiptPk}`}</Card.Title>
         <Row className="g-2">
-          <Col md={3}>
+          <Col md={2}>
             <Form.Group className="mb-3" controlId="receipt-supplier">
               <Form.Label>Supplier</Form.Label>
               <Form.Select value={supplier} onChange={(event) => setSupplier(event.target.value === '' ? '' : Number(event.target.value))}>
@@ -359,7 +377,7 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
               <Form.Control type="date" value={receivedDate} onChange={(event) => setReceivedDate(event.target.value)} />
             </Form.Group>
           </Col>
-          <Col md={3}>
+          <Col md={2}>
             <Form.Group className="mb-3" controlId="receipt-supplier-reference">
               <Form.Label>Supplier reference</Form.Label>
               <Form.Control value={supplierReference} placeholder="Invoice or docket number" onChange={(event) => setSupplierReference(event.target.value)} />
@@ -375,6 +393,27 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
             <Form.Group className="mb-3" controlId="receipt-tax-rate">
               <Form.Label>Tax rate %</Form.Label>
               <Form.Control value={taxRate} inputMode="decimal" placeholder="Workspace default" onChange={(event) => setTaxRate(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={2}>
+            <Form.Group className="mb-3" controlId="receipt-price-basis">
+              <Form.Label>Prices</Form.Label>
+              <Form.Select
+                value={priceIncludesTax ? 'inclusive' : 'exclusive'}
+                onChange={(event) => {
+                  const nextIncludesTax = event.target.value === 'inclusive'
+                  setLines((current) =>
+                    current.map((line) => ({
+                      ...line,
+                      lineCostExTax: convertEntryPrice(line.lineCostExTax, priceIncludesTax, nextIncludesTax, taxRate)
+                    }))
+                  )
+                  setPriceIncludesTax(nextIncludesTax)
+                }}
+              >
+                <option value="exclusive">Ex GST</option>
+                <option value="inclusive">Inc GST</option>
+              </Form.Select>
             </Form.Group>
           </Col>
         </Row>
@@ -404,7 +443,7 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
               <th>Unit</th>
               <th>Normalizes to</th>
               <th>Destination</th>
-              <th>Cost ex tax</th>
+              <th>{priceIncludesTax ? 'Price inc GST' : 'Price ex GST'}</th>
               <th>Lot reference and expiry</th>
               <th />
             </tr>

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -184,6 +184,7 @@ interface StockReceipt {
   supplier_reference: string
   currency_code: string
   tax_rate: string
+  price_includes_tax: boolean
   tax_recoverable: boolean
   notes: string
   created_by: number | null
@@ -203,6 +204,7 @@ interface StockReceiptWrite {
   // Omit these two and the server applies the workspace defaults.
   currency_code?: string
   tax_rate?: string
+  price_includes_tax?: boolean
   tax_recoverable?: boolean
   notes?: string
   lines: Array<StockReceiptLineWrite>

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=too-many-lines
 
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
@@ -210,6 +210,7 @@ class StockReceiptSerializer(
             'supplier_reference',
             'currency_code',
             'tax_rate',
+            'price_includes_tax',
             'tax_recoverable',
             'notes',
             'created_by',
@@ -268,6 +269,7 @@ class StockReceiptSerializer(
     def create(self, validated_data):
         """Create a draft and its normalized nested lines atomically."""
         lines = validated_data.pop('lines', [])
+        lines = self._canonical_lines(validated_data, lines)
         receipt = StockReceipt.objects.create(**validated_data)
         for line in lines:
             StockReceiptLine.objects.create(receipt=receipt, **line)
@@ -277,12 +279,37 @@ class StockReceiptSerializer(
     def update(self, instance, validated_data):
         """Update a draft, replacing nested lines only when supplied."""
         lines = validated_data.pop('lines', None)
+        if lines is not None:
+            lines = self._canonical_lines(
+                {
+                    **validated_data,
+                    'price_includes_tax': validated_data.get(
+                        'price_includes_tax',
+                        instance.price_includes_tax,
+                    ),
+                    'tax_rate': validated_data.get('tax_rate', instance.tax_rate),
+                },
+                lines,
+            )
         instance = super().update(instance, validated_data)
         if lines is not None:
             instance.lines.all().delete()
             for line in lines:
                 StockReceiptLine.objects.create(receipt=instance, **line)
         return instance
+
+    @staticmethod
+    def _canonical_lines(receipt_data, lines):
+        """Store line costs ex tax regardless of how the supplier quoted them."""
+        if not receipt_data.get('price_includes_tax', False):
+            return lines
+        rate = receipt_data.get('tax_rate', Decimal('0'))
+        divisor = Decimal('1') + rate / Decimal('100')
+        for line in lines:
+            line['line_cost_ex_tax'] = (
+                line['line_cost_ex_tax'] / divisor
+            ).quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)
+        return lines
 
 
 class StockLotSerializer(serializers.ModelSerializer):

--- a/inventory/migrations/0006_stockreceipt_price_includes_tax.py
+++ b/inventory/migrations/0006_stockreceipt_price_includes_tax.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0005_normalize_cell_volume_usage'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='price_includes_tax',
+            field=models.BooleanField(
+                default=False,
+                help_text='Whether entered receipt prices include the receipt tax rate.',
+            ),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -465,6 +465,10 @@ class StockReceipt(WorkspaceOwnedModel):
             MaxValueValidator(Decimal('100')),
         ),
     )
+    price_includes_tax = models.BooleanField(
+        default=False,
+        help_text='Whether entered receipt prices include the receipt tax rate.',
+    )
     tax_recoverable = models.BooleanField(default=True)
     notes = models.TextField(blank=True, default='')
     created_by = models.ForeignKey(

--- a/inventory/test_ledger_rest.py
+++ b/inventory/test_ledger_rest.py
@@ -222,6 +222,32 @@ class LedgerRestTests(LedgerRestFixture):
             2,
         )
 
+    def test_inclusive_prices_are_stored_exclusive_and_keep_gross_cost(self):
+        """Inclusive supplier prices convert before canonical ledger storage."""
+        response = self.client.post(
+            self.receipt_url,
+            self.receipt_payload(
+                price_includes_tax=True,
+                lines=[{
+                    **self.receipt_payload()['lines'][0],
+                    'line_cost_ex_tax': '11.5000',
+                }],
+            ),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertTrue(response.data['price_includes_tax'])
+        self.assertEqual(response.data['lines'][0]['line_cost_ex_tax'], '10.0000')
+
+        posted = self.client.post(
+            f"{self.receipt_url}{response.data['pk']}/post/",
+            {},
+            format='json',
+        )
+        self.assertEqual(posted.status_code, 200, posted.data)
+        lot = StockLot.objects.get(receipt_line__receipt_id=response.data['pk'])
+        self.assertEqual(lot.acquisition_total, Decimal('11.5000'))
+
     def test_draft_lines_can_be_replaced_and_invalid_selectors_are_rejected(self):
         """PATCH replaces draft lines without permitting foreign workspace IDs."""
         created = self.client.post(


### PR DESCRIPTION
Allow receiving operators to enter supplier line prices either including or excluding GST. Persist the selected mode and convert inclusive values to the canonical ex-tax ledger amount so stock valuation and tax treatment remain accurate.

## Summary by Sourcery

Allow stock receipt prices to be entered as GST-inclusive while still storing canonical ex-tax line costs in the ledger.

New Features:
- Add a per-receipt flag to indicate whether entered prices include the configured tax rate and expose it in the receipt editor UI.
- Let users toggle between GST-inclusive and GST-exclusive price entry, converting existing line prices accordingly in the frontend.

Enhancements:
- Normalize receipt line costs to tax-exclusive amounts on the backend when prices are entered inclusive of tax to keep stock valuation consistent.

Tests:
- Add coverage to ensure GST-inclusive receipt prices are converted to ex-tax values while preserving gross acquisition totals.