### PR TITLE
feat(seedtrays): attribute sowings and applications to generations

### DIFF
--- a/applications/rest.py
+++ b/applications/rest.py
@@ -109,6 +109,7 @@ class InputApplicationTargetSerializer(serializers.ModelSerializer):
             'target',
             'label',
             'weight',
+            'seed_tray_generation',
             'cell_volume_ml',
             'area_m2',
         ]

--- a/applications/services.py
+++ b/applications/services.py
@@ -35,7 +35,8 @@ from inventory.models import InventoryItem, StockMovement
 from plantings.batches import batch_specific_plants, lock_batch
 from plantings.lifecycle import is_final, lifecycle_summaries
 from plantings.models import ProductionBatch, SpecificPlant
-from seedtrays.models import SeedTrayCell
+from seedtrays.generations import require_open_generation
+from seedtrays.models import SeedTrayCell, SeedTrayGeneration
 
 from .models import InputApplication, InputApplicationLine, InputApplicationTarget
 from .usage import TargetInput, UsageInputs, calculate_usage, workspace_override_required
@@ -97,6 +98,7 @@ class TargetSnapshot(NamedTuple):
     cell_volume_ml: object = None
     area_m2: object = None
     label: str = ''
+    seed_tray_generation: object = None
 
     def as_usage_input(self):
         """Return the pure-calculation view of this target."""
@@ -135,7 +137,13 @@ def measure_target(request):
             raise ValidationError({
                 'targets': f'Tray model {target.tray.model} has no recorded cell volume.',
             })
-        return snapshot._replace(cell_volume_ml=volume)
+        # The cell says where this went; the generation says which crop was
+        # using it. Both are frozen here, because a tray cleaned afterwards
+        # would otherwise leave this document pointing at the next crop's fill.
+        return snapshot._replace(
+            cell_volume_ml=volume,
+            seed_tray_generation=require_open_generation(target.tray, field='targets'),
+        )
     if request.target_type in {
         TargetType.GARDEN_AREA,
         TargetType.GARDEN_BED,
@@ -160,6 +168,7 @@ def stored_snapshot(row):
         cell_volume_ml=row.cell_volume_ml,
         area_m2=row.area_m2,
         label=row.label,
+        seed_tray_generation=row.seed_tray_generation,
     )
 
 
@@ -247,6 +256,28 @@ def _validate_plants(application, plant_ids):
             'targets': (
                 f'These plants did not come from batch '
                 f'{application.batch.code}: {missing}.'
+            ),
+        })
+
+
+def _validate_generations(application):
+    """Refuse a draft whose tray was cleaned while it sat unposted.
+
+    The generation was frozen when the draft was built. Posting against a fill
+    that has since been emptied would charge this media to a crop that is no
+    longer in the tray, so the document has to be rebuilt against the new fill.
+    """
+    closed = sorted(
+        SeedTrayGeneration.objects.filter(
+            application_targets__line__application=application,
+            status=SeedTrayGeneration.Status.CLOSED,
+        ).values_list('code', flat=True).distinct()
+    )
+    if closed:
+        raise ValidationError({
+            'targets': (
+                f'These tray generations have been cleaned since this draft was '
+                f'built: {", ".join(closed)}. Rebuild it against the current fill.'
             ),
         })
 
@@ -464,6 +495,7 @@ def _create_line(application, request):
             cell_volume_ml=snapshot.cell_volume_ml,
             area_m2=snapshot.area_m2,
             label=snapshot.label,
+            seed_tray_generation=snapshot.seed_tray_generation,
             **{snapshot.target_type: snapshot.target},
         )
     return line
@@ -503,6 +535,7 @@ def post_application(application, user, revision=None, digest=None):
 
     _validate_batch(batch, application.applied_at)
     _validate_plants(application, plant_ids)
+    _validate_generations(application)
     _require_current(application, lines, revision, digest)
 
     movements = []

--- a/applications/test_rest.py
+++ b/applications/test_rest.py
@@ -15,6 +15,7 @@ from tests.factories import (
     make_inventory_location,
     make_seed_tray,
     make_seed_tray_cell,
+    make_seed_tray_generation,
     make_seed_tray_model,
     make_stock_lot,
 )
@@ -39,6 +40,7 @@ class ApplicationRESTTestCase(RESTContractTestCase):
         self.lot = make_stock_lot(item=self.media, location=self.location, quantity='50')
         model = make_seed_tray_model(cell_size_ml=40, x_cells=24, y_cells=1)
         self.tray = make_seed_tray(model=model)
