### PR TITLE
feat(seedtrays): backfill legacy tray generations

### DIFF
--- a/seedtrays/migrations/0006_backfill_legacy_generations.py
+++ b/seedtrays/migrations/0006_backfill_legacy_generations.py
@@ -1,0 +1,102 @@
+"""Group each tray's existing sowings into one generation flagged for review.
+
+Nothing here is inferred. A tray that already carries sowings gets exactly one
+deterministic ``LEGACY-TRAY-<id>-1`` generation so the tray is usable again, and
+that generation is flagged ``needs_review`` because the records cannot say
+whether those sowings really were one fill: a tray emptied and re-sown before
+this feature existed left no trace of the boundary.
+
+Posted input applications are deliberately left alone. Their targets keep a NULL
+generation, which reads as "unknown" rather than as an attribution to this fill,
+because assigning historical media to a generation the migration invented is the
+one thing the task forbids.
+"""
+
+from django.db import migrations
+
+
+REVIEW_STATE = 'needs_review'
+MIGRATION_REASON = 'Migrated from sowings recorded before tray generations existed.'
+
+
+def _review_details(tray_id, sowings, orphan_target_count):
+    """Describe what an operator has to confirm before this fill can be used."""
+    notes = [
+        f'{len(sowings)} sowing(s) recorded before tray generations existed were '
+        f'grouped into one fill of tray #{tray_id}. Confirm they went into the '
+        'same media, and split them if the tray was emptied between them.',
+    ]
+    if orphan_target_count:
+        notes.append(
+            f'{orphan_target_count} posted input-application target(s) name cells '
+            f'of tray #{tray_id} with no recorded generation. Their media is not '
+            'attributed to this fill and no cost has been assigned to these '
+            'seedlings; reconcile them explicitly if that media belongs here.'
+        )
+    return '\n'.join(notes)
+
+
+def create_legacy_generations(apps, _schema_editor):
+    """Give every tray with existing sowings one reviewable open generation."""
+    generation_model = apps.get_model('seedtrays', 'SeedTrayGeneration')
+    event_model = apps.get_model('seedtrays', 'SeedTrayGenerationEvent')
+    sowing_model = apps.get_model('plantings', 'SeedTrayPlanting')
+    target_model = apps.get_model('applications', 'InputApplicationTarget')
+
+    tray_ids = sowing_model.objects.filter(
+        seed_tray__isnull=False,
+        generation__isnull=True,
+    ).values_list('seed_tray_id', flat=True).distinct().order_by('seed_tray_id')
+
+    for tray_id in list(tray_ids):
+        sowings = list(
+            sowing_model.objects
+            .filter(seed_tray_id=tray_id, generation__isnull=True)
+            .order_by('planted', 'pk')
+        )
+        orphan_target_count = target_model.objects.filter(
+            seed_tray_cell__tray_id=tray_id,
+            seed_tray_generation__isnull=True,
+        ).count()
+        generation, created = generation_model.objects.get_or_create(
+            workspace_id=sowings[0].workspace_id,
+            code=f'LEGACY-TRAY-{tray_id}-1',
+            defaults={
+                'tray_id': tray_id,
+                'sequence': 1,
+                'status': 'open',
+                'origin': 'legacy',
+                'review_state': REVIEW_STATE,
+                'review_details': _review_details(
+                    tray_id,
+                    sowings,
+                    orphan_target_count,
+                ),
+                'opened_at': sowings[0].planted,
+                'notes': '',
+            },
+        )
+        if created:
+            event_model.objects.create(
+                generation=generation,
+                event_type='opened',
+                occurred_at=generation.opened_at,
+                reason=MIGRATION_REASON,
+            )
+        sowing_model.objects.filter(
+            pk__in=[sowing.pk for sowing in sowings],
+        ).update(generation=generation)
+
+
+class Migration(migrations.Migration):
+    """Backfill legacy generations once every linking column exists."""
+
+    dependencies = [
+        ('seedtrays', '0005_seedtraygeneration_seedtraygenerationevent_and_more'),
+        ('plantings', '0025_seedtrayplanting_generation_and_more'),
+        ('applications', '0002_inputapplicationtarget_seed_tray_generation_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_legacy_generations, migrations.RunPython.noop),
+    ]

--- a/seedtrays/test_migrations.py
+++ b/seedtrays/test_migrations.py
@@ -1,0 +1,193 @@
+"""Tests for seed-tray data migrations.
+
+The backfill is replayed over real rows rather than asserted from the migration
+source, because what matters is the shape of the data an existing deployment
+ends up with: which sowings are grouped, what is flagged, and — most of all —
+what the migration refuses to guess.
+"""
+# pylint: disable=duplicate-code
+
+from django.conf import settings
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+from applications.models import InputApplicationTarget
+from plantings.models import SeedTrayPlanting
+from tests.factories import (
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_planting,
+)
+from workspaces.models import Workspace
+
+from .models import SeedTrayGeneration, SeedTrayGenerationEvent
+
+
+def latest_seedtrays_state():
+    """Return the newest migration state for the seedtrays app.
+
+    Resolved from the graph rather than pinned by name, so a later migration
+    cannot leave the database half-migrated for the rest of the run.
+    """
+    executor = MigrationExecutor(connection)
+    executor.loader.build_graph()
+    return list(executor.loader.graph.leaf_nodes('seedtrays'))
+
+
+class LegacyGenerationBackfillTests(TransactionTestCase):
+    """Existing trays become usable without inventing what was not recorded."""
+
+    UNLINKED_STATE = [('seedtrays', '0005_seedtraygeneration_seedtraygenerationevent_and_more')]
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(self._migrate, latest_seedtrays_state())
+
+    @staticmethod
+    def _migrate(targets):
+        """Move the test database to one explicit migration state."""
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        executor.migrate(targets)
+
+    @staticmethod
+    def _unlink_generations():
+        """Return the database to its pre-generation shape, keeping the sowings."""
+        with connection.cursor() as cursor:
+            cursor.execute('UPDATE plantings_seedtrayplanting SET generation_id = NULL')
+            cursor.execute('DELETE FROM seedtrays_seedtraygenerationevent')
+            cursor.execute('DELETE FROM seedtrays_seedtraygeneration')
+
+    def _run_backfill(self):
+        """Strip the generation links, then replay the backfill over them."""
+        self._migrate(self.UNLINKED_STATE)
+        self._unlink_generations()
+        self._migrate(latest_seedtrays_state())
+
+    def test_a_tray_with_sowings_gets_one_reviewable_generation(self):
+        """Every existing sowing on a tray is grouped into one flagged fill."""
+        tray = make_seed_tray()
+        earlier = make_seed_tray_planting(seed_tray=tray)
+        later = make_seed_tray_planting(seed_tray=tray)
+        SeedTrayPlanting.objects.filter(pk=earlier.pk).update(
+            planted='2026-03-01T08:00:00Z',
+        )
+        SeedTrayPlanting.objects.filter(pk=later.pk).update(
+            planted='2026-04-01T08:00:00Z',
+        )
+
+        self._run_backfill()
+
+        generation = SeedTrayGeneration.objects.get(tray=tray)
+        self.assertEqual(generation.code, f'LEGACY-TRAY-{tray.pk}-1')
+        self.assertEqual(generation.sequence, 1)
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.OPEN)
+        self.assertEqual(generation.origin, SeedTrayGeneration.Origin.LEGACY)
+        self.assertEqual(
+            generation.review_state,
+            SeedTrayGeneration.ReviewState.NEEDS_REVIEW,
+        )
+        self.assertEqual(generation.workspace_id, earlier.workspace_id)
+        self.assertIsNone(generation.created_by)
+        earlier.refresh_from_db()
+        later.refresh_from_db()
+        self.assertEqual(earlier.generation_id, generation.pk)
+        self.assertEqual(later.generation_id, generation.pk)
+
+    def test_the_fill_opens_when_its_earliest_sowing_was_recorded(self):
+        """No date is invented; the first sowing is the earliest defensible one."""
+        tray = make_seed_tray()
+        first = make_seed_tray_planting(seed_tray=tray)
+        make_seed_tray_planting(seed_tray=tray)
+        SeedTrayPlanting.objects.filter(pk=first.pk).update(
+            planted='2026-02-02T09:30:00Z',
+        )
+
+        self._run_backfill()
+
+        generation = SeedTrayGeneration.objects.get(tray=tray)
+        first.refresh_from_db()
+        self.assertEqual(generation.opened_at, first.planted)
+
+    def test_the_review_note_says_what_an_operator_has_to_confirm(self):
+        """A bare flag would not tell anybody which decision is outstanding."""
+        tray = make_seed_tray()
+        make_seed_tray_planting(seed_tray=tray)
+
+        self._run_backfill()
+
+        generation = SeedTrayGeneration.objects.get(tray=tray)
+        self.assertIn('grouped into one fill', generation.review_details)
+        self.assertIn(f'tray #{tray.pk}', generation.review_details)
+
+    def test_historical_media_is_never_attributed_to_the_new_fill(self):
+        """An application recorded before generations keeps an unknown one."""
+        tray = make_seed_tray()
+        cell = make_seed_tray_cell(tray=tray)
+        make_seed_tray_planting(seed_tray=tray)
+        target = InputApplicationTarget.objects.filter(seed_tray_cell=cell)
+
+        self._run_backfill()
+
+        self.assertFalse(target.filter(seed_tray_generation__isnull=False).exists())
+
+    def test_a_tray_with_no_sowings_gets_no_generation(self):
+        """An unused tray has had no fill, and the migration does not claim one."""
+        tray = make_seed_tray()
+
+        self._run_backfill()
+
+        self.assertFalse(SeedTrayGeneration.objects.filter(tray=tray).exists())
+
+    def test_the_backfill_records_why_the_generation_exists(self):
+        """The opening event names the migration rather than an operator."""
+        tray = make_seed_tray()
+        make_seed_tray_planting(seed_tray=tray)
+
+        self._run_backfill()
+
+        event = SeedTrayGenerationEvent.objects.get(generation__tray=tray)
+        self.assertEqual(event.event_type, SeedTrayGenerationEvent.EventType.OPENED)
+        self.assertIn('before tray generations existed', event.reason)
+        self.assertIsNone(event.created_by)
+
+    def test_sowings_without_a_tray_are_left_alone(self):
+        """A sowing that names no tray has no fill to belong to."""
+        trayless = make_seed_tray_planting()
+        SeedTrayPlanting.objects.filter(pk=trayless.pk).update(seed_tray=None)
+
+        self._run_backfill()
+
+        trayless.refresh_from_db()
+        self.assertIsNone(trayless.generation_id)
+
+    def test_replaying_the_backfill_changes_nothing(self):
+        """Re-running a deployment migration must not open a second fill.
+
+        The links are left in place this time, which is what a real re-run sees.
+        A second generation here would be a live tray silently split in two.
+        """
+        tray = make_seed_tray()
+        make_seed_tray_planting(seed_tray=tray)
+        self._run_backfill()
+        generation = SeedTrayGeneration.objects.get(tray=tray)
+
+        self._migrate(self.UNLINKED_STATE)
+        self._migrate(latest_seedtrays_state())
+
+        self.assertEqual(SeedTrayGeneration.objects.filter(tray=tray).count(), 1)
+        self.assertEqual(SeedTrayGeneration.objects.get(tray=tray).pk, generation.pk)
+        self.assertEqual(
+            SeedTrayGenerationEvent.objects.filter(generation=generation).count(),
+            1,
+        )


