### PR TITLE
feat(seedtrays): expose generation and clean endpoints

### DIFF
--- a/plantings/generation_rest.py
+++ b/plantings/generation_rest.py
@@ -7,10 +7,12 @@ rather than more of any of those.
 """
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import models
+from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
 from seedtrays.generations import require_open_generation
-from seedtrays.models import SeedTrayGeneration
+from seedtrays.models import SeedTray, SeedTrayGeneration
 
 
 def _model_errors(error):
@@ -18,6 +20,58 @@ def _model_errors(error):
     if hasattr(error, 'message_dict'):
         return error.message_dict
     return error.messages
+
+
+class TrayGenerationFilterMixin:
+    """Show the tray as it is now, with its earlier fills behind a filter.
+
+    Cleaning a tray archives what was in it. That archive is this filter and
+    nothing else: no row is deleted, and `history=true` or an explicit
+    `generation` brings any closed fill straight back. Sowings recorded before
+    generations existed have no fill to hide behind, so they stay visible.
+    """
+
+    #: How this viewset reaches a generation from the rows it lists.
+    generation_lookup = 'generation'
+    _parent_seed_tray = None
+
+    def get_parent_seed_tray(self):
+        """Resolve the nested tray inside the current workspace."""
+        if self._parent_seed_tray is None:
+            self._parent_seed_tray = get_object_or_404(
+                SeedTray,
+                pk=self.kwargs['seed_tray_pk'],
+                workspace=self.get_current_workspace(),
+            )
+        return self._parent_seed_tray
+
+    def filter_by_generation(self, queryset, tray):
+        """Narrow one tray's rows to the fill the client asked to see."""
+        query = self.request.query_params
+        requested = query.get('generation')
+        if requested is not None:
+            try:
+                generation = int(requested)
+            except ValueError as exc:
+                raise serializers.ValidationError({
+                    'generation': 'Use an integer generation ID.',
+                }) from exc
+            return queryset.filter(**{self.generation_lookup: generation})
+        history = query.get('history')
+        if history is not None:
+            if history not in {'true', 'false'}:
+                raise serializers.ValidationError({'history': 'Use true or false.'})
+            if history == 'true':
+                return queryset
+        active = SeedTrayGeneration.objects.filter(
+            tray=tray,
+            status=SeedTrayGeneration.Status.OPEN,
+        ).values_list('pk', flat=True)
+        visible = models.Q(**{f'{self.generation_lookup}__in': list(active)})
+        # A sowing recorded before generations existed has no fill to hide
+        # behind, so hiding it would lose it rather than archive it.
+        unknown = models.Q(**{f'{self.generation_lookup}__isnull': True})
+        return queryset.filter(visible | unknown)
 
 
 class TrayGenerationSowingSerializerMixin:  # pylint: disable=too-few-public-methods

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -10,12 +10,11 @@ from django.utils import timezone
 from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from seedtrays.models import SeedTray
 from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .batch_rest import BatchedSowingSerializerMixin, InlineBatchSerializer, register_batch_routes
-from .generation_rest import TrayGenerationSowingSerializerMixin
+from .generation_rest import TrayGenerationFilterMixin, TrayGenerationSowingSerializerMixin
 from .harvest_rest import register_harvest_routes
 from .lifecycle import record_germination_event, record_transplant_event
 from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSerializerMixin, PlantOutcomeViewSetMixin, register_lifecycle_routes
