### PR TITLE
feat(frontend): fill, clean, and review tray generations

### DIFF
--- a/frontend/js/api/seedtrays.ts
+++ b/frontend/js/api/seedtrays.ts
@@ -1,5 +1,18 @@
 import { SerializedStockMovement } from '../types/inventory'
-import { SeedTray, SeedTrayCell, SeedTrayFilters, SeedTrayModel, SeedTrayModelCreate, SeedTrayReceiptCreate, SeedTrayReceiptResponse } from '../types/seedtrays'
+import {
+  CleanGenerationRequest,
+  CleanGenerationResponse,
+  GenerationCostBreakdown,
+  SeedTray,
+  SeedTrayCell,
+  SeedTrayFilters,
+  SeedTrayGeneration,
+  SeedTrayGenerationContents,
+  SeedTrayModel,
+  SeedTrayModelCreate,
+  SeedTrayReceiptCreate,
+  SeedTrayReceiptResponse
+} from '../types/seedtrays'
 import { csrfPost, fetchAsJson } from '../utils'
 
 function getSeedTrayModels(signal?: AbortSignal): Promise<Array<SeedTrayModel>> {
@@ -37,4 +50,51 @@ async function postSerializedUnitAction(unitPk: number, action: 'transfer' | 'lo
   await csrfPost(`/inventory/serialized-units/${unitPk}/${action}/`, data)
 }
 
-export { addSeedTrayModel, getSeedTrayCells, getSeedTrayModels, getSeedTrays, getSerializedUnitMovements, postSerializedUnitAction, receiveSeedTrays }
+function getSeedTrayGenerations(trayPk: number, signal?: AbortSignal): Promise<Array<SeedTrayGeneration>> {
+  return fetchAsJson<Array<SeedTrayGeneration>>(`/seedtrays/seedtraygenerations/?tray=${trayPk}`, signal)
+}
+
+async function openSeedTrayGeneration(trayPk: number, notes: string): Promise<SeedTrayGeneration> {
+  const response = await csrfPost('/seedtrays/seedtraygenerations/', { tray: trayPk, notes })
+  return response.json() as Promise<SeedTrayGeneration>
+}
+
+function getSeedTrayGenerationContents(generationPk: number, signal?: AbortSignal): Promise<SeedTrayGenerationContents> {
+  return fetchAsJson<SeedTrayGenerationContents>(`/seedtrays/seedtraygenerations/${generationPk}/contents/`, signal)
+}
+
+async function cleanSeedTrayGeneration(generationPk: number, request: CleanGenerationRequest): Promise<CleanGenerationResponse> {
+  const response = await csrfPost(`/seedtrays/seedtraygenerations/${generationPk}/close/`, request)
+  return response.json() as Promise<CleanGenerationResponse>
+}
+
+async function reopenSeedTrayGeneration(generationPk: number, reason: string): Promise<SeedTrayGeneration> {
+  const response = await csrfPost(`/seedtrays/seedtraygenerations/${generationPk}/reopen/`, { reason })
+  return response.json() as Promise<SeedTrayGeneration>
+}
+
+async function reviewSeedTrayGeneration(generationPk: number, reason: string): Promise<SeedTrayGeneration> {
+  const response = await csrfPost(`/seedtrays/seedtraygenerations/${generationPk}/review/`, { reason })
+  return response.json() as Promise<SeedTrayGeneration>
+}
+
+function getSeedTrayGenerationCost(generationPk: number, signal?: AbortSignal): Promise<GenerationCostBreakdown> {
+  return fetchAsJson<GenerationCostBreakdown>(`/seedtrays/seedtraygenerations/${generationPk}/cost-breakdown/`, signal)
+}
+
+export {
+  addSeedTrayModel,
+  cleanSeedTrayGeneration,
+  getSeedTrayCells,
+  getSeedTrayGenerationContents,
+  getSeedTrayGenerationCost,
+  getSeedTrayGenerations,
+  getSeedTrayModels,
+  getSeedTrays,
+  getSerializedUnitMovements,
+  openSeedTrayGeneration,
+  postSerializedUnitAction,
+  receiveSeedTrays,
+  reopenSeedTrayGeneration,
+  reviewSeedTrayGeneration
+}

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -46,7 +46,11 @@ const queryKeys = {
     models: ['seedTrays', 'models'] as const,
     trays: ['seedTrays', 'trays'] as const,
     movements: (unitPk: number) => ['seedTrays', 'movements', unitPk] as const,
-    cells: (trayPk: number) => ['seedTrays', 'cells', trayPk] as const
+    cells: (trayPk: number) => ['seedTrays', 'cells', trayPk] as const,
+    generationsAll: ['seedTrays', 'generations'] as const,
+    generations: (trayPk: number) => ['seedTrays', 'generations', trayPk] as const,
+    generationContents: (generationPk: number) => ['seedTrays', 'generations', 'contents', generationPk] as const,
+    generationCost: (generationPk: number) => ['seedTrays', 'generations', 'cost', generationPk] as const
   },
   plantings: {
     all: ['plantings'] as const,

--- a/frontend/js/seedtray/generation_clean.tsx
+++ b/frontend/js/seedtray/generation_clean.tsx
@@ -1,0 +1,375 @@
+import React from 'react'
+import { Alert, Button, Card, Form, Table } from 'react-bootstrap'
+
+import {
+  CleanMediaDisposition,
+  CleanPlantDisposition,
+  CleanPlantOutcome,
+  CleanSeedDisposition,
+  MediaDispositionChoice,
+  SeedDispositionChoice,
+  SeedTrayGenerationContents
+} from '../types/seedtrays'
+import { formatDateTime, formatMeasure, formatQuantity } from '../utils'
+
+const PLANT_OUTCOMES: Array<{ value: CleanPlantOutcome; label: string }> = [
+  { value: 'failed', label: 'Failed' },
+  { value: 'culled', label: 'Culled' },
+  { value: 'retained', label: 'Retained' },
+  { value: 'donated', label: 'Donated' }
+]
+
+const SEED_DISPOSITIONS: Array<{ value: SeedDispositionChoice; label: string }> = [
+  { value: 'removed', label: 'Removed and not kept' },
+  { value: 'returned', label: 'Returned to the packet' }
+]
+
+const MEDIA_DISPOSITIONS: Array<{ value: MediaDispositionChoice; label: string }> = [
+  { value: 'waste', label: 'Discarded as waste' },
+  { value: 'reclaimed', label: 'Reclaimed into stock' }
+]
+
+type PlantChoice = { outcome: CleanPlantOutcome; reason: string }
+type SeedChoice = { disposition: SeedDispositionChoice; reason: string }
+type MediaChoice = { disposition: MediaDispositionChoice; reason: string; destination: number | '' }
+
+type CleanDecisions = {
+  plants: Record<number, PlantChoice>
+  seeds: Record<number, SeedChoice>
+  media: Record<number, MediaChoice>
+}
+
+// Every item starts with a disposition selected, but never a silent one: the
+// operator has to read the row and can change it, and the server refuses the
+// clean outright if any row is missing. Defaulting to nothing would only turn a
+// required decision into a form error.
+function initialDecisions(contents: SeedTrayGenerationContents): CleanDecisions {
+  return {
+    plants: Object.fromEntries(contents.plants.map((plant) => [plant.pk, { outcome: 'failed' as CleanPlantOutcome, reason: '' }])),
+    seeds: Object.fromEntries(contents.seeds.map((seed) => [seed.sowing, { disposition: 'removed' as SeedDispositionChoice, reason: '' }])),
+    media: Object.fromEntries(contents.media.map((media) => [media.lot, { disposition: 'waste' as MediaDispositionChoice, reason: '', destination: '' as const }]))
+  }
+}
+
+type InventoryLocationOption = { pk: number; name: string }
+
+type GenerationCleanFormProps = {
+  contents: SeedTrayGenerationContents
+  locations: Array<InventoryLocationOption>
+  busy: boolean
+  onCancel: () => void
+  onConfirm: (request: { reason: string; plants: Array<CleanPlantDisposition>; seeds: Array<CleanSeedDisposition>; media: Array<CleanMediaDisposition>; openNext: boolean }) => void
+}
+
+const GenerationCleanForm: React.FC<GenerationCleanFormProps> = ({ contents, locations, busy, onCancel, onConfirm }) => {
+  const [reason, setReason] = React.useState('')
+  const [openNext, setOpenNext] = React.useState(false)
+  const [decisions, setDecisions] = React.useState<CleanDecisions>(() => initialDecisions(contents))
+
+  // The digest pins this form to the contents it was built from, so rebuilding
+  // it when they change is the same act as taking a fresh digest.
+  React.useEffect(() => {
+    setDecisions(initialDecisions(contents))
+  }, [contents])
+
+  function setPlant(plantPk: number, change: Partial<PlantChoice>) {
+    setDecisions((current) => ({ ...current, plants: { ...current.plants, [plantPk]: { ...current.plants[plantPk], ...change } } }))
+  }
+
+  function setSeed(sowingPk: number, change: Partial<SeedChoice>) {
+    setDecisions((current) => ({ ...current, seeds: { ...current.seeds, [sowingPk]: { ...current.seeds[sowingPk], ...change } } }))
+  }
+
+  function setMedia(lotPk: number, change: Partial<MediaChoice>) {
+    setDecisions((current) => ({ ...current, media: { ...current.media, [lotPk]: { ...current.media[lotPk], ...change } } }))
+  }
+
+  const recoveringWithoutDestination = contents.media.some((media) => {
+    const choice = decisions.media[media.lot]
+    return choice?.disposition === 'reclaimed' && choice.destination === ''
+  })
+
+  function handleConfirm() {
+    onConfirm({
+      reason,
+      openNext,
+      plants: contents.plants.map((plant) => ({ plant: plant.pk, ...decisions.plants[plant.pk] })),
+      seeds: contents.seeds.map((seed) => ({
+        sowing: seed.sowing,
+        quantity: String(seed.quantity),
+        ...decisions.seeds[seed.sowing]
+      })),
+      media: contents.media.map((media) => {
+        const choice = decisions.media[media.lot]
+        return {
+          lot: media.lot,
+          quantity: media.base_quantity,
+          disposition: choice.disposition,
+          reason: choice.reason,
+          destination: choice.destination === '' ? null : choice.destination
+        }
+      })
+    })
+  }
+
+  const nothingLeft = contents.plants.length === 0 && contents.seeds.length === 0 && contents.media.length === 0
+
+  return (
+    <Card className="mb-3 border-warning">
+      <Card.Body>
+        <Card.Title>Clean {contents.code}</Card.Title>
+        <p className="text-muted">
+          Emptying the tray closes this fill. Nothing is deleted — its sowings, plants, and applications stay readable through the tray history — but every item below needs an
+          explicit disposition first.
+        </p>
+        {nothingLeft && <Alert variant="info">Nothing is left in this fill. Cleaning it will close it and leave the tray empty.</Alert>}
+
+        {contents.plants.length > 0 && (
+          <>
+            <h6>Plants still in the tray ({contents.plants.length})</h6>
+            <Table size="sm" responsive>
+              <thead>
+                <tr>
+                  <th>Plant</th>
+                  <th>Germinated</th>
+                  <th>Outcome</th>
+                  <th>Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {contents.plants.map((plant) => (
+                  <tr key={plant.pk}>
+                    <td>#{plant.pk}</td>
+                    <td>{formatDateTime(plant.germinated)}</td>
+                    <td>
+                      <Form.Select
+                        size="sm"
+                        value={decisions.plants[plant.pk]?.outcome ?? 'failed'}
+                        onChange={(event) => setPlant(plant.pk, { outcome: event.target.value as CleanPlantOutcome })}
+                      >
+                        {PLANT_OUTCOMES.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                    </td>
+                    <td>
+                      <Form.Control
+                        size="sm"
+                        value={decisions.plants[plant.pk]?.reason ?? ''}
+                        onChange={(event) => setPlant(plant.pk, { reason: event.target.value })}
+                        placeholder="Optional"
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </>
+        )}
+
+        {contents.seeds.length > 0 && (
+          <>
+            <h6>Seed drawn but never sown</h6>
+            <Table size="sm" responsive>
+              <thead>
+                <tr>
+                  <th>Sowing</th>
+                  <th>Seeds left</th>
+                  <th>Disposition</th>
+                  <th>Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {contents.seeds.map((seed) => (
+                  <tr key={seed.sowing}>
+                    <td>#{seed.sowing}</td>
+                    <td>{seed.quantity}</td>
+                    <td>
+                      <Form.Select
+                        size="sm"
+                        value={decisions.seeds[seed.sowing]?.disposition ?? 'removed'}
+                        onChange={(event) => setSeed(seed.sowing, { disposition: event.target.value as SeedDispositionChoice })}
+                      >
+                        {SEED_DISPOSITIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                    </td>
+                    <td>
+                      <Form.Control
+                        size="sm"
+                        value={decisions.seeds[seed.sowing]?.reason ?? ''}
+                        onChange={(event) => setSeed(seed.sowing, { reason: event.target.value })}
+                        placeholder="Optional"
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </>
+        )}
+
+        {contents.media.length > 0 && (
+          <>
+            <h6>Media applied to this fill</h6>
+            <Table size="sm" responsive>
+              <thead>
+                <tr>
+                  <th>Lot</th>
+                  <th>Applied</th>
+                  <th>Disposition</th>
+                  <th>Back into</th>
+                  <th>Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {contents.media.map((media) => {
+                  const choice = decisions.media[media.lot]
+                  return (
+                    <tr key={media.lot}>
+                      <td>#{media.lot}</td>
+                      <td>{formatMeasure(media.base_quantity, media.base_unit)}</td>
+                      <td>
+                        <Form.Select
+                          size="sm"
+                          value={choice?.disposition ?? 'waste'}
+                          onChange={(event) => setMedia(media.lot, { disposition: event.target.value as MediaDispositionChoice })}
+                        >
+                          {MEDIA_DISPOSITIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </Form.Select>
+                      </td>
+                      <td>
+                        {choice?.disposition === 'reclaimed' ? (
+                          <Form.Select
+                            size="sm"
+                            value={choice.destination}
+                            onChange={(event) => setMedia(media.lot, { destination: event.target.value ? Number(event.target.value) : '' })}
+                          >
+                            <option value="">Select location</option>
+                            {locations.map((location) => (
+                              <option key={location.pk} value={location.pk}>
+                                {location.name}
+                              </option>
+                            ))}
+                          </Form.Select>
+                        ) : (
+                          <span className="text-muted">—</span>
+                        )}
+                      </td>
+                      <td>
+                        <Form.Control size="sm" value={choice?.reason ?? ''} onChange={(event) => setMedia(media.lot, { reason: event.target.value })} placeholder="Optional" />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </Table>
+            <p className="text-muted small">
+              Discarded media moves no stock: the application already consumed it, and recording it again would report twice what was used. Reclaimed media goes back to the lot it
+              came from.
+            </p>
+          </>
+        )}
+
+        <Form.Group className="mt-3">
+          <Form.Label>Why is this fill being cleaned?</Form.Label>
+          <Form.Control value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Required" />
+        </Form.Group>
+        <Form.Check
+          className="mt-2"
+          type="checkbox"
+          id="clean-open-next"
+          label="Fill the tray again straight away"
+          checked={openNext}
+          onChange={(event) => setOpenNext(event.target.checked)}
+        />
+        <div className="mt-3 d-flex gap-2">
+          <Button variant="warning" onClick={handleConfirm} disabled={busy || !reason.trim() || recoveringWithoutDestination}>
+            Clean the tray
+          </Button>
+          <Button variant="secondary" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+        </div>
+        {recoveringWithoutDestination && (
+          <Alert variant="warning" className="mt-2 mb-0">
+            Say where the reclaimed media was put.
+          </Alert>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
+
+type GenerationCostPanelProps = {
+  breakdown: {
+    currency_code: string
+    unknown_cost: boolean
+    applied_cost: string
+    recovered_cost: string
+    wasted_cost: string
+    allocated_cost: string
+    unallocated_cost: string
+    production_loss: string
+    plants: Array<{ plant: number; cost: string | null }>
+  }
+}
+
+const GenerationCostPanel: React.FC<GenerationCostPanelProps> = ({ breakdown }) => (
+  <>
+    {breakdown.unknown_cost && <Alert variant="warning">Some media came from a lot with no recorded unit cost, so these totals understate the real figure.</Alert>}
+    <dl className="row mb-2">
+      <dt className="col-sm-4">Media applied</dt>
+      <dd className="col-sm-8">
+        {formatQuantity(breakdown.applied_cost)} {breakdown.currency_code}
+      </dd>
+      <dt className="col-sm-4">Reclaimed into stock</dt>
+      <dd className="col-sm-8">
+        {formatQuantity(breakdown.recovered_cost)} {breakdown.currency_code}
+      </dd>
+      <dt className="col-sm-4">Reaching seedlings</dt>
+      <dd className="col-sm-8">
+        {formatQuantity(breakdown.allocated_cost)} {breakdown.currency_code}
+      </dd>
+      <dt className="col-sm-4">In cells with no plant yet</dt>
+      <dd className="col-sm-8">
+        {formatQuantity(breakdown.unallocated_cost)} {breakdown.currency_code}
+      </dd>
+      <dt className="col-sm-4">Production loss</dt>
+      <dd className="col-sm-8">
+        {formatQuantity(breakdown.production_loss)} {breakdown.currency_code}
+      </dd>
+    </dl>
+    {breakdown.plants.length > 0 && (
+      <Table size="sm" responsive>
+        <thead>
+          <tr>
+            <th>Plant</th>
+            <th>Media cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {breakdown.plants.map((row) => (
+            <tr key={row.plant}>
+              <td>#{row.plant}</td>
+              <td>
+                {formatQuantity(row.cost, 'Unknown')} {breakdown.currency_code}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    )}
+  </>
+)
+
+export { GenerationCleanForm, GenerationCostPanel }

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -2,9 +2,23 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { QueryClientProvider, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { SeedTray, SeedTrayCell, SeedTrayModel } from '../types/seedtrays'
+import { CleanMediaDisposition, CleanPlantDisposition, CleanSeedDisposition, SeedTray, SeedTrayCell, SeedTrayGeneration, SeedTrayModel } from '../types/seedtrays'
 import { localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime } from '../utils'
-import { getSeedTrayModels, getSeedTrays, getSeedTrayCells, getSerializedUnitMovements, postSerializedUnitAction } from '../api/seedtrays'
+import {
+  cleanSeedTrayGeneration,
+  getSeedTrayCells,
+  getSeedTrayGenerationContents,
+  getSeedTrayGenerationCost,
+  getSeedTrayGenerations,
+  getSeedTrayModels,
+  getSeedTrays,
+  getSerializedUnitMovements,
+  openSeedTrayGeneration,
+  postSerializedUnitAction,
+  reopenSeedTrayGeneration,
+  reviewSeedTrayGeneration
+} from '../api/seedtrays'
+import { GenerationCleanForm, GenerationCostPanel } from './generation_clean'
 import { Alert, Button, Card, Form, Table } from 'react-bootstrap'
 import { PlantLifecycleEvent, PlantOutcomeAction, SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
 import {
@@ -51,6 +65,15 @@ type MoveForm = BaseMoveForm & (GardenSquareMove | SeedTrayMove)
 type InventoryAction = 'transfer' | 'loss' | 'retire' | 'return' | 'reconcile-opening'
 
 type CellPlantingEntry = { cellPlantingPk: number; quantity: number; plantingPk: number }
+
+type CleanGenerationRequestPayload = {
+  reason: string
+  digest: string
+  plants: Array<CleanPlantDisposition>
+  seeds: Array<CleanSeedDisposition>
+  media: Array<CleanMediaDisposition>
+  open_next: boolean
+}
 
 function computeCellData(specificPlants: Array<SpecificPlant> | undefined, plantings: Array<SeedTrayPlanting> | undefined) {
   const { cellCurrentPlantMap, cellPlantingMap, germinatedByCellPlanting } = buildCellMaps(specificPlants, plantings)
@@ -389,6 +412,100 @@ const MovePlantForm: React.FC<MovePlantFormProps> = ({ form, gardenSquares, allS
   </div>
 )
 
+type GenerationCardProps = {
+  generations: Array<SeedTrayGeneration>
+  active?: SeedTrayGeneration
+  busy: boolean
+  cleaning: boolean
+  onFill: () => void
+  onStartClean: () => void
+  onCancelClean: () => void
+  onReview: (generation: SeedTrayGeneration) => void
+  onReopen: (generation: SeedTrayGeneration) => void
+}
+
+const GenerationCard: React.FC<GenerationCardProps> = ({ generations, active, busy, cleaning, onFill, onStartClean, onCancelClean, onReview, onReopen }) => {
+  const closed = generations.filter((generation) => generation.status === 'closed')
+  const needsReview = active?.review_state === 'needs_review'
+
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Tray generation</Card.Title>
+        {active ? (
+          <>
+            <p className="mb-2">
+              Filled as <strong>{active.code}</strong> on {formatDateTime(active.opened_at)}. Media and sowings recorded from now on belong to this fill.
+            </p>
+            {active.notes && <p className="text-muted mb-2">{active.notes}</p>}
+            {needsReview && (
+              <Alert variant="warning">
+                <p className="mb-2">This fill was migrated from sowings recorded before generations existed, so it may cover more than one cultivation cycle.</p>
+                {active.review_details && <pre className="mb-2 small text-wrap">{active.review_details}</pre>}
+                <Button size="sm" variant="outline-dark" onClick={() => onReview(active)} disabled={busy}>
+                  Confirm this is one fill
+                </Button>
+              </Alert>
+            )}
+          </>
+        ) : (
+          <p className="mb-2 text-muted">The tray is empty. Fill it before sowing into it or applying media to its cells.</p>
+        )}
+        <div className="d-flex gap-2 flex-wrap">
+          {!active && (
+            <Button size="sm" onClick={onFill} disabled={busy}>
+              Fill this tray
+            </Button>
+          )}
+          {active && !cleaning && (
+            <Button size="sm" variant="warning" onClick={onStartClean} disabled={busy || needsReview}>
+              Clean this tray
+            </Button>
+          )}
+          {active && cleaning && (
+            <Button size="sm" variant="secondary" onClick={onCancelClean} disabled={busy}>
+              Cancel clean
+            </Button>
+          )}
+        </div>
+        {closed.length > 0 && (
+          <details className="mt-3">
+            <summary style={{ cursor: 'pointer' }}>Earlier fills ({closed.length})</summary>
+            <Table size="sm" responsive className="mt-2">
+              <thead>
+                <tr>
+                  <th>Fill</th>
+                  <th>Opened</th>
+                  <th>Cleaned</th>
+                  <th>Reason</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {closed.map((generation) => (
+                  <tr key={generation.pk}>
+                    <td>{generation.code}</td>
+                    <td>{formatDateTime(generation.opened_at)}</td>
+                    <td>{generation.closed_at ? formatDateTime(generation.closed_at) : ''}</td>
+                    <td>{generation.close_reason}</td>
+                    <td>
+                      {!active && (
+                        <Button size="sm" variant="outline-secondary" onClick={() => onReopen(generation)} disabled={busy}>
+                          Correct this clean
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </details>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
+
 function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const cache = useQueryClient()
   const [germinatingCellPlantingPk, setGerminatingCellPlantingPk] = React.useState<number>()
@@ -399,6 +516,7 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const [inventoryDestination, setInventoryDestination] = React.useState<number>()
   const [inventoryReason, setInventoryReason] = React.useState('')
   const [inventoryCost, setInventoryCost] = React.useState('0.0000')
+  const [cleaning, setCleaning] = React.useState(false)
   const seedTrayModelsQuery = useQuery({
     queryKey: queryKeys.seedTrays.models,
     queryFn: ({ signal }) => getSeedTrayModels(signal)
@@ -437,6 +555,22 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     queryKey: queryKeys.garden.squares,
     queryFn: ({ signal }) => getGardenSquares(signal)
   })
+  const generationsQuery = useQuery({
+    queryKey: queryKeys.seedTrays.generations(seedTrayPk),
+    queryFn: ({ signal }) => getSeedTrayGenerations(seedTrayPk, signal)
+  })
+  const generations = generationsQuery.data ?? []
+  const activeGeneration = generations.find((generation) => generation.status === 'open')
+  const cleanContentsQuery = useQuery({
+    queryKey: queryKeys.seedTrays.generationContents(activeGeneration?.pk ?? 0),
+    queryFn: ({ signal }) => getSeedTrayGenerationContents(activeGeneration?.pk as number, signal),
+    enabled: cleaning && Boolean(activeGeneration)
+  })
+  const generationCostQuery = useQuery({
+    queryKey: queryKeys.seedTrays.generationCost(activeGeneration?.pk ?? 0),
+    queryFn: ({ signal }) => getSeedTrayGenerationCost(activeGeneration?.pk as number, signal),
+    enabled: Boolean(activeGeneration)
+  })
   const moveTrayPk = moveForm?.locationType === 'seed_tray_cell' ? moveForm.moveSeedTrayPk : undefined
   const moveCellsQuery = useQuery({
     queryKey: queryKeys.seedTrays.cells(moveTrayPk ?? 0),
@@ -468,6 +602,33 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const reverseMutation = useMutation({
     mutationFn: ({ plantPk, event, reason }: { plantPk: number; event: number; reason: string }) => reverseSpecificPlantEvent(plantPk, { event, reason }),
     onSuccess: (_event, variables) => invalidatePlantLifecycle(variables.plantPk)
+  })
+  // Filling, cleaning, and correcting all change which sowings and plants the
+  // tray shows, so each one revalidates the same family of keys.
+  function invalidateGenerations() {
+    return Promise.all([
+      cache.invalidateQueries({ queryKey: queryKeys.seedTrays.generationsAll }),
+      cache.invalidateQueries({ queryKey: queryKeys.seedTrays.trays }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.seedTray(seedTrayPk) }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.specificPlants(seedTrayPk) }),
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.currentSeedTrays })
+    ])
+  }
+  const fillMutation = useMutation({
+    mutationFn: ({ notes }: { notes: string }) => openSeedTrayGeneration(seedTrayPk, notes),
+    onSuccess: invalidateGenerations
+  })
+  const cleanMutation = useMutation({
+    mutationFn: ({ generation, request }: { generation: number; request: CleanGenerationRequestPayload }) => cleanSeedTrayGeneration(generation, request),
+    onSuccess: invalidateGenerations
+  })
+  const reopenMutation = useMutation({
+    mutationFn: ({ generation, reason }: { generation: number; reason: string }) => reopenSeedTrayGeneration(generation, reason),
+    onSuccess: invalidateGenerations
+  })
+  const reviewMutation = useMutation({
+    mutationFn: ({ generation, reason }: { generation: number; reason: string }) => reviewSeedTrayGeneration(generation, reason),
+    onSuccess: invalidateGenerations
   })
   const inventoryMutation = useMutation({
     mutationFn: ({ unit, action, data }: { unit: number; action: InventoryAction; data: object }) => postSerializedUnitAction(unit, action, data),
@@ -593,6 +754,49 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     return square ? square.name : `Square #${location.garden_square}`
   }
 
+  async function handleFillTray() {
+    const notes = globalThis.prompt('What was the tray filled with? (optional)') ?? ''
+    await fillMutation.mutateAsync({ notes })
+  }
+
+  async function handleReviewGeneration(generation: SeedTrayGeneration) {
+    const reason = globalThis.prompt('What did you check to confirm this is one fill?')
+    if (!reason || !reason.trim()) return
+    await reviewMutation.mutateAsync({ generation: generation.pk, reason })
+  }
+
+  async function handleReopenGeneration(generation: SeedTrayGeneration) {
+    const reason = globalThis.prompt(`Why was cleaning ${generation.code} a mistake?`)
+    if (!reason || !reason.trim()) return
+    await reopenMutation.mutateAsync({ generation: generation.pk, reason })
+  }
+
+  async function handleCleanGeneration(request: {
+    reason: string
+    plants: Array<CleanPlantDisposition>
+    seeds: Array<CleanSeedDisposition>
+    media: Array<CleanMediaDisposition>
+    openNext: boolean
+  }) {
+    const contents = cleanContentsQuery.data
+    if (!activeGeneration || !contents) return
+    await cleanMutation.mutateAsync({
+      generation: activeGeneration.pk,
+      request: {
+        reason: request.reason,
+        // Echoed straight back from the contents this form was built on, so a
+        // tray that changed underneath the operator is refused rather than
+        // cleaned against decisions they never made.
+        digest: contents.digest,
+        plants: request.plants,
+        seeds: request.seeds,
+        media: request.media,
+        open_next: request.openNext
+      }
+    })
+    setCleaning(false)
+  }
+
   async function handleInventoryAction() {
     if (!seedTray || !inventoryAction) return
     const needsDestination = inventoryAction === 'transfer' || inventoryAction === 'return' || inventoryAction === 'reconcile-opening'
@@ -626,18 +830,58 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
       </p>
       <p>Created: {formatDate(seedTray.created)}</p>
       <p>Notes: {seedTray.notes}</p>
+      <GenerationCard
+        generations={generations}
+        active={activeGeneration}
+        busy={fillMutation.isPending || cleanMutation.isPending || reopenMutation.isPending || reviewMutation.isPending}
+        cleaning={cleaning}
+        onFill={handleFillTray}
+        onStartClean={() => setCleaning(true)}
+        onCancelClean={() => setCleaning(false)}
+        onReview={handleReviewGeneration}
+        onReopen={handleReopenGeneration}
+      />
+      {cleaning &&
+        activeGeneration &&
+        (cleanContentsQuery.isPending ? (
+          <p className="text-muted">Reading what is still in the tray…</p>
+        ) : (
+          cleanContentsQuery.data && (
+            <GenerationCleanForm
+              contents={cleanContentsQuery.data}
+              locations={inventoryDestinations}
+              busy={cleanMutation.isPending}
+              onCancel={() => setCleaning(false)}
+              onConfirm={handleCleanGeneration}
+            />
+          )
+        ))}
       <Card className="mb-3">
         <Card.Body>
           <Card.Title>Inputs</Card.Title>
           <p className="mb-2">
-            Media and treatments applied to this tray are recorded against its cells. This screen is a separate bundle, so it links to the applications page rather than embedding
-            the form.
+            Media and treatments applied to this tray are recorded against its cells and attributed to the fill those cells are serving. This screen is a separate bundle, so it
+            links to the applications page rather than embedding the form.
           </p>
-          <Button href={`/#/applications?tray=${seedTray.pk}`} variant="outline-primary">
-            Apply an input to this tray
-          </Button>
+          {activeGeneration ? (
+            <Button href={`/#/applications?tray=${seedTray.pk}`} variant="outline-primary">
+              Apply an input to {activeGeneration.code}
+            </Button>
+          ) : (
+            <Alert variant="secondary" className="mb-0">
+              Fill the tray before applying media to its cells, so the media has a fill to belong to.
+            </Alert>
+          )}
         </Card.Body>
       </Card>
+      {activeGeneration && generationCostQuery.data && (
+        <Card className="mb-3">
+          <Card.Body>
+            <Card.Title>Media cost of {activeGeneration.code}</Card.Title>
+            <GenerationCostPanel breakdown={generationCostQuery.data} />
+          </Card.Body>
+        </Card>
+      )}
       <Card className="mb-3">
         <Card.Body>
           <Card.Title>Physical inventory</Card.Title>

--- a/frontend/js/types/seedtrays.ts
+++ b/frontend/js/types/seedtrays.ts
@@ -34,6 +34,183 @@ interface SeedTray {
   inventory: SerializedInventoryUnit
   created: string
   notes?: string
+  // Null when the tray is empty: nothing has been filled into it yet, or the
+  // last fill has been cleaned out.
+  active_generation: number | null
+  generation_review_required: boolean
+}
+
+type SeedTrayGenerationStatus = 'open' | 'closed'
+type SeedTrayGenerationOrigin = 'operator' | 'legacy'
+type SeedTrayGenerationReviewState = 'none' | 'needs_review'
+type SeedTrayGenerationEventType = 'opened' | 'closed' | 'reopened' | 'reviewed'
+type ResidualKind = 'media' | 'seed'
+type SeedDispositionChoice = 'removed' | 'returned'
+type MediaDispositionChoice = 'waste' | 'reclaimed'
+type CleanPlantOutcome = 'retained' | 'failed' | 'culled' | 'donated'
+
+interface SeedTrayGenerationEvent {
+  pk: number
+  event_type: SeedTrayGenerationEventType
+  occurred_at: string
+  reason: string
+  created_by: number | null
+  created: string
+}
+
+interface SeedTrayGenerationResidual {
+  pk: number
+  kind: ResidualKind
+  disposition: SeedDispositionChoice | MediaDispositionChoice
+  lot: number
+  sowing: number | null
+  base_quantity: string
+  base_unit: string
+  unit_cost: string | null
+  movement: number | null
+  reason: string
+  created: string
+}
+
+interface SeedTrayGeneration {
+  pk: number
+  tray: number
+  code: string
+  sequence: number
+  status: SeedTrayGenerationStatus
+  origin: SeedTrayGenerationOrigin
+  review_state: SeedTrayGenerationReviewState
+  review_details: string
+  opened_at: string
+  closed_at: string | null
+  close_reason: string
+  notes: string
+  created_by: number | null
+  closed_by: number | null
+  created: string
+  updated: string
+  events: Array<SeedTrayGenerationEvent>
+  residuals: Array<SeedTrayGenerationResidual>
+}
+
+interface GenerationContentsSowing {
+  pk: number
+  planted: string
+  batch: number
+  quantity: number
+  seeds_used: number
+}
+
+interface GenerationContentsPlant {
+  pk: number
+  cell_planting: number
+  cell: number
+  germinated: string
+}
+
+interface GenerationContentsSeed {
+  sowing: number
+  seeds_used: number
+  quantity: number
+}
+
+interface GenerationContentsMedia {
+  lot: number
+  item: number
+  base_quantity: string
+  base_unit: string
+  unit_cost: string | null
+}
+
+interface SeedTrayGenerationContents {
+  generation: number
+  code: string
+  status: SeedTrayGenerationStatus
+  review_state: SeedTrayGenerationReviewState
+  cell_count: number
+  // Echoed back when the clean is confirmed, so a confirmation prepared against
+  // contents that have since moved is refused rather than applied blind.
+  digest: string
+  sowings: Array<GenerationContentsSowing>
+  plants: Array<GenerationContentsPlant>
+  seeds: Array<GenerationContentsSeed>
+  media: Array<GenerationContentsMedia>
+}
+
+interface CleanPlantDisposition {
+  plant: number
+  outcome: CleanPlantOutcome
+  reason: string
+}
+
+interface CleanSeedDisposition {
+  sowing: number
+  quantity: string
+  disposition: SeedDispositionChoice
+  reason: string
+  destination?: number | null
+}
+
+interface CleanMediaDisposition {
+  lot: number
+  quantity: string
+  disposition: MediaDispositionChoice
+  reason: string
+  destination?: number | null
+}
+
+interface CleanGenerationRequest {
+  reason: string
+  digest: string
+  plants: Array<CleanPlantDisposition>
+  seeds: Array<CleanSeedDisposition>
+  media: Array<CleanMediaDisposition>
+  open_next: boolean
+}
+
+interface CleanGenerationResponse {
+  generation: SeedTrayGeneration
+  next_generation: SeedTrayGeneration | null
+}
+
+interface GenerationCostCell {
+  cell: number
+  x_position: number
+  y_position: number
+  cost: string | null
+  plants: Array<number>
+  per_plant_cost: string | null
+  provisional: boolean
+}
+
+interface GenerationCostMedia {
+  line: number
+  application: number
+  lot: number
+  item: number
+  base_quantity: string
+  base_unit: string
+  unit_cost: string | null
+  cost: string | null
+}
+
+interface GenerationCostBreakdown {
+  generation: number
+  code: string
+  status: SeedTrayGenerationStatus
+  currency_code: string
+  // True when a lot has no recorded unit cost. The totals then understate the
+  // real figure, so the screen says so rather than showing them as complete.
+  unknown_cost: boolean
+  media: Array<GenerationCostMedia>
+  applied_cost: string
+  recovered_cost: string
+  wasted_cost: string
+  cells: Array<GenerationCostCell>
+  plants: Array<{ plant: number; cost: string | null }>
+  allocated_cost: string
+  unallocated_cost: string
+  production_loss: string
 }
 
 interface SeedTrayFilters {
@@ -56,4 +233,24 @@ interface SeedTrayCell {
   y_position: number
 }
 
-export { SeedTrayModel, SeedTray, SeedTrayCell, SeedTrayFilters, SeedTrayModelCreate, SeedTrayReceiptCreate, SeedTrayReceiptResponse }
+export {
+  CleanGenerationRequest,
+  CleanGenerationResponse,
+  CleanMediaDisposition,
+  CleanPlantDisposition,
+  CleanPlantOutcome,
+  CleanSeedDisposition,
+  GenerationCostBreakdown,
+  MediaDispositionChoice,
+  SeedDispositionChoice,
+  SeedTray,
+  SeedTrayCell,
+  SeedTrayFilters,
+  SeedTrayGeneration,
+  SeedTrayGenerationContents,
+  SeedTrayGenerationEvent,
+  SeedTrayModel,
+  SeedTrayModelCreate,
+  SeedTrayReceiptCreate,
+  SeedTrayReceiptResponse
+}


### PR DESCRIPTION
The tray screen now says which fill the tray is on, or that it is empty, and every action that changes that is on the same card: fill it, clean it, confirm a migrated fill, or correct a clean that should not have happened. Earlier fills sit behind a disclosure with the reason each was cleaned for.

The clean is a form rather than a button because it is a set of decisions. Every plant still in the tray, every seed drawn but never sown, and every lot of media applied gets its own row with a disposition selected and changeable. Each row starts on the commonest answer instead of on nothing: the server refuses an incomplete confirmation outright, so an empty default would only turn a decision the operator has to make into a form error they have to clear.

The digest the confirmation view returned is echoed straight back, so a tray that changed while the form was open is refused rather than cleaned against decisions nobody made about its current contents.

The inputs card now names the fill an application will be attributed to, and refuses to link to the form at all when the tray is empty — media applied to a fill nobody opened has nothing to belong to. The cost panel reports what reaches seedlings, what is sitting in cells that have grown nothing yet, and what has become production loss, and says plainly when a lot has no recorded cost rather than showing an understated total as if it were complete.

## Summary by Sourcery

Introduce tray generation lifecycle UI for seed trays, covering filling, cleaning, reviewing migrated fills, and correcting mistaken cleans, and surface generation-aware media cost reporting.

New Features:
- Add tray generation card showing current fill, earlier fills, and review state for migrated generations.
- Enable operators to fill a tray, clean a generation through a structured disposition form, and optionally reopen or immediately open the next generation.
- Gate input applications on an active tray generation and label applications with the generation they belong to.
- Display a media cost breakdown per tray generation, including allocated, unallocated, recovered, wasted, and production loss costs.

Enhancements:
- Extend seed tray APIs, types, and react-query keys to support generations, contents, cleaning requests, and cost breakdowns.
- Ensure cleaning, reopening, and reviewing generations consistently invalidate tray- and planting-related caches to keep the UI in sync.