### PR TITLE
feat(frontend): search and open the nursery plant register

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -8,6 +8,9 @@ import {
   HarvestReportFilters,
   HarvestReportRow,
   ReverseHarvest,
+  NurseryRegisterFilters,
+  NurseryRegisterPage,
+  NurseryRegisterSelection,
   PlantLifecycleEvent,
   PlantOutcome,
   PlantOutcomeAction,
@@ -211,6 +214,35 @@ function getHarvestReport(filters: HarvestReportFilters, signal?: AbortSignal): 
   return fetchAsJson<Array<HarvestReportRow>>(`/plantings/harvest-report/${harvestQuery(filters)}`, signal)
 }
 
+// `state` repeats rather than joining, because the backend reads it with
+// getlist so that selecting two states asks for both rather than for neither.
+function registerQuery(filters: NurseryRegisterFilters): string {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === undefined || value === '') {
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        query.append(key, entry)
+      }
+    } else {
+      query.set(key, String(value))
+    }
+  }
+  return query.size > 0 ? `?${query.toString()}` : ''
+}
+
+function getNurseryRegister(filters: NurseryRegisterFilters = {}, signal?: AbortSignal): Promise<NurseryRegisterPage> {
+  return fetchAsJson<NurseryRegisterPage>(`/plantings/register/${registerQuery(filters)}`, signal)
+}
+
+// Resolves a filter to the plants it currently selects. Bulk actions call this
+// at the moment they act, so a selection never goes stale on screen.
+function getNurseryRegisterSelection(filters: NurseryRegisterFilters = {}, signal?: AbortSignal): Promise<NurseryRegisterSelection> {
+  return fetchAsJson<NurseryRegisterSelection>(`/plantings/register/ids/${registerQuery(filters)}`, signal)
+}
+
 export {
   ProductionBatchFilters,
   getProductionBatches,
@@ -247,5 +279,7 @@ export {
   getHarvest,
   addHarvest,
   reverseHarvest,
-  getHarvestReport
+  getHarvestReport,
+  getNurseryRegister,
+  getNurseryRegisterSelection
 }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -16,12 +16,15 @@ import { ApiErrorAlert } from './api_error_alert.js'
 import { queryClient, queryKeys } from './query.js'
 import { SeedTrayDetails } from './seedtray/seedtray_details.js'
 import { getWorkspace } from './api/workspace.js'
+import { Workspace } from './types/workspace.js'
 import { WorkspaceModeRoute, WorkspaceSettings } from './workspace.js'
 import { InventoryCatalog } from './inventory.js'
 import { InventoryReceiptsView } from './inventory/receipts.js'
 import { InputApplicationsView } from './applications/applications.js'
 import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/batches.js'
 import { HarvestsView, YieldReportView } from './plantings/harvests.js'
+import { NurseryRegisterView } from './plantings/register.js'
+import { PlantDetailView } from './plantings/plant_detail.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -43,6 +46,17 @@ function ProductionBatchDetailRoute() {
   }
 
   return <ProductionBatchDetailView batchPk={batchPk} />
