### PR TITLE
build: lint every app, not the nine that were listed

### DIFF
--- a/applications/rest.py
+++ b/applications/rest.py
@@ -1,6 +1,9 @@
 """REST surface for drafting, previewing, posting, and reversing applications."""
 
-# pylint: disable=duplicate-code
+# Most serializers here are action payloads rather than writable resources, so
+# they implement neither of DRF's `create` and `update`; `ActionSerializer`
+# refuses both once on their behalf.
+# pylint: disable=duplicate-code,abstract-method
 
 from decimal import Decimal
 

--- a/applications/services.py
+++ b/applications/services.py
@@ -89,6 +89,19 @@ class ApplicationRequest(NamedTuple):
     lines: tuple = ()
 
 
+class Posting(NamedTuple):
+    """One ledger row a line is about to write: what, how much, and why.
+
+    A line posts consumption and, when there is any, waste. Both draw on the
+    same lot from the same location at the same moment, so only these three
+    differ between them.
+    """
+
+    movement_type: str
+    quantity: object
+    reason: str = ''
+
+
 class TargetSnapshot(NamedTuple):
     """One target with whatever it measured at the moment it was read."""
 
@@ -581,24 +594,18 @@ def _post_line(application, line, user):
         raise ValidationError({
             'lines': f'Line {line.pk}: serialized stock moves through unit actions.',
         })
-    movements = [_post_movement(
-        application,
-        line,
-        user,
-        StockMovement.MovementType.CONSUMPTION,
-        line.applied_base_quantity,
-        line.override_reason,
-    )]
+    movements = [_post_movement(application, line, user, Posting(
+        movement_type=StockMovement.MovementType.CONSUMPTION,
+        quantity=line.applied_base_quantity,
+        reason=line.override_reason,
+    ))]
     line.consumption_movement = movements[0]
     if line.waste_base_quantity > 0:
