### PR TITLE
feat(seedtrays): clean a tray generation and correct a mistaken clean

### DIFF
--- a/seedtrays/generation_costs.py
+++ b/seedtrays/generation_costs.py
@@ -1,0 +1,189 @@
+"""Trace one generation's media cost back to the seedlings it raised.
+
+This is a derivation, not a subledger. Task 43 owns per-plant costing; what a
+generation supplies is the identity that makes it possible — which fill of which
+tray a cell was serving when the media went in — and this module reports the
+allocation that identity implies so the boundary can be checked before the
+subledger is built on top of it.
+
+Three rules keep the numbers honest:
+
+- Media is split across a line's cells by ``weight * cell_volume_ml``, which is
+  the basis ``applications.usage`` already used to calculate the quantity.
+  Dividing any other way would report a number the application never used.
+- A cell's cost is shared equally among the plants observed in it, so a cell
+  that produced three seedlings from one multigerm cluster spreads one cell's
+  worth of media across three plants without changing any count.
+- A lot with no recorded unit cost reports an unknown cost rather than zero. A
+  zero would quietly understate every total built on it.
+"""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from inventory.models import COST_DECIMAL_PLACES
+
+from .generations import applied_media, cell_shares, generation_cells
+from .models import SeedTrayGeneration, SeedTrayGenerationResidual
+
+
+COST_QUANTUM = Decimal(1).scaleb(-COST_DECIMAL_PLACES)
+
+
+def quantize_cost(value):
+    """Return a money amount at the precision unit costs are recorded in."""
+    return None if value is None else Decimal(value).quantize(COST_QUANTUM)
+
+
+def _plants_by_cell(generation):
+    """Return the plants observed in each cell of this fill."""
+    from plantings.models import SpecificPlant  # pylint: disable=import-outside-toplevel
+
+    plants = SpecificPlant.objects.filter(
+        cell_planting__seed_tray_planting__generation=generation,
+    ).select_related('cell_planting').order_by('pk')
+    grouped = {}
+    for plant in plants:
+        grouped.setdefault(plant.cell_planting.cell_id, []).append(plant)
+    return grouped
+
+
+def _residual_totals(generation):
+    """Total what each disposition took back out of this fill, at cost."""
+    totals = {disposition: Decimal('0') for disposition in (
+        SeedTrayGenerationResidual.Disposition.WASTE,
+        SeedTrayGenerationResidual.Disposition.RECLAIMED,
+    )}
+    unknown = False
+    residuals = SeedTrayGenerationResidual.objects.filter(
+        generation=generation,
+        kind=SeedTrayGenerationResidual.Kind.MEDIA,
+        movement__reversal__isnull=True,
+    )
+    for residual in residuals:
+        if residual.unit_cost is None:
+            unknown = True
+            continue
+        totals[residual.disposition] += residual.base_quantity * residual.unit_cost
+    return totals, unknown
+
+
+def _media_and_cells(generation):
+    """Total this fill's media by lot and the cost each of its cells carries."""
+    media = []
+    cell_costs = {}
+    unknown = False
+    for line in applied_media(generation):
+        unit_cost = line.lot.base_unit_cost
+        mine = Decimal('0')
+        for target, share in cell_shares(line):
+            if target.seed_tray_generation_id != generation.pk:
+                continue
+            quantity = Decimal(line.applied_base_quantity) * share
+            mine += quantity
+            if unit_cost is not None:
+                carried = cell_costs.get(target.seed_tray_cell_id, Decimal('0'))
+                cell_costs[target.seed_tray_cell_id] = carried + quantity * unit_cost
+        if not mine:
+            continue
+        if unit_cost is None:
+            unknown = True
+        media.append({
+            'line': line.pk,
+            'application': line.application_id,
+            'lot': line.lot_id,
+            'item': line.item_id,
+            'base_quantity': mine,
+            'base_unit': line.base_unit,
+            'unit_cost': unit_cost,
+            'cost': None if unit_cost is None else mine * unit_cost,
+        })
+    return media, cell_costs, unknown
+
+
+def _allocate_cells(generation, cell_costs, closed):
+    """Share each cell's media cost among the plants that came up in it.
+
+    A cell that produced three seedlings from one multigerm cluster spreads one
+    cell's worth of media across three plants without changing any count. A cell
+    that produced nothing is provisional while the fill is open, because a
+    seedling may still come up in it, and production loss once it is closed.
+    """
+    plants_by_cell = _plants_by_cell(generation)
+    cells = []
+    plant_costs = {}
+    allocated = Decimal('0')
+    unallocated = Decimal('0')
+    for cell in generation_cells(generation):
+        cost = cell_costs.get(cell.pk, Decimal('0'))
+        plants = plants_by_cell.get(cell.pk, [])
+        if not cost and not plants:
+            continue
+        per_plant = (cost / len(plants)) if plants else None
+        for plant in plants:
+            plant_costs[plant.pk] = plant_costs.get(plant.pk, Decimal('0')) + per_plant
+        if plants:
+            allocated += cost
+        else:
+            unallocated += cost
+        cells.append({
+            'cell': cell.pk,
+            'x_position': cell.x_position,
+            'y_position': cell.y_position,
+            'cost': quantize_cost(cost),
+            'plants': [plant.pk for plant in plants],
+            'per_plant_cost': quantize_cost(per_plant),
+            'provisional': not plants and not closed,
+        })
+    return cells, plant_costs, allocated, unallocated
+
+
+def generation_cost_breakdown(generation):
+    """Report which media supplied each seedling of one fill, and what did not.
+
+    Media the operator recorded as discarded when the tray was cleaned is
+    production loss, together with the cost of any cell that never produced a
+    plant once the fill is closed.
+    """
+    media, cell_costs, unknown = _media_and_cells(generation)
+    residuals, residual_unknown = _residual_totals(generation)
+    closed = generation.status == SeedTrayGeneration.Status.CLOSED
+    cells, plant_costs, allocated, unallocated = _allocate_cells(
+        generation,
+        cell_costs,
+        closed,
+    )
+    waste = residuals[SeedTrayGenerationResidual.Disposition.WASTE]
+    reclaimed = residuals[SeedTrayGenerationResidual.Disposition.RECLAIMED]
+    applied = sum(
+        (row['cost'] for row in media if row['cost'] is not None),
+        Decimal('0'),
+    )
+    return {
+        'generation': generation.pk,
+        'code': generation.code,
+        'status': generation.status,
+        'currency_code': generation.workspace.currency_code,
+        'unknown_cost': unknown or residual_unknown,
+        'media': [
+            {
+                **row,
+                'base_quantity': f'{row["base_quantity"]:.9f}',
+                'unit_cost': quantize_cost(row['unit_cost']),
+                'cost': quantize_cost(row['cost']),
+            }
+            for row in media
+        ],
+        'applied_cost': quantize_cost(applied),
+        'recovered_cost': quantize_cost(reclaimed),
+        'wasted_cost': quantize_cost(waste),
+        'cells': cells,
+        'plants': [
+            {'plant': plant_id, 'cost': quantize_cost(cost)}
+            for plant_id, cost in sorted(plant_costs.items())
+        ],
+        'allocated_cost': quantize_cost(allocated),
+        'unallocated_cost': quantize_cost(unallocated),
+        'production_loss': quantize_cost(waste + (unallocated if closed else Decimal('0'))),
+    }

--- a/seedtrays/generations.py
+++ b/seedtrays/generations.py
@@ -1,9 +1,16 @@
-"""Opening one fill of a seed tray, and the identity everything hangs off it.
+"""Opening, cleaning, and correcting one fill of a seed tray.
 
 A generation is the cultivation cycle a tray's cells are currently serving.
 Opening one says the tray has been filled, and it is what a sowing joins and
 what an application's cell target is attributed to. Only one is ever open per
 tray, which is why nothing here has to ask the caller which fill they meant.
