### PR TITLE
feat(plantings): add the nursery plant register

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -11,7 +11,7 @@ from typing import NamedTuple
 
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import Case, F, OuterRef, Q, Subquery, Value, When
+from django.db.models import Case, F, OuterRef, Subquery, Value, When
 from django.utils import timezone
 
 from .models import PlantLifecycleEvent, SpecificPlant, SpecificPlantLocation
@@ -250,11 +250,6 @@ def with_lifecycle_state(queryset):
             ),
         )
     )
-
-
-def lifecycle_state_filter(states):
-    """Return the annotation filter that selects the named derived states."""
-    return Q(lifecycle_state__in=list(states))
 
 
 def plant_lifecycle_summary(plant):

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -1,0 +1,229 @@
+"""The nursery plant register: a filtered projection over individual plants.
+
+The register answers inventory-first questions — what is growing, what is
+ready, where it is, how old it is, what it cost — without becoming a second
+mutable plant table. Every row is derived from the source records, and one
+filter parser feeds both the rows and the whole-filter totals so a screen can
+never report counts that its own list disagrees with.
+
+Filters for growth stage, grade, container, nursery location, reservation, and
+quarantine are deliberately absent: nothing records those facts yet, and tasks
+54, 51, 44, and 56 each add their filter here when they add their model.
+"""
+
+from typing import NamedTuple
+
+from django.db.models import Count, DecimalField, F, OuterRef, Q, Subquery, Sum, TextField, Value
+from django.db.models.functions import Coalesce
+from rest_framework.exceptions import ValidationError
+
+from costing.models import CostAllocation
+from inventory.rest_query import parse_boolean, parse_datetime, parse_integer
+
+from .lifecycle import FINAL_STATES, LifecycleState, with_lifecycle_state
+from .models import SpecificPlant, SpecificPlantLocation
+
+
+#: Where a plant may currently be, plus the absence of anywhere at all.
+LOCATION_TYPES = {
+    SpecificPlantLocation.SEED_TRAY_CELL,
+    SpecificPlantLocation.GARDEN_SQUARE,
+}
+UNPLACED = 'none'
+
+#: The orderings the register offers, each ending in the primary key so that
+#: paging through equal sort values cannot repeat or skip a plant.
+ORDERINGS = {
+    'age': ('germinated', 'pk'),
+    'variety': ('variety_name', 'plant_name', 'pk'),
+    'location': ('current_location_label', 'pk'),
+    'cost': ('cost', 'pk'),
+    'state': ('lifecycle_state', 'pk'),
+    'batch': ('batch_code', 'pk'),
+    'germinated': ('germinated', 'pk'),
+}
+DEFAULT_ORDERING = '-age'
+
+_BATCH = 'cell_planting__seed_tray_planting__batch'
+
+
+class RegisterFilters(NamedTuple):
+    """One validated set of register filters, shared by rows and totals."""
+
+    variety: object = None
+    batch: object = None
+    states: tuple = ()
+    sellable: object = None
+    germinated_from: object = None
+    germinated_to: object = None
+    location_type: object = None
+    seed_tray: object = None
+    garden_square: object = None
+    search: str = ''
+    ordering: str = DEFAULT_ORDERING
+
+
+def parse_register_filters(query_params):
+    """Validate the query string into filters, blaming each parameter by name."""
+    states = tuple(
+        state for state in query_params.getlist('state') if state
+    )
+    valid_states = {state.value for state in LifecycleState}
+    unknown = [state for state in states if state not in valid_states]
+    if unknown:
+        raise ValidationError({'state': 'Select a valid lifecycle state.'})
+
+    location_type = query_params.get('location_type') or None
+    if location_type is not None and location_type not in LOCATION_TYPES | {UNPLACED}:
+        raise ValidationError({'location_type': 'Select a valid location type.'})
+
+    ordering = query_params.get('ordering') or DEFAULT_ORDERING
+    if ordering.lstrip('-') not in ORDERINGS:
+        raise ValidationError({'ordering': 'Select a valid ordering.'})
+
+    return RegisterFilters(
+        variety=parse_integer(query_params.get('variety'), 'variety'),
+        batch=parse_integer(query_params.get('batch'), 'batch'),
+        states=states,
+        sellable=parse_boolean(query_params.get('sellable'), 'sellable'),
+        germinated_from=parse_datetime(query_params.get('germinated_from'), 'germinated_from'),
+        germinated_to=parse_datetime(query_params.get('germinated_to'), 'germinated_to'),
+        location_type=location_type,
+        seed_tray=parse_integer(query_params.get('seed_tray'), 'seed_tray'),
+        garden_square=parse_integer(query_params.get('garden_square'), 'garden_square'),
+        search=(query_params.get('search') or '').strip(),
+        ordering=ordering,
+    )
+
+
+def _current_location(field):
+    """Read one field of the location a plant currently occupies.
+
+    `unique_active_location_per_plant` guarantees there is at most one, so this
+    is a lookup rather than a choice between candidates.
+    """
+    return Subquery(
+        SpecificPlantLocation.objects
+        .filter(specific_plant=OuterRef('pk'), ended__isnull=True)
+        .values(field)[:1]
+    )
+
+
+def _plant_cost():
+    """Sum what one plant's surviving cost layers came to.
+
+    A subquery rather than an aggregate over the join, so that adding it cannot
+    multiply the other annotations. The row selection matches the one
+    `costing.services.plant_cost_breakdown` reports from: a reversal and the
+    layer it reverses both drop out.
+    """
+    return Subquery(
+        CostAllocation.objects
+        .filter(
+            specific_plant=OuterRef('pk'),
+            reversal_of__isnull=True,
+            reversal__isnull=True,
+        )
+        .values('specific_plant')
+        .annotate(total=Sum('amount'))
+        .values('total')[:1],
+        output_field=DecimalField(max_digits=18, decimal_places=4),
+    )
+
+
+def register_projection(workspace):
+    """Return every plant in the workspace with its register columns."""
+    return with_lifecycle_state(
+        SpecificPlant.objects
+        .filter(workspace=workspace)
+        .select_related(f'{_BATCH}__variety__plant')
+    ).annotate(
+        batch_code=F(f'{_BATCH}__code'),
+        variety_name=F(f'{_BATCH}__variety__name'),
+        plant_name=F(f'{_BATCH}__variety__plant__name'),
+        current_location_type=_current_location('location_type'),
+        current_seed_tray_cell=_current_location('seed_tray_cell'),
+        current_seed_tray=_current_location('seed_tray_cell__tray'),
+        current_seed_tray_label=_current_location('seed_tray_cell__tray__model__identifier'),
+        current_garden_square=_current_location('garden_square'),
+        current_garden_square_label=_current_location('garden_square__name'),
+        located_since=_current_location('started'),
+        cost=_plant_cost(),
+    ).annotate(
+        current_location_label=Coalesce(
+            'current_garden_square_label',
+            'current_seed_tray_label',
+            Value(''),
+            output_field=TextField(),
+        ),
+    )
+
+
+def _apply_search(queryset, search):
+    """Match a typed identifier or a name fragment the operator remembers.
+
+    A search that is only digits is read as an identifier and matched against
+    plant IDs and batch codes alone. Someone holding a plant and typing its
+    number wants that plant, not every crop whose catalog name happens to
+    contain the same digit. Label codes join this once task 18 issues them.
+    """
+    matches = Q(batch_code__icontains=search)
+    if search.isdigit():
+        matches |= Q(pk=int(search))
+    else:
+        matches |= Q(variety_name__icontains=search) | Q(plant_name__icontains=search)
+    return queryset.filter(matches)
+
+
+def register_queryset(workspace, filters):
+    """Return the plants one validated filter set selects, in its order."""
+    queryset = register_projection(workspace)
+    if filters.variety is not None:
+        queryset = queryset.filter(**{f'{_BATCH}__variety_id': filters.variety})
+    if filters.batch is not None:
+        queryset = queryset.filter(**{f'{_BATCH}_id': filters.batch})
+    if filters.states:
+        queryset = queryset.filter(lifecycle_state__in=list(filters.states))
+    if filters.sellable is not None:
+        queryset = queryset.filter(sellable=filters.sellable)
+    if filters.germinated_from is not None:
+        queryset = queryset.filter(germinated__gte=filters.germinated_from)
+    if filters.germinated_to is not None:
+        queryset = queryset.filter(germinated__lte=filters.germinated_to)
+    if filters.location_type == UNPLACED:
+        queryset = queryset.filter(current_location_type__isnull=True)
+    elif filters.location_type is not None:
+        queryset = queryset.filter(current_location_type=filters.location_type)
+    if filters.seed_tray is not None:
+        queryset = queryset.filter(current_seed_tray=filters.seed_tray)
+    if filters.garden_square is not None:
+        queryset = queryset.filter(current_garden_square=filters.garden_square)
+    if filters.search:
+        queryset = _apply_search(queryset, filters.search)
+    return queryset.order_by(*_ordering_fields(filters.ordering))
+
+
+def _ordering_fields(ordering):
+    """Expand one ordering name into its fields, keeping the tiebreaker last."""
+    descending = ordering.startswith('-')
+    fields = ORDERINGS[ordering.lstrip('-')]
+    if not descending:
+        return fields
+    return tuple(f'-{field}' for field in fields[:-1]) + fields[-1:]
+
+
+def register_totals(queryset):
+    """Count the whole filtered selection, independent of any page of it.
+
+    Growing and available are reported separately rather than as one present
+    count, and unresolved names the plants still owed an outcome. Reserved and
+    quarantined are absent until tasks 44 and 56 record them.
+    """
+    counted = {'total': Count('pk')}
+    for state in LifecycleState:
+        counted[state.value] = Count('pk', filter=Q(lifecycle_state=state.value))
+    counted['unresolved'] = Count(
+        'pk',
+        filter=~Q(lifecycle_state__in=sorted(FINAL_STATES)),
+    )
+    return queryset.order_by().aggregate(**counted)

