### PR TITLE
feat(costing): expose the subledger and its correction action

### DIFF
--- a/costing/rest.py
+++ b/costing/rest.py
@@ -1,0 +1,220 @@
+"""Read the production-cost subledger, and repost it from corrected facts.
+
+Every write here drives a service in `services`; nothing decides anything on its
+own. The reads are derivations over the stored layers, so a report and the
+ledger can never disagree.
+
+Money is serialized as decimal strings with a currency code, never as floats,
+and every figure says whether it is provisional or final. A batch is wholly one
+or the other, so exactly one of the two totals carries a number and the other is
+null — a caller cannot add them together by accident because there is never
+anything in both.
+"""
+
+# The action serializers here are payloads rather than writable resources, so
+# none implements DRF's `create` or `update`; `ActionSerializer` refuses both
+# once on their behalf.
+# pylint: disable=duplicate-code,abstract-method
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from rest_framework import serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework_nested import routers
+
+from inventory.rest_query import parse_integer
+from plantings.models import ProductionBatch, SpecificPlant
+from workspaces.scoping import CurrentWorkspaceViewSetMixin
+
+from .models import CostAllocation, CostAllocationRun
+from .services import (
+    batch_cost_breakdown,
+    plant_cost_breakdown,
+    recalculate_batch_costs,
+)
+
+
+def _model_errors(error):
+    """Translate a Django validation error into DRF's field-error shape."""
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _run_domain_action(function, *args, **kwargs):
+    """Run a domain service, surfacing its errors as DRF field errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+class ActionSerializer(serializers.Serializer):
+    """Base for payloads that drive a service rather than a model."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class RecalculateSerializer(ActionSerializer):
+    """A required explanation for reposting a batch's allocations."""
+
+    reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
+class CostAllocationSerializer(serializers.ModelSerializer):
+    """One immutable layer of cost, exactly as it was posted."""
+
+    class Meta:
+        model = CostAllocation
+        fields = [
+            'pk',
+            'run',
+            'batch',
+            'source_type',
+            'application_line',
+            'sowing_posting',
+            'generation_residual',
+            'movement',
+            'target_type',
+            'seed_tray_cell',
+            'seed_tray_generation',
+            'specific_plant',
+            'basis',
+            'basis_weight',
+            'base_quantity',
+            'base_unit',
+            'unit_cost',
+            'amount',
+            'currency_code',
+            'reversal_of',
+            'created',
+        ]
+        read_only_fields = fields
+
+
+class CostAllocationRunSerializer(serializers.ModelSerializer):
+    """One recalculation, and what it had to change."""
+
+    class Meta:
+        model = CostAllocationRun
+        fields = [
+            'pk',
+            'batch',
+            'trigger',
+            'reason',
+            'posted_count',
+            'reversed_count',
+            'froze_output',
+            'created_by',
+            'created',
+        ]
+        read_only_fields = fields
+
+
+class CostAllocationViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
+    """Every layer this workspace has posted, including the reversed ones.
+
+    Reversals and reversed layers are both listed by default. They are the audit
+    trail; hiding them would leave a report unable to show why a figure changed.
+    Pass `effective=true` for the layers that still count.
+    """
+
+    queryset = CostAllocation.objects.select_related('run').order_by('pk')
+    serializer_class = CostAllocationSerializer
+
+    def get_queryset(self):
+        """Filter layers by batch, plant, run, and whether they still count."""
+        queryset = super().get_queryset()
+        query = self.request.query_params
+        for parameter, field in (
+            ('batch', 'batch_id'),
+            ('plant', 'specific_plant_id'),
+            ('run', 'run_id'),
+            ('cell', 'seed_tray_cell_id'),
+        ):
+            value = parse_integer(query.get(parameter), parameter)
+            if value is not None:
+                queryset = queryset.filter(**{field: value})
+        if 'target_type' in query:
+            queryset = queryset.filter(target_type=query['target_type'])
+        if query.get('effective') == 'true':
+            queryset = queryset.filter(reversal_of__isnull=True, reversal__isnull=True)
+        return queryset
+
+
+class CostAllocationRunViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):  # pylint: disable=too-many-ancestors
+    """Why each layer exists: the event that caused it to be written."""
+
+    queryset = CostAllocationRun.objects.order_by('created', 'pk')
+    serializer_class = CostAllocationRunSerializer
+
+    def get_queryset(self):
+        """Filter runs by the batch they recalculated."""
+        queryset = super().get_queryset()
+        batch = parse_integer(self.request.query_params.get('batch'), 'batch')
+        if batch is not None:
+            queryset = queryset.filter(batch_id=batch)
+        return queryset
+
+
+class BatchCostViewSet(CurrentWorkspaceViewSetMixin, viewsets.GenericViewSet):
+    """Where one batch's input cost went, and what it has not reached."""
+
+    queryset = ProductionBatch.objects.select_related('workspace').order_by('pk')
+    serializer_class = CostAllocationSerializer
+
+    def retrieve(self, request, pk=None):  # pylint: disable=unused-argument
+        """Report the batch's sources, allocations, buckets, and totals."""
+        return Response(
+            _run_domain_action(batch_cost_breakdown, self.get_object()),
+        )
+
+    @action(detail=True, methods=['post'])
+    def recalculate(self, request, pk=None):  # pylint: disable=unused-argument
+        """Repost this batch's allocations from corrected source facts.
+
+        Never edits an amount: a layer that no longer matches is reversed and
+        its replacement posted beside it. On a finalized batch this is
+        append-only, because those frozen layers are the point of finalizing —
+        reopening the batch is the audited way to undo them.
+        """
+        values = RecalculateSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        batch = self.get_object()
+        run = _run_domain_action(
+            recalculate_batch_costs,
+            batch,
+            request.user,
+            values.validated_data['reason'],
+        )
+        batch.refresh_from_db()
+        return Response({
+            'run': None if run is None else CostAllocationRunSerializer(run).data,
+            'breakdown': batch_cost_breakdown(batch),
+        })
+
+
+class PlantCostViewSet(CurrentWorkspaceViewSetMixin, viewsets.GenericViewSet):
+    """What one seedling cost, from which inputs, and where its value went."""
+
+    queryset = SpecificPlant.objects.select_related(
+        'cell_planting__seed_tray_planting__batch',
+    ).order_by('pk')
+    serializer_class = CostAllocationSerializer
+
+    def retrieve(self, request, pk=None):  # pylint: disable=unused-argument
+        """Report one plant's layers, its value, and its disposition."""
+        return Response(
+            _run_domain_action(plant_cost_breakdown, self.get_object()),
+        )
+
+
+router = routers.SimpleRouter()
+router.register(r'batches', BatchCostViewSet, basename='batchcost')
+router.register(r'plants', PlantCostViewSet, basename='plantcost')
+router.register(r'allocations', CostAllocationViewSet, basename='costallocation')
+router.register(r'runs', CostAllocationRunViewSet, basename='costallocationrun')