+}
+
+function PlantDetailRoute({ workspace }: { workspace: Workspace }) {
+  const { plantId } = useParams()
+  const plantPk = Number(plantId)
+
+  if (!plantId || !Number.isInteger(plantPk) || plantPk <= 0) {
+    return <div>Plant not found.</div>
+  }
+
+  return <PlantDetailView plantPk={plantPk} workspace={workspace} />
 }
 
 function FrontEndPage() {
@@ -81,6 +95,15 @@ function FrontEndPage() {
         <Route path="/plantings/batches/:batchId" element={<ProductionBatchDetailRoute />} />
         <Route path="/plantings/seedtrays" element={<SeedTrayPlantingTable />} />
         <Route path="/plantings/garden-squares" element={<GardenSquarePlantingTable />} />
+        <Route
+          path="/plantings/register"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <NurseryRegisterView />
+            </WorkspaceModeRoute>
+          }
+        />
+        <Route path="/plantings/plants/:plantId" element={<PlantDetailRoute workspace={workspace} />} />
         <Route path="/plantings/harvests" element={<HarvestsView />} />
         <Route path="/plantings/yield" element={<YieldReportView />} />
         <Route path="/inventory" element={<InventoryCatalog />} />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -52,6 +52,11 @@ function GPTopBar({ workspace }: GPTopBarProps) {
             </NavDropdown.Item>
           </NavDropdown>
           <NavDropdown title="Planting" active={plantingActive}>
+            {workspace.mode === 'nursery' && (
+              <NavDropdown.Item as={NavLink} to="/plantings/register">
+                Plant register
+              </NavDropdown.Item>
+            )}
             <NavDropdown.Item as={NavLink} to="/plantings/batches">
               Batches
             </NavDropdown.Item>

--- a/frontend/js/plantings/lifecycle.tsx
+++ b/frontend/js/plantings/lifecycle.tsx
@@ -47,8 +47,12 @@ const OUTCOME_ACTIONS: Array<{ action: PlantOutcomeAction; label: string; varian
   { action: 'donate', label: 'Donate', variant: 'outline-info' }
 ]
 
+function LifecycleStateBadge({ state }: { state: PlantLifecycleState }) {
+  return <Badge bg={STATE_VARIANTS[state]}>{STATE_LABELS[state]}</Badge>
+}
+
 function PlantLifecycleBadge({ plant }: { plant: SpecificPlant }) {
-  return <Badge bg={STATE_VARIANTS[plant.lifecycle_state]}>{STATE_LABELS[plant.lifecycle_state]}</Badge>
+  return <LifecycleStateBadge state={plant.lifecycle_state} />
 }
 
 function availableActions(plant: SpecificPlant): Array<{ action: PlantOutcomeAction; label: string; variant: string }> {
@@ -129,4 +133,4 @@ function PlantLifecycleHistory({ events, onReverse }: PlantLifecycleHistoryProps
   )
 }
 
-export { EVENT_LABELS, STATE_LABELS, PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons }
+export { EVENT_LABELS, STATE_LABELS, LifecycleStateBadge, PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons }

--- a/frontend/js/plantings/plant_detail.tsx
+++ b/frontend/js/plantings/plant_detail.tsx
@@ -1,0 +1,179 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Card, Col, Row, Table } from 'react-bootstrap'
+import { NavLink } from 'react-router'
+
+import { getPlantCostBreakdown } from '../api/costing'
+import { getSpecificPlant, getSpecificPlantLifecycleEvents } from '../api/plantings'
+import { queryKeys } from '../query'
+import { PlantCostBreakdown } from '../types/costing'
+import { SpecificPlantLocation } from '../types/plantings'
+import { Workspace } from '../types/workspace'
+import { formatDateTime, formatMoney } from '../utils'
+import { LifecycleStateBadge, PlantLifecycleHistory } from './lifecycle'
+
+function locationLabel(location: SpecificPlantLocation): string {
+  if (location.location_type === 'seed_tray_cell') {
+    return `Seed tray cell #${location.seed_tray_cell}`
+  }
+  return `Garden square #${location.garden_square}`
+}
+
+// Physical history in the order it happened, which is separate from the
+// lifecycle history beside it: where a plant has been and what became of it
+// are different facts and are never merged into one timeline.
+function LocationHistory({ locations }: { locations: Array<SpecificPlantLocation> }) {
+  if (locations.length === 0) {
+    return <p className="text-muted mb-0">No location has been recorded.</p>
+  }
+  return (
+    <Table size="sm" className="mb-0">
+      <thead>
+        <tr>
+          <th>Where</th>
+          <th>From</th>
+          <th>Until</th>
+        </tr>
+      </thead>
+      <tbody>
+        {locations.map((location) => (
+          <tr key={location.pk}>
+            <td>{locationLabel(location)}</td>
+            <td>{formatDateTime(location.started)}</td>
+            <td>{location.ended === undefined || location.ended === null ? <span className="text-success">Still there</span> : formatDateTime(location.ended)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+// A provisional figure and a final one mean different things, so exactly one of
+// them carries a number and they are never added together.
+function PlantCost({ breakdown }: { breakdown: PlantCostBreakdown }) {
+  return (
+    <>
+      <dl className="row mb-2">
+        <dt className="col-sm-5">Provisional value</dt>
+        <dd className="col-sm-7">{formatMoney(breakdown.provisional_value, breakdown.currency_code, 'Final')}</dd>
+        <dt className="col-sm-5">Final value</dt>
+        <dd className="col-sm-7">{formatMoney(breakdown.final_value, breakdown.currency_code, 'Still provisional')}</dd>
+      </dl>
+      {breakdown.unknown_cost && <p className="text-muted small">Some inputs reaching this plant have no recorded unit cost, so this figure is incomplete.</p>}
+      {breakdown.layers.length === 0 ? (
+        <p className="text-muted mb-0">No cost has reached this plant yet.</p>
+      ) : (
+        <Table size="sm" className="mb-0">
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th>Lot</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {breakdown.layers.map((layer) => (
+              <tr key={layer.allocation}>
+                <td>{layer.item === null ? '—' : `#${layer.item}`}</td>
+                <td>{layer.lot === null ? '—' : `#${layer.lot}`}</td>
+                <td>{formatMoney(layer.amount, layer.currency_code, 'Unknown')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </>
+  )
+}
+
+interface PlantDetailViewProps {
+  plantPk: number
+  workspace: Workspace
+}
+
+function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
+  const { data: plant, isPending } = useQuery({
+    queryKey: queryKeys.plantings.specificPlantDetail(plantPk),
+    queryFn: ({ signal }) => getSpecificPlant(plantPk, signal)
+  })
+  const { data: events = [] } = useQuery({
+    queryKey: queryKeys.plantings.plantLifecycle(plantPk),
+    queryFn: ({ signal }) => getSpecificPlantLifecycleEvents(plantPk, signal)
+  })
+  // Cost is a nursery question. A Garden workspace has the same subledger but
+  // no reason to read a per-seedling valuation, so it is not fetched at all.
+  const { data: cost } = useQuery({
+    queryKey: queryKeys.costing.plant(plantPk),
+    queryFn: ({ signal }) => getPlantCostBreakdown(plantPk, signal),
+    enabled: workspace.mode === 'nursery'
+  })
+
+  if (isPending) {
+    return <main className="container py-3">Loading plant…</main>
+  }
+  if (plant === undefined) {
+    return <main className="container py-3">Plant not found.</main>
+  }
+
+  return (
+    <main className="container py-3">
+      <h1>
+        Plant #{plant.pk} <LifecycleStateBadge state={plant.lifecycle_state} />
+      </h1>
+      <p>
+        Raised in batch <NavLink to={`/plantings/batches/${plant.batch}`}>#{plant.batch}</NavLink>, germinated {formatDateTime(plant.germinated)}.
+      </p>
+
+      <Row className="g-3">
+        <Col md={6}>
+          <Card>
+            <Card.Header>Lineage</Card.Header>
+            <Card.Body>
+              <dl className="row mb-0">
+                <dt className="col-sm-5">Batch</dt>
+                <dd className="col-sm-7">
+                  <NavLink to={`/plantings/batches/${plant.batch}`}>#{plant.batch}</NavLink>
+                </dd>
+                <dt className="col-sm-5">Cell allocation</dt>
+                <dd className="col-sm-7">#{plant.cell_planting}</dd>
+                <dt className="col-sm-5">Germinated</dt>
+                <dd className="col-sm-7">{formatDateTime(plant.germinated)}</dd>
+                <dt className="col-sm-5">Offerable</dt>
+                <dd className="col-sm-7">{plant.sellable ? 'Yes' : 'No'}</dd>
+                <dt className="col-sm-5">Final outcome</dt>
+                <dd className="col-sm-7">{plant.final_outcome === null ? 'Not resolved' : `${plant.final_outcome} on ${formatDateTime(plant.final_outcome_at ?? '')}`}</dd>
+              </dl>
+              {plant.notes && <p className="mt-2 mb-0">{plant.notes}</p>}
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col md={6}>
+          <Card>
+            <Card.Header>Where it has been</Card.Header>
+            <Card.Body>
+              <LocationHistory locations={plant.locations} />
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col md={6}>
+          <Card>
+            <Card.Header>Lifecycle history</Card.Header>
+            <Card.Body>
+              <PlantLifecycleHistory events={events} />
+            </Card.Body>
+          </Card>
+        </Col>
+        {workspace.mode === 'nursery' && (
+          <Col md={6}>
+            <Card>
+              <Card.Header>What it has cost</Card.Header>
+              <Card.Body>{cost === undefined ? <div className="text-muted">Loading cost…</div> : <PlantCost breakdown={cost} />}</Card.Body>
+            </Card>
+          </Col>
+        )}
+      </Row>
+    </main>
+  )
+}
+
+export { PlantDetailView }

--- a/frontend/js/plantings/register.tsx
+++ b/frontend/js/plantings/register.tsx
@@ -1,0 +1,261 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Alert, Badge, Button, ButtonGroup, Card, Col, Form, Row } from 'react-bootstrap'
+
+import { getNurseryRegister, getProductionBatches } from '../api/plantings'
+import { getPlantVarieties } from '../api/plants'
+import { queryKeys } from '../query'
+import { NurseryRegisterFilters, NurseryRegisterOrdering, NurseryRegisterTotals, PlantLifecycleState } from '../types/plantings'
+import { STATE_LABELS } from './lifecycle'
+import { EMPTY_SELECTION, RegisterSelection, RegisterTable } from './register_list'
+
+const PAGE_SIZE = 50
+
+const ORDERING_OPTIONS: Array<{ value: NurseryRegisterOrdering; label: string }> = [
+  { value: '-age', label: 'Newest first' },
+  { value: 'age', label: 'Oldest first' },
+  { value: 'variety', label: 'Crop A–Z' },
+  { value: 'location', label: 'Location' },
+  { value: 'state', label: 'State' },
+  { value: 'batch', label: 'Batch' },
+  { value: '-cost', label: 'Most expensive first' }
+]
+
+const LOCATION_OPTIONS: Array<{ value: NonNullable<NurseryRegisterFilters['location_type']>; label: string }> = [
+  { value: 'seed_tray_cell', label: 'In a seed tray' },
+  { value: 'garden_square', label: 'Planted out' },
+  { value: 'none', label: 'Not placed anywhere' }
+]
+
+// The states an operator asks about first. The rest are reachable through the
+// totals, which always report every state whether or not it is filtered on.
+const STATE_OPTIONS: Array<PlantLifecycleState> = ['growing', 'available', 'retained', 'failed', 'culled', 'donated', 'harvested']
+
+interface TotalsProps {
+  totals: NurseryRegisterTotals
+}
+
+// These describe the whole filter, not the page below them, which is the
+// reason the register exists: "what have I got" is not a question about
+// whichever fifty rows happen to be on screen.
+function RegisterTotals({ totals }: TotalsProps) {
+  const tiles: Array<{ label: string; value: number; variant?: string }> = [
+    { label: 'Matching', value: totals.total },
+    { label: 'Growing', value: totals.growing },
+    { label: 'Available', value: totals.available, variant: 'text-success' },
+    { label: 'Unresolved', value: totals.unresolved },
+    { label: 'Retained', value: totals.retained },
+    { label: 'Lost', value: totals.failed + totals.culled, variant: 'text-danger' }
+  ]
+  return (
+    <Row className="g-2 mb-3">
+      {tiles.map((tile) => (
+        <Col key={tile.label} xs={6} md={2}>
+          <Card body className="py-2">
+            <div className="text-muted small">{tile.label}</div>
+            <div className={`fs-5 ${tile.variant ?? ''}`}>{tile.value}</div>
+          </Card>
+        </Col>
+      ))}
+    </Row>
+  )
+}
+
+interface SelectionBarProps {
+  selection: RegisterSelection
+  matching: number
+  setSelection: (selection: RegisterSelection) => void
+}
+
+function SelectionBar({ selection, matching, setSelection }: SelectionBarProps) {
+  const selected = selection.mode === 'filter' ? matching : selection.ids.length
+  if (selected === 0) {
+    return null
+  }
+  return (
+    <Alert variant="light" className="d-flex align-items-center gap-3 py-2">
+      <span>
+        <Badge bg="secondary">{selected}</Badge> {selection.mode === 'filter' ? 'plants matching these filters are selected.' : 'plants selected.'}
+      </span>
+      {selection.mode === 'ids' && matching > selected && (
+        <Button size="sm" variant="outline-secondary" onClick={() => setSelection({ mode: 'filter' })}>
+          Select all {matching} matching
+        </Button>
+      )}
+      <Button size="sm" variant="outline-secondary" onClick={() => setSelection(EMPTY_SELECTION)}>
+        Clear
+      </Button>
+    </Alert>
+  )
+}
+
+function NurseryRegisterView() {
+  const [search, setSearch] = React.useState('')
+  const [variety, setVariety] = React.useState<number | ''>('')
+  const [batch, setBatch] = React.useState<number | ''>('')
+  const [states, setStates] = React.useState<Array<PlantLifecycleState>>([])
+  const [locationType, setLocationType] = React.useState<NurseryRegisterFilters['location_type'] | ''>('')
+  const [germinatedFrom, setGerminatedFrom] = React.useState('')
+  const [germinatedTo, setGerminatedTo] = React.useState('')
+  const [ordering, setOrdering] = React.useState<NurseryRegisterOrdering>('-age')
+  const [page, setPage] = React.useState(1)
+  const [selection, setSelection] = React.useState<RegisterSelection>(EMPTY_SELECTION)
+
+  const filters: NurseryRegisterFilters = {
+    search: search || undefined,
+    variety: variety === '' ? undefined : variety,
+    batch: batch === '' ? undefined : batch,
+    state: states.length > 0 ? states : undefined,
+    location_type: locationType === '' ? undefined : locationType,
+    germinated_from: germinatedFrom || undefined,
+    germinated_to: germinatedTo || undefined,
+    ordering,
+    page,
+    page_size: PAGE_SIZE
+  }
+
+  // Changing what is being asked for invalidates a selection made against the
+  // previous question, so it is dropped rather than silently re-pointed.
+  function narrow<T>(setter: (value: T) => void): (value: T) => void {
+    return (value: T) => {
+      setter(value)
+      setPage(1)
+      setSelection(EMPTY_SELECTION)
+    }
+  }
+
+  const { data: varieties = [] } = useQuery({
+    queryKey: queryKeys.plants.varieties,
+    queryFn: ({ signal }) => getPlantVarieties(signal)
+  })
+  const { data: batches = [] } = useQuery({
+    queryKey: queryKeys.plantings.batches('active', '', '', false),
+    queryFn: ({ signal }) => getProductionBatches({ status: 'active' }, signal)
+  })
+  const { data: register, isPending } = useQuery({
+    queryKey: queryKeys.plantings.register(filters),
+    queryFn: ({ signal }) => getNurseryRegister(filters, signal)
+  })
+
+  function toggleState(state: PlantLifecycleState) {
+    narrow(setStates)(states.includes(state) ? states.filter((entry) => entry !== state) : [...states, state])
+  }
+
+  const lastPage = register === undefined ? 1 : Math.max(1, Math.ceil(register.count / PAGE_SIZE))
+
+  return (
+    <main className="container py-3">
+      <h1>Plant register</h1>
+      <p>Every plant currently on the books, with what it is, how old it is, where it is standing, and what it has cost so far.</p>
+
+      <Row className="g-2 mb-3">
+        <Col md={3}>
+          <Form.Group controlId="register-search">
+            <Form.Label>Search</Form.Label>
+            <Form.Control type="search" placeholder="Plant number, batch code, or crop" value={search} onChange={(event) => narrow(setSearch)(event.target.value)} />
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-variety">
+            <Form.Label>Variety</Form.Label>
+            <Form.Select value={variety} onChange={(event) => narrow(setVariety)(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">All varieties</option>
+              {varieties.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-batch">
+            <Form.Label>Batch</Form.Label>
+            <Form.Select value={batch} onChange={(event) => narrow(setBatch)(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">All active batches</option>
+              {batches.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.code}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-location">
+            <Form.Label>Where</Form.Label>
+            <Form.Select
+              value={locationType ?? ''}
+              onChange={(event) => narrow(setLocationType)(event.target.value === '' ? '' : (event.target.value as NonNullable<NurseryRegisterFilters['location_type']>))}
+            >
+              <option value="">Anywhere</option>
+              {LOCATION_OPTIONS.map((entry) => (
+                <option key={entry.value} value={entry.value}>
+                  {entry.label}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-germinated-from">
+            <Form.Label>Germinated from</Form.Label>
+            <Form.Control type="date" value={germinatedFrom} onChange={(event) => narrow(setGerminatedFrom)(event.target.value)} />
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-germinated-to">
+            <Form.Label>Germinated to</Form.Label>
+            <Form.Control type="date" value={germinatedTo} onChange={(event) => narrow(setGerminatedTo)(event.target.value)} />
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-ordering">
+            <Form.Label>Sort by</Form.Label>
+            <Form.Select value={ordering} onChange={(event) => narrow(setOrdering)(event.target.value as NurseryRegisterOrdering)}>
+              {ORDERING_OPTIONS.map((entry) => (
+                <option key={entry.value} value={entry.value}>
+                  {entry.label}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <div className="d-flex flex-wrap gap-2 mb-3">
+        {STATE_OPTIONS.map((state) => (
+          <Button key={state} size="sm" variant={states.includes(state) ? 'primary' : 'outline-secondary'} onClick={() => toggleState(state)}>
+            {STATE_LABELS[state]}
+          </Button>
+        ))}
+      </div>
+
+      {register !== undefined && <RegisterTotals totals={register.totals} />}
+      {register !== undefined && <SelectionBar selection={selection} matching={register.count} setSelection={setSelection} />}
+
+      {isPending ? (
+        <div>Loading plants…</div>
+      ) : (
+        <>
+          <RegisterTable rows={register?.results ?? []} selection={selection} setSelection={setSelection} />
+          <div className="d-flex align-items-center gap-3">
+            <ButtonGroup>
+              <Button variant="outline-secondary" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                Previous
+              </Button>
+              <Button variant="outline-secondary" disabled={page >= lastPage} onClick={() => setPage(page + 1)}>
+                Next
+              </Button>
+            </ButtonGroup>
+            <span className="text-muted">
+              Page {page} of {lastPage}
+            </span>
+          </div>
+        </>
+      )}
+    </main>
+  )
+}
+
+export { NurseryRegisterView }

--- a/frontend/js/plantings/register_list.tsx
+++ b/frontend/js/plantings/register_list.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { Form, Table } from 'react-bootstrap'
+import { NavLink } from 'react-router'
+
+import { formatDate, formatDateTime, formatMoney } from '../utils'
+import { NurseryRegisterRow } from '../types/plantings'
+import { LifecycleStateBadge } from './lifecycle'
+
+// A selection is either the plants an operator ticked, or the filter itself.
+// Storing the filter rather than the IDs it currently matches means a bulk
+// action acts on what is true when it runs, not on what was on screen when
+// the box was ticked.
+type RegisterSelection = { mode: 'ids'; ids: Array<number> } | { mode: 'filter' }
+
+const EMPTY_SELECTION: RegisterSelection = { mode: 'ids', ids: [] }
+
+function isSelected(selection: RegisterSelection, plantPk: number): boolean {
+  return selection.mode === 'filter' || selection.ids.includes(plantPk)
+}
+
+function toggleSelected(selection: RegisterSelection, plantPk: number): RegisterSelection {
+  // Unticking one row out of "everything matching" leaves the operator with no
+  // honest way to describe what is left, so it is refused rather than guessed.
+  if (selection.mode === 'filter') {
+    return selection
+  }
+  if (selection.ids.includes(plantPk)) {
+    return { mode: 'ids', ids: selection.ids.filter((entry) => entry !== plantPk) }
+  }
+  return { mode: 'ids', ids: [...selection.ids, plantPk] }
+}
+
+// A tray is named by its number first and its model second. The model alone
+// names every tray of that kind at once, which is no help to somebody trying
+// to find the one plant they are looking at.
+function LocationCell({ row }: { row: NurseryRegisterRow }) {
+  if (row.location_type === null) {
+    return <span className="text-muted">Not placed</span>
+  }
+  return (
+    <>
+      {row.location_type === 'seed_tray_cell' ? (
+        <>
+          Tray #{row.seed_tray}
+          <div className="text-muted small">{row.location_label}</div>
+        </>
+      ) : (
+        row.location_label
+      )}
+      {row.located_since !== null && <div className="text-muted small">since {formatDate(row.located_since)}</div>}
+    </>
+  )
+}
+
+// Projected from the crop's maturity range, so a variety that records only one
+// end of that range still says something useful rather than nothing.
+function ReadyCell({ row }: { row: NurseryRegisterRow }) {
+  const early = row.expected_ready_early
+  const late = row.expected_ready_late
+  if (early === null && late === null) {
+    return <span className="text-muted">Unknown</span>
+  }
+  if (early !== null && late !== null && early !== late) {
+    return (
+      <>
+        {formatDate(early)} – {formatDate(late)}
+      </>
+    )
+  }
+  return <>{formatDate(early ?? late ?? '')}</>
+}
+
+interface RegisterTableProps {
+  rows: Array<NurseryRegisterRow>
+  selection: RegisterSelection
+  setSelection: (selection: RegisterSelection) => void
+}
+
+function RegisterTable({ rows, selection, setSelection }: RegisterTableProps) {
+  if (rows.length === 0) {
+    return <p className="text-muted">No plants match these filters.</p>
+  }
+  return (
+    <Table striped hover responsive size="sm">
+      <thead>
+        <tr>
+          <th />
+          <th>Plant</th>
+          <th>Crop</th>
+          <th>Batch</th>
+          <th>State</th>
+          <th>Age</th>
+          <th>Expected ready</th>
+          <th>Where</th>
+          <th>Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.pk}>
+            <td>
+              <Form.Check
+                aria-label={`Select plant ${row.pk}`}
+                checked={isSelected(selection, row.pk)}
+                disabled={selection.mode === 'filter'}
+                onChange={() => setSelection(toggleSelected(selection, row.pk))}
+              />
+            </td>
+            <td>
+              <NavLink to={`/plantings/plants/${row.pk}`}>#{row.pk}</NavLink>
+            </td>
+            <td>
+              {row.variety_name}
+              <div className="text-muted small">{row.plant_name}</div>
+            </td>
+            <td>
+              <NavLink to={`/plantings/batches/${row.batch}`}>{row.batch_code}</NavLink>
+            </td>
+            <td>
+              <LifecycleStateBadge state={row.lifecycle_state} />
+            </td>
+            <td>
+              {row.age_days} days
+              <div className="text-muted small">{formatDateTime(row.germinated)}</div>
+            </td>
+            <td>
+              <ReadyCell row={row} />
+            </td>
+            <td>
+              <LocationCell row={row} />
+            </td>
+            <td>{formatMoney(row.cost, row.currency_code, 'Not costed')}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+export { EMPTY_SELECTION, RegisterSelection, RegisterTable, isSelected, toggleSelected }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -1,5 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
 
+import { NurseryRegisterFilters } from './types/plantings'
+
 const queryKeys = {
   workspace: {
     all: ['workspace'] as const,
@@ -66,12 +68,16 @@ const queryKeys = {
     currentGardenSquares: ['plantings', 'currentGardenSquares'] as const,
     specificPlantsAll: ['plantings', 'specificPlants'] as const,
     specificPlants: (trayPk: number) => ['plantings', 'specificPlants', trayPk] as const,
+    specificPlantDetail: (plantPk: number) => ['plantings', 'specificPlants', 'detail', plantPk] as const,
     plantLifecycleAll: ['plantings', 'plantLifecycle'] as const,
     plantLifecycle: (plantPk: number) => ['plantings', 'plantLifecycle', plantPk] as const,
     harvestsAll: ['plantings', 'harvests'] as const,
     harvests: (batch: number | '', variety: number | '', square: number | '', row: number | '', status: string, from: string, to: string) =>
       ['plantings', 'harvests', batch, variety, square, row, status, from, to] as const,
     harvest: (harvestPk: number) => ['plantings', 'harvests', 'detail', harvestPk] as const,
+    registerAll: ['plantings', 'register'] as const,
+    register: (filters: NurseryRegisterFilters) => ['plantings', 'register', filters] as const,
+    registerSelection: (filters: NurseryRegisterFilters) => ['plantings', 'register', 'ids', filters] as const,
     harvestReportAll: ['plantings', 'harvestReport'] as const,
     harvestReport: (groupBy: string, batch: number | '', variety: number | '', from: string, to: string) =>
       ['plantings', 'harvestReport', groupBy, batch, variety, from, to] as const

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -299,6 +299,72 @@ interface SowingCorrection {
   reason: string
 }
 
+// The nursery plant register. Rows are a projection of current plants, so a
+// row carries where a plant is now rather than everywhere it has been.
+interface NurseryRegisterRow {
+  pk: number
+  batch: number
+  batch_code: string
+  variety: number
+  variety_name: string
+  plant_name: string
+  germinated: string
+  age_days: number
+  lifecycle_state: PlantLifecycleState
+  sellable: boolean
+  final_outcome: PlantLifecycleEventType | null
+  final_outcome_at: string | null
+  location_type: 'seed_tray_cell' | 'garden_square' | null
+  location_label: string
+  seed_tray: number | null
+  seed_tray_cell: number | null
+  garden_square: number | null
+  located_since: string | null
+  // Projected from the crop's maturity range, not an observed readiness date.
+  expected_ready_early: string | null
+  expected_ready_late: string | null
+  cost: string | null
+  currency_code: string
+}
+
+type NurseryRegisterOrdering = 'age' | '-age' | 'variety' | '-variety' | 'location' | '-location' | 'cost' | '-cost' | 'state' | '-state' | 'batch' | '-batch'
+
+// Keys are the query-parameter names the register endpoint validates.
+interface NurseryRegisterFilters {
+  variety?: number
+  batch?: number
+  state?: Array<PlantLifecycleState>
+  sellable?: boolean
+  germinated_from?: string
+  germinated_to?: string
+  location_type?: 'seed_tray_cell' | 'garden_square' | 'none'
+  seed_tray?: number
+  garden_square?: number
+  search?: string
+  ordering?: NurseryRegisterOrdering
+  page?: number
+  page_size?: number
+}
+
+// Counts describe the whole filtered selection, never the visible page.
+type NurseryRegisterTotals = Record<PlantLifecycleState, number> & {
+  total: number
+  unresolved: number
+}
+
+interface NurseryRegisterPage {
+  count: number
+  next: string | null
+  previous: string | null
+  totals: NurseryRegisterTotals
+  results: Array<NurseryRegisterRow>
+}
+
+interface NurseryRegisterSelection {
+  count: number
+  plants: Array<number>
+}
+
 // The five units a yield may be measured in. The backend rejects the seed and
 // area codes the inventory registry also publishes, so this list is the
 // contract rather than /inventory/units/.
@@ -433,6 +499,12 @@ export {
   PlantOutcomeAction,
   ReversePlantEvent,
   NewBatchInline,
+  NurseryRegisterFilters,
+  NurseryRegisterOrdering,
+  NurseryRegisterPage,
+  NurseryRegisterRow,
+  NurseryRegisterSelection,
+  NurseryRegisterTotals,
   Planting,
   ProductionBatch,
   ProductionBatchCell,


### PR DESCRIPTION
Adds the Plant register screen and the plant detail screen its rows link to. The register is Nursery-only in the navigation and behind WorkspaceModeRoute, matching the server-side profile boundary.

The counts above the table describe the whole filter rather than the page, so they stay put while an operator pages through; narrowing a filter moves the rows and the counts together. A selection is either the plants ticked or the filter itself, never a frozen list of IDs standing in for a filter, and changing what is being asked for clears it rather than silently re-pointing it at a different question. Task 52 resolves the filter to plants when it acts.

A tray is named by its number with its model underneath, because the model alone names every tray of that kind at once.

## Summary by Sourcery

Add nursery-only plant register and plant detail screens, wiring them into the frontend APIs, routing, and navigation to let operators search, inspect, and act on individual plants and filtered sets.

New Features:
- Introduce nursery plant register view with filtering, sorting, totals, paging, and selection for bulk actions.
- Add plant detail view showing lifecycle state, lineage, location history, and nursery-only cost breakdown.

Enhancements:
- Extend planting and query types, API helpers, and react-query keys to support nursery register data and plant detail queries.
- Update navigation and routing so the plant register and plant detail screens are accessible only in nursery workspaces.
- Refactor lifecycle badges for reuse across register and plant detail views.