### PR TITLE
fix(tests): restore every app's migrations after a backfill test

### DIFF
--- a/plantings/test_migrations.py
+++ b/plantings/test_migrations.py
@@ -42,15 +42,21 @@ from .models import (
 
 
 def latest_plantings_state():
-    """Return the newest migration state for the plantings app.
+    """Return the newest migration state for the whole project.
 
     Backfill tests rewind the schema and must restore it completely, so the
     target is resolved from the migration graph instead of a pinned name that
     every later migration would silently invalidate.
+
+    Every app's leaf is included, not just this one's. Rewinding plantings also
+    unapplies the migrations of the apps that depend on it — `applications`
+    builds on `plantings.0024_harvest` — and restoring only the plantings leaf
+    leaves their tables dropped for the rest of the process, which surfaces much
+    later as an unrelated test failing on a missing relation.
     """
     executor = MigrationExecutor(connection)
     executor.loader.build_graph()
-    return list(executor.loader.graph.leaf_nodes('plantings'))
+    return list(executor.loader.graph.leaf_nodes())
 
 
 class PlantingsDataMigrationTests(TestCase):  # pylint: disable=too-many-instance-attributes

--- a/seedtrays/test_migrations.py
+++ b/seedtrays/test_migrations.py
@@ -25,14 +25,16 @@ from .models import SeedTrayGeneration, SeedTrayGenerationEvent
 
 
 def latest_seedtrays_state():
-    """Return the newest migration state for the seedtrays app.
+    """Return the newest migration state for the whole project.
 
     Resolved from the graph rather than pinned by name, so a later migration
-    cannot leave the database half-migrated for the rest of the run.
+    cannot leave the database half-migrated for the rest of the run, and every
+    app's leaf is included because rewinding one app also unapplies the
+    migrations of the apps that depend on it.
     """
     executor = MigrationExecutor(connection)
     executor.loader.build_graph()
-    return list(executor.loader.graph.leaf_nodes('seedtrays'))
+    return list(executor.loader.graph.leaf_nodes())
 
 
 class LegacyGenerationBackfillTests(TransactionTestCase):


### PR DESCRIPTION
A backfill test rewinds the schema and restores it afterwards, but it only restored its own app's leaf. Rewinding plantings also unapplies the apps built on top of it — applications depends on plantings.0024_harvest — so their tables stayed dropped for the rest of the process.

Nothing caught it because the tests that use those tables are TestCase classes, which run before the TransactionTestCase that does the rewind. Adding a TransactionTestCase that touches applications surfaced it as "relation applications_inputapplicationline does not exist" in a test with no connection to migrations at all.

Restoring every leaf in the graph rather than one app's puts the schema back the way it was found.

## Summary by Sourcery

Tests:
- Update migration state helpers in plantings and seedtrays tests to use all apps' leaf migrations so tables for dependent apps are correctly restored after rewind.