+        self.generation = make_seed_tray_generation(tray=self.tray)
         self.cells = [
             make_seed_tray_cell(tray=self.tray, x_position=index)
             for index in range(24)

--- a/applications/test_services.py
+++ b/applications/test_services.py
@@ -14,6 +14,8 @@ from inventory.models import InventoryItem, StockMovement
 from inventory.units import UnitCode
 from plantings.lifecycle import EventType, OutcomeRequest, record_bulk_outcome
 from plantings.models import ProductionBatch
+from seedtrays.generations import open_generation_for
+from seedtrays.models import SeedTrayGeneration
 from tests.factories import (
     make_garden_bed,
     make_garden_geometry_confirmation,
@@ -24,6 +26,7 @@ from tests.factories import (
     make_seed_tray,
     make_seed_tray_cell,
     make_seed_tray_cell_planting,
+    make_seed_tray_generation,
     make_seed_tray_model,
     make_specific_plant,
     make_stock_lot,
@@ -83,9 +86,14 @@ class ApplicationServiceMixin:
         return LineRequest(**values)
 
     def tray_cells(self, count=24, cell_size_ml=40):
-        """Create one tray and `count` cells of a known volume."""
+        """Create one filled tray and `count` cells of a known volume.
+
+        The tray is filled because media goes into a fill, not into bare cells;
+        an unfilled tray is refused, which `GenerationTargetTests` covers.
+        """
         model = make_seed_tray_model(cell_size_ml=cell_size_ml, x_cells=count, y_cells=1)
         tray = make_seed_tray(model=model)
+        make_seed_tray_generation(tray=tray)
         return [make_seed_tray_cell(tray=tray, x_position=index) for index in range(count)]
 
     def cell_targets(self, cells):
@@ -564,3 +572,96 @@ class ApplicationStateTests(ApplicationServiceMixin, TestCase):
             digest=state['availability_digest'],
         )
         self.assertEqual(application.status, InputApplication.Status.POSTED)
+
+
+class GenerationTargetTests(ApplicationServiceMixin, TestCase):
+    """Media applied to a cell is attributed to the fill using that cell."""
+
+    def test_a_cell_target_records_the_fill_it_went_into(self):
+        """The cell says where; the generation says which crop was there."""
+        cells = self.tray_cells()
+        generation = open_generation_for(cells[0].tray)
+
+        application = self.draft([self.media_line(self.cell_targets(cells))])
+
+        targets = application.lines.get().targets.all()
+        self.assertTrue(targets)
+        for target in targets:
+            with self.subTest(target=target.pk):
+                self.assertEqual(target.seed_tray_generation_id, generation.pk)
+
+    def test_an_unfilled_tray_cannot_receive_media(self):
+        """Attributing media to a fill nobody recorded is the ambiguity itself."""
+        model = make_seed_tray_model(cell_size_ml=40, x_cells=2, y_cells=1)
+        tray = make_seed_tray(model=model)
+        cells = [make_seed_tray_cell(tray=tray, x_position=index) for index in range(2)]
+
+        with self.assertRaises(ValidationError) as caught:
+            self.draft([self.media_line(self.cell_targets(cells))])
+
+        self.assertIn('no open generation', ' '.join(caught.exception.messages))
+
+    def test_a_whole_tray_shortcut_records_the_same_fill(self):
+        """The expansion goes through the same measurement, so it must agree."""
+        cells = self.tray_cells()
+        generation = open_generation_for(cells[0].tray)
+
+        application = self.draft([self.media_line(cells_for_tray(cells[0].tray))])
+
+        recorded = set(
+            application.lines.get().targets.values_list(
+                'seed_tray_generation_id',
+                flat=True,
+            )
+        )
+        self.assertEqual(recorded, {generation.pk})
+
+    def test_a_target_of_another_kind_records_no_fill(self):
+        """A batch or a garden square has no tray fill to attribute."""
+        application = self.draft([LineRequest(
+            item=self.media,
+            lot=self.lot,
+            applied_quantity=Decimal('1'),
+            unit_code=UnitCode.LITRE,
+            usage_basis=InventoryItem.UsageBasis.MANUAL,
+            targets=(TargetRequest(TargetType.BATCH, self.batch),),
+        )])
+
+        target = application.lines.get().targets.get()
+        self.assertIsNone(target.seed_tray_generation_id)
+
+    def test_a_draft_cannot_be_posted_after_its_tray_is_cleaned(self):
+        """Posting would charge this media to a crop no longer in the tray."""
+        cells = self.tray_cells()
+        generation = open_generation_for(cells[0].tray)
+        application = self.draft([self.media_line(self.cell_targets(cells))])
+        SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+            status=SeedTrayGeneration.Status.CLOSED,
+            closed_at=timezone.now(),
+        )
+
+        with self.assertRaises(ValidationError) as caught:
+            post_application(application, None)
+
+        self.assertIn('have been cleaned', ' '.join(caught.exception.messages))
+        application.refresh_from_db()
+        self.assertEqual(application.status, InputApplication.Status.DRAFT)
+
+    def test_a_posted_document_keeps_the_fill_it_named(self):
+        """Cleaning the tray afterwards must not repoint the history."""
+        cells = self.tray_cells()
+        generation = open_generation_for(cells[0].tray)
+        application = self.draft([self.media_line(self.cell_targets(cells))])
+        application, _ = post_application(application, None)
+        SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+            status=SeedTrayGeneration.Status.CLOSED,
+            closed_at=timezone.now(),
+        )
+
+        recorded = set(
+            application.lines.get().targets.values_list(
+                'seed_tray_generation_id',
+                flat=True,
+            )
+        )
+        self.assertEqual(recorded, {generation.pk})