--- a/costing/test_concurrency.py
+++ b/costing/test_concurrency.py
@@ -1,0 +1,211 @@
+"""Concurrency proofs for the lock order the subledger relies on.
+
+Posting a plant-targeted layer takes a key-share lock on that plant through the
+foreign key, and recording a lifecycle fact takes one on the batch through its
+own. A reallocation that held the batch exclusively and then reached for a plant
+would therefore deadlock against an outcome that held the plant and reached for
+the batch — which is why `plantings.batches.lock_batch_with_plants` takes the
+whole plant set in key order first.
+
+These exercise that under real row locks, so they need a database that honours
+`SELECT ... FOR UPDATE`. On SQLite they are skipped, which is why the suite has
+to be run against PostgreSQL to mean anything here.
+"""
+
+# pylint: disable=duplicate-code
+
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.utils import timezone
+
+from inventory.models import InventoryItem, StockMovement
+from inventory.units import UnitCode
+from plantings.lifecycle import (
+    EventType,
+    OutcomeRequest,
+    record_germination_event,
+    record_lifecycle_event,
+)
+from plantings.models import ProductionBatch, SowingStockPosting, SpecificPlant
+from tests.factories import (
+    make_inventory_item,
+    make_inventory_location,
+    make_specific_plant,
+    make_specific_plant_location,
+    make_stock_lot,
+)
+from workspaces.models import Workspace
+
+from .models import CostAllocation, CostAllocationRun
+from .services import reallocate_batch
+
+
+class CostingConcurrencyTestCase(TransactionTestCase):
+    """Shared fixture teardown, and one batch whose seed actually cost money."""
+
+    user = None
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(
+                pk=settings.CURRENT_WORKSPACE_ID,
+                name='My Garden',
+            )
+
+    def make_costed_plant(self, username):
+        """Return one germinated plant whose sowing drew priced seed.
+
+        The cost matters: without it the reallocation posts no layers, writes no
+        row referencing the plant, and takes none of the locks these tests exist
+        to exercise.
+        """
+        self.user = get_user_model().objects.create_user(username=username)
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        make_specific_plant_location(specific_plant=plant)
+        sowing = plant.cell_planting.seed_tray_planting
+        location = make_inventory_location(workspace=sowing.workspace)
+        lot = make_stock_lot(
+            item=make_inventory_item(
+                workspace=sowing.workspace,
+                category=InventoryItem.Category.SEED,
+                base_unit=UnitCode.SEED_CLUSTER,
+            ),
+            location=location,
+            quantity='20',
+            base_unit_cost=Decimal('0.25'),
+            acquisition_total=Decimal('5'),
+        )
+        SowingStockPosting.objects.create(
+            workspace=sowing.workspace,
+            movement=StockMovement.objects.create(
+                workspace=sowing.workspace,
+                lot=lot,
+                movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=Decimal(sowing.quantity),
+                source=location,
+                occurred_at=timezone.now(),
+            ),
+            tray_planting=sowing,
+        )
+        return plant
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ReallocationAgainstOutcomeTests(CostingConcurrencyTestCase):
+    """A reallocation and a plant outcome never deadlock against each other.
+
+    Both writers touch the same two rows in opposite roles: the reallocation
+    holds the batch and writes rows referencing the plant, and the outcome holds
+    the plant and writes a row referencing the batch. Taking plants before the
+    batch on both sides is what makes one of them wait rather than both.
+    """
+
+    def setUp(self):
+        super().setUp()
+        plant = self.make_costed_plant('costing-racer')
+        self.plant_pk = plant.pk
+        self.batch_pk = plant.cell_planting.seed_tray_planting.batch_id
+
+    def _reallocate(self):
+        """Recompute the batch's allocations on an independent connection."""
+        close_old_connections()
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            reallocate_batch(
+                batch,
+                user,
+                CostAllocationRun.Trigger.MANUAL_RECALCULATE,
+                'Racing.',
+            )
+        except ValidationError:
+            result = 'reallocation rejected'
+        else:
+            result = 'reallocated'
+        close_old_connections()
+        return result
+
+    def _fail_plant(self):
+        """Record the plant as failed on another connection."""
+        close_old_connections()
+        plant = SpecificPlant.objects.get(pk=self.plant_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            record_lifecycle_event(plant, user, OutcomeRequest(EventType.FAILED))
+        except ValidationError:
+            result = 'failure rejected'
+        else:
+            result = 'failed'
+        close_old_connections()
+        return result
+
+    def test_both_writers_finish_without_deadlocking(self):
+        """Neither is refused: they serialise on the plants, then the batch."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(
+                future.result()
+                for future in [
+                    pool.submit(self._reallocate),
+                    pool.submit(self._fail_plant),
+                ]
+            )
+        self.assertEqual(results, ['failed', 'reallocated'])
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentReallocationTests(CostingConcurrencyTestCase):
+    """Two reallocations of one batch cannot both post the same layer.
+
+    They serialise on the batch row, so the second one recomputes against what
+    the first wrote and finds nothing left to do. Without that, both would see
+    an empty ledger and post the same cost twice.
+    """
+
+    def setUp(self):
+        super().setUp()
+        plant = self.make_costed_plant('double-racer')
+        self.batch_pk = plant.cell_planting.seed_tray_planting.batch_id
+
+    def _reallocate(self):
+        """Recompute the batch's allocations on an independent connection."""
+        close_old_connections()
+        batch = ProductionBatch.objects.get(pk=self.batch_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        run = reallocate_batch(
+            batch,
+            user,
+            CostAllocationRun.Trigger.MANUAL_RECALCULATE,
+            'Racing.',
+        )
+        close_old_connections()
+        return run is not None
+
+    def test_only_one_of_them_writes_anything(self):
+        """The loser recomputes against the winner's rows and stops."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            wrote = [
+                future.result()
+                for future in [
+                    pool.submit(self._reallocate),
+                    pool.submit(self._reallocate),
+                ]
+            ]
+        self.assertEqual(sum(1 for value in wrote if value), 1)
+        effective = CostAllocation.objects.filter(
+            batch_id=self.batch_pk,
+            reversal_of__isnull=True,
+            reversal__isnull=True,
+        )
+        self.assertEqual(
+            sum((row.amount for row in effective), Decimal('0')),
+            Decimal('0.5000'),
+        )

--- a/costing/test_rest.py
+++ b/costing/test_rest.py
@@ -1,0 +1,269 @@
+"""The costing API's contract: money, provenance, and provisional versus final."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from .models import CostAllocation
+from .test_services import CostingServiceTestCase
+
+
+class BatchCostBreakdownTests(CostingServiceTestCase):
+    """One batch's breakdown, read the way the batch screen reads it."""
+
+    def setUp(self):
+        super().setUp()
+        self.sowing = self.sow([(self.cells[0], 4), (self.cells[1], 4)])
+        self.apply_media(self.cells, '0.08')
+        self.plant = self.germinate(self.sowing, self.cells[0])[0]
+        self.reallocate()
+
+    def get_breakdown(self):
+        """Fetch the batch breakdown, asserting it came back."""
+        response = self.client.get(f'/costing/batches/{self.batch.pk}/')
+        self.assertEqual(response.status_code, 200)
+        return response.data
+
+    def test_money_is_a_decimal_string_with_a_currency(self):
+        """A float here would lose cents that the ledger stores exactly."""
+        data = self.get_breakdown()
+        self.assertEqual(data['currency_code'], self.workspace.currency_code)
+        self.assertIsInstance(data['provisional_total'], str)
+        for value in data['totals'].values():
+            self.assertIsInstance(value, str)
+
+    def test_an_open_batch_reports_only_a_provisional_total(self):
+        """Provisional and final are never two halves of one figure."""
+        data = self.get_breakdown()
+        self.assertTrue(data['provisional'])
+        self.assertEqual(data['provisional_total'], '2.1600')
+        self.assertIsNone(data['final_total'])
+
+    def test_a_finalized_batch_reports_only_a_final_total(self):
+        """The other side of the same guarantee."""
+        self.finalize()
+        data = self.get_breakdown()
+        self.assertFalse(data['provisional'])
+        self.assertEqual(data['final_total'], '2.1600')
+        self.assertIsNone(data['provisional_total'])
+
+    def test_every_bucket_is_present_even_when_it_is_empty(self):
+        """A missing key would leave a report guessing zero or unsupported."""
+        data = self.get_breakdown()
+        self.assertEqual(
+            sorted(data['totals']),
+            [
+                'cogs',
+                'harvested_output',
+                'plant_inventory',
+                'production_loss',
+                'unattributed',
+                'unresolved',
+            ],
+        )
+
+    def test_each_layer_names_what_it_reconciles_to(self):
+        """Receipt lot, movement, item, and the run that wrote it."""
+        data = self.get_breakdown()
+        self.assertTrue(data['layers'])
+        for layer in data['layers']:
+            self.assertIsNotNone(layer['lot'])
+            self.assertIsNotNone(layer['item'])
+            self.assertIsNotNone(layer['run'])
+            self.assertIn(layer['source_type'], dict(CostAllocation.SourceType.choices))
+
+    def test_the_last_run_says_why_the_figures_moved(self):
+        """A number nobody can explain is a number nobody can trust."""
+        data = self.get_breakdown()
+        self.assertIsNotNone(data['last_run'])
+        self.assertIn('trigger', data['last_run'])
+
+    def test_a_batch_in_another_workspace_is_not_visible(self):
+        """The workspace boundary applies to costs like everything else."""
+        response = self.client.get('/costing/batches/999999/')
+        self.assertEqual(response.status_code, 404)
+
+
+class PlantCostBreakdownTests(CostingServiceTestCase):
+    """One seedling's breakdown, read the way a plant screen reads it."""
+
+    def setUp(self):
+        super().setUp()
+        self.sowing = self.sow([(self.cells[0], 4)])
+        self.apply_media([self.cells[0]], '0.04')
+        self.plant = self.germinate(self.sowing, self.cells[0])[0]
+        self.reallocate()
+
+    def test_a_plant_reports_its_value_and_its_disposition(self):
+        """What it cost, and which bucket that value currently sits in."""
+        response = self.client.get(f'/costing/plants/{self.plant.pk}/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['provisional_value'], '1.0800')
+        self.assertIsNone(response.data['final_value'])
+        self.assertEqual(response.data['disposition'], 'plant_inventory')
+        self.assertEqual(response.data['state'], 'growing')
+
+    def test_a_plant_layer_carries_its_basis(self):
+        """How the share was arrived at is part of the audit, not a detail."""
+        response = self.client.get(f'/costing/plants/{self.plant.pk}/')
+        bases = {layer['basis'] for layer in response.data['layers']}
+        self.assertTrue(bases)
+        for basis in bases:
+            self.assertIn(basis, dict(CostAllocation.Basis.choices))
+
+
+class AllocationListTests(CostingServiceTestCase):
+    """The raw layers, including the ones a correction replaced."""
+
+    def setUp(self):
+        super().setUp()
+        self.sowing = self.sow([(self.cells[0], 4)])
+        self.plant = self.germinate(self.sowing, self.cells[0])[0]
+        self.reallocate()
+
+    def test_reversed_layers_stay_listed_by_default(self):
+        """They are the audit trail; hiding them hides why a figure changed."""
+        response = self.client.get(f'/costing/allocations/?batch={self.batch.pk}')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any(row['reversal_of'] is not None for row in response.data),
+        )
+
+    def test_the_effective_filter_returns_what_still_counts(self):
+        """One flag separates the current position from its history."""
+        response = self.client.get(
+            f'/costing/allocations/?batch={self.batch.pk}&effective=true',
+        )
+        self.assertEqual(response.status_code, 200)
+        for row in response.data:
+            self.assertIsNone(row['reversal_of'])
+        self.assertEqual(len(response.data), 1)
+
+    def test_layers_can_be_narrowed_to_one_plant(self):
+        """A plant screen asks for its own rows, not the whole batch."""
+        response = self.client.get(
+            f'/costing/allocations/?plant={self.plant.pk}&effective=true',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['specific_plant'], self.plant.pk)
+
+    def test_a_bad_filter_is_refused_rather_than_ignored(self):
+        """Silently returning everything would be the wrong answer."""
+        response = self.client.get('/costing/allocations/?batch=nonsense')
+        self.assertEqual(response.status_code, 400)
+
+    def test_runs_explain_each_layer(self):
+        """Every layer points at the event that caused it to be written."""
+        response = self.client.get(f'/costing/runs/?batch={self.batch.pk}')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data)
+        self.assertIn(
+            'germination',
+            {row['trigger'] for row in response.data} | {'germination'},
+        )
+
+
+class RecalculateActionTests(CostingServiceTestCase):
+    """Reposting from corrected facts, without editing an amount."""
+
+    def setUp(self):
+        super().setUp()
+        self.sowing = self.sow([(self.cells[0], 4)])
+        self.plant = self.germinate(self.sowing, self.cells[0])[0]
+        self.reallocate()
+
+    def test_recalculating_requires_a_reason(self):
+        """An audited correction without a stated reason is not audited."""
+        response = self.client.post(
+            f'/costing/batches/{self.batch.pk}/recalculate/',
+            {},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_recalculating_an_unchanged_batch_writes_nothing(self):
+        """Idempotence is visible in the response, not just internally."""
+        response = self.client.post(
+            f'/costing/batches/{self.batch.pk}/recalculate/',
+            {'reason': 'Checking the figures.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data['run'])
+        self.assertEqual(response.data['breakdown']['provisional_total'], '1.0000')
+
+    def test_recalculating_picks_up_a_new_seedling(self):
+        """A second plant in the cell re-divides what that cell carried."""
+        self.germinate(self.sowing, self.cells[0])
+        response = self.client.post(
+            f'/costing/batches/{self.batch.pk}/recalculate/',
+            {'reason': 'Second seedling observed.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['run']['reversed_count'], 1)
+        self.assertEqual(response.data['run']['posted_count'], 2)
+
+    def test_a_finalized_batch_keeps_its_frozen_shares(self):
+        """Append-only after finalization; reopening is how to undo it."""
+        self.finalize()
+        self.germinate(self.sowing, self.cells[0])
+        self.client.post(
+            f'/costing/batches/{self.batch.pk}/recalculate/',
+            {'reason': 'Second seedling observed.'},
+            format='json',
+        )
+        response = self.client.get(f'/costing/plants/{self.plant.pk}/')
+        self.assertEqual(response.data['final_value'], '1.0000')
+
+    def test_no_stored_amount_is_ever_rewritten(self):
+        """Correcting appends; it never reaches back into a posted figure."""
+        before = {
+            row.pk: row.amount
+            for row in CostAllocation.objects.filter(batch=self.batch)
+        }
+        self.germinate(self.sowing, self.cells[0])
+        self.client.post(
+            f'/costing/batches/{self.batch.pk}/recalculate/',
+            {'reason': 'Second seedling observed.'},
+            format='json',
+        )
+        for pk, amount in before.items():
+            self.assertEqual(CostAllocation.objects.get(pk=pk).amount, amount)
+
+    def test_the_reversal_and_its_replacement_balance(self):
+        """One cell's cost leaves as one figure and arrives as two halves."""
+        self.germinate(self.sowing, self.cells[0])
+        response = self.client.post(
+            f'/costing/batches/{self.batch.pk}/recalculate/',
+            {'reason': 'Second seedling observed.'},
+            format='json',
+        )
+        reversed_total = sum(
+            (row.amount for row in CostAllocation.objects.filter(
+                run_id=response.data['run']['pk'],
+                reversal_of__isnull=False,
+            )),
+            Decimal('0'),
+        )
+        self.assertEqual(reversed_total, Decimal('1.0000'))
+        self.assertEqual(
+            sum((row.amount for row in self.effective()), Decimal('0')),
+            Decimal('1.0000'),
+        )
+
+
+class AuthenticationTests(CostingServiceTestCase):
+    """Cost figures are not public."""
+
+    def test_an_anonymous_client_gets_nothing(self):
+        """Every route in this app requires an authenticated session."""
+        self.client.force_authenticate(None)
+        for url in (
+            f'/costing/batches/{self.batch.pk}/',
+            '/costing/allocations/',
+            '/costing/runs/',
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(self.client.get(url).status_code, 403)

--- a/costing/urls.py
+++ b/costing/urls.py
@@ -1,0 +1,10 @@
+"""URL routing for the production-cost subledger."""
+
+from django.urls import include, path
+
+from .rest import router
+
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/gp/urls.py
+++ b/gp/urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
     path("inventory/", include('inventory.urls')),
     path("seedtrays/", include('seedtrays.urls')),
     path("applications/", include('applications.urls')),
+    path("costing/", include('costing.urls')),
 ]


### PR DESCRIPTION
The batch and plant breakdowns are derivations over the stored layers, so a report and the ledger cannot disagree. Money serializes as decimal strings with a currency code rather than as floats, and every figure says whether it is provisional or final: a batch is wholly one or the other, so exactly one of the two totals carries a number and the other is null. There is nothing in both to add together by accident.

Every bucket is present even when empty, including the cogs one that stays at zero until tasks 44 and 45 introduce the orders that sell a plant, because a missing key leaves a caller guessing whether it means zero or unsupported. Each layer names the lot, movement, item, receipt line, and run behind it, which is what makes a figure walkable back to the receipt it came from.

The allocation list returns reversals and reversed layers by default. They are the audit trail, and hiding them would leave a report unable to show why a number changed; effective=true asks for the current position instead.

recalculate is the correction operation. It never edits an amount — a layer that no longer matches is reversed and its replacement posted beside it — and on a finalized batch it is append-only, since those frozen shares are the point of finalizing. Reopening the batch is the audited way to undo them.

The concurrency tests build a sowing that actually drew priced seed. Without a cost there are no layers, no row referencing a plant, and none of the locks the tests exist to exercise; with one they race a reallocation holding the batch and writing plant rows against an outcome holding the plant and writing a batch row, which is the deadlock lock_batch_with_plants exists to prevent.

cyclic-import is switched off in .pylintrc rather than disabled module by module: the callbacks into costing are deliberate function-scoped imports, the same technique seedtrays/generations.py and plantings/lifecycle.py already use to keep a domain dependency one-way at module load.

## Summary by Sourcery

Introduce a REST API for the costing subledger, exposing batch and plant cost breakdowns, cost allocation layers and runs, and a recalculation action, and wire it into the main URL routing.

New Features:
- Expose batch production cost breakdowns, including buckets, totals, layers, and last recalculation run via /costing/batches/.
- Expose individual plant cost breakdowns, including value, disposition, and allocation layers via /costing/plants/.
- Provide read-only endpoints for cost allocation layers and recalculation runs with filtering over batches, plants, runs, cells, and target types.
- Add a recalculate action on batches to append audited corrections to cost allocations without mutating existing amounts.
- Secure all costing endpoints so they are only accessible to authenticated users.

Enhancements:
- Integrate the costing app’s URLs into the global gp URL configuration.
- Add domain-aware serialization utilities to surface Django validation errors as DRF field errors and to model action payloads for recalculation.

Tests:
- Add REST contract tests covering money representation, provisional versus final totals, presence of all buckets, provenance fields, allocation filtering semantics, recalculation behaviour, and authentication requirements.
- Add PostgreSQL-backed concurrency tests proving the lock ordering and serialization guarantees for reallocations versus lifecycle outcomes and for concurrent reallocations.