-        movements.append(_post_movement(
-            application,
-            line,
-            user,
-            StockMovement.MovementType.WASTE,
-            line.waste_base_quantity,
-            line.waste_reason,
-        ))
+        movements.append(_post_movement(application, line, user, Posting(
+            movement_type=StockMovement.MovementType.WASTE,
+            quantity=line.waste_base_quantity,
+            reason=line.waste_reason,
+        )))
         line.waste_movement = movements[1]
     InputApplicationLine.objects.filter(pk=line.pk).update(
         consumption_movement=line.consumption_movement,
@@ -608,18 +615,18 @@ def _post_line(application, line, user):
     return movements
 
 
-def _post_movement(application, line, user, movement_type, quantity, reason):
+def _post_movement(application, line, user, posting):
     """Append one ledger row for this line."""
     return post_stock_movement(
         application.workspace,
         user,
         MovementRequest(
             lot=line.lot,
-            movement_type=movement_type,
-            quantity=quantity,
+            movement_type=posting.movement_type,
+            quantity=posting.quantity,
             source=application.source_location,
             occurred_at=application.applied_at,
-            reason=reason,
+            reason=posting.reason,
             reference=f'application:{application.pk} line:{line.pk}',
         ),
     )

--- a/applications/test_services.py
+++ b/applications/test_services.py
@@ -48,10 +48,11 @@ from .services import (
 TargetType = InputApplicationTarget.TargetType
 
 
-class ApplicationServiceMixin:
+class ApplicationServiceTestCase(TestCase):
     """Stock, a batch, and helpers for building one document."""
 
     def setUp(self):
+        """Stock one media lot and open a batch every case draws on."""
         super().setUp()
         self.workspace = Workspace.objects.get(pk=1)
         self.location = make_inventory_location()
@@ -101,7 +102,7 @@ class ApplicationServiceMixin:
         return [TargetRequest(TargetType.SEED_TRAY_CELL, cell) for cell in cells]
 
 
-class DraftApplicationTests(ApplicationServiceMixin, TestCase):
+class DraftApplicationTests(ApplicationServiceTestCase):
     """Assembling a draft freezes every measurement it calculates from."""
 
     def test_a_draft_records_the_calculation(self):
@@ -160,7 +161,7 @@ class DraftApplicationTests(ApplicationServiceMixin, TestCase):
         self.assertIn('targets', caught.exception.message_dict)
 
 
-class PostApplicationTests(ApplicationServiceMixin, TestCase):
+class PostApplicationTests(ApplicationServiceTestCase):
     """Posting turns a confirmed draft into ledger movements."""
 
     def test_posting_consumes_the_confirmed_quantity(self):
@@ -266,7 +267,7 @@ class PostApplicationTests(ApplicationServiceMixin, TestCase):
         self.assertIn('batch', caught.exception.message_dict)
 
 
-class PlantTargetTests(ApplicationServiceMixin, TestCase):
+class PlantTargetTests(ApplicationServiceTestCase):
     """Applying an input to individual plants."""
 
     def setUp(self):
@@ -341,7 +342,7 @@ class PlantTargetTests(ApplicationServiceMixin, TestCase):
         self.assertIn('targets', caught.exception.message_dict)
 
 
-class SurfaceAreaTargetTests(ApplicationServiceMixin, TestCase):
+class SurfaceAreaTargetTests(ApplicationServiceTestCase):
     """Applying a treatment over measured ground."""
 
     def setUp(self):
@@ -408,7 +409,7 @@ class SurfaceAreaTargetTests(ApplicationServiceMixin, TestCase):
         self.assertEqual(movements[0].quantity, Decimal('8.000000000'))
 
 
-class SnapshotDurabilityTests(ApplicationServiceMixin, TestCase):
+class SnapshotDurabilityTests(ApplicationServiceTestCase):
     """A posted document cannot be rewritten by a later configuration edit."""
 
     def test_editing_the_tray_model_leaves_the_document_alone(self):
@@ -442,7 +443,7 @@ class SnapshotDurabilityTests(ApplicationServiceMixin, TestCase):
         self.assertEqual(state['lines'][0]['calculated_base_quantity'], Decimal('0.960000000'))
 
 
-class ReverseApplicationTests(ApplicationServiceMixin, TestCase):
+class ReverseApplicationTests(ApplicationServiceTestCase):
     """Reversal restores stock and keeps the document readable."""
 
     def posted(self, **overrides):
@@ -507,7 +508,7 @@ class ReverseApplicationTests(ApplicationServiceMixin, TestCase):
         self.assertIn('status', caught.exception.message_dict)
 
 
-class ApplicationStateTests(ApplicationServiceMixin, TestCase):
+class ApplicationStateTests(ApplicationServiceTestCase):
     """What a preview reports and what posting revalidates against."""
 
     def test_state_reports_availability_before_and_after(self):
@@ -574,7 +575,7 @@ class ApplicationStateTests(ApplicationServiceMixin, TestCase):
         self.assertEqual(application.status, InputApplication.Status.POSTED)
 
 
-class GenerationTargetTests(ApplicationServiceMixin, TestCase):
+class GenerationTargetTests(ApplicationServiceTestCase):
     """Media applied to a cell is attributed to the fill using that cell."""
 
     def test_a_cell_target_records_the_fill_it_went_into(self):

--- a/applications/tests.py
+++ b/applications/tests.py
@@ -39,10 +39,11 @@ def _next_workspace_name():
     return f'Other workspace {next(_WORKSPACES)}'
 
 
-class ApplicationFixtureMixin:
+class ApplicationFixtureTestCase(TestCase):
     """Shared draft, line, and target builders."""
 
     def setUp(self):
+        """Stock one lot at one location for every case to draw on."""
         super().setUp()
         self.location = make_inventory_location()
         self.item = make_inventory_item()
@@ -101,7 +102,7 @@ class ApplicationFixtureMixin:
         return InputApplicationTarget.objects.create(**values)
 
 
-class InputApplicationTests(ApplicationFixtureMixin, TestCase):
+class InputApplicationTests(ApplicationFixtureTestCase):
     """Rules governing the document header."""
 
     def test_an_application_starts_as_a_draft(self):
@@ -173,7 +174,7 @@ class InputApplicationTests(ApplicationFixtureMixin, TestCase):
             )
 
 
-class InputApplicationLineTests(ApplicationFixtureMixin, TestCase):
+class InputApplicationLineTests(ApplicationFixtureTestCase):
     """Rules governing one item drawn from one exact lot."""
 
     def test_a_line_records_the_lot_it_drew_from(self):
@@ -243,7 +244,7 @@ class InputApplicationLineTests(ApplicationFixtureMixin, TestCase):
         self.assertIn('item', caught.exception.message_dict)
 
 
-class InputApplicationTargetTests(ApplicationFixtureMixin, TestCase):
+class InputApplicationTargetTests(ApplicationFixtureTestCase):
     """Rules governing what a line was applied to."""
 
     def test_target_fields_match_the_declared_choices(self):

--- a/applications/usage.py
+++ b/applications/usage.py
@@ -207,8 +207,13 @@ def _manual_usage(inputs):
     return _result(inputs, None, '', len(inputs.targets), None, 'Manual entry')
 
 
-def _result(inputs, basis_quantity, basis_unit, target_count, calculated, formula):
-    """Assemble one calculation, quantizing the suggestion for the ledger."""
+def _result(inputs, basis_quantity, basis_unit, target_count, calculated, formula):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """Assemble one calculation, quantizing the suggestion for the ledger.
+
+    The parameters are the fields of the value this builds, so there is no
+    smaller thing to group them into: that thing is `UsageCalculation`, which is
+    what comes back out.
+    """
     return UsageCalculation(
         basis=inputs.basis,
         basis_quantity=None if basis_quantity is None else quantize_quantity(basis_quantity),

--- a/check-code.sh
+++ b/check-code.sh
@@ -4,6 +4,11 @@ source venv/bin/activate
 
 pycodestyle --ignore=E501 */*.py
 
-pylint frontend/ garden/ inventory/ plantings/ plants/ seeds/ seedtrays/ supplies/ workspaces/
+# Every package with checked-in Python except gp/, which is excluded on purpose:
+# it holds gp/local_settings.py, which is gitignored and differs on every
+# machine, so linting it would gate the build on an untracked file. When a new
+# app is added, add it here — applications/ was missed and went unlinted from
+# the day it landed until the seed-tray generation work noticed.
+pylint applications/ frontend/ garden/ inventory/ plantings/ plants/ seeds/ seedtrays/ supplies/ tests/ workspaces/
 
 deactivate

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,4 +1,7 @@
 """Small dependency-free model builders shared by API tests."""
+# These deliberately mirror the shape of the real creation paths they stand
+# in for, so they read the same way; the overlap is the point.
+# pylint: disable=duplicate-code
 from datetime import date
 from decimal import Decimal
 from itertools import count


### PR DESCRIPTION
check-code.sh named its pylint targets one by one, so applications/ went unlinted from the day it landed and tests/ never was. Adding both found real findings in code that had passed review: two fixture mixins whose setUp pylint could not place, argument counts on two helpers, and the action-serializer pattern that trips abstract-method.

The two mixins are now the base test cases they already were in every use. A line's ledger row becomes a Posting — what, how much, and why, which is all that differs between the consumption and the waste a line posts. `_result` keeps its parameters with a note, because they are the fields of the value it builds and the thing to group them into is what it already returns.

gp/ stays out on purpose, and the script now says why: it holds the gitignored local_settings.py, so linting it would gate the build on an untracked file that differs on every machine. The comment also asks for new apps to be added, which is the step that was missed.

## Summary by Sourcery

Lint all Python apps including applications/ and tests/, addressing new pylint findings and documenting intentional exclusions.

New Features:
- Introduce a Posting value object to represent a single ledger row for stock movements.

Bug Fixes:
- Fix missing pylint coverage for applications/ and tests/ and resolve the issues it uncovered in application services and usage calculations.

Enhancements:
- Refactor application stock posting logic to use the new Posting type, clarifying how consumption and waste movements are constructed.
- Convert shared application test mixins into concrete TestCase base classes to align with test discovery and linting expectations.
- Document the ActionSerializer pattern and factory duplication in REST and test modules to satisfy abstract-method and duplicate-code lint rules.

Build:
- Expand check-code.sh pylint targets to cover all tracked apps and tests while explicitly excluding gp/ with rationale.

Tests:
- Update application tests to inherit from new base TestCase classes that provide shared fixtures for services and application models.