--- a/plantings/generation_rest.py
+++ b/plantings/generation_rest.py
@@ -1,0 +1,75 @@
+"""Attach each tray sowing to the fill of the tray it went into.
+
+This sits beside `batch_rest`, `harvest_rest`, and `lifecycle_rest` for the same
+reason they do: the seed-tray sowing serializer already carries the cell,
+capacity, batch, and stock rules, and the generation rule is a fourth concern
+rather than more of any of those.
+"""
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers
+
+from seedtrays.generations import require_open_generation
+from seedtrays.models import SeedTrayGeneration
+
+
+def _model_errors(error):
+    """Translate Django validation into field-friendly REST errors."""
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
+
+
+class TrayGenerationSowingSerializerMixin:  # pylint: disable=too-few-public-methods
+    """Keep a tray sowing on one fill of one tray for life."""
+
+    def _validate_generation(self, data):
+        """Attach this sowing to the fill of the tray it is going into.
+
+        A client that names no generation gets the tray's open one, because
+        there is only ever one and asking twice would invite the two answers to
+        disagree. A tray with no open fill is refused rather than guessed at:
+        seed sown into media nobody recorded has no cost to inherit.
+        """
+        if self.instance is not None:
+            self._require_same_generation(data)
+            return
+        seed_tray = data.get('seed_tray')
+        if seed_tray is None:
+            if data.get('generation') is not None:
+                raise serializers.ValidationError({
+                    'generation': 'A generation belongs to a tray; name the tray too.',
+                })
+            return
+        generation = data.get('generation')
+        if generation is None:
+            data['generation'] = self._open_generation(seed_tray)
+            return
+        self._require_usable_generation(generation, seed_tray)
+
+    def _require_same_generation(self, data):
+        """An existing sowing keeps the fill it was made into."""
+        if 'generation' in data and data['generation'] != self.instance.generation:
+            raise serializers.ValidationError({
+                'generation': 'Cannot move a sowing between tray generations.',
+            })
+
+    @staticmethod
+    def _open_generation(seed_tray):
+        """Return the tray's open fill, reported as a serializer error."""
+        try:
+            return require_open_generation(seed_tray)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_model_errors(exc)) from exc
+
+    @staticmethod
+    def _require_usable_generation(generation, seed_tray):
+        """Reject a fill of another tray, or one that has been cleaned."""
+        if generation.tray_id != seed_tray.pk:
+            raise serializers.ValidationError({
+                'generation': f'Generation {generation.code} belongs to another tray.',
+            })
+        if generation.status != SeedTrayGeneration.Status.OPEN:
+            raise serializers.ValidationError({
+                'generation': f'Generation {generation.code} has been cleaned.',
+            })

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -15,6 +15,7 @@ from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .batch_rest import BatchedSowingSerializerMixin, InlineBatchSerializer, register_batch_routes
+from .generation_rest import TrayGenerationSowingSerializerMixin
 from .harvest_rest import register_harvest_routes
 from .lifecycle import record_germination_event, record_transplant_event
 from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSerializerMixin, PlantOutcomeViewSetMixin, register_lifecycle_routes
