### PR TITLE
feat(costing): split a source input exactly across what it reached

### DIFF
--- a/costing/allocation.py
+++ b/costing/allocation.py
@@ -1,0 +1,275 @@
+"""Decide what share of one source input belongs to each thing it reached.
+
+These functions are pure in the same way and for the same reason as
+`applications.usage`: they take already-measured facts and return shares,
+without reading the database. A layer posted from them can therefore be
+recalculated from its stored snapshot years later and come out the same.
+
+The whole module rests on one invariant, which `inventory.ledger.distribute_exactly`
+supplies: **the shares of a source always add back up to the source**. Nothing
+is dropped to rounding and nothing is quietly absorbed into one arbitrary
+share, so a batch's layers can always be reconciled against the stock movements
+that created them.
+
+Cost never rests in two places at once. A share whose plant is not yet known
+sits on the cell, or in the batch pool; when a plant is observed it moves to the
+plant, and when output is finalized without one it moves to production loss.
+Each of those moves is a reversal plus a replacement, never a second layer on
+top of the first, because two layers would double the cost of one input.
+"""
+
+from decimal import Decimal
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+
+from inventory.ledger import QUANTITY_QUANTUM, distribute_exactly
+
+from .models import CostAllocation
+
+
+#: The key standing in for "nowhere individual yet". Shares carrying it become
+#: batch-pool layers, and at output finalization production-loss layers.
+POOL = None
+
+
+class Share(NamedTuple):
+    """One destination and the weight that earns it a part of the source."""
+
+    key: object
+    target_type: str
+    weight: Decimal
+    basis: str
+    cell_id: object = None
+    generation_id: object = None
+    plant_id: object = None
+
+
+class Part(NamedTuple):
+    """One share, valued: what quantity and what money it carries."""
+
+    share: Share
+    base_quantity: Decimal
+    amount: object
+
+
+def _require(condition, field, message):
+    """Raise a field error unless a precondition holds."""
+    if not condition:
+        raise ValidationError({field: message})
+
+
+def value_shares(shares, base_quantity, amount):
+    """Split one source's quantity and cost across its shares exactly.
+
+    Quantity and money are distributed separately because they are stored at
+    different precisions, but both go through the same exact split, so a report
+    can reconcile either one back to the source without a residue.
+    """
+    _require(shares, 'shares', 'A source input needs somewhere to go.')
+    weights = [share.weight for share in shares]
+    quantities = distribute_exactly(base_quantity, weights, QUANTITY_QUANTUM)
+    amounts = distribute_exactly(amount, weights)
+    return [
+        Part(share=share, base_quantity=quantity, amount=part)
+        for share, quantity, part in zip(shares, quantities, amounts)
+    ]
+
+
+def seed_shares(sowing_quantity, cell_quantities):
+    """Split a sowing's seed cost by the seed actually placed in each cell.
+
+    Seed drawn from the packet but never placed in a cell has not reached a
+    seedling and may never, so it stays in the batch pool rather than inflating
+    the cells that did get sown. That remainder is what
+    `seedtrays.generations.unsown_seed` reports on the tray screen.
+    """
+    sowing_quantity = Decimal(sowing_quantity)
+    shares = [
+        Share(
+            key=('cell', cell_id),
+            target_type=CostAllocation.TargetType.SEED_TRAY_CELL,
+            weight=Decimal(quantity),
+            basis=CostAllocation.Basis.SEEDS_SOWN,
+            cell_id=cell_id,
+            generation_id=generation_id,
+        )
+        for cell_id, generation_id, quantity in cell_quantities
+        if Decimal(quantity) > 0
+    ]
+    placed = sum((share.weight for share in shares), Decimal('0'))
+    _require(
+        placed <= sowing_quantity,
+        'cell_quantities',
+        'More seed is allocated to cells than the sowing drew.',
+    )
+    remainder = sowing_quantity - placed
+    if remainder > 0:
+        shares.append(_pool_share(remainder, CostAllocation.Basis.SEEDS_SOWN))
+    return shares
+
+
+def cell_volume_shares(cell_targets):
+    """Split cell-targeted cost the way the application calculated it.
+
+    The weights are `weight * cell_volume_ml`, which is the basis
+    `applications.usage` used to arrive at the quantity in the first place, and
+    which `seedtrays.generations.cell_shares` already applies when it reports a
+    fill's media. Dividing any other way would attribute a number the
+    application never used.
+    """
+    return [
+        Share(
+            key=('cell', target.seed_tray_cell_id),
+            target_type=CostAllocation.TargetType.SEED_TRAY_CELL,
+            weight=Decimal(target.weight) * Decimal(target.cell_volume_ml),
+            basis=CostAllocation.Basis.CELL_VOLUME,
+            cell_id=target.seed_tray_cell_id,
+            generation_id=target.seed_tray_generation_id,
+        )
+        for target in cell_targets
+        if target.cell_volume_ml
+    ]
+
+
+def plant_shares(plant_ids, weights=None):
+    """Send per-plant cost straight to the plants it was applied to."""
+    weights = weights or {}
+    return [
+        Share(
+            key=('plant', plant_id),
+            target_type=CostAllocation.TargetType.SPECIFIC_PLANT,
+            weight=Decimal(weights.get(plant_id, 1)),
+            basis=CostAllocation.Basis.PER_PLANT,
+            plant_id=plant_id,
+        )
+        for plant_id in plant_ids
+    ]
+
+
+def area_plant_shares(areas):
+    """Split area-targeted cost by area, then among the plants standing in it.
+
+    Each area's weight is divided by its own plant count before the single
+    exact split runs, rather than splitting twice. The proportions are identical
+    either way, but one split means one set of rounding remainders to reconcile
+    instead of a remainder per area on top of a remainder overall.
+
+    An area with no eligible plants keeps its share in the batch pool. Spreading
+    it over the other areas' plants would charge a seedling for ground it never
+    occupied.
+    """
+    shares = []
+    orphaned = Decimal('0')
+    for area_weight, plant_ids, plant_weights in areas:
+        area_weight = Decimal(area_weight)
+        if not plant_ids:
+            orphaned += area_weight
+            continue
+        supplied = plant_weights or {}
+        basis = sum(
+            (Decimal(supplied.get(plant_id, 1)) for plant_id in plant_ids),
+            Decimal('0'),
+        )
+        _require(
+            basis > 0,
+            'targets',
+            'The per-plant weights for an area total zero.',
+        )
+        shares.extend(
+            Share(
+                key=('plant', plant_id),
+                target_type=CostAllocation.TargetType.SPECIFIC_PLANT,
+                weight=area_weight * Decimal(supplied.get(plant_id, 1)) / basis,
+                basis=CostAllocation.Basis.AREA,
+                plant_id=plant_id,
+            )
+            for plant_id in plant_ids
+        )
+    if orphaned > 0:
+        shares.append(_pool_share(orphaned, CostAllocation.Basis.AREA))
+    return shares
+
+
+def resolve_cells_to_plants(shares, plants_by_cell):
+    """Move each cell's share onto the seedlings that actually came up in it.
+
+    A cell that produced three plants from one multigerm cluster spreads one
+    cell's worth of cost across three seedlings without changing any count —
+    the quantity sown stays exactly what was sown. A cell that produced nothing
+    keeps its share, which stays provisional while a seedling might still
+    appear and becomes production loss when output is finalized without one.
+
+    Shares that never named a cell pass through untouched.
+    """
+    resolved = []
+    for share in shares:
+        plants = plants_by_cell.get(share.cell_id) if share.cell_id else None
+        if not plants:
+            resolved.append(share)
+            continue
+        portion = share.weight / Decimal(len(plants))
+        resolved.extend(
+            Share(
+                key=('plant', plant_id),
+                target_type=CostAllocation.TargetType.SPECIFIC_PLANT,
+                weight=portion,
+                basis=CostAllocation.Basis.EQUAL_SHARE,
+                plant_id=plant_id,
+            )
+            for plant_id in plants
+        )
+    return combine(resolved)
+
+
+def combine(shares):
+    """Total the weights of shares that ended up in the same place.
+
+    Two sources of shared cost can reach one plant — seed through its cell and
+    media through the same cell — and one plant can be reached twice by one
+    source when it is named directly as well. One layer per destination per
+    source keeps the ledger readable and the diff stable.
+    """
+    merged = {}
+    for share in shares:
+        existing = merged.get(share.key)
+        if existing is None:
+            merged[share.key] = share
+        else:
+            merged[share.key] = existing._replace(weight=existing.weight + share.weight)
+    return list(merged.values())
+
+
+def whole_source_share(basis=CostAllocation.Basis.DIRECT):
+    """Return the single share for cost that reached nothing individual."""
+    return [_pool_share(Decimal('1'), basis)]
+
+
+def loss_shares(shares):
+    """Turn unresolved shares into production loss, keeping their weights.
+
+    Called once, at output finalization: a cell with no seedling and a pool
+    nothing ever claimed are both cost the batch incurred and never recovered.
+    Dropping them would understate what the crop cost; leaving them on the cell
+    would imply a seedling that does not exist.
+    """
+    return [
+        share._replace(
+            key=('production_loss', share.key),
+            target_type=CostAllocation.TargetType.PRODUCTION_LOSS,
+            cell_id=None,
+            generation_id=None,
+            plant_id=None,
+        )
+        for share in shares
+    ]
+
+
+def _pool_share(weight, basis):
+    """Return one share of cost that has not reached anything individual."""
+    return Share(
+        key=('pool', POOL),
+        target_type=CostAllocation.TargetType.BATCH_POOL,
+        weight=Decimal(weight),
+        basis=basis,
+    )