+
+Cleaning is where the care goes. It writes nothing until every remaining plant,
+every seed drawn but never sown, and every quantity of media applied has an
+explicit disposition, because the alternative is a workflow that quietly decides
+seedlings failed and media was thrown away. Nothing is deleted either: sowings
+leave the tray's normal view by deriving that view from the generation's status,
+so the archive is a filter rather than a loss.
 
 A generation migrated from records that predate the feature is flagged for
 review, because those records genuinely cannot say whether the sowings grouped
@@ -13,14 +20,80 @@ inference, so it is recorded as its own fact.
 
 # pylint: disable=duplicate-code
 
+import hashlib
+from decimal import Decimal
+from typing import NamedTuple
+
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Sum
 from django.utils import timezone
 
-from .models import SeedTrayGeneration, SeedTrayGenerationEvent
+from inventory.ledger import (
+    MovementRequest,
+    lock_lots,
+    post_stock_movement,
+    quantize_quantity,
+    reverse_tray_generation_movements,
+)
+from inventory.models import StockMovement
+
+from .models import (
+    SeedTrayCell,
+    SeedTrayGeneration,
+    SeedTrayGenerationEvent,
+    SeedTrayGenerationResidual,
+)
 
 
 EventType = SeedTrayGenerationEvent.EventType
+Kind = SeedTrayGenerationResidual.Kind
+Disposition = SeedTrayGenerationResidual.Disposition
+
+#: Outcomes a clean may record for a plant still sitting in the tray. Everything
+#: here resolves the plant; `retained` resolves its availability while leaving it
+#: alive, which is what an operator picks for a seedling they are keeping.
+CLEAN_OUTCOMES = ('retained', 'failed', 'culled', 'donated')
+
+
+class PlantDisposition(NamedTuple):
+    """What an operator decided about one plant still in the tray."""
+
+    plant_id: int
+    outcome: str
+    reason: str = ''
+
+
+class SeedDisposition(NamedTuple):
+    """What became of the seed one sowing drew but never placed in a cell."""
+
+    sowing_id: int
+    quantity: object
+    disposition: str
+    reason: str = ''
+    destination: object = None
+
+
+class MediaDisposition(NamedTuple):
+    """What became of the media one applied line left in the tray."""
+
+    lot_id: int
+    quantity: object
+    disposition: str
+    reason: str = ''
+    destination: object = None
+
+
+class CloseRequest(NamedTuple):
+    """Caller intent for one whole clean."""
+
+    reason: str
+    occurred_at: object = None
+    plants: tuple = ()
+    seeds: tuple = ()
+    media: tuple = ()
+    digest: object = None
+    open_next: bool = False
 
 
 def _require_reason(reason):
@@ -51,8 +124,16 @@ def require_open_generation(tray, field='generation'):
 
 
 def lock_generation(generation):