--- a/plantings/register_rest.py
+++ b/plantings/register_rest.py
@@ -1,0 +1,196 @@
+"""The nursery plant register endpoint.
+
+The page and its totals come back from one request built from one validated
+filter set, so the counts an operator reads always describe the list underneath
+them. This is the only paginated collection in the project; task 04 owns the
+global contract change, and this endpoint carries its own pagination class so
+that change does not have to arrive first.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import timedelta
+
+from rest_framework import mixins, serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+from django.utils import timezone
+
+from workspaces.models import Workspace
+from workspaces.scoping import CurrentWorkspaceViewSetMixin, RequireWorkspaceModeMixin
+
+from .register import (
+    parse_register_filters,
+    register_queryset,
+    register_totals,
+)
+
+
+#: The largest selection the register will resolve to explicit plant IDs. A
+#: bigger answer than this is a filter the operator has not finished writing.
+MAX_SELECTION = 5000
+
+
+class NurseryRegisterPagination(PageNumberPagination):
+    """Page the register and report the whole selection's counts alongside.
+
+    The totals are computed from the queryset before it is sliced, so paging
+    never narrows them — an operator reading "412 available" on page 3 is
+    reading the filter, not the page.
+    """
+
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+    def __init__(self):
+        super().__init__()
+        self.totals = {}
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """Count the whole selection, then return the requested page of it."""
+        self.totals = register_totals(queryset)
+        return super().paginate_queryset(queryset, request, view=view)
+
+    def get_paginated_response(self, data):
+        """Return the page and the counts it was drawn from together."""
+        response = super().get_paginated_response(data)
+        response.data['totals'] = self.totals
+        return response
+
+
+class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """One register row: a projection, not the plant's editable record.
+
+    Deliberately flat and shallow where `SpecificPlantSerializer` is nested —
+    a register row needs where a plant is now, not everywhere it has been.
+    """
+
+    pk = serializers.IntegerField(read_only=True)
+    batch = serializers.IntegerField(
+        source='cell_planting.seed_tray_planting.batch_id',
+        read_only=True,
+    )
+    batch_code = serializers.CharField(read_only=True)
+    variety = serializers.IntegerField(
+        source='cell_planting.seed_tray_planting.batch.variety_id',
+        read_only=True,
+    )
+    variety_name = serializers.CharField(read_only=True)
+    plant_name = serializers.CharField(read_only=True)
+    germinated = serializers.DateTimeField(read_only=True)
+    age_days = serializers.SerializerMethodField()
+    lifecycle_state = serializers.CharField(read_only=True)
+    sellable = serializers.BooleanField(read_only=True)
+    final_outcome = serializers.CharField(read_only=True, allow_null=True)
+    final_outcome_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    location_type = serializers.CharField(
+        source='current_location_type',
+        read_only=True,
+        allow_null=True,
+    )
+    location_label = serializers.CharField(source='current_location_label', read_only=True)
+    seed_tray = serializers.IntegerField(source='current_seed_tray', read_only=True, allow_null=True)
+    seed_tray_cell = serializers.IntegerField(
+        source='current_seed_tray_cell',
+        read_only=True,
+        allow_null=True,
+    )
+    garden_square = serializers.IntegerField(
+        source='current_garden_square',
+        read_only=True,
+        allow_null=True,
+    )
+    located_since = serializers.DateTimeField(read_only=True, allow_null=True)
+    expected_ready_early = serializers.SerializerMethodField()
+    expected_ready_late = serializers.SerializerMethodField()
+    cost = serializers.DecimalField(max_digits=18, decimal_places=4, read_only=True, allow_null=True)
+    currency_code = serializers.SerializerMethodField()
+
+    def get_age_days(self, plant):
+        """Report how long this plant has been growing, in whole days."""
+        return (timezone.now() - plant.germinated).days
+
+    def get_expected_ready_early(self, plant):
+        """Project the earliest ready date from the crop's maturity range.
+
+        A projection from catalog data, not a recorded readiness date; task 54
+        adds the observed one, and until then this is display only and neither
+        filterable nor sortable.
+        """
+        return self._expected_ready(plant, 'maturity_days_min')
+
+    def get_expected_ready_late(self, plant):
+        """Project the latest ready date from the crop's maturity range."""
+        return self._expected_ready(plant, 'maturity_days_max')
+
+    def get_currency_code(self, plant):  # pylint: disable=unused-argument
+        """Name the currency the cost is expressed in, so it cannot separate."""
+        return self.context['workspace'].currency_code
+
+    @staticmethod
+    def _expected_ready(plant, field):
+        """Offset germination by the variety's days, falling back to the crop."""
+        variety = plant.cell_planting.seed_tray_planting.batch.variety
+        days = getattr(variety, field) or getattr(variety.plant, field)
+        if days is None:
+            return None
+        return plant.germinated + timedelta(days=days)
+
+
+class NurseryPlantRegisterViewSet(
+    RequireWorkspaceModeMixin,
+    CurrentWorkspaceViewSetMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Search current plants as operational nursery inventory.
+
+    A projection over the source records rather than a second plant inventory,
+    so a row links to the plant's own detail route for lineage, history, and
+    cost instead of restating them here.
+    """
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    serializer_class = NurseryRegisterSerializer
+    pagination_class = NurseryRegisterPagination
+
+    def get_queryset(self):
+        """Select the plants the request's validated filters describe."""
+        return register_queryset(
+            self.get_current_workspace(),
+            parse_register_filters(self.request.query_params),
+        )
+
+    def get_serializer_context(self):
+        """Give rows the workspace their money and measurements belong to."""
+        context = super().get_serializer_context()
+        context['workspace'] = self.get_current_workspace()
+        return context
+
+    @action(detail=False, url_path='ids')
+    def ids(self, request):  # pylint: disable=unused-argument
+        """Resolve the current filters to the plant IDs they select.
+
+        Bulk actions act on a filter, not on a page. Returning the IDs at the
+        moment of the action — rather than freezing them when the operator
+        first ticked "everything matching" — means a selection describes what
+        is true now instead of what was on screen several edits ago.
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        plants = list(queryset.values_list('pk', flat=True)[:MAX_SELECTION + 1])
+        if len(plants) > MAX_SELECTION:
+            raise ValidationError({
+                'detail': (
+                    f'That selection is larger than {MAX_SELECTION} plants. '
+                    'Narrow the filters before acting on it.'
+                ),
+            })
+        return Response({'count': len(plants), 'plants': plants})
+
+
+def register_register_routes(router):
+    """Register the nursery plant register with the plantings router."""
+    router.register(r'register', NurseryPlantRegisterViewSet, basename='plant-register')

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -20,6 +20,7 @@ from .harvest_rest import register_harvest_routes
 from .lifecycle import record_germination_event, record_transplant_event
 from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSerializerMixin, PlantOutcomeViewSetMixin, register_lifecycle_routes
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
+from .register_rest import register_register_routes
 from .sowing import correct_sowing_consumption, post_sowing_consumption
 
 
@@ -988,3 +989,4 @@ router.register(r'seedtray-data/(?P<seed_tray_pk>[^/.]+)/specificplants', Specif
 router.register(r'specificplants/(?P<specific_plant_pk>[^/.]+)/locations', SpecificPlantLocationByPlantViewSet, basename='specificplant-locations')
 register_lifecycle_routes(router)
 register_harvest_routes(router)
+register_register_routes(router)

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -1,0 +1,427 @@
+"""Tests for the nursery plant register.
+
+The register's promise is that its counts describe its filters rather than its
+current page, so most of these tests compare a total against the rows the same
+filter returns.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_garden_square,
+    make_plant_variety,
+    make_production_batch,
+    make_seed_packet,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_seed_tray_model,
+    make_seed_tray_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace, get_current_workspace
+
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    record_germination_event,
+    record_lifecycle_event,
+)
+from . import register_rest
+from .models import SpecificPlantLocation
+
+
+class RegisterTestCase(RESTContractTestCase):
+    """Shared nursery workspace and plant-building helpers."""
+
+    url = '/plantings/register/'
+    ids_url = '/plantings/register/ids/'
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        self.operator = get_user_model().objects.create_user(username='register-operator')
+        self.start = timezone.now() - timedelta(days=40)
+
+    def make_batch(self, **overrides):
+        """Create an active batch whose sowing can carry plants."""
+        return make_production_batch(**overrides)
+
+    def make_plant(self, batch=None, germinated=None, tray=None):
+        """Germinate one plant from a new cell allocation on a batch."""
+        packet = make_seed_packet()
+        if batch is None:
+            batch = self.make_batch(variety=packet.seeds.plant_variety)
+        planting = make_seed_tray_planting(
+            batch=batch,
+            seeds_used=packet,
+            seed_tray=tray or make_seed_tray(),
+        )
+        cell_planting = make_seed_tray_cell_planting(seed_tray_planting=planting)
+        plant = make_specific_plant(
+            cell_planting=cell_planting,
+            germinated=germinated or self.start,
+        )
+        record_germination_event(plant, self.operator)
+        return plant
+
+    def make_plant_in_state(self, state, **kwargs):
+        """Germinate a plant and drive it to one derived lifecycle state."""
+        plant = self.make_plant(**kwargs)
+        outcomes = {
+            LifecycleState.AVAILABLE: EventType.READY,
+            LifecycleState.RETAINED: EventType.RETAINED,
+            LifecycleState.DONATED: EventType.DONATED,
+            LifecycleState.FAILED: EventType.FAILED,
+            LifecycleState.CULLED: EventType.CULLED,
+            LifecycleState.HARVESTED: EventType.HARVEST_FINISHED,
+        }
+        if state != LifecycleState.GROWING:
+            record_lifecycle_event(
+                plant,
+                self.operator,
+                OutcomeRequest(outcomes[state], occurred_at=self.start + timedelta(days=1)),
+            )
+        return plant
+
+    def page(self, **params):
+        """Request one page of the register and assert it succeeded."""
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+    def row_ids(self, payload):
+        """Return the plant IDs in one page of results."""
+        return [row['pk'] for row in payload['results']]
+
+
+class RegisterContractTests(RegisterTestCase):
+    """The register's shape, permissions, and profile boundary."""
+
+    def test_the_register_requires_authentication(self):
+        """Plant inventory is workspace data, not a public catalog."""
+        self.assert_authentication_required([self.url, self.ids_url])
+
+    def test_the_register_returns_a_page_and_its_totals_together(self):
+        """One request answers both questions the screen asks at once."""
+        self.make_plant()
+        payload = self.page()
+        self.assertEqual(payload['count'], 1)
+        self.assertIsInstance(payload['results'], list)
+        self.assertEqual(payload['totals']['total'], 1)
+
+    def test_a_row_reports_the_lineage_the_detail_route_expands(self):
+        """A row identifies its plant well enough to act on or open."""
+        plant = self.make_plant()
+        row = self.page()['results'][0]
+        batch = plant.cell_planting.seed_tray_planting.batch
+        self.assertEqual(row['pk'], plant.pk)
+        self.assertEqual(row['batch'], batch.pk)
+        self.assertEqual(row['batch_code'], batch.code)
+        self.assertEqual(row['variety'], batch.variety_id)
+        self.assertEqual(row['variety_name'], batch.variety.name)
+        self.assertEqual(row['lifecycle_state'], LifecycleState.GROWING)
+        self.assertEqual(row['age_days'], 40)
+
+    def test_a_garden_workspace_cannot_reach_the_register(self):
+        """The Garden profile has plants but no nursery to run them through."""
+        self.workspace.mode = Workspace.Mode.GARDEN
+        self.workspace.save()
+        for url in (self.url, self.ids_url):
+            with self.subTest(url=url):
+                self.assertEqual(self.client.get(url).status_code, 403)
+
+    def test_another_workspace_s_plants_are_invisible(self):
+        """The register is scoped by the same boundary as every other read."""
+        other = Workspace.objects.create(name='Other nursery')
+        variety = make_plant_variety(workspace=other)
+        foreign_batch = make_production_batch(workspace=other, variety=variety)
+        self.assertEqual(self.page()['count'], 0)
+        self.assertEqual(self.page()['totals']['total'], 0)
+        self.assertEqual(foreign_batch.workspace_id, other.pk)
+
+
+class RegisterFilterTests(RegisterTestCase):
+    """Every filter narrows the rows and the totals by the same amount."""
+
+    def assert_filter_agrees(self, **params):
+        """Assert a filtered page's own total matches the rows it returns."""
+        payload = self.page(**params, page_size=200)
+        self.assertEqual(payload['totals']['total'], payload['count'])
+        self.assertEqual(len(payload['results']), payload['count'])
+        return payload
+
+    def test_filtering_by_lifecycle_state_moves_rows_and_totals_together(self):
+        """A count that outlived its filter would be worse than no count."""
+        self.make_plant_in_state(LifecycleState.GROWING)
+        available = self.make_plant_in_state(LifecycleState.AVAILABLE)
+        self.make_plant_in_state(LifecycleState.FAILED)
+
+        everything = self.page()
+        self.assertEqual(everything['totals']['total'], 3)
+        self.assertEqual(everything['totals']['available'], 1)
+        self.assertEqual(everything['totals']['unresolved'], 2)
+
+        payload = self.assert_filter_agrees(state=LifecycleState.AVAILABLE)
+        self.assertEqual(self.row_ids(payload), [available.pk])
+
+    def test_several_states_may_be_selected_at_once(self):
+        """An operator asks for what is live, not for one state at a time."""
+        growing = self.make_plant_in_state(LifecycleState.GROWING)
+        available = self.make_plant_in_state(LifecycleState.AVAILABLE)
+        self.make_plant_in_state(LifecycleState.CULLED)
+        response = self.client.get(
+            self.url,
+            {'state': [LifecycleState.GROWING, LifecycleState.AVAILABLE]},
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(
+            sorted(row['pk'] for row in response.data['results']),
+            sorted([growing.pk, available.pk]),
+        )
+        self.assertEqual(response.data['totals']['total'], 2)
+
+    def test_sellable_selects_only_what_may_be_offered(self):
+        """Growing stock is not available to promise, and must not be counted."""
+        available = self.make_plant_in_state(LifecycleState.AVAILABLE)
+        self.make_plant_in_state(LifecycleState.GROWING)
+        self.make_plant_in_state(LifecycleState.RETAINED)
+        payload = self.assert_filter_agrees(sellable='true')
+        self.assertEqual(self.row_ids(payload), [available.pk])
+
+    def test_filtering_by_variety_and_batch_narrows_the_selection(self):
+        """The two identities a nursery plans by are both first-class filters."""
+        packet = make_seed_packet()
+        batch = self.make_batch(variety=packet.seeds.plant_variety)
+        wanted = self.make_plant(batch=batch)
+        self.make_plant()
+        by_batch = self.assert_filter_agrees(batch=batch.pk)
+        self.assertEqual(self.row_ids(by_batch), [wanted.pk])
+        by_variety = self.assert_filter_agrees(variety=batch.variety_id)
+        self.assertEqual(self.row_ids(by_variety), [wanted.pk])
+
+    def test_age_filters_select_by_when_a_plant_germinated(self):
+        """How old stock is drives what is worth chasing and what is late."""
+        old = self.make_plant(germinated=timezone.now() - timedelta(days=60))
+        young = self.make_plant(germinated=timezone.now() - timedelta(days=2))
+        cutoff = (timezone.now() - timedelta(days=30)).isoformat()
+        older = self.assert_filter_agrees(germinated_to=cutoff)
+        self.assertEqual(self.row_ids(older), [old.pk])
+        newer = self.assert_filter_agrees(germinated_from=cutoff)
+        self.assertEqual(self.row_ids(newer), [young.pk])
+
+    def test_location_filters_separate_trays_gardens_and_nowhere(self):
+        """Where stock is standing is the question that starts a nursery day."""
+        tray = make_seed_tray()
+        in_tray = self.make_plant(tray=tray)
+        make_specific_plant_location(specific_plant=in_tray, started=self.start)
+
+        square = make_garden_square()
+        planted_out = self.make_plant()
+        make_specific_plant_location(
+            specific_plant=planted_out,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            seed_tray_cell=None,
+            garden_square=square,
+            started=self.start,
+        )
+        unplaced = self.make_plant()
+
+        in_trays = self.assert_filter_agrees(
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+        )
+        self.assertEqual(self.row_ids(in_trays), [in_tray.pk])
+        self.assertEqual(in_trays['results'][0]['seed_tray'], tray.pk)
+
+        in_gardens = self.assert_filter_agrees(garden_square=square.pk)
+        self.assertEqual(self.row_ids(in_gardens), [planted_out.pk])
+
+        nowhere = self.assert_filter_agrees(location_type='none')
+        self.assertEqual(self.row_ids(nowhere), [unplaced.pk])
+
+    def test_a_finished_plant_leaves_its_location_behind(self):
+        """An outcome that ends a location must stop reporting it as current."""
+        plant = self.make_plant()
+        make_specific_plant_location(specific_plant=plant, started=self.start)
+        record_lifecycle_event(
+            plant,
+            self.operator,
+            OutcomeRequest(EventType.CULLED, occurred_at=self.start + timedelta(days=1)),
+        )
+        row = self.page()['results'][0]
+        self.assertIsNone(row['location_type'])
+        self.assertEqual(self.page(location_type='none')['count'], 1)
+
+    def test_search_matches_an_identifier_or_a_remembered_name(self):
+        """An operator searches for the label in their hand or the crop's name."""
+        packet = make_seed_packet()
+        batch = self.make_batch(variety=packet.seeds.plant_variety, code='TOMATO-SPRING-1')
+        wanted = self.make_plant(batch=batch)
+        other = make_seed_packet()
+        self.make_plant(batch=self.make_batch(
+            variety=other.seeds.plant_variety,
+            code='BASIL-SUMMER',
+        ))
+        by_code = self.assert_filter_agrees(search='tomato-spring')
+        self.assertEqual(self.row_ids(by_code), [wanted.pk])
+        by_id = self.assert_filter_agrees(search=str(wanted.pk))
+        self.assertEqual(self.row_ids(by_id), [wanted.pk])
+        by_variety = self.assert_filter_agrees(search=batch.variety.name)
+        self.assertEqual(self.row_ids(by_variety), [wanted.pk])
+
+    def test_combined_filters_agree_with_their_own_totals(self):
+        """Filters compose, and the counts compose with them."""
+        packet = make_seed_packet()
+        batch = self.make_batch(variety=packet.seeds.plant_variety)
+        wanted = self.make_plant_in_state(LifecycleState.AVAILABLE, batch=batch)
+        self.make_plant_in_state(LifecycleState.GROWING, batch=batch)
+        self.make_plant_in_state(LifecycleState.AVAILABLE)
+        payload = self.assert_filter_agrees(
+            batch=batch.pk,
+            state=LifecycleState.AVAILABLE,
+        )
+        self.assertEqual(self.row_ids(payload), [wanted.pk])
+        self.assertEqual(payload['totals']['available'], 1)
+
+    def test_bad_filter_values_blame_the_parameter_that_carried_them(self):
+        """A typo in a query string should say which one it was."""
+        for params, field in (
+            ({'variety': 'tomato'}, 'variety'),
+            ({'state': 'sprouting'}, 'state'),
+            ({'sellable': 'maybe'}, 'sellable'),
+            ({'germinated_from': 'last week'}, 'germinated_from'),
+            ({'location_type': 'bench'}, 'location_type'),
+            ({'ordering': 'whim'}, 'ordering'),
+        ):
+            with self.subTest(params=params):
+                response = self.client.get(self.url, params)
+                self.assertEqual(response.status_code, 400, response.data)
+                self.assertIn(field, response.data)
+
+
+class RegisterPaginationTests(RegisterTestCase):
+    """Paging moves the rows without moving what the totals describe."""
+
+    def test_the_totals_are_the_same_on_every_page(self):
+        """The counts describe the filter; only the rows describe the page."""
+        for _ in range(5):
+            self.make_plant_in_state(LifecycleState.AVAILABLE)
+        first = self.page(page_size=2)
+        second = self.page(page_size=2, page=2)
+        self.assertEqual(len(first['results']), 2)
+        self.assertEqual(first['totals'], second['totals'])
+        self.assertEqual(first['totals']['total'], 5)
+        self.assertEqual(first['totals']['available'], 5)
+
+    def test_paging_visits_every_plant_exactly_once(self):
+        """Equal sort values must not repeat or skip a plant across a boundary."""
+        germinated = timezone.now() - timedelta(days=10)
+        expected = {self.make_plant(germinated=germinated).pk for _ in range(7)}
+        seen = []
+        for page in (1, 2, 3, 4):
+            seen.extend(self.row_ids(self.page(page_size=2, page=page)))
+        self.assertEqual(len(seen), len(set(seen)))
+        self.assertEqual(set(seen), expected)
+
+    def test_the_page_size_is_capped(self):
+        """A client cannot ask the register for the whole nursery at once."""
+        for _ in range(3):
+            self.make_plant()
+        payload = self.page(page_size=10000)
+        self.assertLessEqual(len(payload['results']), 200)
+
+
+class RegisterOrderingTests(RegisterTestCase):
+    """Sorting answers a question rather than reordering rows arbitrarily."""
+
+    def test_plants_sort_by_age_newest_first_by_default(self):
+        """The newest germinations are what an operator has just recorded."""
+        old = self.make_plant(germinated=timezone.now() - timedelta(days=30))
+        new = self.make_plant(germinated=timezone.now() - timedelta(days=1))
+        self.assertEqual(self.row_ids(self.page()), [new.pk, old.pk])
+        self.assertEqual(self.row_ids(self.page(ordering='age')), [old.pk, new.pk])
+
+    def test_plants_sort_by_variety_name(self):
+        """Sorting by crop groups the register the way a bench is walked."""
+        first = self.make_plant(batch=self.make_batch(
+            variety=make_plant_variety(name='Aubergine'),
+        ))
+        last = self.make_plant(batch=self.make_batch(
+            variety=make_plant_variety(name='Zucchini'),
+        ))
+        self.assertEqual(self.row_ids(self.page(ordering='variety')), [first.pk, last.pk])
+        self.assertEqual(self.row_ids(self.page(ordering='-variety')), [last.pk, first.pk])
+
+
+class RegisterSelectionTests(RegisterTestCase):
+    """A bulk selection is a filter, resolved when it is acted on."""
+
+    def test_the_ids_action_returns_what_the_same_filters_select(self):
+        """Bulk actions and the list they came from must agree exactly."""
+        available = self.make_plant_in_state(LifecycleState.AVAILABLE)
+        self.make_plant_in_state(LifecycleState.GROWING)
+        response = self.client.get(self.ids_url, {'state': LifecycleState.AVAILABLE})
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data, {'count': 1, 'plants': [available.pk]})
+
+    def test_a_selection_larger_than_the_cap_is_refused(self):
+        """A selection too big to state is a filter nobody finished writing."""
+        for _ in range(3):
+            self.make_plant()
+        with mock.patch.object(register_rest, 'MAX_SELECTION', 2):
+            response = self.client.get(self.ids_url)
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('detail', response.data)
+
+    def test_a_selection_inside_the_cap_is_returned_whole(self):
+        """The cap bounds the answer without truncating a legitimate one."""
+        plants = {self.make_plant().pk for _ in range(3)}
+        with mock.patch.object(register_rest, 'MAX_SELECTION', 3):
+            response = self.client.get(self.ids_url)
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(set(response.data['plants']), plants)
+
+
+class RegisterQueryBudgetTests(RegisterTestCase):
+    """The register's cost must not grow with the size of its answer."""
+
+    def test_a_page_costs_the_same_number_of_queries_at_any_volume(self):
+        """A register that queried per row could not serve a real nursery."""
+        packet = make_seed_packet()
+        batch = self.make_batch(variety=packet.seeds.plant_variety)
+        tray = make_seed_tray(model=make_seed_tray_model(x_cells=10, y_cells=10))
+        planting = make_seed_tray_planting(batch=batch, seeds_used=packet, seed_tray=tray)
+        for index in range(60):
+            cell_planting = make_seed_tray_cell_planting(
+                seed_tray_planting=planting,
+                cell=make_seed_tray_cell(
+                    tray=tray,
+                    x_position=index % 10,
+                    y_position=index // 10,
+                ),
+            )
+            plant = make_specific_plant(cell_planting=cell_planting, germinated=self.start)
+            record_germination_event(plant, self.operator)
+
+        with CaptureQueriesContext(connection) as small_queries:
+            small = self.client.get(self.url, {'page_size': 5})
+        with CaptureQueriesContext(connection) as large_queries:
+            large = self.client.get(self.url, {'page_size': 60})
+
+        self.assertEqual(len(small.data['results']), 5)
+        self.assertEqual(len(large.data['results']), 60)
+        self.assertEqual(len(large_queries), len(small_queries))
+        self.assertLessEqual(len(small_queries), 6, small_queries.captured_queries)

