### PR TITLE
feat(plantings): make derived lifecycle state queryable

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -11,6 +11,7 @@ from typing import NamedTuple
 
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
+from django.db.models import Case, F, OuterRef, Q, Subquery, Value, When
 from django.utils import timezone
 
 from .models import PlantLifecycleEvent, SpecificPlant, SpecificPlantLocation
@@ -177,6 +178,83 @@ def derive_state(events):
         final_outcome=outcome,
         final_outcome_at=outcome_at,
     )
+
+
+#: The facts `derive_state` reads. Every other event type records something that
+#: happened without changing the condition it leaves behind.
+STATE_EVENT_TYPES = tuple(STATE_AFTER)
+
+
+def effective_state_events(plant_ref):
+    """Return one plant's surviving state-changing facts, latest first.
+
+    This is the database's view of the same events `derive_state` replays: a
+    correction reverses its target, and `reversal__isnull` reads that reverse
+    relation, so a reversed fact and the correction itself are both excluded.
+    """
+    return (
+        PlantLifecycleEvent.objects
+        .filter(
+            plant=plant_ref,
+            event_type__in=STATE_EVENT_TYPES,
+            reversal__isnull=True,
+        )
+        .order_by('-occurred_at', '-pk')
+    )
+
+
+def with_lifecycle_state(queryset):
+    """Annotate derived lifecycle state onto a `SpecificPlant` queryset.
+
+    The replay in `derive_state` keeps the last surviving state-changing fact,
+    so taking the newest one here reaches the same answer while leaving the
+    result filterable, sortable, countable, and pageable in the database. The
+    two derivations share `STATE_AFTER`, `FINAL_STATES`, and `SELLABLE_STATES`
+    so neither can quietly describe a different vocabulary from the other.
+    """
+    events = effective_state_events(OuterRef('pk'))
+    return (
+        queryset
+        .annotate(
+            last_state_event=Subquery(events.values('event_type')[:1]),
+            last_state_at=Subquery(events.values('occurred_at')[:1]),
+        )
+        .annotate(
+            lifecycle_state=Case(
+                *[
+                    When(last_state_event=event_type, then=Value(state))
+                    for event_type, state in STATE_AFTER.items()
+                ],
+                default=Value(LifecycleState.GROWING),
+                output_field=models.CharField(),
+            ),
+        )
+        .annotate(
+            sellable=Case(
+                When(
+                    lifecycle_state__in=sorted(SELLABLE_STATES),
+                    then=Value(True),
+                ),
+                default=Value(False),
+                output_field=models.BooleanField(),
+            ),
+            final_outcome=Case(
+                When(lifecycle_state__in=sorted(FINAL_STATES), then=F('last_state_event')),
+                default=Value(None),
+                output_field=models.CharField(null=True),
+            ),
+            final_outcome_at=Case(
+                When(lifecycle_state__in=sorted(FINAL_STATES), then=F('last_state_at')),
+                default=Value(None),
+                output_field=models.DateTimeField(null=True),
+            ),
+        )
+    )
+
+
+def lifecycle_state_filter(states):
+    """Return the annotation filter that selects the named derived states."""
+    return Q(lifecycle_state__in=list(states))
 
 
 def plant_lifecycle_summary(plant):

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -22,12 +22,14 @@ from .lifecycle import (
     EventType,
     LifecycleState,
     OutcomeRequest,
+    lifecycle_summaries,
     plant_lifecycle_summary,
     record_bulk_outcome,
     record_germination_event,
     record_lifecycle_event,
     record_transplant_event,
     reverse_lifecycle_event,
+    with_lifecycle_state,
 )
 from .models import PlantLifecycleEvent, SpecificPlant, SpecificPlantLocation
 
@@ -96,6 +98,115 @@ class LifecycleStateDerivationTests(TestCase):
                 self.assertEqual(summary.final_outcome, event_type)
                 self.assertEqual(summary.final_outcome_at, occurred_at)
                 self.assertFalse(summary.sellable)