-    """Reload one generation under a row lock, serialising its transitions."""
-    return SeedTrayGeneration.objects.select_for_update().select_related(
+    """Reload one generation under a row lock, serialising its transitions.
+
+    ``of=('self',)`` is load-bearing, for the reason
+    `applications.services.post_application` records. Selecting the tray and the
+    workspace alongside builds joins, and an unqualified lock would take those
+    rows too — including the workspace row that every plant fact takes a
+    key-share lock on. A concurrent outcome would then wait on this transaction
+    while this one waited on its plant, which is a deadlock rather than a queue.
+    """
+    return SeedTrayGeneration.objects.select_for_update(of=('self',)).select_related(
         'tray',
         'workspace',
     ).get(pk=generation.pk)
@@ -120,3 +201,502 @@ def review_generation(generation, user, reason):
     _record_event(generation, user, EventType.REVIEWED, occurred_at, reason)
     generation.refresh_from_db()
     return generation
+
+
+def generation_cells(generation):
+    """Return every cell of the tray this fill occupies."""
+    return SeedTrayCell.objects.filter(
+        tray_id=generation.tray_id,
+    ).order_by('y_position', 'x_position')
+
+
+def generation_sowings(generation):
+    """Return the sowings made into this fill."""
+    from plantings.models import SeedTrayPlanting  # pylint: disable=import-outside-toplevel
+
+    return SeedTrayPlanting.objects.filter(
+        generation=generation,
+    ).select_related('seeds_used__stock_lot__item', 'batch').order_by('planted', 'pk')
+
+
+def generation_plants(generation):
+    """Return the plants this fill raised that are still sitting in the tray.
+
+    Physical presence is the test rather than lineage. A seedling planted out
+    into a garden square already left, and holding up the clean for it would ask
+    an operator to dispose of something that is not in the tray.
+    """
+    from plantings.models import SpecificPlant  # pylint: disable=import-outside-toplevel
+
+    return SpecificPlant.objects.filter(
+        cell_planting__seed_tray_planting__generation=generation,
+        locations__ended__isnull=True,
+        locations__seed_tray_cell__tray_id=generation.tray_id,
+    ).select_related('cell_planting').prefetch_related('lifecycle_events').distinct().order_by('pk')
+
+
+def unresolved_plants(generation):
+    """Return the plants in the tray that have recorded no final outcome."""
+    from plantings.lifecycle import is_final, plant_lifecycle_summary  # pylint: disable=import-outside-toplevel
+
+    return [
+        plant for plant in generation_plants(generation)
+        if not is_final(plant_lifecycle_summary(plant).state)
+    ]
+
+
+def unsown_seed(sowing):
+    """Return the seed this sowing drew from the packet but never placed.
+
+    Seed sown into a cell that never came up is a plant outcome, not loose seed,
+    so only the unallocated remainder is counted here.
+    """
+    allocated = sowing.cell_plantings.aggregate(total=Sum('quantity'))['total'] or 0
+    return max(sowing.quantity - allocated, 0)
+
+
+def applied_media(generation):
+    """Return every posted application line that put media into this fill.
+
+    A reversed application put its stock back, so it left nothing in the tray
+    and nothing here to dispose of.
+    """
+    from applications.models import InputApplication, InputApplicationLine  # pylint: disable=import-outside-toplevel
+
+    return InputApplicationLine.objects.filter(
+        application__status=InputApplication.Status.POSTED,
+        targets__seed_tray_generation=generation,
+    ).select_related(
+        'item',
+        'lot',
+        'application',
+    ).prefetch_related('targets').distinct().order_by('pk')
+
+
+def cell_shares(line):
+    """Return each cell target of one line paired with its share of it.
+
+    A line can spread over two trays, so its cells are weighted the same way
+    ``applications.usage`` weighted them when it calculated the quantity: by
+    ``weight * cell_volume_ml``. The basis spans the whole line, including cells
+    belonging to another fill, because that is how the quantity was arrived at;
+    splitting any other way would report a number the application never used.
+    """
+    targets = [row for row in line.targets.all() if row.cell_volume_ml]
+    basis = sum(
+        Decimal(row.weight) * Decimal(row.cell_volume_ml)
+        for row in targets
+    )
+    if not basis:
+        return []
+    return [
+        (row, (Decimal(row.weight) * Decimal(row.cell_volume_ml)) / basis)
+        for row in targets
+    ]
+
+
+def _media_rows(generation):
+    """Total what each lot contributed to this fill, at its recorded cost."""
+    totals = {}
+    for line in applied_media(generation):
+        share = sum(
+            (
+                Decimal(line.applied_base_quantity) * portion
+                for target, portion in cell_shares(line)
+                if target.seed_tray_generation_id == generation.pk
+            ),
+            Decimal('0'),
+        )
+        if not share:
+            continue
+        row = totals.setdefault(line.lot_id, {
+            'lot': line.lot,
+            'item': line.item,
+            'base_unit': line.base_unit,
+            'unit_cost': line.lot.base_unit_cost,
+            'base_quantity': Decimal('0'),
+        })
+        row['base_quantity'] += share
+    return [
+        {**row, 'base_quantity': quantize_quantity(row['base_quantity'])}
+        for row in totals.values()
+    ]
+
+
+def generation_contents(generation):
+    """Describe everything a clean has to find a disposition for."""
+    sowings = list(generation_sowings(generation))
+    seeds = [
+        {'sowing': sowing, 'quantity': unsown_seed(sowing)}
+        for sowing in sowings
+    ]
+    return {
+        'generation': generation,
+        'cell_count': generation_cells(generation).count(),
+        'sowings': sowings,
+        'plants': unresolved_plants(generation),
+        'seeds': [row for row in seeds if row['quantity'] > 0],
+        'media': _media_rows(generation),
+    }
+
+
+def contents_digest(contents):
+    """Summarize what a confirmation screen showed, so a stale one is refused.
+
+    Formatted like ``applications.services.availability_digest`` so both halves
+    of this codebase describe drift the same way. Anything that would change
+    what the operator has to decide about is in here.
+    """
+    rows = [f'plant:{plant.pk}' for plant in contents['plants']]
+    rows.extend(
+        f'seed:{row["sowing"].pk}:{row["quantity"]}'
+        for row in contents['seeds']
+    )
+    rows.extend(
+        f'media:{row["lot"].pk}:{quantize_quantity(row["base_quantity"]):.9f}'
+        for row in contents['media']
+    )
+    canonical = '\n'.join(sorted(rows))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _require_current(contents, digest):
+    """Refuse a confirmation submitted against contents that have since moved."""
+    if digest is not None and contents_digest(contents) != digest:
+        raise ValidationError({
+            'digest': (
+                'The tray changed after this clean was prepared. Review it again.'
+            ),
+        })
+
+
+def _require_cleanable(generation):
+    """Refuse to clean a fill that is closed or still awaiting review."""
+    if generation.status != SeedTrayGeneration.Status.OPEN:
+        raise ValidationError({
+            'status': f'Generation {generation.code} is already closed.',
+        })
+    if generation.review_state == SeedTrayGeneration.ReviewState.NEEDS_REVIEW:
+        raise ValidationError({
+            'review_state': (
+                f'Generation {generation.code} was migrated from earlier records '
+                'and must be reviewed before the tray can be cleaned.'
+            ),
+        })
+
+
+def _match_plants(contents, dispositions):
+    """Pair every plant in the tray with the outcome an operator chose."""
+    wanted = {plant.pk: plant for plant in contents['plants']}
+    chosen = {}
+    for row in dispositions:
+        if row.plant_id not in wanted:
+            raise ValidationError({
+                'plants': f'Plant {row.plant_id} is not in this generation.',
+            })
+        if row.outcome not in CLEAN_OUTCOMES:
+            raise ValidationError({
+                'plants': (
+                    f'Plant {row.plant_id}: record one of '
+                    f'{", ".join(CLEAN_OUTCOMES)}.'
+                ),
+            })
+        chosen[row.plant_id] = row
+    missing = sorted(set(wanted) - set(chosen))
+    if missing:
+        raise ValidationError({
+            'plants': f'These plants still need an outcome: {missing}.',
+        })
+    return [(wanted[plant_id], chosen[plant_id]) for plant_id in sorted(chosen)]
+
+
+def _match_quantities(expected, dispositions, key, field, allowed):
+    """Pair every leftover quantity with the disposition an operator recorded.
+
+    Both halves are checked. An unlisted leftover would be silently assumed away,
+    and a disposition for more than was left would put stock back that never
+    existed.
+    """
+    chosen = {}
+    for row in dispositions:
+        identifier = getattr(row, key)
+        if identifier not in expected:
+            raise ValidationError({
+                field: f'{identifier} has nothing left over in this generation.',
+            })
+        if row.disposition not in allowed:
+            raise ValidationError({
+                field: f'{identifier}: record one of {", ".join(allowed)}.',
+            })
+        quantity = quantize_quantity(row.quantity)
+        if quantity <= 0:
+            raise ValidationError({
+                field: f'{identifier}: record a quantity greater than zero.',
+            })
+        chosen[identifier] = chosen.get(identifier, Decimal('0')) + quantity
+        if chosen[identifier] > quantize_quantity(expected[identifier]):
+            raise ValidationError({
+                field: (
+                    f'{identifier}: {chosen[identifier]} is more than the '
+                    f'{quantize_quantity(expected[identifier])} left over.'
+                ),
+            })
+    for identifier, quantity in sorted(expected.items()):
+        if chosen.get(identifier, Decimal('0')) != quantize_quantity(quantity):
+            raise ValidationError({
+                field: (
+                    f'{identifier}: account for all '
+                    f'{quantize_quantity(quantity)} left over.'
+                ),
+            })
+
+
+def _resolve_plants(pairs, user, occurred_at):
+    """Record each chosen outcome, then empty the cell the plant occupied."""
+    from plantings.lifecycle import OutcomeRequest, record_lifecycle_event  # pylint: disable=import-outside-toplevel
+    from plantings.models import SpecificPlant, SpecificPlantLocation  # pylint: disable=import-outside-toplevel
+
+    # Every plant is locked up front in primary-key order, before any of them is
+    # written, so two cleans of overlapping selections queue rather than each
+    # holding half of what the other needs.
+    list(
+        SpecificPlant.objects
+        .select_for_update()
+        .filter(pk__in=[plant.pk for plant, _ in pairs])
+        .order_by('pk')
+    )
+    events = []
+    for plant, chosen in pairs:
+        events.append(record_lifecycle_event(plant, user, OutcomeRequest(
+            event_type=chosen.outcome,
+            occurred_at=occurred_at,
+            reason=chosen.reason,
+        )))
+        # A retained plant keeps growing, so its outcome does not close a
+        # location. The tray is being emptied all the same, so the cell it was
+        # sitting in has to stop being where it is.
+        SpecificPlantLocation.objects.filter(
+            specific_plant=plant,
+            ended__isnull=True,
+        ).update(ended=occurred_at)
+    return events
+
+
+def _recover_stock(generation, user, values, occurred_at):
+    """Put one recovered remainder back into stock as an adjustment gain."""
+    if values['destination'] is None:
+        raise ValidationError({
+            'destination': 'Name where the recovered stock was put.',
+        })
+    return post_stock_movement(
+        generation.workspace,
+        user,
+        MovementRequest(
+            lot=values['lot'],
+            movement_type=StockMovement.MovementType.ADJUSTMENT_GAIN,
+            quantity=values['quantity'],
+            destination=values['destination'],
+            occurred_at=occurred_at,
+            reason=values['reason'],
+            reference=f'tray generation:{generation.pk}',
+        ),
+    )
+
+
+def _write_residual(generation, user, values, occurred_at):
+    """Record one disposition, moving stock only when something came back."""
+    movement = None
+    if values['disposition'] in SeedTrayGenerationResidual.RECOVERING:
+        movement = _recover_stock(generation, user, values, occurred_at)
+    return SeedTrayGenerationResidual.objects.create(
+        generation=generation,
+        kind=values['kind'],
+        disposition=values['disposition'],
+        lot=values['lot'],
+        sowing=values.get('sowing'),
+        base_quantity=values['quantity'],
+        base_unit=values['lot'].item.base_unit,
+        unit_cost=values['lot'].base_unit_cost,
+        movement=movement,
+        reason=values['reason'],
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+
+
+def _seed_lot(sowing):
+    """Return the lot a sowing's leftover seed goes back to, or refuse."""
+    lot = sowing.seeds_used.stock_lot
+    if lot is None:
+        raise ValidationError({
+            'seeds': (
+                f'Sowing {sowing.pk} draws on a packet with no stock lot, so its '
+                'leftover seed cannot be recorded.'
+            ),
+        })
+    return lot
+
+
+@transaction.atomic
+def close_generation(generation, user, request):  # pylint: disable=too-many-locals
+    """Empty the tray, resolving everything left in it and closing the fill.
+
+    Locks are taken as generation, then plants, then batches, then lots.
+    ``applications.services.post_application`` documents why the last three run
+    in that order; the generation is a new outermost level that nothing else
+    takes, so extending the chain rather than starting a new one keeps this
+    compatible with sowing, harvesting, and posting an application.
+
+    Repeating a submission is refused rather than half-applied: the status check
+    runs under the lock, and everything happens in one transaction.
+    """
+    _require_reason(request.reason)
+    generation = lock_generation(generation)
+    _require_cleanable(generation)
+    occurred_at = request.occurred_at or timezone.now()
+
+    contents = generation_contents(generation)
+    _require_current(contents, request.digest)
+
+    plant_pairs = _match_plants(contents, request.plants)
+    seed_totals = {
+        row['sowing'].pk: Decimal(row['quantity'])
+        for row in contents['seeds']
+    }
+    media_totals = {
+        row['lot'].pk: Decimal(row['base_quantity'])
+        for row in contents['media']
+    }
+    _match_quantities(
+        seed_totals,
+        request.seeds,
+        'sowing_id',
+        'seeds',
+        (Disposition.REMOVED, Disposition.RETURNED),
+    )
+    _match_quantities(
+        media_totals,
+        request.media,
+        'lot_id',
+        'media',
+        (Disposition.WASTE, Disposition.RECLAIMED),
+    )
+
+    _resolve_plants(plant_pairs, user, occurred_at)
+
+    sowings = {sowing.pk: sowing for sowing in contents['sowings']}
+    lots = {row['lot'].pk: row['lot'] for row in contents['media']}
+    lock_lots(generation.workspace, sorted(lots))
+    for row in request.seeds:
+        sowing = sowings[row.sowing_id]
+        _write_residual(generation, user, {
+            'kind': Kind.SEED,
+            'disposition': row.disposition,
+            'lot': _seed_lot(sowing),
+            'sowing': sowing,
+            'quantity': quantize_quantity(row.quantity),
+            'destination': row.destination or sowing.seeds_used.storage_location,
+            'reason': row.reason,
+        }, occurred_at)
+    for row in request.media:
+        _write_residual(generation, user, {
+            'kind': Kind.MEDIA,
+            'disposition': row.disposition,
+            'lot': lots[row.lot_id],
+            'quantity': quantize_quantity(row.quantity),
+            'destination': row.destination,
+            'reason': row.reason,
+        }, occurred_at)
+
+    SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+        status=SeedTrayGeneration.Status.CLOSED,
+        closed_at=occurred_at,
+        close_reason=request.reason.strip(),
+        closed_by=user if user is not None and user.is_authenticated else None,
+        updated=occurred_at,
+    )
+    _record_event(generation, user, EventType.CLOSED, occurred_at, request.reason)
+    generation.refresh_from_db()
+
+    following = None
+    if request.open_next:
+        following = open_generation(generation.tray, user, occurred_at)
+    return generation, following
+
+
+@transaction.atomic
+def reopen_generation(generation, user, reason):
+    """Undo a clean that should not have happened, without erasing it.
+
+    Everything the clean wrote stays: the closing event keeps its time and its
+    stated reason, each residual keeps its quantity, and every lifecycle outcome
+    keeps its row. What is appended is the correction — a reversal per recovered
+    movement, a correction per outcome, and the reopening itself.
+
+    A closed location is deliberately not reopened. Where a plant has been
+    remains true, and `plantings.lifecycle` records a replacement location
+    rather than rewinding one.
+    """
+    _require_reason(reason)
+    generation = lock_generation(generation)
+    if generation.status != SeedTrayGeneration.Status.CLOSED:
+        raise ValidationError({'status': 'Only a closed generation can be reopened.'})
+    if open_generation_for(generation.tray) is not None:
+        raise ValidationError({
+            'tray': (
+                'The tray has been filled again. Clean the current generation '
+                'before correcting the previous one.'
+            ),
+        })
+    occurred_at = timezone.now()
+    _reverse_recovered_stock(generation, user, reason)
+    _reverse_close_outcomes(generation, user, reason, occurred_at)
+    SeedTrayGeneration.objects.filter(pk=generation.pk).update(
+        status=SeedTrayGeneration.Status.OPEN,
+        closed_at=None,
+        close_reason='',
+        closed_by=None,
+        updated=occurred_at,
+    )
+    _record_event(generation, user, EventType.REOPENED, occurred_at, reason)
+    generation.refresh_from_db()
+    return generation
+
+
+def _reverse_recovered_stock(generation, user, reason):
+    """Take back every quantity this clean returned to the shelf."""
+    movements = list(
+        StockMovement.objects.select_for_update(of=('self',))
+        .select_related('lot__item', 'workspace', 'source', 'destination')
+        .filter(tray_generation_residual__generation=generation)
+        .order_by('pk')
+    )
+    if not movements:
+        return []
+    return reverse_tray_generation_movements(
+        generation.workspace,
+        movements,
+        user,
+        reason,
+    )
+
+
+def _reverse_close_outcomes(generation, user, reason, occurred_at):
+    """Correct each outcome this clean recorded, leaving the mistake visible."""
+    from plantings.lifecycle import reverse_lifecycle_event  # pylint: disable=import-outside-toplevel
+    from plantings.models import PlantLifecycleEvent  # pylint: disable=import-outside-toplevel
+
+    events = list(
+        PlantLifecycleEvent.objects
+        .filter(
+            plant__cell_planting__seed_tray_planting__generation=generation,
+            occurred_at=generation.closed_at,
+            event_type__in=CLEAN_OUTCOMES,
+            reversal__isnull=True,
+        )
+        .select_related('plant')
+        .order_by('pk')
+    )
+    return [
+        reverse_lifecycle_event(event, user, reason, occurred_at)
+        for event in events
+    ]

--- a/seedtrays/test_generation_concurrency.py
+++ b/seedtrays/test_generation_concurrency.py
@@ -1,0 +1,167 @@
+"""Concurrency proofs for the locks cleaning a tray relies on.
+
+`close_generation` takes the generation lock, then plants, then batches, then
+lots. `applications.services.post_application` documents why the last three run
+in that order; the generation is a new outermost level that nothing else takes,
+so extending the chain rather than starting a new one is what keeps this
+compatible with sowing, harvesting, and posting an application.
+
+Real row locks are what these prove, so they need a database that honours
+`SELECT ... FOR UPDATE`.
+"""
+# pylint: disable=duplicate-code
+
+from concurrent.futures import ThreadPoolExecutor
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.utils import timezone
+
+from plantings.lifecycle import (
+    EventType,
+    OutcomeRequest,
+    record_germination_event,
+    record_lifecycle_event,
+)
+from plantings.models import PlantLifecycleEvent, SpecificPlant
+from tests.factories import (
+    make_seed_tray,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace
+
+from .generations import (
+    CloseRequest,
+    PlantDisposition,
+    close_generation,
+    open_generation,
+)
+from .models import SeedTrayGeneration
+
+
+class GenerationConcurrencyTestCase(TransactionTestCase):
+    """Shared fixture teardown for the tray-cleaning race tests."""
+
+    #: Set by each subclass's setUp before any thread starts.
+    generation_pk = None
+    user_pk = None
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+    def _clean(self, dispositions=()):
+        """Attempt one clean from an independent connection."""
+        close_old_connections()
+        generation = SeedTrayGeneration.objects.get(pk=self.generation_pk)
+        user = get_user_model().objects.get(pk=self.user_pk)
+        try:
+            close_generation(generation, user, CloseRequest(
+                reason='End of the run.',
+                plants=dispositions,
+            ))
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'cleaned'
+        close_old_connections()
+        return result
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentCleanTests(GenerationConcurrencyTestCase):
+    """Two operators cleaning the same tray resolve its contents once."""
+
+    def setUp(self):
+        super().setUp()
+        user = get_user_model().objects.create_user(username='clean-racer')
+        self.user_pk = user.pk
+        tray = make_seed_tray()
+        self.generation_pk = open_generation(tray, user).pk
+
+    def test_only_one_clean_closes_the_generation(self):
+        """The loser is refused outright rather than half-applied."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [pool.submit(self._clean), pool.submit(self._clean)]
+            )
+
+        self.assertEqual(results, ['cleaned', 'rejected'])
+        generation = SeedTrayGeneration.objects.get(pk=self.generation_pk)
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.CLOSED)
+        self.assertEqual(
+            generation.events.filter(event_type='closed').count(),
+            1,
+        )
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentCleanAndOutcomeTests(GenerationConcurrencyTestCase):
+    """A clean and a plant-level outcome cannot both resolve one seedling.
+
+    The clean writes plant facts, and recording an outcome directly writes the
+    same kind of fact without touching the generation at all. The plant lock is
+    therefore the only thing keeping one seedling from ending twice, which is
+    the same guarantee `plantings.test_harvest_concurrency` relies on.
+    """
+
+    def setUp(self):
+        super().setUp()
+        user = get_user_model().objects.create_user(username='outcome-racer')
+        self.user_pk = user.pk
+        plant = make_specific_plant()
+        record_germination_event(plant, user)
+        make_specific_plant_location(specific_plant=plant)
+        self.plant_pk = plant.pk
+        tray = plant.cell_planting.cell.tray
+        generation = open_generation(tray, user, opened_at=timezone.now())
+        sowing = plant.cell_planting.seed_tray_planting
+        type(sowing).objects.filter(pk=sowing.pk).update(generation=generation)
+        self.generation_pk = generation.pk
+
+    def _cull_plant(self):
+        """Attempt to record the plant as culled from another connection."""
+        close_old_connections()
+        plant = SpecificPlant.objects.get(pk=self.plant_pk)
+        user = get_user_model().objects.get(pk=self.user_pk)
+        try:
+            record_lifecycle_event(plant, user, OutcomeRequest(EventType.CULLED))
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'culled'
+        close_old_connections()
+        return result
+
+    def test_a_plant_is_resolved_by_exactly_one_writer(self):
+        """Whichever wins, the seedling ends with a single final outcome."""
+        dispositions = (PlantDisposition(self.plant_pk, 'failed', 'Damped off.'),)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._clean, dispositions),
+                    pool.submit(self._cull_plant),
+                ]
+            )
+
+        outcomes = PlantLifecycleEvent.objects.filter(
+            plant_id=self.plant_pk,
+            event_type__in=(
+                PlantLifecycleEvent.EventType.FAILED,
+                PlantLifecycleEvent.EventType.CULLED,
+            ),
+        )
+        self.assertEqual(outcomes.count(), 1)
+        self.assertIn('rejected', results)

--- a/seedtrays/test_generations.py
+++ b/seedtrays/test_generations.py
@@ -1,16 +1,62 @@
-"""Opening a fill of a tray, and confirming a migrated one."""
+"""Opening a fill of a tray, cleaning it, and correcting a mistaken clean."""
 # pylint: disable=duplicate-code
+
+from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
-from tests.factories import make_seed_tray, make_seed_tray_generation
+from applications.models import InputApplication
+from applications.services import (
+    ApplicationRequest,
+    LineRequest,
+    TargetRequest,
+    create_application_draft,
+    post_application,
+)
+from inventory.ledger import physical_balance, reverse_movement
+from inventory.models import InventoryItem, StockLot, StockMovement
+from inventory.units import UnitCode
+from plantings.lifecycle import (
+    LifecycleState,
+    plant_lifecycle_summary,
+    record_germination_event,
+)
+from plantings.models import SeedTrayPlanting, SpecificPlant
+from seeds.services import ensure_packet_inventory_identity
+from tests.factories import (
+    make_batch_for_packet,
+    make_inventory_item,
+    make_inventory_location,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_generation,
+    make_seed_tray_model,
+    make_seed_tray_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+    make_stock_lot,
+)
+from workspaces.models import Workspace
 
+from .generation_costs import generation_cost_breakdown
 from .generations import (
+    CloseRequest,
+    Disposition,
+    Kind,
+    MediaDisposition,
+    PlantDisposition,
+    SeedDisposition,
+    close_generation,
+    contents_digest,
+    generation_contents,
     open_generation,
     open_generation_for,
+    reopen_generation,
     require_open_generation,
     review_generation,
 )
@@ -129,3 +175,604 @@ class ReviewGenerationTests(TestCase):
             review_generation(self.generation, self.user, 'Confirmed again.')
 
         self.assertIn('review_state', caught.exception.message_dict)
+
+
+class GenerationContentsTestCase(TestCase):  # pylint: disable=too-many-instance-attributes
+    """One filled tray with media, seedlings, and leftover seed in it."""
+
+    def setUp(self):
+        """Fill one two-cell tray and stock the media it draws on."""
+        super().setUp()
+        self.workspace = Workspace.objects.get(pk=1)
+        self.user = get_user_model().objects.create_user('cleaner', password='x')
+        self.location = make_inventory_location()
+        self.media_item = make_inventory_item(
+            base_unit=UnitCode.LITRE,
+            default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+        )
+        self.media_lot = make_stock_lot(
+            item=self.media_item,
+            location=self.location,
+            quantity='50',
+            base_unit_cost=Decimal('2'),
+        )
+        tray_model = make_seed_tray_model(cell_size_ml=40, x_cells=2, y_cells=1)
+        self.tray = make_seed_tray(model=tray_model)
+        self.generation = open_generation(self.tray, self.user)
+        self.cells = [
+            make_seed_tray_cell(tray=self.tray, x_position=index)
+            for index in range(2)
+        ]
+
+    def apply_media(self, quantity='0.08'):
+        """Post one media application filling both cells of the tray."""
+        application = create_application_draft(
+            self.workspace,
+            self.user,
+            ApplicationRequest(
+                applied_at=timezone.now(),
+                source_location=self.location,
+                lines=(LineRequest(
+                    item=self.media_item,
+                    lot=self.media_lot,
+                    applied_quantity=Decimal(quantity),
+                    unit_code=UnitCode.LITRE,
+                    targets=tuple(
+                        TargetRequest('seed_tray_cell', cell)
+                        for cell in self.cells
+                    ),
+                ),),
+            ),
+        )
+        return post_application(application, self.user)[0]
+
+    def sow(self, quantity=4, allocations=((0, 2),)):
+        """Sow into this fill, allocating the given (cell index, count) pairs."""
+        packet = ensure_packet_inventory_identity(make_seed_packet())
+        sowing = make_seed_tray_planting(
+            seeds_used=packet,
+            batch=make_batch_for_packet(packet),
+            quantity=quantity,
+            seed_tray=self.tray,
+            generation=self.generation,
+        )
+        for index, count in allocations:
+            make_seed_tray_cell_planting(
+                seed_tray_planting=sowing,
+                cell=self.cells[index],
+                quantity=count,
+            )
+        return sowing
+
+    def germinate(self, sowing, cell_index=0):
+        """Observe one plant in a cell and put it there."""
+        cell_planting = sowing.cell_plantings.get(cell=self.cells[cell_index])
+        plant = make_specific_plant(cell_planting=cell_planting)
+        record_germination_event(plant, self.user)
+        make_specific_plant_location(specific_plant=plant)
+        return plant
+
+    def close(self, **overrides):
+        """Clean the tray with a fully specified set of dispositions."""
+        contents = generation_contents(self.generation)
+        values = {
+            'reason': 'End of the propagation run.',
+            'plants': tuple(
+                PlantDisposition(plant.pk, 'failed', 'Did not size up.')
+                for plant in contents['plants']
+            ),
+            'seeds': tuple(
+                SeedDisposition(
+                    row['sowing'].pk,
+                    row['quantity'],
+                    Disposition.REMOVED,
+                    'Swept up.',
+                )
+                for row in contents['seeds']
+            ),
+            'media': tuple(
+                MediaDisposition(
+                    row['lot'].pk,
+                    row['base_quantity'],
+                    Disposition.WASTE,
+                    'Tipped out.',
+                )
+                for row in contents['media']
+            ),
+        }
+        values.update(overrides)
+        return close_generation(self.generation, self.user, CloseRequest(**values))
+
+
+class CleanGenerationTests(GenerationContentsTestCase):  # pylint: disable=too-many-public-methods
+    """Emptying a tray resolves everything in it, and deletes nothing."""
+
+    def test_contents_report_what_is_still_in_the_tray(self):
+        """The confirmation screen is built from this, so it has to be complete."""
+        self.apply_media()
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+        plant = self.germinate(sowing)
+
+        contents = generation_contents(self.generation)
+
+        self.assertEqual([row.pk for row in contents['plants']], [plant.pk])
+        self.assertEqual(
+            [(row['sowing'].pk, row['quantity']) for row in contents['seeds']],
+            [(sowing.pk, 2)],
+        )
+        self.assertEqual(
+            [(row['lot'].pk, row['base_quantity']) for row in contents['media']],
+            [(self.media_lot.pk, Decimal('0.080000000'))],
+        )
+
+    def test_a_plant_already_planted_out_does_not_hold_up_the_clean(self):
+        """It is not in the tray, so asking to dispose of it makes no sense."""
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+        plant.locations.update(ended=timezone.now())
+
+        contents = generation_contents(self.generation)
+
+        self.assertEqual(contents['plants'], [])
+
+    def test_cleaning_closes_the_fill_and_records_why(self):
+        """The close is a fact with a stated reason, kept for good."""
+        generation, following = self.close()
+
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.CLOSED)
+        self.assertIsNotNone(generation.closed_at)
+        self.assertEqual(generation.close_reason, 'End of the propagation run.')
+        self.assertEqual(generation.closed_by, self.user)
+        self.assertIsNone(following)
+        event = generation.events.get(
+            event_type=SeedTrayGenerationEvent.EventType.CLOSED,
+        )
+        self.assertEqual(event.reason, 'End of the propagation run.')
+
+    def test_every_remaining_plant_needs_an_explicit_outcome(self):
+        """Nothing is quietly assumed to have failed."""
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close(plants=())
+
+        self.assertIn(str(plant.pk), ' '.join(caught.exception.messages))
+        self.generation.refresh_from_db()
+        self.assertEqual(self.generation.status, SeedTrayGeneration.Status.OPEN)
+
+    def test_a_resolved_plant_leaves_the_cell_it_was_sitting_in(self):
+        """The tray is being emptied, so nothing can still be in a cell."""
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+
+        self.close()
+
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.FAILED)
+        self.assertFalse(plant.locations.filter(ended__isnull=True).exists())
+
+    def test_a_retained_plant_keeps_its_state_but_leaves_the_tray(self):
+        """Retention does not close a location, but an emptied tray does."""
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+
+        self.close(plants=(PlantDisposition(plant.pk, 'retained', 'Keeping it.'),))
+
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.RETAINED)
+        self.assertFalse(plant.locations.filter(ended__isnull=True).exists())
+
+    def test_every_leftover_seed_needs_an_explicit_disposition(self):
+        """Seed drawn from the packet went somewhere; the record says where."""
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close(seeds=())
+
+        self.assertIn(str(sowing.pk), ' '.join(caught.exception.messages))
+
+    def test_leftover_seed_thrown_away_moves_no_stock(self):
+        """Sowing already consumed it; a second row would double count."""
+        self.sow(quantity=4, allocations=((0, 2),))
+        packet_lot = self.generation.sowings.get().seeds_used.stock_lot
+        before = StockMovement.objects.filter(lot=packet_lot).count()
+
+        self.close()
+
+        residual = self.generation.residuals.get(kind=Kind.SEED)
+        self.assertEqual(residual.disposition, Disposition.REMOVED)
+        self.assertEqual(residual.base_quantity, Decimal('2.000000000'))
+        self.assertIsNone(residual.movement)
+        self.assertEqual(
+            StockMovement.objects.filter(lot=packet_lot).count(),
+            before,
+        )
+
+    def test_leftover_seed_put_back_returns_to_its_packet(self):
+        """It physically came back, so the ledger has to say so."""
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+        packet = sowing.seeds_used
+
+        self.close(seeds=(SeedDisposition(
+            sowing.pk,
+            2,
+            Disposition.RETURNED,
+            'Back in the packet.',
+        ),))
+
+        residual = self.generation.residuals.get(kind=Kind.SEED)
+        self.assertIsNotNone(residual.movement)
+        self.assertEqual(
+            residual.movement.movement_type,
+            StockMovement.MovementType.ADJUSTMENT_GAIN,
+        )
+        self.assertEqual(residual.movement.destination, packet.storage_location)
+        self.assertEqual(residual.movement.quantity, Decimal('2.000000000'))
+
+    def test_more_seed_than_was_left_over_is_refused(self):
+        """Putting back stock that never existed would invent inventory."""
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close(seeds=(SeedDisposition(
+                sowing.pk,
+                5,
+                Disposition.RETURNED,
+                'Too many.',
+            ),))
+
+        self.assertIn('more than the', ' '.join(caught.exception.messages))
+
+    def test_every_applied_lot_of_media_needs_a_disposition(self):
+        """Media does not vanish because the tray was tipped out."""
+        self.apply_media()
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close(media=())
+
+        self.assertIn('account for all', ' '.join(caught.exception.messages))
+
+    def test_discarded_media_records_no_movement(self):
+        """The application consumed it already."""
+        self.apply_media()
+        before = physical_balance(self.media_lot, self.location)
+
+        self.close()
+
+        residual = self.generation.residuals.get(kind=Kind.MEDIA)
+        self.assertEqual(residual.disposition, Disposition.WASTE)
+        self.assertEqual(residual.base_quantity, Decimal('0.080000000'))
+        self.assertEqual(residual.unit_cost, Decimal('2'))
+        self.assertIsNone(residual.movement)
+        self.assertEqual(physical_balance(self.media_lot, self.location), before)
+
+    def test_reclaimed_media_goes_back_on_the_shelf(self):
+        """Both the quantity and its cost return to the lot it came from."""
+        self.apply_media()
+        before = physical_balance(self.media_lot, self.location)
+
+        self.close(media=(MediaDisposition(
+            self.media_lot.pk,
+            Decimal('0.08'),
+            Disposition.RECLAIMED,
+            'Scooped back into the bag.',
+            destination=self.location,
+        ),))
+
+        residual = self.generation.residuals.get(kind=Kind.MEDIA)
+        self.assertEqual(
+            residual.movement.movement_type,
+            StockMovement.MovementType.ADJUSTMENT_GAIN,
+        )
+        self.assertEqual(
+            physical_balance(self.media_lot, self.location),
+            before + Decimal('0.08'),
+        )
+
+    def test_recovering_media_needs_somewhere_to_put_it(self):
+        """Stock has to come back to a place, not to nowhere."""
+        self.apply_media()
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close(media=(MediaDisposition(
+                self.media_lot.pk,
+                Decimal('0.08'),
+                Disposition.RECLAIMED,
+                'Kept it.',
+            ),))
+
+        self.assertIn('destination', caught.exception.message_dict)
+
+    def test_cleaning_deletes_nothing(self):
+        """The archive is a filter on status, not a loss."""
+        self.apply_media()
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+        applications = list(InputApplication.objects.values_list('pk', flat=True))
+        movements = StockMovement.objects.count()
+
+        self.close()
+
+        self.assertTrue(SeedTrayPlanting.objects.filter(pk=sowing.pk).exists())
+        self.assertTrue(SpecificPlant.objects.filter(pk=plant.pk).exists())
+        self.assertEqual(
+            list(InputApplication.objects.values_list('pk', flat=True)),
+            applications,
+        )
+        self.assertGreaterEqual(StockMovement.objects.count(), movements)
+        self.assertEqual(self.generation.sowings.count(), 1)
+
+    def test_cleaning_twice_is_refused_without_half_applying(self):
+        """A resubmitted confirmation must not resolve anything a second time."""
+        self.apply_media()
+        self.close()
+        residuals = self.generation.residuals.count()
+
+        with self.assertRaises(ValidationError) as caught:
+            close_generation(
+                self.generation,
+                self.user,
+                CloseRequest(reason='Again.'),
+            )
+
+        self.assertIn('already closed', ' '.join(caught.exception.messages))
+        self.assertEqual(self.generation.residuals.count(), residuals)
+
+    def test_a_stale_confirmation_is_refused(self):
+        """The operator has to see what they are deciding about."""
+        digest = contents_digest(generation_contents(self.generation))
+        self.sow()
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close(digest=digest)
+
+        self.assertIn('changed after', ' '.join(caught.exception.messages))
+
+    def test_a_current_confirmation_is_accepted(self):
+        """Nothing moved, so the operator saw what they decided about."""
+        self.sow()
+        digest = contents_digest(generation_contents(self.generation))
+
+        generation, _ = self.close(digest=digest)
+
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.CLOSED)
+
+    def test_a_migrated_fill_cannot_be_cleaned_before_review(self):
+        """Its contents may belong to two cycles nobody has separated yet."""
+        SeedTrayGeneration.objects.filter(pk=self.generation.pk).update(
+            origin=SeedTrayGeneration.Origin.LEGACY,
+            review_state=SeedTrayGeneration.ReviewState.NEEDS_REVIEW,
+        )
+        self.generation.refresh_from_db()
+
+        with self.assertRaises(ValidationError) as caught:
+            self.close()
+
+        self.assertIn('review_state', caught.exception.message_dict)
+
+    def test_a_clean_needs_a_reason(self):
+        """The closing reason is the one thing the history cannot derive."""
+        with self.assertRaises(ValidationError) as caught:
+            self.close(reason='  ')
+
+        self.assertIn('reason', caught.exception.message_dict)
+
+    def test_the_tray_can_be_refilled_in_the_same_step(self):
+        """Filling again is the usual next act, and it is still its own fill."""
+        generation, following = self.close(open_next=True)
+
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.CLOSED)
+        self.assertEqual(following.sequence, 2)
+        self.assertEqual(following.status, SeedTrayGeneration.Status.OPEN)
+        self.assertEqual(following.sowings.count(), 0)
+
+
+class ReopenGenerationTests(GenerationContentsTestCase):
+    """A mistaken clean is corrected by appending, never by erasing."""
+
+    def test_reopening_leaves_the_close_on_file(self):
+        """The mistake and its correction are both visible afterwards."""
+        generation, _ = self.close()
+        closed_at = generation.closed_at
+
+        generation = reopen_generation(generation, self.user, 'Cleaned the wrong tray.')
+
+        self.assertEqual(generation.status, SeedTrayGeneration.Status.OPEN)
+        self.assertIsNone(generation.closed_at)
+        self.assertEqual(generation.close_reason, '')
+        closed = generation.events.get(
+            event_type=SeedTrayGenerationEvent.EventType.CLOSED,
+        )
+        self.assertEqual(closed.occurred_at, closed_at)
+        self.assertEqual(closed.reason, 'End of the propagation run.')
+        reopened = generation.events.get(
+            event_type=SeedTrayGenerationEvent.EventType.REOPENED,
+        )
+        self.assertEqual(reopened.reason, 'Cleaned the wrong tray.')
+
+    def test_reopening_corrects_the_outcomes_the_clean_recorded(self):
+        """The seedling is growing again, and the mistake stays readable."""
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+        generation, _ = self.close()
+
+        reopen_generation(generation, self.user, 'Wrong tray.')
+
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.GROWING)
+        self.assertTrue(
+            plant.lifecycle_events.filter(event_type='failed').exists(),
+        )
+        self.assertTrue(
+            plant.lifecycle_events.filter(event_type='corrected').exists(),
+        )
+
+    def test_reopening_takes_back_the_stock_the_clean_recovered(self):
+        """Media put back on a mistaken clean was never really recovered."""
+        self.apply_media()
+        before = physical_balance(self.media_lot, self.location)
+        generation, _ = self.close(media=(MediaDisposition(
+            self.media_lot.pk,
+            Decimal('0.08'),
+            Disposition.RECLAIMED,
+            'Scooped back.',
+            destination=self.location,
+        ),))
+
+        reopen_generation(generation, self.user, 'Wrong tray.')
+
+        self.assertEqual(physical_balance(self.media_lot, self.location), before)
+        residual = generation.residuals.get(kind=Kind.MEDIA)
+        self.assertIsNotNone(residual.reversed_movement)
+
+    def test_the_residual_record_survives_the_correction(self):
+        """What the operator said happened stays on file either way."""
+        self.apply_media()
+        generation, _ = self.close()
+
+        reopen_generation(generation, self.user, 'Wrong tray.')
+
+        residual = generation.residuals.get(kind=Kind.MEDIA)
+        self.assertEqual(residual.base_quantity, Decimal('0.080000000'))
+        self.assertEqual(residual.disposition, Disposition.WASTE)
+
+    def test_a_closed_location_is_not_reopened(self):
+        """Where a plant has been remains true; a replacement is recorded."""
+        sowing = self.sow()
+        plant = self.germinate(sowing)
+        generation, _ = self.close()
+
+        reopen_generation(generation, self.user, 'Wrong tray.')
+
+        self.assertFalse(plant.locations.filter(ended__isnull=True).exists())
+
+    def test_an_open_generation_cannot_be_reopened(self):
+        """There is nothing to correct."""
+        with self.assertRaises(ValidationError) as caught:
+            reopen_generation(self.generation, self.user, 'Why not.')
+
+        self.assertIn('status', caught.exception.message_dict)
+
+    def test_a_correction_needs_a_reason(self):
+        """Undoing an audited action without saying why is not an audit trail."""
+        generation, _ = self.close()
+
+        with self.assertRaises(ValidationError) as caught:
+            reopen_generation(generation, self.user, '')
+
+        self.assertIn('reason', caught.exception.message_dict)
+
+    def test_a_refilled_tray_blocks_the_correction(self):
+        """Two open fills of one tray is the state this feature forbids."""
+        generation, _ = self.close(open_next=True)
+
+        with self.assertRaises(ValidationError) as caught:
+            reopen_generation(generation, self.user, 'Wrong tray.')
+
+        self.assertIn('filled again', ' '.join(caught.exception.messages))
+
+    def test_the_recovered_movement_cannot_be_reversed_on_its_own(self):
+        """It belongs to the clean, so it comes back through the correction."""
+        self.apply_media()
+        generation, _ = self.close(media=(MediaDisposition(
+            self.media_lot.pk,
+            Decimal('0.08'),
+            Disposition.RECLAIMED,
+            'Scooped back.',
+            destination=self.location,
+        ),))
+        movement = generation.residuals.get(kind=Kind.MEDIA).movement
+
+        with self.assertRaises(ValidationError) as caught:
+            reverse_movement(movement, self.user, 'Standalone.')
+
+        self.assertIn('through their generation', ' '.join(caught.exception.messages))
+
+
+class GenerationCostTests(GenerationContentsTestCase):
+    """Media cost reaches the seedlings of one fill, and no others."""
+
+    def test_a_fill_carries_only_its_own_media_cost(self):
+        """Two litres a litre over 0.08 litres is 0.16 across two cells."""
+        self.apply_media()
+        sowing = self.sow(quantity=4, allocations=((0, 2), (1, 2)))
+        plant = self.germinate(sowing, cell_index=0)
+
+        breakdown = generation_cost_breakdown(self.generation)
+
+        self.assertEqual(breakdown['applied_cost'], Decimal('0.160000000000'))
+        self.assertFalse(breakdown['unknown_cost'])
+        self.assertEqual(
+            breakdown['plants'],
+            [{'plant': plant.pk, 'cost': Decimal('0.080000000000')}],
+        )
+        self.assertEqual(breakdown['allocated_cost'], Decimal('0.080000000000'))
+        self.assertEqual(breakdown['unallocated_cost'], Decimal('0.080000000000'))
+
+    def test_plants_sharing_a_cell_share_its_media(self):
+        """A multigerm cluster splits one cell's cost without changing counts."""
+        self.apply_media()
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+        first = self.germinate(sowing)
+        second = self.germinate(sowing)
+
+        breakdown = generation_cost_breakdown(self.generation)
+
+        self.assertEqual(
+            breakdown['plants'],
+            [
+                {'plant': first.pk, 'cost': Decimal('0.040000000000')},
+                {'plant': second.pk, 'cost': Decimal('0.040000000000')},
+            ],
+        )
+        self.assertEqual(sowing.quantity, 4)
+        self.assertEqual(SpecificPlant.objects.count(), 2)
+
+    def test_an_empty_cell_is_provisional_until_the_fill_is_closed(self):
+        """A seedling may still come up in it."""
+        self.apply_media()
+        sowing = self.sow(quantity=4, allocations=((0, 2), (1, 2)))
+        self.germinate(sowing, cell_index=0)
+
+        breakdown = generation_cost_breakdown(self.generation)
+
+        empty = [row for row in breakdown['cells'] if not row['plants']]
+        self.assertTrue(all(row['provisional'] for row in empty))
+        self.assertEqual(breakdown['production_loss'], Decimal('0'))
+
+    def test_a_closed_fill_turns_its_empty_cells_into_production_loss(self):
+        """Nothing more will come up, so the cost has to land somewhere."""
+        self.apply_media()
+        sowing = self.sow(quantity=4, allocations=((0, 2), (1, 2)))
+        plant = self.germinate(sowing, cell_index=0)
+        self.close(plants=(PlantDisposition(plant.pk, 'retained', 'Kept.'),))
+        self.generation.refresh_from_db()
+
+        breakdown = generation_cost_breakdown(self.generation)
+
+        empty = [row for row in breakdown['cells'] if not row['plants']]
+        self.assertFalse(any(row['provisional'] for row in empty))
+        self.assertEqual(breakdown['wasted_cost'], Decimal('0.160000000000'))
+
+    def test_the_next_fill_starts_with_no_cost_carried_over(self):
+        """Reusing the tray must not hand the old crop's media to the new one."""
+        self.apply_media()
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+        self.germinate(sowing)
+        _, following = self.close(open_next=True)
+
+        breakdown = generation_cost_breakdown(following)
+
+        self.assertEqual(breakdown['applied_cost'], Decimal('0'))
+        self.assertEqual(breakdown['media'], [])
+        self.assertEqual(breakdown['plants'], [])
+
+    def test_a_lot_with_no_recorded_cost_reports_unknown(self):
+        """A zero would quietly understate every total built on it."""
+        StockLot.objects.filter(pk=self.media_lot.pk).update(base_unit_cost=None)
+        self.media_lot.refresh_from_db()
+        self.apply_media()
+
+        breakdown = generation_cost_breakdown(self.generation)
+
+        self.assertTrue(breakdown['unknown_cost'])
+        self.assertIsNone(breakdown['media'][0]['cost'])
+        self.assertEqual(breakdown['applied_cost'], Decimal('0'))


### PR DESCRIPTION
Cleaning is the boundary that makes reuse safe, so it refuses to guess. It writes nothing until every plant still sitting in the tray, every seed a sowing drew but never placed in a cell, and every quantity of media applied to the fill has an explicit disposition. An unlisted item is an error, and so is a disposition for more than was left over.

A plant that already went out to a garden square does not hold up the clean; presence in the tray is the test, not lineage. A retained plant keeps its state but still leaves the cell it was in, because the tray is being emptied and `retained` does not close a location on its own.

Media and seed both left inventory when they were applied or sown, so a discarded remainder is recorded and moves no stock — a second movement would decrement a lot the original consumption already decremented, and task 43 reads these rows for production loss instead. Only a remainder physically put back on the shelf posts an adjustment gain.

Nothing is deleted. Sowings leave the tray's normal view because that view derives from the generation's status, and correcting a mistaken clean appends: a reversal per recovered movement, a correction per outcome, and the reopening itself, with the close and every residual still readable. A closed location is not reopened, following the rule `plantings.lifecycle` already sets.

The cost breakdown traces each fill's media to the seedlings it raised, splitting a line across cells on the same weight-by-volume basis the usage calculation used, and sharing a cell equally among the plants in it so a multigerm cluster costs one cell rather than three. Task 43 still owns the subledger; this is the identity it will consume.

Locks run generation, plants, batches, lots. The generation lock names of=('self',) for the reason post_application records: an unqualified lock would take the joined workspace row, which every plant fact needs a key-share lock on, and a concurrent outcome then deadlocked against a clean instead of queueing behind it. PostgreSQL caught that; SQLite cannot.

## Summary by Sourcery

Implement tray generation cleaning workflow with explicit dispositions, support reopening mistaken cleans, and add media cost breakdown per generation.

New Features:
- Add generation cleaning API that requires explicit outcomes for plants, leftover seeds, and applied media and records residuals without deleting source data.
- Support reopening a closed generation to correct a mistaken clean while retaining the original close and residual records.
- Introduce generation-level media cost breakdown that allocates cost per cell and per plant and reports production loss.

Bug Fixes:
- Prevent double resolution of plants and inventory by validating quantities and enforcing generation status checks during cleaning and reopening.

Enhancements:
- Extend generation utilities to expose contents (cells, sowings, plants, seed, media) and a digest used to reject stale clean confirmations.
- Tighten generation row locking to avoid deadlocks with application posting and plant outcomes, and add concurrency tests to prove locking behaviour.

Tests:
- Add extensive tests covering generation contents, cleaning behaviour, reopening corrections, media cost breakdown, and concurrency between cleans and plant-level outcomes.