--- a/costing/test_allocation.py
+++ b/costing/test_allocation.py
@@ -1,0 +1,296 @@
+"""The splitting rules, checked without a database in the way.
+
+`costing.allocation` is pure, so these tests feed it measured facts directly.
+The rules it applies to real application targets and real cells are exercised
+end to end in `costing.test_services`; what is checked here is the arithmetic
+those rules stand on, above all that nothing is ever lost to rounding.
+"""
+
+from decimal import Decimal
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+
+from inventory.ledger import MONEY_QUANTUM, QUANTITY_QUANTUM, distribute_exactly
+
+from .allocation import (
+    area_plant_shares,
+    cell_volume_shares,
+    combine,
+    loss_shares,
+    plant_shares,
+    resolve_cells_to_plants,
+    seed_shares,
+    value_shares,
+    whole_source_share,
+)
+from .models import CostAllocation
+
+
+class StubTarget(NamedTuple):
+    """The three fields `cell_volume_shares` reads off a real target.
+
+    Named after `applications.models.InputApplicationTarget`, whose columns
+    these are. The real object is used in `costing.test_services`; this stand-in
+    keeps the arithmetic tests free of a tray, a fill, and an application.
+    """
+
+    seed_tray_cell_id: int
+    seed_tray_generation_id: int
+    weight: Decimal
+    cell_volume_ml: int
+
+
+def _total(values):
+    """Sum a list of shares, treating it as exact."""
+    return sum(values, Decimal('0'))
+
+
+class DistributeExactlyTests(SimpleTestCase):
+    """Splitting money must never invent or lose a cent."""
+
+    def test_an_even_split_that_does_not_divide_reconciles(self):
+        """A third of ten dollars has to come back as ten dollars."""
+        parts = distribute_exactly(Decimal('10'), [1, 1, 1])
+        self.assertEqual(_total(parts), Decimal('10.0000'))
+        self.assertEqual(
+            parts,
+            [Decimal('3.3334'), Decimal('3.3333'), Decimal('3.3333')],
+        )
+
+    def test_the_remainder_goes_to_the_largest_fractional_parts(self):
+        """Handing every step to one arbitrary share would misreport it."""
+        parts = distribute_exactly(Decimal('1'), [1, 1, 1, 1, 1, 1, 7])
+        self.assertEqual(_total(parts), Decimal('1.0000'))
+        self.assertEqual(parts[-1], Decimal('0.5385'))
+
+    def test_uneven_weights_reconcile(self):
+        """Weighted splits carry the same guarantee as even ones."""
+        parts = distribute_exactly(Decimal('12.3456'), [7, 11, 13, 17])
+        self.assertEqual(_total(parts), Decimal('12.3456'))
+
+    def test_ties_are_broken_by_position(self):
+        """The same inputs must produce the same split, run after run."""
+        first = distribute_exactly(Decimal('10'), [1, 1, 1])
+        second = distribute_exactly(Decimal('10'), [1, 1, 1])
+        self.assertEqual(first, second)
+
+    def test_a_quantity_quantum_reconciles_at_nine_places(self):
+        """Quantities are stored finer than money and split the same way."""
+        parts = distribute_exactly(Decimal('1'), [1, 1, 3], QUANTITY_QUANTUM)
+        self.assertEqual(_total(parts), Decimal('1.000000000'))
+
+    def test_an_unknown_total_splits_into_unknowns(self):
+        """A share of an unknown cost is unknown, never zero."""
+        self.assertEqual(distribute_exactly(None, [1, 2]), [None, None])
+
+    def test_weights_totalling_zero_are_refused(self):
+        """There is no proportional answer when nothing has any weight."""
+        with self.assertRaises(ValidationError):
+            distribute_exactly(Decimal('1'), [0, 0])
+
+    def test_a_negative_weight_is_refused(self):
+        """A negative share would take cost off another destination."""
+        with self.assertRaises(ValidationError):
+            distribute_exactly(Decimal('1'), [2, -1])
+
+    def test_a_single_share_takes_the_whole_total(self):
+        """The degenerate case still reconciles exactly."""
+        self.assertEqual(distribute_exactly(Decimal('7.77'), [3]), [Decimal('7.7700')])
+
+
+class ValueSharesTests(SimpleTestCase):
+    """Quantity and money are split separately but both reconcile."""
+
+    def setUp(self):
+        self.shares = seed_shares(3, [(1, 9, 1), (2, 9, 1), (3, 9, 1)])
+
+    def test_both_columns_reconcile_to_their_source(self):
+        """A report can tie either number back to the movement that made it."""
+        parts = value_shares(self.shares, Decimal('1'), Decimal('10'))
+        self.assertEqual(
+            _total([part.base_quantity for part in parts]),
+            Decimal('1.000000000'),
+        )
+        self.assertEqual(_total([part.amount for part in parts]), Decimal('10.0000'))
+
+    def test_an_unknown_cost_leaves_every_amount_unknown(self):
+        """Quantity stays exact even when the lot never recorded a price."""
+        parts = value_shares(self.shares, Decimal('1'), None)
+        self.assertTrue(all(part.amount is None for part in parts))
+        self.assertEqual(
+            _total([part.base_quantity for part in parts]),
+            Decimal('1.000000000'),
+        )
+
+    def test_a_source_with_nowhere_to_go_is_refused(self):
+        """Cost that reached nothing at all is a bug, not an empty split."""
+        with self.assertRaises(ValidationError):
+            value_shares([], Decimal('1'), Decimal('1'))
+
+
+class SeedShareTests(SimpleTestCase):
+    """Seed cost follows the seed into the cells that received it."""
+
+    def test_seed_follows_the_cells_it_was_placed_in(self):
+        """A cell sown with twice the seed carries twice the cost."""
+        shares = seed_shares(6, [(1, 9, 2), (2, 9, 4)])
+        self.assertEqual([share.cell_id for share in shares], [1, 2])
+        self.assertEqual([share.weight for share in shares], [Decimal('2'), Decimal('4')])
+
+    def test_seed_never_placed_stays_in_the_pool(self):
+        """Unplaced seed has reached no seedling and may never."""
+        shares = seed_shares(10, [(1, 9, 4)])
+        pool = [share for share in shares if share.target_type == CostAllocation.TargetType.BATCH_POOL]
+        self.assertEqual(len(pool), 1)
+        self.assertEqual(pool[0].weight, Decimal('6'))
+
+    def test_a_fully_placed_sowing_leaves_no_pool(self):
+        """A zero remainder is not a layer worth carrying."""
+        shares = seed_shares(4, [(1, 9, 4)])
+        self.assertEqual(len(shares), 1)
+        self.assertEqual(shares[0].cell_id, 1)
+
+    def test_placing_more_seed_than_was_drawn_is_refused(self):
+        """That would allocate cost the sowing never paid for."""
+        with self.assertRaises(ValidationError):
+            seed_shares(3, [(1, 9, 2), (2, 9, 2)])
+
+    def test_a_cell_sown_with_nothing_earns_no_share(self):
+        """A zero weight would make the proportional split meaningless."""
+        shares = seed_shares(4, [(1, 9, 4), (2, 9, 0)])
+        self.assertEqual([share.cell_id for share in shares], [1])
+
+
+class CellVolumeShareTests(SimpleTestCase):
+    """Media is divided the way the application calculated it."""
+
+    def test_cells_are_weighted_by_weight_times_volume(self):
+        """This is the basis `applications.usage` used for the quantity."""
+        shares = cell_volume_shares([
+            StubTarget(1, 9, Decimal('1'), 40),
+            StubTarget(2, 9, Decimal('0.5'), 40),
+        ])
+        self.assertEqual(
+            [share.weight for share in shares],
+            [Decimal('40'), Decimal('20.0')],
+        )
+
+    def test_a_target_with_no_measured_volume_is_skipped(self):
+        """An unmeasured cell cannot be given a proportional share."""
+        shares = cell_volume_shares([StubTarget(1, 9, Decimal('1'), None)])
+        self.assertEqual(shares, [])
+
+
+class ResolveCellsToPlantsTests(SimpleTestCase):
+    """A cell's cost reaches the seedlings that actually came up in it."""
+
+    def test_a_multigerm_cell_splits_equally_between_its_plants(self):
+        """One cell's worth of cost, three seedlings, no count changed."""
+        shares = resolve_cells_to_plants(
+            cell_volume_shares([StubTarget(1, 9, Decimal('1'), 30)]),
+            {1: [11, 12, 13]},
+        )
+        self.assertEqual({share.plant_id for share in shares}, {11, 12, 13})
+        self.assertEqual([share.weight for share in shares], [Decimal('10')] * 3)
+
+    def test_an_empty_cell_keeps_its_own_share(self):
+        """A seedling may still come up, so the cost stays where it is."""
+        shares = resolve_cells_to_plants(
+            cell_volume_shares([StubTarget(1, 9, Decimal('1'), 30)]),
+            {},
+        )
+        self.assertEqual(shares[0].target_type, CostAllocation.TargetType.SEED_TRAY_CELL)
+        self.assertEqual(shares[0].weight, Decimal('30'))
+
+    def test_two_cells_feeding_one_plant_produce_one_layer(self):
+        """A plant reached twice by one source is one destination, not two."""
+        shares = resolve_cells_to_plants(
+            cell_volume_shares([
+                StubTarget(1, 9, Decimal('1'), 30),
+                StubTarget(2, 9, Decimal('1'), 30),
+            ]),
+            {1: [11], 2: [11]},
+        )
+        self.assertEqual(len(shares), 1)
+        self.assertEqual(shares[0].weight, Decimal('60'))
+
+    def test_a_pool_share_passes_through(self):
+        """Cost that never named a cell is not a cell to resolve."""
+        shares = resolve_cells_to_plants(whole_source_share(), {1: [11]})
+        self.assertEqual(shares[0].target_type, CostAllocation.TargetType.BATCH_POOL)
+
+
+class AreaShareTests(SimpleTestCase):
+    """Ground-applied cost reaches the plants standing on that ground."""
+
+    def test_area_splits_by_area_then_equally_within_it(self):
+        """Twice the ground, twice the cost, shared by whoever is on it."""
+        shares = area_plant_shares([
+            (Decimal('2'), [11, 12], None),
+            (Decimal('1'), [13], None),
+        ])
+        weights = {share.plant_id: share.weight for share in shares}
+        self.assertEqual(weights[11], Decimal('1'))
+        self.assertEqual(weights[12], Decimal('1'))
+        self.assertEqual(weights[13], Decimal('1'))
+
+    def test_an_explicit_per_plant_weight_overrides_the_equal_split(self):
+        """An item snapshot may say one plant took more than another."""
+        shares = area_plant_shares([
+            (Decimal('3'), [11, 12], {11: Decimal('2'), 12: Decimal('1')}),
+        ])
+        weights = {share.plant_id: share.weight for share in shares}
+        self.assertEqual(weights[11], Decimal('2'))
+        self.assertEqual(weights[12], Decimal('1'))
+
+    def test_ground_with_nobody_on_it_stays_in_the_pool(self):
+        """Charging another area's seedlings for it would misreport both."""
+        shares = area_plant_shares([
+            (Decimal('2'), [], None),
+            (Decimal('1'), [13], None),
+        ])
+        pool = [share for share in shares if share.target_type == CostAllocation.TargetType.BATCH_POOL]
+        self.assertEqual(pool[0].weight, Decimal('2'))
+
+    def test_per_plant_weights_totalling_zero_are_refused(self):
+        """There is no proportional answer inside that area."""
+        with self.assertRaises(ValidationError):
+            area_plant_shares([(Decimal('1'), [11], {11: Decimal('0')})])
+
+
+class CombineAndLossTests(SimpleTestCase):
+    """Merging destinations and retiring the ones that never produced."""
+
+    def test_shares_reaching_one_place_become_one_layer(self):
+        """One layer per destination keeps the ledger readable."""
+        shares = combine(plant_shares([11, 12]) + plant_shares([11]))
+        self.assertEqual(len(shares), 2)
+        weights = {share.plant_id: share.weight for share in shares}
+        self.assertEqual(weights[11], Decimal('2'))
+
+    def test_loss_keeps_the_weight_and_drops_the_target(self):
+        """The cost is real; the seedling it was waiting for is not."""
+        unresolved = cell_volume_shares([StubTarget(1, 9, Decimal('1'), 30)])
+        losses = loss_shares(unresolved)
+        self.assertEqual(losses[0].target_type, CostAllocation.TargetType.PRODUCTION_LOSS)
+        self.assertEqual(losses[0].weight, Decimal('30'))
+        self.assertIsNone(losses[0].cell_id)
+
+    def test_loss_shares_stay_distinct_from_each_other(self):
+        """Two retired cells are two losses, not one merged figure."""
+        unresolved = cell_volume_shares([
+            StubTarget(1, 9, Decimal('1'), 30),
+            StubTarget(2, 9, Decimal('1'), 10),
+        ])
+        losses = combine(loss_shares(unresolved))
+        self.assertEqual(len(losses), 2)
+        self.assertEqual(
+            _total([share.weight for share in losses]),
+            Decimal('40'),
+        )
+
+    def test_money_quantum_is_the_stored_currency_precision(self):
+        """The exactness guarantee is stated in the unit the column keeps."""
+        self.assertEqual(MONEY_QUANTUM, Decimal('0.0001'))