+
+
+class LifecycleStateAnnotationTests(TestCase):
+    """The database annotation answers exactly what the replay answers.
+
+    The register filters, counts, sorts, and pages by lifecycle state, which
+    the Python replay cannot do. Both derivations must therefore agree on every
+    shape of history, or a screen would disagree with the plant it is showing.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='annotator')
+
+    def germinated_plant(self, occurred_at):
+        """Create one plant whose germination is already on file."""
+        plant = make_specific_plant(germinated=occurred_at)
+        record_germination_event(plant, self.user)
+        return plant
+
+    def population(self):
+        """Build one plant per derived state, plus the awkward histories."""
+        start = timezone.now() - timedelta(days=30)
+        plants = {'unrecorded': make_specific_plant(germinated=start)}
+        plants['growing'] = self.germinated_plant(start)
+        plants['available'] = self.germinated_plant(start)
+        record_lifecycle_event(
+            plants['available'],
+            self.user,
+            OutcomeRequest(EventType.READY, occurred_at=start + timedelta(days=1)),
+        )
+        for name, (event_type, _) in zip(
+            ('retained', 'donated', 'failed', 'culled', 'harvested'),
+            FINAL_OUTCOMES,
+        ):
+            plant = self.germinated_plant(start)
+            make_specific_plant_location(specific_plant=plant, started=start)
+            record_lifecycle_event(
+                plant,
+                self.user,
+                OutcomeRequest(event_type, occurred_at=start + timedelta(days=2)),
+            )
+            plants[name] = plant
+
+        plants['transplanted'] = self.germinated_plant(start)
+        record_lifecycle_event(
+            plants['transplanted'],
+            self.user,
+            OutcomeRequest(EventType.READY, occurred_at=start + timedelta(days=1)),
+        )
+        record_transplant_event(
+            plants['transplanted'],
+            self.user,
+            start + timedelta(days=2),
+        )
+
+        plants['corrected'] = self.germinated_plant(start)
+        record_lifecycle_event(
+            plants['corrected'],
+            self.user,
+            OutcomeRequest(EventType.READY, occurred_at=start + timedelta(days=1)),
+        )
+        mistake = record_lifecycle_event(
+            plants['corrected'],
+            self.user,
+            OutcomeRequest(EventType.FAILED, occurred_at=start + timedelta(days=2)),
+        )
+        reverse_lifecycle_event(
+            mistake,
+            self.user,
+            'Recorded against the wrong plant.',
+            occurred_at=start + timedelta(days=3),
+        )
+        return plants
+
+    def annotated(self, plants):
+        """Return the annotated summary of every plant, keyed by primary key."""
+        queryset = with_lifecycle_state(
+            SpecificPlant.objects.filter(pk__in=[plant.pk for plant in plants]),
+        )
+        return {
+            row.pk: (row.lifecycle_state, row.sellable, row.final_outcome, row.final_outcome_at)
+            for row in queryset
+        }
+
+    def test_the_annotation_matches_the_replay_for_every_history(self):
+        """One vocabulary, two derivations, no drift between them."""
+        plants = self.population()
+        annotated = self.annotated(plants.values())
+        replayed = lifecycle_summaries([plant.pk for plant in plants.values()])
+        for name, plant in plants.items():
+            with self.subTest(history=name):
+                summary = replayed[plant.pk]
+                self.assertEqual(
+                    annotated[plant.pk],
+                    (summary.state, summary.sellable, summary.final_outcome, summary.final_outcome_at),
+                )
+
+    def test_the_population_exercises_every_derived_state(self):
+        """A new state cannot be added without being compared here."""
+        plants = self.population()
+        derived = {state for state, _, _, _ in self.annotated(plants.values()).values()}
+        self.assertEqual(derived, {state.value for state in LifecycleState})
+
+    def test_a_correction_returns_the_annotation_to_the_surviving_facts(self):
+        """A reversed outcome stops counting the moment it is corrected."""
+        plants = self.population()
+        annotated = self.annotated([plants['corrected']])[plants['corrected'].pk]
+        self.assertEqual(annotated, (LifecycleState.AVAILABLE, True, None, None))
 
 
 class LifecycleTransitionTests(TestCase):


### PR DESCRIPTION
The register has to filter, count, sort, and page by a plant's condition, which the Python replay cannot do because no column holds it. Mirror the replay as a database annotation instead of storing a status that could drift from the facts: the newest surviving state-changing event is the same one the replay keeps last, and both read the same STATE_AFTER, FINAL_STATES, and SELLABLE_STATES.

A parity test compares the two derivations over every shape of history, including a corrected outcome and a plant with no facts at all, and fails if a new state is added without being compared.

## Summary by Sourcery

Annotate derived lifecycle state onto plant querysets so lifecycle conditions can be queried directly from the database instead of only via Python replay.

New Features:
- Provide a `with_lifecycle_state` annotation helper to attach derived lifecycle state, sellable flag, and final outcome metadata to `SpecificPlant` querysets.
- Expose a `lifecycle_state_filter` helper for filtering plants by derived lifecycle state from the database.

Enhancements:
- Define `effective_state_events` to express the database view of surviving state-changing lifecycle events consistent with the replay logic.

Tests:
- Add comprehensive parity tests ensuring the lifecycle state annotation matches the Python replay for all lifecycle histories, including corrections and plants with no surviving state events.
- Add tests guaranteeing every defined lifecycle state is exercised and compared by the annotation-based derivation.