### PR TITLE
fix(frontend): load the stylesheet the seed tray page links

### DIFF
--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -1,3 +1,8 @@
+// This is an entry point, not a view imported by one, so it has to pull in the
+// stylesheet itself: esbuild emits a bundle's CSS only from what that bundle
+// imports, and `seedtray_detail.html` links the file this produces.
+import 'bootstrap/dist/css/bootstrap.css'
+
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { QueryClientProvider, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'


### PR DESCRIPTION
seedtray_detail.html has linked seedtray/seedtray_details.css since the page was added, and the build has never produced it. esbuild emits a bundle's CSS from what that bundle imports, and this entry point imported none — every other view module imports bootstrap's stylesheet, but the second entry point was missed.

So the page has rendered unstyled all along: cards without borders, buttons without variants, definition lists in one flat column. Task 39's physical inventory card and this task's generation card were both landing into that.

Importing the stylesheet here makes esbuild emit the file the template was already asking for.

## Summary by Sourcery

Bug Fixes:
- Fix missing Bootstrap stylesheet import in the seed tray details entry bundle so the linked CSS file is generated by the build.