--- a/workspaces/scoping.py
+++ b/workspaces/scoping.py
@@ -1,6 +1,8 @@
 """Reusable REST helpers for the single-workspace deployment boundary."""
 
-from .models import get_current_workspace
+from rest_framework.exceptions import PermissionDenied
+
+from .models import Workspace, get_current_workspace
 
 
 class CurrentWorkspaceSerializerMixin:  # pylint: disable=too-few-public-methods
@@ -47,3 +49,27 @@ class CurrentWorkspaceViewSetMixin:
             serializer.save(workspace=self.get_current_workspace())
         else:
             super().perform_create(serializer)
+
+
+class RequireWorkspaceModeMixin:  # pylint: disable=too-few-public-methods
+    """Serve a route only while the workspace presents the profile it belongs to.
+
+    The mode is a presentation choice over one set of records, so this refuses
+    a request rather than hiding data: a Garden workspace has plants, it simply
+    has no nursery to run them through. Enforcing it on the server as well as
+    in the navigation keeps a bookmarked or scripted URL honest.
+    """
+
+    required_workspace_modes = ()
+
+    def initial(self, request, *args, **kwargs):
+        """Check the profile before the view does any work for the request."""
+        super().initial(request, *args, **kwargs)
+        workspace = get_current_workspace()
+        if workspace.mode not in self.required_workspace_modes:
+            profiles = ' or '.join(
+                Workspace.Mode(mode).label for mode in self.required_workspace_modes
+            )
+            raise PermissionDenied(
+                f'This feature is available in the {profiles} profile.',
+            )