@@ -120,7 +121,7 @@ class SeedTrayCellPlantingNestedSerializer(CurrentWorkspaceSerializerMixin, seri
         return data
 
 
-class SeedTrayPlantingSerializer(BatchedSowingSerializerMixin, PostedSowingSerializerMixin, CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+class SeedTrayPlantingSerializer(TrayGenerationSowingSerializerMixin, BatchedSowingSerializerMixin, PostedSowingSerializerMixin, CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):  # pylint: disable=too-many-ancestors
     """
     Serializer for SeedTrayPlanting
     """
@@ -131,14 +132,19 @@ class SeedTrayPlantingSerializer(BatchedSowingSerializerMixin, PostedSowingSeria
         model = SeedTrayPlanting
         fields = [
             'pk', 'planted', 'seeds_used', 'batch', 'new_batch', 'quantity',
-            'seed_tray', 'location', 'removed', 'notes', 'cell_plantings',
+            'seed_tray', 'generation', 'location', 'removed', 'notes',
+            'cell_plantings',
         ]
-        extra_kwargs = {'batch': {'required': False}}
+        extra_kwargs = {
+            'batch': {'required': False},
+            'generation': {'required': False},
+        }
 
     workspace_field_lookups = {
         'seeds_used': 'workspace',
         'batch': 'workspace',
         'seed_tray': 'workspace',
+        'generation': 'tray__workspace',
     }
 
     def _get_effective_cell_plantings(self, data):
@@ -230,6 +236,9 @@ class SeedTrayPlantingSerializer(BatchedSowingSerializerMixin, PostedSowingSeria
         self._validate_stock_fields(data)
         cell_plantings = self._get_effective_cell_plantings(data)
         self._validate_cell_allocations(data, cell_plantings)
+        # After the cell rules, because a sowing that names only its cells has
+        # its tray derived there and the generation follows from the tray.
+        self._validate_generation(data)
 
         return data
 

--- a/plantings/test_batched_sowing.py
+++ b/plantings/test_batched_sowing.py
@@ -10,6 +10,7 @@ from tests.factories import (
     make_seed_tray,
     make_seed_tray_cell,
     make_seed_tray_cell_planting,
+    make_seed_tray_generation,
     make_seed_tray_planting,
     make_specific_plant,
 )
@@ -34,6 +35,7 @@ class BatchedSowingRESTTests(RESTContractTestCase):
         self.row = make_garden_row()
         self.square = make_garden_square()
         self.tray = make_seed_tray()
+        make_seed_tray_generation(tray=self.tray)
         self.cell = make_seed_tray_cell(tray=self.tray)
         self.batch = make_batch_for_packet(self.packet)
 

--- a/plantings/test_generation_sowing.py
+++ b/plantings/test_generation_sowing.py
@@ -1,0 +1,142 @@
+"""Every tray sowing names the fill of the tray it went into.
+
+A sowing that does not is the ambiguity the whole feature exists to remove: the
+seedlings it raises have no way to say which media they grew in, so a later fill
+of the same cells would look like theirs.
+"""
+# pylint: disable=duplicate-code
+
+from django.utils import timezone
+
+from seedtrays.generations import open_generation
+from seedtrays.models import SeedTrayGeneration
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_batch_for_packet,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_generation,
+)
+
+from .models import SeedTrayPlanting
+
+
+class SowingGenerationTests(RESTContractTestCase):
+    """The API attaches a sowing to the tray's open fill, or refuses it."""
+
+    def setUp(self):
+        super().setUp()
+        self.packet = make_seed_packet()
+        self.batch = make_batch_for_packet(self.packet)
+        self.tray = make_seed_tray()
+        self.cell = make_seed_tray_cell(tray=self.tray)
+
+    def sow(self, **overrides):
+        """Post one tray sowing through the API."""
+        payload = {
+            'seeds_used': self.packet.pk,
+            'batch': self.batch.pk,
+            'quantity': 4,
+            'seed_tray': self.tray.pk,
+        }
+        payload.update(overrides)
+        if payload.get('seed_tray') is None:
+            payload.pop('seed_tray', None)
+        return self.client.post('/plantings/seedtray/', payload, format='json')
+
+    def test_a_sowing_joins_the_open_generation_without_being_told(self):
+        """There is only one open fill, so asking twice invites disagreement."""
+        generation = make_seed_tray_generation(tray=self.tray)
+
+        response = self.sow()
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['generation'], generation.pk)
+        sowing = SeedTrayPlanting.objects.get(pk=response.data['pk'])
+        self.assertEqual(sowing.generation_id, generation.pk)
+
+    def test_sowing_into_an_unfilled_tray_is_refused(self):
+        """Seed sown into media nobody recorded has no cost to inherit."""
+        response = self.sow()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('no open generation', str(response.data['generation']))
+        self.assertFalse(SeedTrayPlanting.objects.exists())
+
+    def test_sowing_into_a_cleaned_generation_is_refused(self):
+        """A closed fill has been emptied; nothing can be sown into it."""
+        generation = make_seed_tray_generation(tray=self.tray)
+        SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+            status=SeedTrayGeneration.Status.CLOSED,
+            closed_at=timezone.now(),
+        )
+
+        response = self.sow(generation=generation.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('cleaned', str(response.data['generation']))
+
+    def test_a_generation_from_another_tray_is_refused(self):
+        """Cells and media would otherwise cross between two trays."""
+        make_seed_tray_generation(tray=self.tray)
+        other = make_seed_tray_generation()
+
+        response = self.sow(generation=other.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('another tray', str(response.data['generation']))
+
+    def test_a_generation_needs_the_tray_it_belongs_to(self):
+        """A sowing with no tray has no fill to join."""
+        generation = make_seed_tray_generation(tray=self.tray)
+
+        response = self.sow(seed_tray=None, generation=generation.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('name the tray too', str(response.data['generation']))
+
+    def test_the_tray_derived_from_cells_supplies_the_generation(self):
+        """A sowing that names only its cells still lands in the right fill."""
+        generation = make_seed_tray_generation(tray=self.tray)
+
+        response = self.sow(
+            seed_tray=None,
+            cell_plantings=[{'cell': self.cell.pk, 'quantity': 4}],
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['generation'], generation.pk)
+
+    def test_a_sowing_cannot_move_between_generations(self):
+        """Its media history would move with it."""
+        generation = make_seed_tray_generation(tray=self.tray)
+        created = self.sow()
+        SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+            status=SeedTrayGeneration.Status.CLOSED,
+            closed_at=timezone.now(),
+        )
+        following = open_generation(self.tray, None)
+
+        response = self.client.patch(
+            f'/plantings/seedtray/{created.data["pk"]}/',
+            {'generation': following.pk},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Cannot move', str(response.data['generation']))
+
+    def test_a_sowing_recorded_before_generations_keeps_its_unknown_fill(self):
+        """Migration never guesses, so the API must tolerate a null generation."""
+        sowing = SeedTrayPlanting.objects.create(
+            seeds_used=self.packet,
+            batch=self.batch,
+            quantity=4,
+            seed_tray=self.tray,
+        )
+
+        response = self.client.get(f'/plantings/seedtray/{sowing.pk}/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data['generation'])

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -14,7 +14,7 @@ from plants.models import Plant, PlantFamily, PlantVariety
 from seeds.models import SeedPacket, Seeds
 from seedtrays.models import SeedTrayCell, SeedTrayModel
 from supplies.models import Supplier
-from tests.factories import make_batch_for_packet, make_seed_tray
+from tests.factories import make_batch_for_packet, make_seed_tray, make_seed_tray_generation
 from .models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
@@ -75,6 +75,7 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
             cell_size_ml=40,
         )
         self.tray = make_seed_tray(model=tray_model)
+        make_seed_tray_generation(tray=self.tray)
         self.cell = SeedTrayCell.objects.create(
             tray=self.tray,
             x_position=0,
@@ -668,6 +669,7 @@ class ConcurrentGerminationTests(TransactionTestCase):
             cell_size_ml=40,
         )
         tray = make_seed_tray(model=tray_model)
+        make_seed_tray_generation(tray=tray)
         cell = SeedTrayCell.objects.create(
             tray=tray,
             x_position=0,

--- a/plantings/test_rest.py
+++ b/plantings/test_rest.py
@@ -8,6 +8,7 @@ from tests.factories import (
     make_seed_tray,
     make_seed_tray_cell,
     make_seed_tray_cell_planting,
+    make_seed_tray_generation,
     make_seed_tray_planting,
     make_specific_plant,
     make_specific_plant_location,
@@ -26,6 +27,7 @@ class PlantingRESTContractTests(RESTContractTestCase):
         self.row = make_garden_row()
         self.square = make_garden_square()
         self.tray = make_seed_tray()
+        make_seed_tray_generation(tray=self.tray)
         self.cell = make_seed_tray_cell(tray=self.tray)
         self.tray_planting = make_seed_tray_planting(
             seeds_used=self.packet,
@@ -200,6 +202,7 @@ class PlantingRESTContractTests(RESTContractTestCase):
     def test_filtered_routes_only_expose_parent_resources(self):
         """Filtered collection and detail routes enforce their URL parent."""
         other_tray = make_seed_tray()
+        make_seed_tray_generation(tray=other_tray)
         other_cell = make_seed_tray_cell(tray=other_tray)
         other_planting = make_seed_tray_planting(
             seed_tray=other_tray,

--- a/plantings/test_sowing_inventory.py
+++ b/plantings/test_sowing_inventory.py
@@ -31,6 +31,7 @@ from tests.factories import (
     make_plant_variety,
     make_seed_tray,
     make_seed_tray_cell,
+    make_seed_tray_generation,
     make_supplier,
 )
 from workspaces.models import Workspace
@@ -53,6 +54,7 @@ class SowingInventoryTests(APITestCase):
         self.row = make_garden_row()
         self.square = make_garden_square()
         self.tray = make_seed_tray()
+        make_seed_tray_generation(tray=self.tray)
         self.cell = make_seed_tray_cell(tray=self.tray)
         self.packet = self.receive_packet(QuantityCertainty.EXACT, '20')
         self.batch = make_batch_for_packet(self.packet)

--- a/seedtrays/generations.py
+++ b/seedtrays/generations.py
@@ -1,0 +1,122 @@
+"""Opening one fill of a seed tray, and the identity everything hangs off it.
+
+A generation is the cultivation cycle a tray's cells are currently serving.
+Opening one says the tray has been filled, and it is what a sowing joins and
+what an application's cell target is attributed to. Only one is ever open per
+tray, which is why nothing here has to ask the caller which fill they meant.
+
+A generation migrated from records that predate the feature is flagged for
+review, because those records genuinely cannot say whether the sowings grouped
+under it were one fill. Reviewing it is an operator's statement, not an
+inference, so it is recorded as its own fact.
+"""
+
+# pylint: disable=duplicate-code
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from .models import SeedTrayGeneration, SeedTrayGenerationEvent
+
+
+EventType = SeedTrayGenerationEvent.EventType
+
+
+def _require_reason(reason):
+    """Reject an audit-critical action without a stated reason."""
+    if not reason or not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+
+
+def open_generation_for(tray):
+    """Return the fill this tray is currently using, or None when it is empty."""
+    return SeedTrayGeneration.objects.filter(
+        tray=tray,
+        status=SeedTrayGeneration.Status.OPEN,
+    ).first()
+
+
+def require_open_generation(tray, field='generation'):
+    """Return this tray's open fill, refusing to guess when there is none."""
+    generation = open_generation_for(tray)
+    if generation is None:
+        raise ValidationError({
+            field: (
+                f'Tray {tray.pk} has no open generation. Fill the tray before '
+                'sowing into it or applying an input to its cells.'
+            ),
+        })
+    return generation
+
+
+def lock_generation(generation):
+    """Reload one generation under a row lock, serialising its transitions."""
+    return SeedTrayGeneration.objects.select_for_update().select_related(
+        'tray',
+        'workspace',
+    ).get(pk=generation.pk)
+
+
+def _record_event(generation, user, event_type, occurred_at, reason=''):
+    """Append one immutable fact about this generation."""
+    return SeedTrayGenerationEvent.objects.create(
+        generation=generation,
+        event_type=event_type,
+        occurred_at=occurred_at,
+        reason=reason,
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+
+
+@transaction.atomic
+def open_generation(tray, user, opened_at=None, notes=''):
+    """Record that this tray has been filled and is ready to sow into."""
+    existing = SeedTrayGeneration.objects.select_for_update().filter(
+        tray=tray,
+    ).order_by('-sequence')
+    rows = list(existing)
+    current = next(
+        (row for row in rows if row.status == SeedTrayGeneration.Status.OPEN),
+        None,
+    )
+    if current is not None:
+        raise ValidationError({
+            'tray': (
+                f'Generation {current.code} is still open. Clean the tray before '
+                'filling it again.'
+            ),
+        })
+    sequence = (rows[0].sequence + 1) if rows else 1
+    opened_at = opened_at or timezone.now()
+    generation = SeedTrayGeneration(
+        workspace=tray.workspace,
+        tray=tray,
+        code=f'TRAY-{tray.pk}-{sequence}',
+        sequence=sequence,
+        opened_at=opened_at,
+        notes=notes,
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+    generation.save()
+    _record_event(generation, user, EventType.OPENED, opened_at, 'Tray filled.')
+    return generation
+
+
+@transaction.atomic
+def review_generation(generation, user, reason):
+    """Confirm a migrated fill really is one fill, unblocking its clean."""
+    _require_reason(reason)
+    generation = lock_generation(generation)
+    if generation.review_state != SeedTrayGeneration.ReviewState.NEEDS_REVIEW:
+        raise ValidationError({
+            'review_state': 'This generation has already been reviewed.',
+        })
+    occurred_at = timezone.now()
+    SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+        review_state=SeedTrayGeneration.ReviewState.NONE,
+        updated=occurred_at,
+    )
+    _record_event(generation, user, EventType.REVIEWED, occurred_at, reason)
+    generation.refresh_from_db()
+    return generation

--- a/seedtrays/test_generations.py
+++ b/seedtrays/test_generations.py
@@ -1,0 +1,131 @@
+"""Opening a fill of a tray, and confirming a migrated one."""
+# pylint: disable=duplicate-code
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from tests.factories import make_seed_tray, make_seed_tray_generation
+
+from .generations import (
+    open_generation,
+    open_generation_for,
+    require_open_generation,
+    review_generation,
+)
+from .models import SeedTrayGeneration, SeedTrayGenerationEvent
+
+
+class OpenGenerationTests(TestCase):
+    """Filling a tray is an explicit act with a record behind it."""
+
+    def setUp(self):
+        self.tray = make_seed_tray()
+        self.user = get_user_model().objects.create_user('filler', password='x')
+
+    def test_the_first_fill_is_numbered_from_one(self):
+        """A tray's fills are numbered so its history reads in order."""
+        generation = open_generation(self.tray, self.user)
+
+        self.assertEqual(generation.sequence, 1)
+        self.assertEqual(generation.code, f'TRAY-{self.tray.pk}-1')
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.OPEN)
+        self.assertEqual(generation.origin, SeedTrayGeneration.Origin.OPERATOR)
+        self.assertEqual(generation.review_state, SeedTrayGeneration.ReviewState.NONE)
+        self.assertEqual(generation.created_by, self.user)
+
+    def test_opening_records_why_the_fill_exists(self):
+        """The history starts at the moment the tray was filled."""
+        generation = open_generation(self.tray, self.user)
+
+        event = generation.events.get()
+        self.assertEqual(event.event_type, SeedTrayGenerationEvent.EventType.OPENED)
+        self.assertEqual(event.occurred_at, generation.opened_at)
+        self.assertEqual(event.created_by, self.user)
+
+    def test_a_tray_cannot_be_filled_twice_over(self):
+        """The second fill would inherit the first one's seedlings and media."""
+        existing = open_generation(self.tray, self.user)
+
+        with self.assertRaises(ValidationError) as caught:
+            open_generation(self.tray, self.user)
+
+        self.assertIn(existing.code, ' '.join(caught.exception.messages))
+        self.assertEqual(SeedTrayGeneration.objects.filter(tray=self.tray).count(), 1)
+
+    def test_refilling_a_cleaned_tray_takes_the_next_number(self):
+        """Reuse is the point; the numbering keeps the cycles apart."""
+        first = open_generation(self.tray, self.user)
+        SeedTrayGeneration.objects.filter(pk=first.pk).update(
+            status=SeedTrayGeneration.Status.CLOSED,
+            closed_at=timezone.now(),
+        )
+
+        second = open_generation(self.tray, self.user)
+
+        self.assertEqual(second.sequence, 2)
+        self.assertEqual(second.code, f'TRAY-{self.tray.pk}-2')
+
+    def test_an_empty_tray_reports_no_open_fill(self):
+        """Nothing pretends a tray is filled when it is not."""
+        self.assertIsNone(open_generation_for(self.tray))
+
+        with self.assertRaises(ValidationError) as caught:
+            require_open_generation(self.tray)
+
+        self.assertIn('no open generation', ' '.join(caught.exception.messages))
+
+    def test_the_error_field_follows_the_caller(self):
+        """An application reports this under its own targets field."""
+        with self.assertRaises(ValidationError) as caught:
+            require_open_generation(self.tray, field='targets')
+
+        self.assertIn('targets', caught.exception.message_dict)
+
+
+class ReviewGenerationTests(TestCase):
+    """A migrated fill stays flagged until somebody confirms it."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('reviewer', password='x')
+        self.generation = make_seed_tray_generation(
+            origin=SeedTrayGeneration.Origin.LEGACY,
+            review_state=SeedTrayGeneration.ReviewState.NEEDS_REVIEW,
+        )
+
+    def test_reviewing_clears_the_flag_and_records_who_said_so(self):
+        """The confirmation is an operator's statement, so it is kept."""
+        generation = review_generation(
+            self.generation,
+            self.user,
+            'Checked against the sowing notebook; one fill.',
+        )
+
+        self.assertEqual(generation.review_state, SeedTrayGeneration.ReviewState.NONE)
+        event = generation.events.get(
+            event_type=SeedTrayGenerationEvent.EventType.REVIEWED,
+        )
+        self.assertEqual(event.created_by, self.user)
+        self.assertIn('sowing notebook', event.reason)
+
+    def test_a_review_needs_a_reason(self):
+        """An unexplained confirmation is indistinguishable from a guess."""
+        with self.assertRaises(ValidationError) as caught:
+            review_generation(self.generation, self.user, '   ')
+
+        self.assertIn('reason', caught.exception.message_dict)
+        self.generation.refresh_from_db()
+        self.assertEqual(
+            self.generation.review_state,
+            SeedTrayGeneration.ReviewState.NEEDS_REVIEW,
+        )
+
+    def test_a_reviewed_generation_cannot_be_reviewed_again(self):
+        """Repeating it would append a second confirmation of nothing."""
+        review_generation(self.generation, self.user, 'Confirmed.')
+
+        with self.assertRaises(ValidationError) as caught:
+            review_generation(self.generation, self.user, 'Confirmed again.')
+
+        self.assertIn('review_state', caught.exception.message_dict)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -393,13 +393,23 @@ def _sowing_values(overrides, defaults):
 
 
 def make_seed_tray_planting(**overrides):
-    """Create a seed-tray planting and its related seed and tray graph."""
+    """Create a seed-tray planting and its related seed and tray graph.
+
+    An open generation on the tray is joined when there is one, and none is
+    opened when there is not, so a test that never filled its tray keeps the
+    unlinked shape sowings had before generations existed.
+    """
     values = _sowing_values(overrides, {
         'quantity': 2,
         'notes': 'Shared test tray planting',
     })
     if 'seed_tray' not in values:
         values['seed_tray'] = make_seed_tray()
+    if 'generation' not in values and values['seed_tray'] is not None:
+        values['generation'] = SeedTrayGeneration.objects.filter(
+            tray=values['seed_tray'],
+            status=SeedTrayGeneration.Status.OPEN,
+        ).first()
     return SeedTrayPlanting.objects.create(**values)
 
 


### PR DESCRIPTION
Filling a tray is now an explicit act, and it is what a sowing joins and what an application's cell target is attributed to. Only one generation is ever open per tray, so neither caller has to say which fill it meant: the server derives it, and an existing client keeps working.

What that same derivation buys is the refusal. A tray with no open fill cannot be sown into or have media applied to its cells, because seed and media recorded against a fill nobody opened have nothing to inherit a cost from — which is exactly the ambiguity this task exists to remove.

The generation is frozen onto each cell target beside the volume that target measured, and posting rechecks it. A draft built before the tray was cleaned would otherwise charge its media to whatever crop is in the tray now, so it is refused and has to be rebuilt against the current fill. A document already posted keeps the fill it named.

A sowing cannot move between generations for the same reason it cannot move between batches: its media history would move with it. Sowings recorded before generations existed keep a null one, and the API reads them back that way rather than inventing an answer.

Reviewing a migrated generation is an operator's statement rather than an inference, so it is recorded as its own fact and needs its own reason.

## Summary by Sourcery

Associate seed tray sowings and media applications with explicit tray generations (fills), enforcing one open generation per tray and preventing ambiguous attribution when trays are unfilled or cleaned.

New Features:
- Introduce seed tray generation management utilities to open, lookup, require, lock, and review tray fills, with event history and sequencing.
- Attach seed tray sowings to a tray generation via the REST API, deriving the open generation when not specified and exposing it as a field on sowings and application targets.
- Store generation information on application targets for seed tray cells so media usage is attributed to the correct tray fill.

Enhancements:
- Prevent sowings and media applications into trays with no open generation or into cleaned/closed generations, requiring drafts to be rebuilt against the current fill.
- Ensure existing sowings cannot be moved between tray generations and that legacy sowings without generation data remain valid with a null generation.
- Require operator review and a reason before confirming migrated generations, with audit events recorded.
- Extend serializers, factories, and tests to cover generation-aware sowing and application workflows, including whole-tray shortcuts and cell-only sowings.

Tests:
- Add comprehensive tests for generation opening, review, and validation, and for generation-aware sowing and application behaviour across REST and service layers.