@@ -823,6 +822,7 @@ class SeedTrayPlantingViewSet(
 
 
 class SeedTrayPlantingViewSeedTraySet(
+    TrayGenerationFilterMixin,
     SowingCorrectionViewSetMixin,
     ProtectedSeedTrayPlantingDestroyMixin,
     CurrentWorkspaceViewSetMixin,
@@ -833,20 +833,13 @@ class SeedTrayPlantingViewSeedTraySet(
     """
     queryset = SeedTrayPlanting.objects.all()
     serializer_class = SeedTrayPlantingSerializer
-    _parent_seed_tray = None
-
-    def get_parent_seed_tray(self):
-        """Resolve the nested tray inside the current workspace."""
-        if self._parent_seed_tray is None:
-            self._parent_seed_tray = get_object_or_404(
-                SeedTray,
-                pk=self.kwargs['seed_tray_pk'],
-                workspace=self.get_current_workspace(),
-            )
-        return self._parent_seed_tray
 
     def get_queryset(self):
-        return super().get_queryset().filter(seed_tray=self.get_parent_seed_tray())
+        tray = self.get_parent_seed_tray()
+        return self.filter_by_generation(
+            super().get_queryset().filter(seed_tray=tray),
+            tray,
+        )
 
     def perform_create(self, serializer):
         serializer.save(
@@ -895,33 +888,24 @@ class SpecificPlantViewSet(PlantOutcomeViewSetMixin, CurrentWorkspaceViewSetMixi
         return Response(SpecificPlantLocationSerializer(location).data, status=status.HTTP_201_CREATED)
 
 
-class SpecificPlantBySeedTrayViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
+class SpecificPlantBySeedTrayViewSet(TrayGenerationFilterMixin, CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
     """
     ViewSet of SpecificPlant filtered by SeedTray
     """
     queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square', 'lifecycle_events')
     serializer_class = SpecificPlantSerializer
-    _parent_seed_tray = None
-
-    def get_parent_seed_tray(self):
-        """Resolve the filtered tray inside the current workspace."""
-        if self._parent_seed_tray is None:
-            self._parent_seed_tray = get_object_or_404(
-                SeedTray,
-                pk=self.kwargs['seed_tray_pk'],
-                workspace=self.get_current_workspace(),
-            )
-        return self._parent_seed_tray
+    generation_lookup = 'cell_planting__seed_tray_planting__generation'
 
     def get_queryset(self):
-        tray_pk = self.get_parent_seed_tray().pk
+        tray = self.get_parent_seed_tray()
         queryset = super().get_queryset()
         currently_here = queryset.filter(
-            locations__seed_tray_cell__tray__pk=tray_pk,
+            locations__seed_tray_cell__tray__pk=tray.pk,
             locations__ended__isnull=True,
         )
-        originated_here = queryset.filter(
-            cell_planting__seed_tray_planting__seed_tray__pk=tray_pk,
+        originated_here = self.filter_by_generation(
+            queryset.filter(cell_planting__seed_tray_planting__seed_tray__pk=tray.pk),
+            tray,
         )
         return (currently_here | originated_here).distinct()
 

--- a/seedtrays/generation_rest.py
+++ b/seedtrays/generation_rest.py
@@ -1,0 +1,388 @@
+"""REST surface for filling, cleaning, and correcting a tray generation.
+
+Every write here drives a service in `generations`; nothing decides anything on
+its own. That is deliberate — the clean has to be one transaction with one set
+of rules whether it arrives from this screen, a management command, or a test.
+"""
+
+# Every serializer here is an action payload rather than a writable resource, so
+# none of them implements DRF's `create` or `update`; `ActionSerializer` refuses
+# both once on their behalf.
+# pylint: disable=duplicate-code,abstract-method
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework_nested import routers
+
+from inventory.ledger import quantize_quantity
+from inventory.models import InventoryLocation
+from inventory.rest_query import parse_integer
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
+from .generation_costs import generation_cost_breakdown
+from .generations import (
+    CloseRequest,
+    MediaDisposition,
+    PlantDisposition,
+    SeedDisposition,
+    close_generation,
+    contents_digest,
+    generation_contents,
+    open_generation,
+    reopen_generation,
+    review_generation,
+)
+from .models import SeedTray, SeedTrayGeneration, SeedTrayGenerationEvent, SeedTrayGenerationResidual
+
+
+def _model_errors(error):
+    """Translate a Django validation error into DRF's field-error shape."""
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _run_domain_action(function, *args, **kwargs):
+    """Run a domain service, surfacing its errors as DRF field errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+def _decimal(value):
+    """Render a ledger decimal as the fixed-precision string clients expect."""
+    return None if value is None else f'{quantize_quantity(value):.9f}'
+
+
+class ActionSerializer(serializers.Serializer):
+    """Base for payloads that drive a service rather than a model."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class ReasonSerializer(ActionSerializer):
+    """A required explanation for an audited action."""
+
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
+class OpenGenerationSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):
+    """What an operator says when they fill a tray."""
+
+    tray = serializers.PrimaryKeyRelatedField(queryset=SeedTray.objects.all())
+    opened_at = serializers.DateTimeField(required=False, allow_null=True, default=None)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+    workspace_field_lookups = {'tray': 'workspace'}
+
+
+class PlantDispositionSerializer(ActionSerializer):
+    """What an operator decided about one plant still in the tray."""
+
+    plant = serializers.IntegerField()
+    outcome = serializers.CharField()
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class SeedDispositionSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):
+    """What became of the seed one sowing drew but never placed."""
+
+    sowing = serializers.IntegerField()
+    quantity = serializers.DecimalField(max_digits=24, decimal_places=9)
+    disposition = serializers.CharField()
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+    destination = serializers.PrimaryKeyRelatedField(
+        queryset=InventoryLocation.objects.all(),
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+
+    workspace_field_lookups = {'destination': 'workspace'}
+
+
+class MediaDispositionSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):
+    """What became of the media one lot left in the tray."""
+
+    lot = serializers.IntegerField()
+    quantity = serializers.DecimalField(max_digits=24, decimal_places=9)
+    disposition = serializers.CharField()
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+    destination = serializers.PrimaryKeyRelatedField(
+        queryset=InventoryLocation.objects.all(),
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+
+    workspace_field_lookups = {'destination': 'workspace'}
+
+
+class CloseGenerationSerializer(ActionSerializer):
+    """The confirmed disposition of everything the tray still holds."""
+
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+    occurred_at = serializers.DateTimeField(required=False, allow_null=True, default=None)
+    plants = PlantDispositionSerializer(many=True, required=False, default=list)
+    seeds = SeedDispositionSerializer(many=True, required=False, default=list)
+    media = MediaDispositionSerializer(many=True, required=False, default=list)
+    digest = serializers.CharField(required=False, allow_null=True, default=None)
+    open_next = serializers.BooleanField(required=False, default=False)
+
+
+class SeedTrayGenerationEventSerializer(serializers.ModelSerializer):
+    """One immutable record of a generation lifecycle change."""
+
+    class Meta:
+        model = SeedTrayGenerationEvent
+        fields = ['pk', 'event_type', 'occurred_at', 'reason', 'created_by', 'created']
+        read_only_fields = fields
+
+
+class SeedTrayGenerationResidualSerializer(serializers.ModelSerializer):
+    """One disposition an operator recorded while cleaning."""
+
+    class Meta:
+        model = SeedTrayGenerationResidual
+        fields = [
+            'pk',
+            'kind',
+            'disposition',
+            'lot',
+            'sowing',
+            'base_quantity',
+            'base_unit',
+            'unit_cost',
+            'movement',
+            'reason',
+            'created',
+        ]
+        read_only_fields = fields
+
+
+class SeedTrayGenerationSerializer(serializers.ModelSerializer):
+    """The full readable record of one fill of one tray."""
+
+    events = SeedTrayGenerationEventSerializer(many=True, read_only=True)
+    residuals = SeedTrayGenerationResidualSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SeedTrayGeneration
+        fields = [
+            'pk',
+            'tray',
+            'code',
+            'sequence',
+            'status',
+            'origin',
+            'review_state',
+            'review_details',
+            'opened_at',
+            'closed_at',
+            'close_reason',
+            'notes',
+            'created_by',
+            'closed_by',
+            'created',
+            'updated',
+            'events',
+            'residuals',
+        ]
+        read_only_fields = fields
+
+
+def _contents_response(generation):
+    """Render what a clean has to find a disposition for, plus its digest."""
+    contents = generation_contents(generation)
+    return {
+        'generation': generation.pk,
+        'code': generation.code,
+        'status': generation.status,
+        'review_state': generation.review_state,
+        'cell_count': contents['cell_count'],
+        'digest': contents_digest(contents),
+        'sowings': [
+            {
+                'pk': sowing.pk,
+                'planted': sowing.planted,
+                'batch': sowing.batch_id,
+                'quantity': sowing.quantity,
+                'seeds_used': sowing.seeds_used_id,
+            }
+            for sowing in contents['sowings']
+        ],
+        'plants': [
+            {
+                'pk': plant.pk,
+                'cell_planting': plant.cell_planting_id,
+                'cell': plant.cell_planting.cell_id,
+                'germinated': plant.germinated,
+            }
+            for plant in contents['plants']
+        ],
+        'seeds': [
+            {
+                'sowing': row['sowing'].pk,
+                'seeds_used': row['sowing'].seeds_used_id,
+                'quantity': row['quantity'],
+            }
+            for row in contents['seeds']
+        ],
+        'media': [
+            {
+                'lot': row['lot'].pk,
+                'item': row['item'].pk,
+                'base_quantity': _decimal(row['base_quantity']),
+                'base_unit': row['base_unit'],
+                'unit_cost': row['unit_cost'],
+            }
+            for row in contents['media']
+        ],
+    }
+
+
+def _close_request(values):
+    """Turn a validated confirmation payload into the service's request."""
+    return CloseRequest(
+        reason=values['reason'],
+        occurred_at=values['occurred_at'],
+        plants=tuple(
+            PlantDisposition(row['plant'], row['outcome'], row['reason'])
+            for row in values['plants']
+        ),
+        seeds=tuple(
+            SeedDisposition(
+                row['sowing'],
+                row['quantity'],
+                row['disposition'],
+                row['reason'],
+                row['destination'],
+            )
+            for row in values['seeds']
+        ),
+        media=tuple(
+            MediaDisposition(
+                row['lot'],
+                row['quantity'],
+                row['disposition'],
+                row['reason'],
+                row['destination'],
+            )
+            for row in values['media']
+        ),
+        digest=values['digest'],
+        open_next=values['open_next'],
+    )
+
+
+class SeedTrayGenerationViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+    """Fill a tray, clean it, and correct a clean that should not have happened."""
+
+    queryset = SeedTrayGeneration.objects.select_related('tray').prefetch_related(
+        'events',
+        'residuals',
+    )
+    serializer_class = SeedTrayGenerationSerializer
+    http_method_names = ['get', 'post', 'head', 'options']
+    bind_workspace_on_create = False
+
+    def get_queryset(self):
+        """Filter fills by tray and by whether they are still in use."""
+        queryset = super().get_queryset()
+        query = self.request.query_params
+        tray = parse_integer(query.get('tray'), 'tray')
+        if tray is not None:
+            queryset = queryset.filter(tray_id=tray)
+        if 'status' in query:
+            queryset = queryset.filter(status=query['status'])
+        if 'review_state' in query:
+            queryset = queryset.filter(review_state=query['review_state'])
+        return queryset
+
+    def create(self, request, *args, **kwargs):
+        """Record that a tray has been filled and is ready to sow into."""
+        values = OpenGenerationSerializer(data=request.data, context={'request': request})
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        generation = _run_domain_action(
+            open_generation,
+            data['tray'],
+            request.user,
+            data['opened_at'],
+            data['notes'],
+        )
+        return Response(
+            self.get_serializer(generation).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=['get'])
+    def contents(self, request, pk=None):  # pylint: disable=unused-argument
+        """Report everything still in the tray, and the digest that pins it."""
+        return Response(_run_domain_action(_contents_response, self.get_object()))
+
+    @action(detail=True, methods=['post'])
+    def close(self, request, pk=None):  # pylint: disable=unused-argument
+        """Empty the tray, resolving everything the operator confirmed."""
+        values = CloseGenerationSerializer(data=request.data, context={'request': request})
+        values.is_valid(raise_exception=True)
+        generation, following = _run_domain_action(
+            close_generation,
+            self.get_object(),
+            request.user,
+            _close_request(values.validated_data),
+        )
+        return Response({
+            'generation': self.get_serializer(generation).data,
+            'next_generation': (
+                self.get_serializer(following).data if following else None
+            ),
+        })
+
+    @action(detail=True, methods=['post'])
+    def reopen(self, request, pk=None):  # pylint: disable=unused-argument
+        """Correct a clean that should not have happened, without erasing it."""
+        values = ReasonSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        generation = _run_domain_action(
+            reopen_generation,
+            self.get_object(),
+            request.user,
+            values.validated_data['reason'],
+        )
+        return Response(self.get_serializer(generation).data)
+
+    @action(detail=True, methods=['post'])
+    def review(self, request, pk=None):  # pylint: disable=unused-argument
+        """Confirm a migrated fill really is one fill."""
+        values = ReasonSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        generation = _run_domain_action(
+            review_generation,
+            self.get_object(),
+            request.user,
+            values.validated_data['reason'],
+        )
+        return Response(self.get_serializer(generation).data)
+
+    @action(detail=True, methods=['get'], url_path='cost-breakdown')
+    def cost_breakdown(self, request, pk=None):  # pylint: disable=unused-argument
+        """Trace this fill's media cost to the seedlings it raised."""
+        return Response(
+            _run_domain_action(generation_cost_breakdown, self.get_object()),
+        )
+
+
+generation_router = routers.SimpleRouter()
+generation_router.register(
+    r'seedtraygenerations',
+    SeedTrayGenerationViewSet,
+    basename='seedtraygeneration',
+)

--- a/seedtrays/rest.py
+++ b/seedtrays/rest.py
@@ -25,7 +25,8 @@ from inventory.units import UnitCode
 from supplies.models import Supplier
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
-from .models import SeedTrayModel, SeedTray, SeedTrayCell
+from .generations import open_generation_for
+from .models import SeedTrayModel, SeedTray, SeedTrayCell, SeedTrayGeneration
 
 
 class SeedTrayModelSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
@@ -68,13 +69,37 @@ class SeedTraySerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSeria
     Serializer for a Seed Tray
     """
     inventory = InventoryUnitSerializer(source='inventory_unit', read_only=True)
+    active_generation = serializers.SerializerMethodField()
+    generation_review_required = serializers.SerializerMethodField()
 
     class Meta:
         model = SeedTray
-        fields = ['pk', 'model', 'inventory_unit', 'inventory', 'created', 'notes']
-        read_only_fields = ['inventory_unit', 'inventory', 'created']
+        fields = [
+            'pk', 'model', 'inventory_unit', 'inventory', 'created', 'notes',
+            'active_generation', 'generation_review_required',
+        ]
+        read_only_fields = [
+            'inventory_unit', 'inventory', 'created',
+            'active_generation', 'generation_review_required',
+        ]
 
     workspace_field_lookups = {'model': 'workspace'}
+
+    def _open_generation(self, tray):
+        """Return the fill this tray is currently using, or None if empty."""
+        return open_generation_for(tray)
+
+    def get_active_generation(self, tray):
+        """Report which fill the tray is on, so a screen can say `empty`."""
+        generation = self._open_generation(tray)
+        return generation.pk if generation else None
+
+    def get_generation_review_required(self, tray):
+        """Flag a migrated fill an operator has not confirmed yet."""
+        generation = self._open_generation(tray)
+        if generation is None:
+            return False
+        return generation.review_state == SeedTrayGeneration.ReviewState.NEEDS_REVIEW
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """A created tray keeps the model that defined its generated cell grid."""

--- a/seedtrays/test_generation_rest.py
+++ b/seedtrays/test_generation_rest.py
@@ -1,0 +1,497 @@
+"""The endpoints a tray screen uses to fill, clean, and review a generation.
+
+These also cover the archive contract, which the frontend depends on and no
+JavaScript test runner exists to check: a cleaned fill's sowings leave the
+tray's normal view without leaving the database.
+"""
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.utils import timezone
+
+from applications.services import (
+    ApplicationRequest,
+    LineRequest,
+    TargetRequest,
+    create_application_draft,
+    post_application,
+)
+from inventory.models import InventoryItem
+from inventory.units import UnitCode
+from plantings.lifecycle import record_germination_event
+from seeds.services import ensure_packet_inventory_identity
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_batch_for_packet,
+    make_inventory_item,
+    make_inventory_location,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_model,
+    make_seed_tray_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+    make_stock_lot,
+)
+from workspaces.models import Workspace
+
+from .generations import open_generation
+from .models import SeedTrayGeneration
+
+
+class GenerationRESTTestCase(RESTContractTestCase):
+    """One two-cell tray, ready to be filled through the API."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = Workspace.objects.get(pk=1)
+        tray_model = make_seed_tray_model(cell_size_ml=40, x_cells=2, y_cells=1)
+        self.tray = make_seed_tray(model=tray_model)
+        self.cells = [
+            make_seed_tray_cell(tray=self.tray, x_position=index)
+            for index in range(2)
+        ]
+
+    def fill(self):
+        """Fill the tray through the API and return the response body."""
+        response = self.client.post(
+            '/seedtrays/seedtraygenerations/',
+            {'tray': self.tray.pk, 'notes': 'Peat-free mix.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def sow(self, generation, quantity=4, allocations=((0, 2),)):
+        """Sow into one fill, allocating the given (cell index, count) pairs."""
+        packet = ensure_packet_inventory_identity(make_seed_packet())
+        sowing = make_seed_tray_planting(
+            seeds_used=packet,
+            batch=make_batch_for_packet(packet),
+            quantity=quantity,
+            seed_tray=self.tray,
+            generation=SeedTrayGeneration.objects.get(pk=generation),
+        )
+        for index, count in allocations:
+            make_seed_tray_cell_planting(
+                seed_tray_planting=sowing,
+                cell=self.cells[index],
+                quantity=count,
+            )
+        return sowing
+
+
+class GenerationContractTests(GenerationRESTTestCase):
+    """Filling, listing, and reading one fill of a tray."""
+
+    @property
+    def list_urls(self):
+        """Return the generation collection route."""
+        return ('/seedtrays/seedtraygenerations/',)
+
+    def test_the_collection_requires_authentication(self):
+        """Anonymous requests cannot read a workspace's tray history."""
+        self.assert_authentication_required(self.list_urls)
+
+    def test_the_collection_uses_the_common_list_contract(self):
+        """Generations list the way every other collection does."""
+        self.assert_list_contract(self.list_urls)
+
+    def test_filling_a_tray_returns_the_new_fill(self):
+        """The response is what a screen needs to show the tray is in use."""
+        data = self.fill()
+
+        self.assertEqual(data['tray'], self.tray.pk)
+        self.assertEqual(data['sequence'], 1)
+        self.assertEqual(data['status'], SeedTrayGeneration.Status.OPEN)
+        self.assertEqual(data['origin'], SeedTrayGeneration.Origin.OPERATOR)
+        self.assertEqual(data['notes'], 'Peat-free mix.')
+        self.assertEqual(len(data['events']), 1)
+
+    def test_filling_a_tray_that_is_already_in_use_is_refused(self):
+        """The second fill would inherit the first one's crop."""
+        self.fill()
+
+        response = self.client.post(
+            '/seedtrays/seedtraygenerations/',
+            {'tray': self.tray.pk},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('still open', str(response.data['tray']))
+
+    def test_the_tray_reports_which_fill_it_is_on(self):
+        """A screen has to be able to say the tray is empty."""
+        response = self.client.get(f'/seedtrays/seedtrays/{self.tray.pk}/')
+        self.assertIsNone(response.data['active_generation'])
+        self.assertFalse(response.data['generation_review_required'])
+
+        data = self.fill()
+
+        response = self.client.get(f'/seedtrays/seedtrays/{self.tray.pk}/')
+        self.assertEqual(response.data['active_generation'], data['pk'])
+
+    def test_a_migrated_fill_is_flagged_on_the_tray(self):
+        """The banner that blocks cleaning is driven by this."""
+        SeedTrayGeneration.objects.filter(pk=self.fill()['pk']).update(
+            origin=SeedTrayGeneration.Origin.LEGACY,
+            review_state=SeedTrayGeneration.ReviewState.NEEDS_REVIEW,
+        )
+
+        response = self.client.get(f'/seedtrays/seedtrays/{self.tray.pk}/')
+
+        self.assertTrue(response.data['generation_review_required'])
+
+    def test_generations_can_be_filtered_by_tray_and_status(self):
+        """The history panel asks for one tray's closed fills."""
+        data = self.fill()
+        other = make_seed_tray()
+        open_generation(other, None)
+
+        response = self.client.get(
+            f'/seedtrays/seedtraygenerations/?tray={self.tray.pk}&status=open'
+        )
+
+        self.assertEqual([row['pk'] for row in response.data], [data['pk']])
+
+    def test_a_bad_tray_filter_is_reported_as_a_field_error(self):
+        """A typo should not read as an empty history."""
+        response = self.client.get('/seedtrays/seedtraygenerations/?tray=maybe')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('tray', response.data)
+
+
+class GenerationCleanContractTests(GenerationRESTTestCase):
+    """The guided clean, its confirmation view, and its correction."""
+
+    def setUp(self):
+        super().setUp()
+        self.location = make_inventory_location()
+        self.media_item = make_inventory_item(
+            base_unit=UnitCode.LITRE,
+            default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
+        )
+        self.media_lot = make_stock_lot(
+            item=self.media_item,
+            location=self.location,
+            quantity='50',
+            base_unit_cost=Decimal('2'),
+        )
+        self.generation = self.fill()['pk']
+
+    def apply_media(self):
+        """Post one media application filling both cells of the tray."""
+        application = create_application_draft(
+            self.workspace,
+            None,
+            ApplicationRequest(
+                applied_at=timezone.now(),
+                source_location=self.location,
+                lines=(LineRequest(
+                    item=self.media_item,
+                    lot=self.media_lot,
+                    applied_quantity=Decimal('0.08'),
+                    unit_code=UnitCode.LITRE,
+                    targets=tuple(
+                        TargetRequest('seed_tray_cell', cell)
+                        for cell in self.cells
+                    ),
+                ),),
+            ),
+        )
+        return post_application(application, None)[0]
+
+    def contents(self):
+        """Read the pre-clean confirmation view."""
+        response = self.client.get(
+            f'/seedtrays/seedtraygenerations/{self.generation}/contents/'
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+    def close(self, **overrides):
+        """Post a fully specified clean built from the confirmation view."""
+        contents = self.contents()
+        payload = {
+            'reason': 'End of the propagation run.',
+            'digest': contents['digest'],
+            'plants': [
+                {'plant': row['pk'], 'outcome': 'failed', 'reason': 'Damped off.'}
+                for row in contents['plants']
+            ],
+            'seeds': [
+                {
+                    'sowing': row['sowing'],
+                    'quantity': str(row['quantity']),
+                    'disposition': 'removed',
+                    'reason': 'Swept up.',
+                }
+                for row in contents['seeds']
+            ],
+            'media': [
+                {
+                    'lot': row['lot'],
+                    'quantity': row['base_quantity'],
+                    'disposition': 'waste',
+                    'reason': 'Tipped out.',
+                }
+                for row in contents['media']
+            ],
+        }
+        payload.update(overrides)
+        return self.client.post(
+            f'/seedtrays/seedtraygenerations/{self.generation}/close/',
+            payload,
+            format='json',
+        )
+
+    def test_contents_report_everything_needing_a_decision(self):
+        """The screen is built from this, so it has to be complete."""
+        self.apply_media()
+        sowing = self.sow(self.generation)
+        plant = make_specific_plant(cell_planting=sowing.cell_plantings.get())
+        record_germination_event(plant, None)
+        make_specific_plant_location(specific_plant=plant)
+
+        contents = self.contents()
+
+        self.assertEqual([row['pk'] for row in contents['plants']], [plant.pk])
+        self.assertEqual(
+            [(row['sowing'], row['quantity']) for row in contents['seeds']],
+            [(sowing.pk, 2)],
+        )
+        self.assertEqual(
+            [(row['lot'], row['base_quantity']) for row in contents['media']],
+            [(self.media_lot.pk, '0.080000000')],
+        )
+        self.assertTrue(contents['digest'])
+
+    def test_cleaning_closes_the_fill(self):
+        """The confirmed clean is what empties the tray."""
+        self.apply_media()
+
+        response = self.close()
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(
+            response.data['generation']['status'],
+            SeedTrayGeneration.Status.CLOSED,
+        )
+        self.assertIsNone(response.data['next_generation'])
+        self.assertEqual(len(response.data['generation']['residuals']), 1)
+
+    def test_an_incomplete_clean_is_refused(self):
+        """Nothing is quietly assumed about what was left in the tray."""
+        self.apply_media()
+
+        response = self.close(media=[])
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('media', response.data)
+        self.assertEqual(
+            SeedTrayGeneration.objects.get(pk=self.generation).status,
+            SeedTrayGeneration.Status.OPEN,
+        )
+
+    def test_a_stale_confirmation_is_refused(self):
+        """An operator must decide about what is actually in the tray."""
+        contents = self.contents()
+        self.sow(self.generation)
+
+        response = self.close(digest=contents['digest'])
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('digest', response.data)
+
+    def test_cleaning_twice_is_refused(self):
+        """A resubmitted confirmation resolves nothing a second time."""
+        self.close()
+
+        response = self.client.post(
+            f'/seedtrays/seedtraygenerations/{self.generation}/close/',
+            {'reason': 'Again.'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('already closed', str(response.data))
+
+    def test_the_tray_can_be_refilled_in_the_same_step(self):
+        """Filling again is the usual next act."""
+        response = self.close(open_next=True)
+
+        following = response.data['next_generation']
+        self.assertEqual(following['sequence'], 2)
+        self.assertEqual(following['status'], SeedTrayGeneration.Status.OPEN)
+
+    def test_a_migrated_fill_must_be_reviewed_before_it_is_cleaned(self):
+        """Its contents may belong to two cycles nobody has separated."""
+        SeedTrayGeneration.objects.filter(pk=self.generation).update(
+            origin=SeedTrayGeneration.Origin.LEGACY,
+            review_state=SeedTrayGeneration.ReviewState.NEEDS_REVIEW,
+        )
+
+        refused = self.close()
+        reviewed = self.client.post(
+            f'/seedtrays/seedtraygenerations/{self.generation}/review/',
+            {'reason': 'Checked the sowing notebook.'},
+            format='json',
+        )
+
+        self.assertEqual(refused.status_code, 400)
+        self.assertIn('review_state', refused.data)
+        self.assertEqual(reviewed.status_code, 200, reviewed.data)
+        self.assertEqual(
+            reviewed.data['review_state'],
+            SeedTrayGeneration.ReviewState.NONE,
+        )
+        self.assertEqual(self.close().status_code, 200)
+
+    def test_a_mistaken_clean_can_be_corrected(self):
+        """The close stays on file next to the correction that undid it."""
+        self.close()
+
+        response = self.client.post(
+            f'/seedtrays/seedtraygenerations/{self.generation}/reopen/',
+            {'reason': 'Cleaned the wrong tray.'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['status'], SeedTrayGeneration.Status.OPEN)
+        types = [event['event_type'] for event in response.data['events']]
+        self.assertEqual(types, ['opened', 'closed', 'reopened'])
+
+    def test_a_correction_needs_a_reason(self):
+        """Undoing an audited action without saying why is not an audit trail."""
+        self.close()
+
+        response = self.client.post(
+            f'/seedtrays/seedtraygenerations/{self.generation}/reopen/',
+            {'reason': ''},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('reason', response.data)
+
+    def test_the_cost_breakdown_reaches_the_seedlings(self):
+        """An operator can ask which media lot supplied each plant."""
+        self.apply_media()
+        sowing = self.sow(self.generation)
+        plant = make_specific_plant(cell_planting=sowing.cell_plantings.get())
+        record_germination_event(plant, None)
+
+        response = self.client.get(
+            f'/seedtrays/seedtraygenerations/{self.generation}/cost-breakdown/'
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['applied_cost'], Decimal('0.160000000000'))
+        self.assertEqual(
+            [row['plant'] for row in response.data['plants']],
+            [plant.pk],
+        )
+        self.assertFalse(response.data['unknown_cost'])
+
+
+class GenerationArchiveTests(GenerationRESTTestCase):
+    """A cleaned fill leaves the tray's normal view without leaving the data."""
+
+    def setUp(self):
+        super().setUp()
+        self.generation = self.fill()['pk']
+        self.sowing = self.sow(self.generation, quantity=2, allocations=((0, 2),))
+        self.plant = make_specific_plant(
+            cell_planting=self.sowing.cell_plantings.get(),
+        )
+        record_germination_event(self.plant, None)
+        make_specific_plant_location(specific_plant=self.plant)
+        self.client.post(
+            f'/seedtrays/seedtraygenerations/{self.generation}/close/',
+            {
+                'reason': 'End of the run.',
+                'plants': [
+                    {'plant': self.plant.pk, 'outcome': 'failed', 'reason': 'Damped.'},
+                ],
+            },
+            format='json',
+        )
+
+    def test_an_archived_sowing_leaves_the_tray_view(self):
+        """The screen shows what is in the tray now, which is nothing."""
+        response = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
+    def test_history_brings_the_archived_sowing_straight_back(self):
+        """The archive is a filter, so nothing was lost."""
+        response = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/?history=true'
+        )
+
+        self.assertEqual([row['pk'] for row in response.data], [self.sowing.pk])
+        self.assertEqual(response.data[0]['generation'], self.generation)
+
+    def test_an_explicit_generation_reads_one_closed_fill(self):
+        """Traceability asks for the fill, not for everything ever."""
+        response = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/'
+            f'?generation={self.generation}'
+        )
+
+        self.assertEqual([row['pk'] for row in response.data], [self.sowing.pk])
+
+    def test_the_new_fill_starts_with_no_sowings(self):
+        """Reusing the tray must not inherit the previous crop."""
+        following = self.client.post(
+            '/seedtrays/seedtraygenerations/',
+            {'tray': self.tray.pk},
+            format='json',
+        ).data
+
+        response = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/'
+        )
+
+        self.assertEqual(response.data, [])
+        self.assertEqual(following['sequence'], 2)
+
+    def test_an_archived_plant_leaves_the_tray_view_but_keeps_its_history(self):
+        """Its cost and lifecycle stay readable through the old fill."""
+        current = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/specificplants/'
+        )
+        history = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/specificplants/?history=true'
+        )
+
+        self.assertEqual(current.data, [])
+        self.assertEqual([row['pk'] for row in history.data], [self.plant.pk])
+
+    def test_a_sowing_predating_generations_stays_visible(self):
+        """It has no fill to hide behind, so hiding it would lose it."""
+        legacy = make_seed_tray_planting(seed_tray=self.tray, generation=None)
+
+        response = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/'
+        )
+
+        self.assertEqual([row['pk'] for row in response.data], [legacy.pk])
+
+    def test_a_bad_history_flag_is_reported_as_a_field_error(self):
+        """A typo should not silently read as the default view."""
+        response = self.client.get(
+            f'/plantings/seedtray-data/{self.tray.pk}/plantings/?history=maybe'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('history', response.data)

--- a/seedtrays/urls.py
+++ b/seedtrays/urls.py
@@ -4,11 +4,12 @@ URL Routing for seed trays
 
 from django.urls import path, include
 
+from .generation_rest import generation_router
 from .rest import router, filtered_router
 from .views import SeedTrayDetailView
 
 
 urlpatterns = [
     path('seedtray/<int:pk>/', SeedTrayDetailView.as_view(), name='seedtray-detail'),
-    path('', include(router.urls + filtered_router.urls)),
+    path('', include(router.urls + filtered_router.urls + generation_router.urls)),
 ]


### PR DESCRIPTION
A tray screen can now fill a tray, read everything still in it, confirm a clean, correct a mistaken one, and trace the media cost of a fill to the seedlings it raised. Every write drives a service in `generations` and decides nothing itself, so the clean is one transaction with one set of rules whether it arrives from a screen, a command, or a test.

The confirmation view returns a digest alongside its contents, and the clean echoes it back. That is the whole of the staleness guard: an operator has to be deciding about what is actually in the tray, not what was in it when another tab loaded the page.

The archive is a filter and nothing else. A tray's plantings and plants default to the fill it is on; `history=true` or an explicit `generation` brings any closed fill straight back with its costs and lifecycle intact. A sowing recorded before generations existed has no fill to hide behind, so it stays visible rather than disappearing into an archive it was never put in.

Coverage is Django contract tests rather than frontend tests: this repository has no JavaScript test runner and this task does not introduce one, so the behaviour the tray screen depends on is pinned at the API it consumes.

## Summary by Sourcery

Expose REST endpoints for managing seed tray generations and integrate generation-aware filtering into tray and planting APIs.

New Features:
- Add seed tray generation API to fill trays, read contents, close (clean), reopen, review migrated fills, and view media cost breakdown.
- Expose tray metadata about the currently active generation and whether a migrated fill requires operator review.
- Support generation-based and history-aware filtering of seed tray plantings and specific plants, including explicit generation selection via query params.

Enhancements:
- Treat cleaned generations as an archive layer so closed fills are hidden from normal tray views but remain fully readable via history or generation filters.
- Ensure legacy sowings recorded before generations existed remain visible instead of being hidden by archival filtering.

Tests:
- Add Django REST contract tests covering generation lifecycle endpoints, archive behaviour for sowings and plants, and tray-level generation metadata.