### PR DESCRIPTION
A nursery operator could reach a plant only through the tray or batch that raised it, so the inventory-first questions that start a day — what is growing, what is ready, where it is standing, how old it is, what it has cost — had no answer. /plantings/register/ answers them as a projection over the source records rather than as a second plant table.

One filter parser feeds both the rows and the counts, and the counts are taken before the page is sliced, so "412 available" on page 3 describes the filter rather than the fifty rows underneath it. The ids action resolves a filter to the plants it selects at the moment a bulk action runs, so a selection cannot go stale between ticking a box and acting on it.

Filters for stage, grade, container, nursery location, reservation, and quarantine are absent because nothing records those facts yet; tasks 54, 51, 44, and 56 each add theirs. Expected-ready is projected from the variety's maturity range and is display only, because it is a guess from catalog data rather than an observed date.

This is the project's first paginated collection, so it carries its own pagination class instead of waiting for task 04's global contract change, and the first server-side profile boundary: mode was previously enforced only in the navigation, where a bookmarked URL walked straight past it.

## Summary by Sourcery

Introduce a nursery plant register endpoint that exposes a paginated, filterable projection of specific plants as operational inventory, including server-enforced workspace profile boundaries.

New Features:
- Add a nursery plant register projection over specific plants with search, filtering, sorting, totals, and cost annotations.
- Expose a REST endpoint for the nursery plant register with custom pagination returning both page data and whole-selection totals.
- Provide an ids endpoint that resolves the current register filters into explicit plant IDs for bulk actions.

Enhancements:
- Enforce workspace mode/profile constraints on server-side views via a reusable RequireWorkspaceModeMixin.
- Centralize register filter parsing and validation so rows and totals share a consistent filter set, including user-facing error messages for bad parameters.

Tests:
- Add comprehensive tests covering register contract, filtering, pagination, ordering, bulk selection limits, and query budget to ensure consistent counts, performance, and permissions.