### PR TITLE
fix(inventory): reverse a movement into a lot nobody counted

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -180,6 +180,17 @@ def _validate_location(location, workspace, field_name, require_active=True):
         raise ValidationError({field_name: 'The location is inactive.'})
 
 
+def balance_is_known(lot):
+    """Return whether this lot's balance is a figure worth enforcing.
+
+    Sowing already depends on the answer being no for an unopened packet: the
+    packet is truthfully sowable and its container goes negative as seed comes
+    out of it. Anything that has to take stock back out of such a lot cannot be
+    held to a figure that was never known in the first place.
+    """
+    return lot.quantity_certainty != QuantityCertainty.UNKNOWN
+
+
 def _validate_source_balance(lot, source, quantity):
     """Reject an outbound effect that exceeds physical stock at its source."""
     available = physical_balance(lot, source)
@@ -631,7 +642,7 @@ def _validate_reversible(original, reason, document_kind=None):
     for kind, (is_linked, message) in DOCUMENT_LINKS.items():
         if kind != document_kind and is_linked(original):
             raise ValidationError({'movement': message})
-    if original.destination_id:
+    if original.destination_id and balance_is_known(original.lot):
         _validate_source_balance(
             original.lot,
             original.destination,
@@ -659,6 +670,7 @@ def _create_reversal(original, user, reason, occurred_at):
         reason=reason,
         reference=f'Reversal of movement {original.pk}',
         reversal_of=original,
+        enforce_source_balance=balance_is_known(original.lot),
     ))
 
 

--- a/inventory/test_ledger.py
+++ b/inventory/test_ledger.py
@@ -26,6 +26,7 @@ from .ledger import (
 from .models import (
     InventoryItem,
     InventoryLocation,
+    QuantityCertainty,
     StockLot,
     StockMovement,
     StockReceipt,
@@ -322,3 +323,88 @@ class LedgerServiceTests(TestCase):
                         ),
                     )
                 self.assertIn('reason', context.exception.message_dict)