### PR DESCRIPTION
An existing tray already carries sowings, and until they belong to a fill the tray cannot be cleaned or reused through the new workflow. Each tray with sowings gets exactly one deterministic LEGACY-TRAY-<id>-1 generation opened at its earliest sowing, following the LEGACY-* batch backfill.

It is flagged needs_review because the records genuinely cannot say whether those sowings were one fill: a tray emptied and re-sown before this feature existed left no trace of the boundary. The flag carries the note explaining which decision is outstanding, since a bare state would not tell an operator what to check.

Posted applications are left alone. Their targets keep a null generation, which reads as unknown rather than as an attribution to a fill this migration invented, and the review note says how many of them name cells of the tray so the operator knows what is unaccounted for.

## Summary by Sourcery

Backfill legacy seed tray generations so existing trays with sowings gain a single reviewable open generation without attributing historical media to invented fills.

New Features:
- Introduce a data migration that creates deterministic LEGACY-TRAY-<id>-1 generations for trays with existing sowings, flagged for operator review.

Enhancements:
- Record migration-origin opening events explaining why each legacy generation exists and what needs operator confirmation.

Tests:
- Add transactional migration tests that replay the backfill over real data to verify generation creation, review details, handling of trays without sowings or trayless sowings, preservation of historical applications, and idempotent re-runs.