--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -105,6 +105,57 @@ def quantize_quantity(value):
     return Decimal(value).quantize(QUANTITY_QUANTUM, rounding=ROUND_HALF_UP)
 
 
+def quantize_money(value):
+    """Return a money amount at the precision the money columns store.
+
+    Deliberately not the same precision as a lot's `base_unit_cost`, which
+    carries twelve places. A unit cost is a rate that has to survive being
+    multiplied by a large quantity without losing significance; an amount is a
+    figure that gets reported and summed, and holding it at anything finer than
+    `MONEY_DECIMAL_PLACES` would mean storing digits the column cannot keep.
+    """
+    return None if value is None else Decimal(value).quantize(
+        MONEY_QUANTUM,
+        rounding=ROUND_HALF_UP,
+    )
+
+
+def distribute_exactly(total, weights, quantum=MONEY_QUANTUM):
+    """Split `total` in proportion to `weights`, losing nothing to rounding.
+
+    Each share is floored to `quantum` and the shortfall is then handed out one
+    step at a time, largest fractional part first. The parts therefore always
+    sum back to exactly `total`. Rounding each share independently would leave a
+    remainder that has to be either dropped, which understates the cost, or
+    absorbed into one arbitrary share, which misreports it.
+
+    Ties go to the earlier weight, so the same inputs always produce the same
+    split and a recalculation does not churn the ledger.
+
+    A `total` of None means the source cost is unknown, and every share of an
+    unknown is unknown too — never zero.
+    """
+    weights = [Decimal(weight) for weight in weights]
+    if any(weight < 0 for weight in weights):
+        raise ValidationError({'weights': 'A share weight cannot be negative.'})
+    basis = sum(weights, Decimal('0'))
+    if basis <= 0:
+        raise ValidationError({'weights': 'At least one share must be positive.'})
+    if total is None:
+        return [None] * len(weights)
+    total = Decimal(total).quantize(quantum, rounding=ROUND_HALF_UP)
+    exact = [total * weight / basis for weight in weights]
+    parts = [value.quantize(quantum, rounding=ROUND_DOWN) for value in exact]
+    steps = int((total - sum(parts, Decimal('0'))) / quantum)
+    order = sorted(
+        range(len(weights)),
+        key=lambda index: (parts[index] - exact[index], index),
+    )
+    for index in order[:steps]:
+        parts[index] += quantum
+    return parts
+
+
 def normalize_quantity(
     item,
     quantity,
@@ -423,14 +474,8 @@ def _receipt_acquisition_cost(receipt, line):
 
 
 def _serialized_unit_costs(total, quantity):
-    """Split a receipt total exactly at stored currency precision."""
-    count = int(quantity)
-    share = (total / count).quantize(MONEY_QUANTUM, rounding=ROUND_DOWN)
-    remainder_steps = int((total - (share * count)) / MONEY_QUANTUM)
-    return [
-        share + (MONEY_QUANTUM if index < remainder_steps else Decimal('0'))
-        for index in range(count)
-    ]
+    """Split a receipt total evenly across its units, losing no cent."""
+    return distribute_exactly(total, [Decimal('1')] * int(quantity))
 
 
 def _validate_serialized_receipt_line(line):


### PR DESCRIPTION
The splitting rules are pure in the same way and for the same reason as applications/usage.py: they take already-measured facts and return shares without reading the database, so a layer posted from them recalculates from its stored snapshot years later and comes out the same.

All of it rests on distribute_exactly, which floors each share and hands the shortfall out one step at a time, largest fractional part first, so the parts always sum back to the source. Rounding each share independently leaves a remainder that has to be either dropped, understating the cost, or absorbed into one arbitrary share, misreporting it. Ties go to the earlier weight so a recalculation does not churn the ledger. It lives next to quantize_quantity because inventory/ledger.py already had the even-split special case: _serialized_unit_costs is now that call with equal weights, which keeps one rounding rule in the tree instead of two.

Cost never rests in two places at once. A share whose plant is not yet known sits on its cell or in the batch pool; observing a plant moves it to the plant and finalizing output without one moves it to production loss. Each move is a reversal plus a replacement rather than a second layer, because two layers would double the cost of one input.

Cell weights are weight * cell_volume_ml, which is what applications/usage.py used to arrive at the quantity and what seedtrays/generations.py already applies when reporting a fill's media; dividing any other way would attribute a number the application never used. Area cost divides each area's weight by its own plant count before one exact split, rather than splitting twice: the proportions are identical and there is one set of remainders to reconcile instead of one per area on top of one overall.

## Summary by Sourcery

Introduce a precise, database-independent costing allocation layer that splits source inputs exactly across the cells, plants, pool, and production loss they reached, ensuring no cost is lost or duplicated through rounding.

New Features:
- Add a generic `distribute_exactly` helper for proportionally splitting quantities and money without losing precision.
- Add a pure `costing.allocation` module that derives seed, cell-volume, per-plant, area, pool, and loss shares from measured application facts.

Enhancements:
- Align serialized unit cost splitting with the new exact distribution helper to keep a single rounding rule for receipt unit costs.
- Add `quantize_money` to standardize monetary precision at the level stored in money columns.

Tests:
- Add `costing.test_allocation` tests that exercise the new allocation arithmetic and distribution invariants without hitting the database.