+
+
+class UnknownQuantityReversalTests(TestCase):
+    """A lot of unknown quantity has no balance to hold a reversal to.
+
+    An unopened seed packet is truthfully sowable, so its container goes
+    negative as seed comes out of it. Anything that later has to take stock back
+    out of that container — correcting a return, say — cannot be measured
+    against a figure that was never known.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.user = get_user_model().objects.create_user(username='unknown-lot-user')
+        self.item = InventoryItem.objects.create(
+            workspace=self.workspace,
+            name='Unopened packet contents',
+            category=InventoryItem.Category.SEED,
+            base_unit=UnitCode.SEED,
+        )
+        self.container = InventoryLocation.objects.create(
+            workspace=self.workspace,
+            name='Seed packet',
+            code='PACKET-UNKNOWN',
+            location_type=InventoryLocation.LocationType.SEED_PACKET,
+        )
+        self.lot = StockLot.objects.create(
+            workspace=self.workspace,
+            item=self.item,
+            origin=StockLot.Origin.OPENING,
+            received_on=date(2026, 1, 1),
+            initial_base_quantity=None,
+            quantity_certainty=QuantityCertainty.UNKNOWN,
+            currency_code=self.workspace.currency_code,
+        )
+
+    def _put_back(self, quantity):
+        """Record seed going back into the packet it came out of."""
+        return post_stock_movement(self.workspace, self.user, MovementRequest(
+            lot=self.lot,
+            movement_type=StockMovement.MovementType.ADJUSTMENT_GAIN,
+            quantity=Decimal(quantity),
+            destination=self.container,
+            occurred_at=timezone.now(),
+            reason='Unsown seed returned.',
+        ))
+
+    def _sow(self, quantity):
+        """Take seed out of a packet whose contents were never counted."""
+        return post_stock_movement(self.workspace, self.user, MovementRequest(
+            lot=self.lot,
+            movement_type=StockMovement.MovementType.CONSUMPTION,
+            quantity=Decimal(quantity),
+            source=self.container,
+            occurred_at=timezone.now(),
+            reason='Sown.',
+            enforce_source_balance=False,
+        ))
+
+    def test_a_return_can_be_reversed_from_a_negative_container(self):
+        """The container is negative by design, not by error."""
+        self._sow('8')
+        gain = self._put_back('2')
+        self.assertEqual(physical_balance(self.lot, self.container), Decimal('-6'))
+
+        reversal = reverse_movement(gain, self.user, 'Recorded against the wrong sowing.')
+
+        self.assertEqual(reversal.movement_type, StockMovement.MovementType.REVERSAL)
+        self.assertEqual(physical_balance(self.lot, self.container), Decimal('-8'))
+
+    def test_a_counted_lot_still_has_its_balance_enforced(self):
+        """Relaxing the check where a figure exists would hide real errors."""
+        StockLot.objects.filter(pk=self.lot.pk).update(
+            quantity_certainty=QuantityCertainty.EXACT,
+            initial_base_quantity=Decimal('10'),
+        )
+        self.lot.refresh_from_db()
+        gain = self._put_back('2')
+        self._sow('5')
+
+        with self.assertRaises(ValidationError) as caught:
+            reverse_movement(gain, self.user, 'Wrong sowing.')
+
+        self.assertIn('quantity', caught.exception.message_dict)

--- a/seedtrays/test_generations.py
+++ b/seedtrays/test_generations.py
@@ -634,6 +634,30 @@ class ReopenGenerationTests(GenerationContentsTestCase):
         self.assertEqual(residual.base_quantity, Decimal('0.080000000'))
         self.assertEqual(residual.disposition, Disposition.WASTE)
 
+    def test_returned_seed_is_taken_back_out_of_the_packet(self):
+        """An unopened packet's container is negative by design, not by error.
+
+        Sowing takes seed out of a container whose contents were never counted,
+        so the balance goes below zero. Correcting a clean that put seed back
+        has to be able to take it out again anyway.
+        """
+        sowing = self.sow(quantity=4, allocations=((0, 2),))
+        packet = sowing.seeds_used
+        generation, _ = self.close(seeds=(SeedDisposition(
+            sowing.pk,
+            2,
+            Disposition.RETURNED,
+            'Back in the packet.',
+        ),))
+        returned = physical_balance(packet.stock_lot, packet.storage_location)
+
+        reopen_generation(generation, self.user, 'Wrong tray.')
+
+        self.assertEqual(
+            physical_balance(packet.stock_lot, packet.storage_location),
+            returned - Decimal('2'),
+        )
+
     def test_a_closed_location_is_not_reopened(self):
         """Where a plant has been remains true; a replacement is recorded."""
         sowing = self.sow()


### PR DESCRIPTION
Correcting a tray clean that had returned unsown seed failed with "Only -6.000000000 seed is available" — a figure that reads like a bug but is the intended state. An unopened packet is truthfully sowable, so its container goes negative as seed comes out of it, and sowing already passes enforce_source_balance=False for exactly that reason.

Reversal did not. Both its guards measured the take-back against a balance that a lot of unknown quantity can never satisfy, so a return into such a container could be recorded but never corrected.

The rule now lives in one place: a lot whose quantity was never known has no balance worth enforcing, and both guards ask the same question. A counted lot keeps its check, because relaxing it where a figure exists would hide the errors it is there to catch.

Found by driving the clean and its correction through the running app.

## Summary by Sourcery

Ensure reversals of stock movements respect whether a lot’s quantity is known, allowing corrections for packets with unknown contents while preserving balance checks for counted lots.

Bug Fixes:
- Allow reversing adjustments on lots with unknown quantity without enforcing an impossible container balance.
- Prevent reversals from bypassing quantity validation on lots where the stock level is known and tracked.

Enhancements:
- Introduce a balance_is_known helper to centralize the rule for when lot balances should be enforced.
- Gate reversal source-balance validation and enforcement based on lot quantity certainty instead of always enforcing it.

Tests:
- Add ledger tests covering reversals on lots with unknown and exact quantities to verify balance enforcement behavior.
- Add seed tray generation test to ensure returned seed corrections correctly re-take seed from an unopened packet’s container.