### PR TITLE
feat(locations): extract the location catalog into its own app

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,15 @@ API endpoints (examples)
   - GET /seeds/seeds/ — list Seeds entries
   - GET /seeds/packets/ — list non-empty SeedPacket (current stock)
   - POST /seeds/packets/empty/ — mark a SeedPacket empty
+- Locations:
+  - GET /locations/ — list the physical places the workspace uses, filterable by `active` and `location_type`
+  - POST /locations/ — name a new place; PATCH `{"active": false}` retires one that stock has passed through
 - REST routers are registered in each app (see `*.rest.py` files) and wired into the Django URL config.
 
 Project layout (high level)
 - gp/ — Django project settings and WSGI/ASGI entry points
 - frontend/ — JS React components and build configuration
+- locations/ — the shared catalog of physical places, referenced by stock, trays, and plants
 - garden/, plants/, seeds/, plantings/, supplies/ — Django apps with models, views, rest.py, urls
 - setup-venv.sh, setup-db.sh, build-frontend.sh, start-wsgi.sh — helper scripts
 - requirements.txt, package.json — dependency manifests

--- a/applications/migrations/0003_point_applications_at_the_locations_app.py
+++ b/applications/migrations/0003_point_applications_at_the_locations_app.py
@@ -1,0 +1,32 @@
+"""Point an application's source location at the locations app.
+
+State-only: the column and its constraint already reference the same table.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Record that an application draws stock from a locations.Location."""
+
+    dependencies = [
+        ("applications", "0002_inputapplicationtarget_seed_tray_generation_and_more"),
+        ("locations", "0001_adopt_inventory_location"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="inputapplication",
+                    name="source_location",
+                    field=models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="input_applications",
+                        to="locations.location",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/applications/models.py
+++ b/applications/models.py
@@ -27,13 +27,13 @@ from inventory.models import (
     QUANTITY_DECIMAL_PLACES,
     QUANTITY_MAX_DIGITS,
     InventoryItem,
-    InventoryLocation,
     InventoryUnit,
     ItemUnitConversion,
     StockLot,
     StockMovement,
 )
 from inventory.units import UnitCode
+from locations.models import Location
 from plantings.models import ProductionBatch, SpecificPlant
 from seedtrays.models import SeedTrayCell, SeedTrayGeneration
 from workspaces.models import WorkspaceOwnedModel
@@ -100,7 +100,7 @@ class InputApplication(WorkspaceOwnedModel):
     )
     applied_at = models.DateTimeField()
     source_location = models.ForeignKey(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         related_name='input_applications',
     )

--- a/applications/rest.py
+++ b/applications/rest.py
@@ -18,12 +18,12 @@ from garden.models import GardenArea, GardenBed, GardenRow, GardenSquare
 from inventory.ledger import quantize_quantity
 from inventory.models import (
     InventoryItem,
-    InventoryLocation,
     InventoryUnit,
     ItemUnitConversion,
     StockLot,
 )
 from inventory.rest_query import parse_datetime, parse_integer
+from locations.models import Location
 from plantings.models import ProductionBatch, SpecificPlant
 from seedtrays.models import SeedTray, SeedTrayCell
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
@@ -250,7 +250,7 @@ class ApplicationDraftSerializer(CurrentWorkspaceSerializerMixin, ActionSerializ
 
     applied_at = serializers.DateTimeField()
     source_location = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
     )
     batch = serializers.PrimaryKeyRelatedField(
         queryset=ProductionBatch.objects.all(),

--- a/applications/test_ledger_link.py
+++ b/applications/test_ledger_link.py
@@ -19,7 +19,7 @@ from inventory.models import InventoryItem, StockMovement
 from inventory.units import UnitCode
 from tests.factories import (
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_stock_lot,
 )
 
@@ -31,7 +31,7 @@ class ApplicationMovementOwnershipTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.location = make_inventory_location()
+        self.location = make_location()
         self.item = make_inventory_item()
         self.lot = make_stock_lot(item=self.item, location=self.location, quantity='50')
         self.application = InputApplication.objects.create(

--- a/applications/test_rest.py
+++ b/applications/test_rest.py
@@ -12,7 +12,7 @@ from inventory.units import UnitCode
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_seed_tray,
     make_seed_tray_cell,
     make_seed_tray_generation,
@@ -32,7 +32,7 @@ class ApplicationRESTTestCase(RESTContractTestCase):
 
     def setUp(self):
         super().setUp()
-        self.location = make_inventory_location()
+        self.location = make_location()
         self.media = make_inventory_item(
             base_unit=UnitCode.LITRE,
             default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,
@@ -323,7 +323,7 @@ class ApplicationIsolationTests(ApplicationRESTTestCase):
         """A document cannot consume stock it does not own."""
         other = Workspace.objects.create(name='Other workspace')
         item = make_inventory_item(workspace=other)
-        location = make_inventory_location(workspace=other)
+        location = make_location(workspace=other)
         lot = make_stock_lot(item=item, location=location)
 
         response = self.client.post(
@@ -339,7 +339,7 @@ class ApplicationIsolationTests(ApplicationRESTTestCase):
         InputApplication.objects.create(
             workspace=other,
             applied_at=timezone.now(),
-            source_location=make_inventory_location(workspace=other),
+            source_location=make_location(workspace=other),
         )
         self.create_draft()
 

--- a/applications/test_services.py
+++ b/applications/test_services.py
@@ -21,7 +21,7 @@ from tests.factories import (
     make_garden_geometry_confirmation,
     make_garden_square,
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_production_batch,
     make_seed_tray,
     make_seed_tray_cell,
@@ -55,7 +55,7 @@ class ApplicationServiceTestCase(TestCase):
         """Stock one media lot and open a batch every case draws on."""
         super().setUp()
         self.workspace = Workspace.objects.get(pk=1)
-        self.location = make_inventory_location()
+        self.location = make_location()
         self.media = make_inventory_item(
             base_unit=UnitCode.LITRE,
             default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,

--- a/applications/tests.py
+++ b/applications/tests.py
@@ -15,7 +15,7 @@ from inventory.units import UnitCode
 from tests.factories import (
     make_garden_square,
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_production_batch,
     make_seed_tray,
     make_seed_tray_cell,
@@ -45,7 +45,7 @@ class ApplicationFixtureTestCase(TestCase):
     def setUp(self):
         """Stock one lot at one location for every case to draw on."""
         super().setUp()
-        self.location = make_inventory_location()
+        self.location = make_location()
         self.item = make_inventory_item()
         self.lot = make_stock_lot(item=self.item, location=self.location, quantity='50')
 
@@ -80,7 +80,7 @@ class ApplicationFixtureTestCase(TestCase):
         direction a cross-workspace mistake actually arrives from.
         """
         other = Workspace.objects.create(name=_next_workspace_name())
-        location = make_inventory_location(workspace=other)
+        location = make_location(workspace=other)
         item = make_inventory_item(workspace=other)
         lot = make_stock_lot(item=item, location=location)
         application = InputApplication.objects.create(
@@ -147,7 +147,7 @@ class InputApplicationTests(ApplicationFixtureTestCase):
 
     def test_an_inactive_source_location_is_refused(self):
         """Stock cannot be drawn from a location that is out of service."""
-        retired = make_inventory_location(active=False)
+        retired = make_location(active=False)
         with self.assertRaises(ValidationError) as caught:
             self.make_application(source_location=retired)
         self.assertIn('source_location', caught.exception.message_dict)
@@ -159,7 +159,7 @@ class InputApplicationTests(ApplicationFixtureTestCase):
             InputApplication.objects.create(
                 workspace=other,
                 applied_at=timezone.now(),
-                source_location=make_inventory_location(workspace=other),
+                source_location=make_location(workspace=other),
                 batch=make_production_batch(),
             )
         self.assertIn('batch', caught.exception.message_dict)

--- a/check-code.sh
+++ b/check-code.sh
@@ -9,6 +9,6 @@ pycodestyle --ignore=E501 */*.py
 # machine, so linting it would gate the build on an untracked file. When a new
 # app is added, add it here — applications/ was missed and went unlinted from
 # the day it landed until the seed-tray generation work noticed.
-pylint applications/ costing/ frontend/ garden/ inventory/ plantings/ plants/ seeds/ seedtrays/ supplies/ tests/ workspaces/
+pylint applications/ costing/ frontend/ garden/ inventory/ locations/ plantings/ plants/ seeds/ seedtrays/ supplies/ tests/ workspaces/
 
 deactivate

--- a/costing/test_concurrency.py
+++ b/costing/test_concurrency.py
@@ -35,7 +35,7 @@ from plantings.lifecycle import (
 from plantings.models import ProductionBatch, SowingStockPosting, SpecificPlant
 from tests.factories import (
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_specific_plant,
     make_specific_plant_location,
     make_stock_lot,
@@ -72,7 +72,7 @@ class CostingConcurrencyTestCase(TransactionTestCase):
         record_germination_event(plant, self.user)
         make_specific_plant_location(specific_plant=plant)
         sowing = plant.cell_planting.seed_tray_planting
-        location = make_inventory_location(workspace=sowing.workspace)
+        location = make_location(workspace=sowing.workspace)
         lot = make_stock_lot(
             item=make_inventory_item(
                 workspace=sowing.workspace,

--- a/costing/test_services.py
+++ b/costing/test_services.py
@@ -38,7 +38,7 @@ from seeds.models import SeedPacket
 from tests.factories import (
     make_batch_for_packet,
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_plant_variety,
     make_seed_tray,
     make_seed_tray_cell,
@@ -74,7 +74,7 @@ class CostingServiceTestCase(APITestCase):  # pylint: disable=too-many-instance-
         self.user = get_user_model().objects.create_user(username='costing')
         self.client.force_authenticate(self.user)
         self.workspace = Workspace.objects.get(pk=1)
-        self.location = make_inventory_location()
+        self.location = make_location()
         model = make_seed_tray_model(
             cell_size_ml=self.CELL_SIZE_ML,
             x_cells=self.CELL_COUNT,

--- a/frontend/js/api/inventory.ts
+++ b/frontend/js/api/inventory.ts
@@ -3,7 +3,6 @@ import {
   InventoryItem,
   InventoryItemCreate,
   InventoryItemFilters,
-  InventoryLocation,
   InventoryUnit,
   ItemUnitConversion,
   ItemUnitConversionCreate,
@@ -23,10 +22,6 @@ function getInventoryBalances(item: number, signal?: AbortSignal): Promise<Array
 
 function getInventoryUnits(signal?: AbortSignal): Promise<Array<InventoryUnit>> {
   return fetchAsJson<Array<InventoryUnit>>('/inventory/units/', signal)
-}
-
-function getInventoryLocations(signal?: AbortSignal): Promise<Array<InventoryLocation>> {
-  return fetchAsJson<Array<InventoryLocation>>('/inventory/locations/?active=true', signal)
 }
 
 function getInventoryItems(filters: InventoryItemFilters, signal?: AbortSignal): Promise<Array<InventoryItem>> {
@@ -106,7 +101,6 @@ export {
   deleteStockReceipt,
   getInventoryBalances,
   getInventoryItems,
-  getInventoryLocations,
   getInventoryUnits,
   getItemUnitConversions,
   getStockReceipts,

--- a/frontend/js/api/locations.ts
+++ b/frontend/js/api/locations.ts
@@ -1,0 +1,12 @@
+import { Location } from '../types/locations'
+import { fetchAsJson } from '../utils'
+
+const LOCATIONS_URL = '/locations/'
+
+// Pickers only ever offer places a workflow can still use, so the default asks
+// for active ones. The catalog screen passes active=false to review retirements.
+function getLocations(signal?: AbortSignal, active: boolean = true): Promise<Array<Location>> {
+  return fetchAsJson<Array<Location>>(`${LOCATIONS_URL}?active=${String(active)}`, signal)
+}
+
+export { getLocations }

--- a/frontend/js/inventory/receipt_editor.tsx
+++ b/frontend/js/inventory/receipt_editor.tsx
@@ -4,7 +4,8 @@ import { Alert, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
 
 import { createStockReceipt, getItemUnitConversions, updateStockReceipt } from '../api/inventory'
 import { ApiError, formatMeasure, formatQuantity } from '../utils'
-import { InventoryItem, InventoryLocation, InventoryUnit, QuantityCertainty, StockReceipt, StockReceiptLine, StockReceiptLineWrite, UnitCode } from '../types/inventory'
+import { InventoryItem, InventoryUnit, QuantityCertainty, StockReceipt, StockReceiptLine, StockReceiptLineWrite, UnitCode } from '../types/inventory'
+import { Location } from '../types/locations'
 import { Supplier } from '../types/suppliers'
 import { queryKeys } from '../query'
 import { documentErrors, invalidateReceipts, lineFieldErrors, localErrorMessage } from './receipt_list'
@@ -96,7 +97,7 @@ function linePayload(line: ReceiptLineDraft): StockReceiptLineWrite {
   }
 }
 
-function receivableLocations(locations: Array<InventoryLocation>) {
+function receivableLocations(locations: Array<Location>) {
   // Seed packet containers are system-managed, and SYSTEM-TRAY-UNKNOWN exists
   // only so the tray migration had somewhere to put unplaced assets.
   return locations.filter((location) => location.location_type !== 'seed_packet' && location.code !== 'SYSTEM-TRAY-UNKNOWN')
@@ -110,7 +111,7 @@ interface LineRowProps {
   line: ReceiptLineDraft
   index: number
   items: Array<InventoryItem>
-  locations: Array<InventoryLocation>
+  locations: Array<Location>
   units: Array<InventoryUnit>
   errors: Record<string, string>
   removable: boolean
@@ -249,7 +250,7 @@ function LineRow({ line, index, items, locations, units, errors, removable, onCh
 interface ReceiptEditorProps {
   receipt?: StockReceipt
   items: Array<InventoryItem>
-  locations: Array<InventoryLocation>
+  locations: Array<Location>
   suppliers: Array<Supplier>
   units: Array<InventoryUnit>
   onClosed: () => void

--- a/frontend/js/inventory/receipt_list.tsx
+++ b/frontend/js/inventory/receipt_list.tsx
@@ -4,7 +4,8 @@ import { Alert, Badge, Button, Form, Table } from 'react-bootstrap'
 
 import { deleteStockReceipt, postStockReceipt, reverseStockReceipt } from '../api/inventory'
 import { formatMeasure } from '../utils'
-import { InventoryItem, InventoryLocation, StockReceipt, StockReceiptLine } from '../types/inventory'
+import { InventoryItem, StockReceipt, StockReceiptLine } from '../types/inventory'
+import { Location } from '../types/locations'
 import { Supplier } from '../types/suppliers'
 import { queryKeys } from '../query'
 
@@ -191,7 +192,7 @@ function LineQuantity({ line }: { line: StockReceiptLine }) {
 interface ReceiptLinesTableProps {
   receipt: StockReceipt
   items: Array<InventoryItem>
-  locations: Array<InventoryLocation>
+  locations: Array<Location>
 }
 
 function ReceiptLinesTable({ receipt, items, locations }: ReceiptLinesTableProps) {
@@ -231,7 +232,7 @@ function ReceiptLinesTable({ receipt, items, locations }: ReceiptLinesTableProps
 interface ReceiptTableProps {
   receipts: Array<StockReceipt>
   items: Array<InventoryItem>
-  locations: Array<InventoryLocation>
+  locations: Array<Location>
   suppliers: Array<Supplier>
   onEdit: (pk: number) => void
   onCancelled: (pk: number) => void

--- a/frontend/js/inventory/receipts.tsx
+++ b/frontend/js/inventory/receipts.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Button, Col, Form, Row } from 'react-bootstrap'
 
-import { getInventoryItems, getInventoryLocations, getInventoryUnits, getStockReceipts } from '../api/inventory'
+import { getInventoryItems, getInventoryUnits, getStockReceipts } from '../api/inventory'
+import { getLocations } from '../api/locations'
 import { getSuppliers } from '../api/supplies'
 import { queryKeys } from '../query'
 import { StockReceiptStatus } from '../types/inventory'
@@ -22,8 +23,8 @@ function InventoryReceiptsView() {
     queryFn: ({ signal }) => getInventoryItems({ active: true }, signal)
   })
   const { data: locations = [] } = useQuery({
-    queryKey: queryKeys.inventory.locations,
-    queryFn: ({ signal }) => getInventoryLocations(signal)
+    queryKey: queryKeys.locations.list(true),
+    queryFn: ({ signal }) => getLocations(signal)
   })
   const { data: suppliers = [] } = useQuery({
     queryKey: queryKeys.suppliers.all,

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -7,10 +7,13 @@ const queryKeys = {
     all: ['workspace'] as const,
     current: ['workspace', 'current'] as const
   },
+  locations: {
+    all: ['locations'] as const,
+    list: (active: boolean) => ['locations', 'list', active] as const
+  },
   inventory: {
     all: ['inventory'] as const,
     units: ['inventory', 'units'] as const,
-    locations: ['inventory', 'locations'] as const,
     items: (search: string, category: string, trackingMode: string, status: string) => ['inventory', 'items', search, category, trackingMode, status] as const,
     conversions: (itemPk: number) => ['inventory', 'conversions', itemPk] as const,
     receiptsAll: ['inventory', 'receipts'] as const,

--- a/frontend/js/seedtray/generation_clean.tsx
+++ b/frontend/js/seedtray/generation_clean.tsx
@@ -51,11 +51,11 @@ function initialDecisions(contents: SeedTrayGenerationContents): CleanDecisions 
   }
 }
 
-type InventoryLocationOption = { pk: number; name: string }
+type LocationOption = { pk: number; name: string }
 
 type GenerationCleanFormProps = {
   contents: SeedTrayGenerationContents
-  locations: Array<InventoryLocationOption>
+  locations: Array<LocationOption>
   busy: boolean
   onCancel: () => void
   onConfirm: (request: { reason: string; plants: Array<CleanPlantDisposition>; seeds: Array<CleanSeedDisposition>; media: Array<CleanMediaDisposition>; openNext: boolean }) => void

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -41,7 +41,7 @@ import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
 import { GardenSquare } from '../types/garden'
 import { getGardenSquares } from '../api/garden'
-import { getInventoryLocations } from '../api/inventory'
+import { getLocations } from '../api/locations'
 import { queryClient, queryKeys } from '../query'
 
 interface SeedTrayDetailsProps {
@@ -532,8 +532,8 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   })
   const selectedSeedTray = seedTraysQuery.data?.find((tray) => tray.pk === seedTrayPk)
   const inventoryLocationsQuery = useQuery({
-    queryKey: queryKeys.inventory.locations,
-    queryFn: ({ signal }) => getInventoryLocations(signal)
+    queryKey: queryKeys.locations.list(true),
+    queryFn: ({ signal }) => getLocations(signal)
   })
   const inventoryMovementsQuery = useQuery({
     queryKey: queryKeys.seedTrays.movements(selectedSeedTray?.inventory_unit ?? 0),

--- a/frontend/js/seedtrays.tsx
+++ b/frontend/js/seedtrays.tsx
@@ -6,11 +6,12 @@ import { Button, Form, Table } from 'react-bootstrap'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router'
 
-import { InventoryLocation, SerializedPhysicalState } from './types/inventory'
+import { SerializedPhysicalState } from './types/inventory'
+import { Location } from './types/locations'
 import { Supplier } from './types/suppliers'
 import { SeedTrayModel, SeedTrayModelCreate, SeedTrayReceiptCreate } from './types/seedtrays'
 import { getSeedTrayModels, getSeedTrays, addSeedTrayModel, receiveSeedTrays } from './api/seedtrays'
-import { getInventoryLocations } from './api/inventory'
+import { getLocations } from './api/locations'
 import { getSuppliers } from './api/supplies'
 import { formatDate } from './utils'
 import { queryKeys } from './query'
@@ -130,7 +131,7 @@ interface SeedTrayReceiveProps {
   done: () => void
   models: Array<SeedTrayModel>
   suppliers: Array<Supplier>
-  locations: Array<InventoryLocation>
+  locations: Array<Location>
   receiveTrays: (model: number, data: SeedTrayReceiptCreate) => Promise<void>
 }
 
@@ -252,8 +253,8 @@ function SeedTraysTable() {
     queryFn: ({ signal }) => getSuppliers(signal)
   })
   const { data: locations = [] } = useQuery({
-    queryKey: queryKeys.inventory.locations,
-    queryFn: ({ signal }) => getInventoryLocations(signal)
+    queryKey: queryKeys.locations.list(true),
+    queryFn: ({ signal }) => getLocations(signal)
   })
   const trayMutation = useMutation({
     mutationFn: ({ model, receipt }: { model: number; receipt: SeedTrayReceiptCreate }) => receiveSeedTrays(model, receipt),
@@ -264,7 +265,7 @@ function SeedTraysTable() {
     return models
   }, {})
 
-  const locationsMap = locations.reduce<Record<number, InventoryLocation>>((result, entry) => {
+  const locationsMap = locations.reduce<Record<number, Location>>((result, entry) => {
     result[entry.pk] = entry
     return result
   }, {})

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -14,17 +14,6 @@ interface InventoryUnit {
 
 type SerializedPhysicalState = 'available' | 'quarantined' | 'lost' | 'retired' | 'dispatched' | 'returned'
 
-interface InventoryLocation {
-  pk: number
-  name: string
-  code: string
-  location_type: 'receiving' | 'storage' | 'growing' | 'dispatch' | 'quarantine' | 'adjustment' | 'seed_packet'
-  active: boolean
-  notes: string
-  created: string
-  updated: string
-}
-
 interface SerializedInventoryUnit {
   pk: number
   item: number
@@ -221,7 +210,6 @@ export {
   InventoryItem,
   InventoryItemCreate,
   InventoryItemFilters,
-  InventoryLocation,
   InventoryTrackingMode,
   InventoryUnit,
   InventoryUsageBasis,

--- a/frontend/js/types/locations.ts
+++ b/frontend/js/types/locations.ts
@@ -1,0 +1,14 @@
+type LocationType = 'receiving' | 'storage' | 'growing' | 'dispatch' | 'quarantine' | 'adjustment' | 'seed_packet'
+
+interface Location {
+  pk: number
+  name: string
+  code: string
+  location_type: LocationType
+  active: boolean
+  notes: string
+  created: string
+  updated: string
+}
+
+export { Location, LocationType }

--- a/gp/settings.py
+++ b/gp/settings.py
@@ -42,6 +42,7 @@ if not SECRET_KEY:
 
 INSTALLED_APPS = [
     "workspaces",
+    "locations",
     "inventory",
     "plants",
     "seeds",

--- a/gp/urls.py
+++ b/gp/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("seeds/", include('seeds.urls')),
     path("plantings/", include('plantings.urls')),
     path("supplies/", include('supplies.urls')),
+    path("locations/", include('locations.urls')),
     path("inventory/", include('inventory.urls')),
     path("seedtrays/", include('seedtrays.urls')),
     path("applications/", include('applications.urls')),

--- a/inventory/balance_rest.py
+++ b/inventory/balance_rest.py
@@ -7,10 +7,11 @@ from typing import NamedTuple
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from locations.models import Location
 from workspaces.models import get_current_workspace
 
 from .ledger import MONEY_QUANTUM, physical_balance
-from .models import InventoryLocation, StockLot, StockMovement
+from .models import StockLot, StockMovement
 from .rest_query import parse_boolean, parse_date, parse_integer
 
 
@@ -89,7 +90,7 @@ class BalanceView(APIView):
                 location_ids[movement['lot_id']].add(movement['destination_id'])
         locations = {
             location.pk: location
-            for location in InventoryLocation.objects.filter(
+            for location in Location.objects.filter(
                 workspace=workspace,
                 pk__in={pk for values in location_ids.values() for pk in values},
             )

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -6,12 +6,13 @@ from decimal import Decimal, ROUND_HALF_UP
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
-from django.db.models import ProtectedError, Q
+from django.db.models import Q
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from locations.models import Location
 from workspaces.models import get_current_workspace
 from workspaces.scoping import (
     CurrentWorkspaceSerializerMixin,
@@ -32,7 +33,6 @@ from .ledger import (
 )
 from .models import (
     InventoryItem,
-    InventoryLocation,
     ItemUnitConversion,
     QuantityCertainty,
     StockLot,
@@ -64,38 +64,6 @@ def _run_domain_action(function, *args):
         return function(*args)
     except DjangoValidationError as exc:
         raise ValidationError(_model_errors(exc)) from exc
-
-
-class InventoryLocationSerializer(serializers.ModelSerializer):
-    """Serialize one current-workspace physical inventory location."""
-
-    class Meta:
-        model = InventoryLocation
-        fields = [
-            'pk',
-            'name',
-            'code',
-            'location_type',
-            'active',
-            'notes',
-            'created',
-            'updated',
-        ]
-        read_only_fields = ['created', 'updated']
-
-    def validate(self, attrs):
-        """Reserve packet-container locations for the seed workflow."""
-        if self.instance and self.instance.code == 'SYSTEM-TRAY-UNKNOWN':
-            raise ValidationError({
-                'location': 'The legacy tray location is system-managed.',
-            })
-        current_type = getattr(self.instance, 'location_type', None)
-        requested_type = attrs.get('location_type', current_type)
-        if requested_type == InventoryLocation.LocationType.SEED_PACKET:
-            raise ValidationError({
-                'location_type': 'Seed packet locations are system-managed.',
-            })
-        return attrs
 
 
 class StockReceiptLineSerializer(
@@ -544,12 +512,12 @@ class MovementActionSerializer(
         required=False,
     )
     source = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
         allow_null=True,
         required=False,
     )
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
         allow_null=True,
         required=False,
     )
@@ -588,7 +556,7 @@ class AdjustmentActionSerializer(MovementActionSerializer):  # pylint: disable=a
 
     direction = serializers.ChoiceField(choices=['gain', 'loss'])
     location = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
     )
     reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
     workspace_field_lookups = {
@@ -616,7 +584,7 @@ class OpeningBalanceActionSerializer(
         required=False,
     )
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
     )
     acquisition_total = serializers.DecimalField(
         max_digits=18,
@@ -656,44 +624,6 @@ class OpeningBalanceActionSerializer(
         except DjangoValidationError as exc:
             raise ValidationError(_model_errors(exc)) from exc
         return attrs
-
-
-class InventoryLocationViewSet(
-    CurrentWorkspaceViewSetMixin,
-    viewsets.ModelViewSet,
-):  # pylint: disable=too-many-ancestors
-    """Configure active physical locations without deleting used history."""
-
-    queryset = InventoryLocation.objects.all()
-    serializer_class = InventoryLocationSerializer
-    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        active = _parse_boolean(self.request.query_params.get('active'), 'active')
-        if active is not None:
-            queryset = queryset.filter(active=active)
-        location_type = self.request.query_params.get('location_type')
-        if location_type:
-            if location_type not in InventoryLocation.LocationType.values:
-                raise ValidationError(
-                    {'location_type': 'Select a valid location type.'},
-                )
-            queryset = queryset.filter(location_type=location_type)
-        return queryset
-
-    def perform_destroy(self, instance):
-        seed_packet = instance.location_type == InventoryLocation.LocationType.SEED_PACKET
-        if seed_packet or instance.code == 'SYSTEM-TRAY-UNKNOWN':
-            raise ValidationError({
-                'location': 'This inventory location is system-managed.',
-            })
-        try:
-            instance.delete()
-        except ProtectedError as exc:
-            raise ValidationError(
-                {'location': 'Used locations must be deactivated, not deleted.'},
-            ) from exc
 
 
 class StockReceiptViewSet(
@@ -1058,7 +988,6 @@ def register_ledger_routes(router):
     """Attach ledger viewsets to the inventory API router."""
     from .serialized_rest import InventoryUnitViewSet  # pylint: disable=import-outside-toplevel
 
-    router.register(r'locations', InventoryLocationViewSet)
     router.register(r'receipts', StockReceiptViewSet)
     router.register(r'lots', StockLotViewSet)
     router.register(r'serialized-units', InventoryUnitViewSet)

--- a/inventory/migrations/0007_point_stock_at_the_locations_app.py
+++ b/inventory/migrations/0007_point_stock_at_the_locations_app.py
@@ -1,0 +1,83 @@
+"""Hand the location model over to the locations app.
+
+Every foreign key here already points at the same table; only the app label
+Django records for it changes. That makes the whole migration state-only, so no
+constraint is dropped and rebuilt on a live database.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Repoint stock's location keys and give up ownership of the model."""
+
+    dependencies = [
+        ("inventory", "0006_stockreceipt_price_includes_tax"),
+        ("locations", "0001_adopt_inventory_location"),
+        ("seeds", "0007_point_packets_at_the_locations_app"),
+        ("applications", "0003_point_applications_at_the_locations_app"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="stockreceiptline",
+                    name="destination",
+                    field=models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="receipt_lines",
+                        to="locations.location",
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="inventoryunit",
+                    name="current_location",
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="serialized_units",
+                        to="locations.location",
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="stocktakeline",
+                    name="location",
+                    field=models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="stocktake_lines",
+                        to="locations.location",
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="stockmovement",
+                    name="source",
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="outgoing_stock_movements",
+                        to="locations.location",
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="stockmovement",
+                    name="destination",
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="incoming_stock_movements",
+                        to="locations.location",
+                    ),
+                ),
+                migrations.RemoveConstraint(
+                    model_name="inventorylocation",
+                    name="inventory_location_workspace_code_unique",
+                ),
+                migrations.DeleteModel(name="InventoryLocation"),
+            ],
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -11,6 +11,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator, RegexVa
 from django.db import models
 from django.utils import timezone
 
+from locations.models import Location
 from workspaces.models import WorkspaceOwnedModel
 
 from .ledger_validation import movement_validation_errors
@@ -385,45 +386,6 @@ class ItemUnitConversion(WorkspaceOwnedModel):
         )
 
 
-class InventoryLocation(WorkspaceOwnedModel):
-    """A physical or operational place that can hold stock."""
-
-    class LocationType(models.TextChoices):
-        """Controlled location roles used by stock workflows."""
-
-        RECEIVING = 'receiving', 'Receiving'
-        STORAGE = 'storage', 'Storage'
-        GROWING = 'growing', 'Nursery or growing area'
-        DISPATCH = 'dispatch', 'Customer dispatch'
-        QUARANTINE = 'quarantine', 'Quarantine'
-        ADJUSTMENT = 'adjustment', 'Adjustment'
-        SEED_PACKET = 'seed_packet', 'Seed packet'
-
-    name = models.CharField(max_length=255)
-    code = models.CharField(max_length=64)
-    location_type = models.CharField(max_length=16, choices=LocationType.choices)
-    active = models.BooleanField(default=True)
-    notes = models.TextField(blank=True, default='')
-    created = models.DateTimeField(auto_now_add=True)
-    updated = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        ordering = ['name', 'pk']
-        constraints = [
-            models.UniqueConstraint(
-                fields=['workspace', 'code'],
-                name='inventory_location_workspace_code_unique',
-            ),
-        ]
-
-    def __str__(self):
-        return self.name
-
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        super().save(*args, **kwargs)
-
-
 class StockReceipt(WorkspaceOwnedModel):
     """A supplier document whose lines create exact stock lots when posted."""
 
@@ -569,7 +531,7 @@ class StockReceiptLine(models.Model):
         validators=[MinValueValidator(Decimal('0'))],
     )
     destination = models.ForeignKey(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         related_name='receipt_lines',
     )
@@ -789,7 +751,7 @@ class InventoryUnit(WorkspaceOwnedModel):
     )
     currency_code = models.CharField(max_length=3)
     current_location = models.ForeignKey(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -977,7 +939,7 @@ class StocktakeLine(models.Model):
         related_name='stocktake_lines',
     )
     location = models.ForeignKey(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         related_name='stocktake_lines',
     )
@@ -1116,14 +1078,14 @@ class StockMovement(WorkspaceOwnedModel):
         validators=[MinValueValidator(POSITIVE_DECIMAL)],
     )
     source = models.ForeignKey(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         null=True,
         blank=True,
         related_name='outgoing_stock_movements',
     )
     destination = models.ForeignKey(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         null=True,
         blank=True,

--- a/inventory/serialized_rest.py
+++ b/inventory/serialized_rest.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from locations.models import Location
 from workspaces.scoping import (
     CurrentWorkspaceSerializerMixin,
     CurrentWorkspaceViewSetMixin,
@@ -23,7 +24,7 @@ from .ledger import (
     unit_is_in_use,
     unit_physical_state,
 )
-from .models import InventoryLocation, InventoryUnit, StockLot, StockMovement
+from .models import InventoryUnit, StockLot, StockMovement
 from .rest_query import parse_boolean, parse_integer
 
 
@@ -145,7 +146,7 @@ class UnitMovementActionSerializer(
     """Validate a destination and audit metadata for one unit action."""
 
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
         allow_null=True,
         required=False,
     )
@@ -167,7 +168,7 @@ class UnitReconciliationActionSerializer(
         min_value=Decimal('0'),
     )
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
     )
     occurred_at = serializers.DateTimeField(required=False)
     reason = serializers.CharField(allow_blank=False, trim_whitespace=True)

--- a/inventory/test_ledger.py
+++ b/inventory/test_ledger.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
+from locations.models import Location
 from supplies.models import Supplier
 from workspaces.models import get_current_workspace
 
@@ -25,7 +26,6 @@ from .ledger import (
 )
 from .models import (
     InventoryItem,
-    InventoryLocation,
     QuantityCertainty,
     StockLot,
     StockMovement,
@@ -57,17 +57,17 @@ class LedgerServiceTests(TestCase):
             category=InventoryItem.Category.GROWING_MEDIA,
             base_unit=UnitCode.MILLILITRE,
         )
-        self.store = InventoryLocation.objects.create(
+        self.store = Location.objects.create(
             workspace=self.workspace,
             name='Store',
             code='STORE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
-        self.growing = InventoryLocation.objects.create(
+        self.growing = Location.objects.create(
             workspace=self.workspace,
             name='Propagation house',
             code='PROP',
-            location_type=InventoryLocation.LocationType.GROWING,
+            location_type=Location.LocationType.GROWING,
         )
 
     def make_receipt(self, **overrides):
@@ -159,11 +159,11 @@ class LedgerServiceTests(TestCase):
         """An invalid later line prevents every lot and movement from posting."""
         receipt = self.make_receipt()
         self.add_receipt_line(receipt)
-        inactive = InventoryLocation.objects.create(
+        inactive = Location.objects.create(
             workspace=self.workspace,
             name='Closed store',
             code='CLOSED',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
             active=False,
         )
         self.add_receipt_line(receipt, destination=inactive)
@@ -344,11 +344,11 @@ class UnknownQuantityReversalTests(TestCase):
             category=InventoryItem.Category.SEED,
             base_unit=UnitCode.SEED,
         )
-        self.container = InventoryLocation.objects.create(
+        self.container = Location.objects.create(
             workspace=self.workspace,
             name='Seed packet',
             code='PACKET-UNKNOWN',
-            location_type=InventoryLocation.LocationType.SEED_PACKET,
+            location_type=Location.LocationType.SEED_PACKET,
         )
         self.lot = StockLot.objects.create(
             workspace=self.workspace,

--- a/inventory/test_ledger_concurrency.py
+++ b/inventory/test_ledger_concurrency.py
@@ -11,6 +11,7 @@ from django.db import close_old_connections
 from django.test import TransactionTestCase, skipUnlessDBFeature
 from django.utils import timezone
 
+from locations.models import Location
 from workspaces.models import Workspace, get_current_workspace
 
 from .ledger import (
@@ -21,7 +22,7 @@ from .ledger import (
     post_stock_movement,
     post_unit_movement,
 )
-from .models import InventoryItem, InventoryLocation, InventoryUnit, StockLot, StockMovement
+from .models import InventoryItem, Location, InventoryUnit, StockLot, StockMovement
 from .units import UnitCode
 
 
@@ -52,11 +53,11 @@ class ConcurrentLedgerTests(TransactionTestCase):
             category=InventoryItem.Category.PACKAGING,
             base_unit=UnitCode.EACH,
         )
-        location = InventoryLocation.objects.create(
+        location = Location.objects.create(
             workspace=workspace,
             name='Concurrency store',
             code='CONCURRENT',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
         lot, _movement = post_opening_balance(
             workspace,
@@ -78,7 +79,7 @@ class ConcurrentLedgerTests(TransactionTestCase):
         close_old_connections()
         workspace = get_current_workspace()
         lot = StockLot.objects.get(pk=self.lot_pk)
-        location = InventoryLocation.objects.get(pk=self.location_pk)
+        location = Location.objects.get(pk=self.location_pk)
         user = get_user_model().objects.get(pk=self.user.pk)
         try:
             post_stock_movement(
@@ -142,17 +143,17 @@ class ConcurrentSerializedUnitTests(TransactionTestCase):
             base_unit=UnitCode.EACH,
             tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
         )
-        source = InventoryLocation.objects.create(
+        source = Location.objects.create(
             workspace=workspace,
             name='Unit source',
             code='UNIT-SOURCE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
-        destination = InventoryLocation.objects.create(
+        destination = Location.objects.create(
             workspace=workspace,
             name='Unit destination',
             code='UNIT-DESTINATION',
-            location_type=InventoryLocation.LocationType.GROWING,
+            location_type=Location.LocationType.GROWING,
         )
         lot = StockLot.objects.create(
             workspace=workspace,
@@ -189,7 +190,7 @@ class ConcurrentSerializedUnitTests(TransactionTestCase):
         close_old_connections()
         workspace = get_current_workspace()
         unit = InventoryUnit.objects.get(pk=self.unit_pk)
-        destination = InventoryLocation.objects.get(pk=self.destination_pk)
+        destination = Location.objects.get(pk=self.destination_pk)
         user = get_user_model().objects.get(pk=self.user.pk)
         try:
             post_unit_movement(

--- a/inventory/test_ledger_models.py
+++ b/inventory/test_ledger_models.py
@@ -9,12 +9,12 @@ from django.db import IntegrityError, transaction
 from django.test import TestCase
 from django.utils import timezone
 
+from locations.models import Location
 from supplies.models import Supplier
 from workspaces.models import Workspace, get_current_workspace
 
 from .models import (
     InventoryItem,
-    InventoryLocation,
     InventoryUnit,
     QuantityCertainty,
     StockLot,
@@ -46,11 +46,11 @@ class LedgerModelTests(TestCase):
             base_unit=UnitCode.MILLILITRE,
             reorder_level=Decimal('1000'),
         )
-        self.location = InventoryLocation.objects.create(
+        self.location = Location.objects.create(
             workspace=self.workspace,
             name='Main store',
             code='STORE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
 
     def make_opening_lot(self, **overrides):
@@ -71,11 +71,11 @@ class LedgerModelTests(TestCase):
     def test_location_code_and_lot_identifier_are_workspace_scoped(self):
         """Operational identifiers can repeat only across workspace boundaries."""
         with self.assertRaises(ValidationError):
-            InventoryLocation.objects.create(
+            Location.objects.create(
                 workspace=self.workspace,
                 name='Duplicate store',
                 code='STORE',
-                location_type=InventoryLocation.LocationType.STORAGE,
+                location_type=Location.LocationType.STORAGE,
             )
 
         first = self.make_opening_lot(identifier='KNOWN-LOT')
@@ -129,11 +129,11 @@ class LedgerModelTests(TestCase):
         self.assertIn('base_quantity', context.exception.message_dict)
 
         other = Workspace.objects.create(name='Foreign receipt workspace')
-        foreign_location = InventoryLocation.objects.create(
+        foreign_location = Location.objects.create(
             workspace=other,
             name='Foreign store',
             code='STORE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
         line.base_quantity = Decimal('2000')
         line.destination = foreign_location
@@ -374,11 +374,11 @@ class LedgerModelTests(TestCase):
         self.assertEqual(line.normalized_quantity(), Decimal('0'))
 
         other = Workspace.objects.create(name='Foreign count workspace')
-        foreign_location = InventoryLocation.objects.create(
+        foreign_location = Location.objects.create(
             workspace=other,
             name='Foreign count store',
             code='COUNT',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
         line.location = foreign_location
         with self.assertRaises(ValidationError) as context:

--- a/inventory/test_ledger_rest.py
+++ b/inventory/test_ledger_rest.py
@@ -6,12 +6,12 @@ from decimal import Decimal
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
+from locations.models import Location
 from supplies.models import Supplier
 from workspaces.models import Workspace, get_current_workspace
 
 from .models import (
     InventoryItem,
-    InventoryLocation,
     ItemUnitConversion,
     StockLot,
     StockMovement,
@@ -25,7 +25,6 @@ from .units import UnitCode
 class LedgerRestFixture(APITestCase):
     """Shared ledger fixture: one workspace, supplier, item, and two places."""
 
-    location_url = '/inventory/locations/'
     receipt_url = '/inventory/receipts/'
     lot_url = '/inventory/lots/'
     balance_url = '/inventory/balances/'
@@ -54,17 +53,17 @@ class LedgerRestFixture(APITestCase):
             base_unit=UnitCode.MILLILITRE,
             reorder_level=Decimal('250'),
         )
-        self.store = InventoryLocation.objects.create(
+        self.store = Location.objects.create(
             workspace=self.workspace,
             name='API store',
             code='API-STORE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
-        self.growing = InventoryLocation.objects.create(
+        self.growing = Location.objects.create(
             workspace=self.workspace,
             name='API growing house',
             code='API-GROW',
-            location_type=InventoryLocation.LocationType.GROWING,
+            location_type=Location.LocationType.GROWING,
         )
 
     def receipt_payload(self, **overrides):
@@ -138,7 +137,6 @@ class LedgerRestTests(LedgerRestFixture):
         """No ledger or balance data is anonymously readable."""
         self.client.force_authenticate(user=None)
         for url in (
-            self.location_url,
             self.receipt_url,
             self.lot_url,
             self.balance_url,
@@ -147,40 +145,6 @@ class LedgerRestTests(LedgerRestFixture):
         ):
             with self.subTest(url=url):
                 self.assertEqual(self.client.get(url).status_code, 403)
-
-    def test_locations_are_filterable_and_used_locations_cannot_be_deleted(self):
-        """Unused places may be removed while ledger places require deactivation."""
-        created = self.client.post(
-            self.location_url,
-            {
-                'name': 'Temporary receiving',
-                'code': 'TEMP-RECV',
-                'location_type': InventoryLocation.LocationType.RECEIVING,
-            },
-            format='json',
-        )
-        self.assertEqual(created.status_code, 201, created.data)
-        self.assertEqual(
-            self.client.delete(
-                f"{self.location_url}{created.data['pk']}/",
-            ).status_code,
-            204,
-        )
-
-        opening = self.create_opening()
-        response = self.client.delete(f'{self.location_url}{self.store.pk}/')
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('location', response.data)
-        self.assertEqual(opening['movement']['destination'], self.store.pk)
-
-        filtered = self.client.get(
-            self.location_url,
-            {'active': 'true', 'location_type': 'growing'},
-        )
-        self.assertEqual(
-            [location['pk'] for location in filtered.data],
-            [self.growing.pk],
-        )
 
     def test_nested_receipt_normalizes_posts_and_reverses(self):
         """Receipt actions preserve display data, provenance, and inverse history."""

--- a/inventory/test_serialized.py
+++ b/inventory/test_serialized.py
@@ -9,13 +9,13 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
+from locations.models import Location
 from supplies.models import Supplier
 from workspaces.models import get_current_workspace
 
 from .ledger import unit_physical_state
 from .models import (
     InventoryItem,
-    InventoryLocation,
     InventoryUnit,
     InventoryUnitReconciliation,
     StockLot,
@@ -45,17 +45,17 @@ class SerializedInventoryTests(TestCase):
             base_unit=UnitCode.EACH,
             tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
         )
-        self.store = InventoryLocation.objects.create(
+        self.store = Location.objects.create(
             workspace=self.workspace,
             name='Tray store',
             code='TRAY-STORE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
-        self.growing = InventoryLocation.objects.create(
+        self.growing = Location.objects.create(
             workspace=self.workspace,
             name='Propagation house',
             code='PROP-HOUSE',
-            location_type=InventoryLocation.LocationType.GROWING,
+            location_type=Location.LocationType.GROWING,
         )
 
     def create_receipt(self, quantity='3', cost='10.0000'):
@@ -192,11 +192,11 @@ class SerializedInventoryTests(TestCase):
 
     def test_legacy_opening_reconciliation_sets_cost_and_location_once(self):
         """Unknown opening facts become audited without rewriting the opening."""
-        unknown = InventoryLocation.objects.create(
+        unknown = Location.objects.create(
             workspace=self.workspace,
             name='Unknown tray location',
             code='SYSTEM-TRAY-UNKNOWN',
-            location_type=InventoryLocation.LocationType.ADJUSTMENT,
+            location_type=Location.LocationType.ADJUSTMENT,
         )
         lot = StockLot.objects.create(
             workspace=self.workspace,

--- a/locations/apps.py
+++ b/locations/apps.py
@@ -1,0 +1,10 @@
+"""Application configuration for the shared physical location catalog."""
+
+from django.apps import AppConfig
+
+
+class LocationsConfig(AppConfig):
+    """Configure the catalog of places a workspace physically uses."""
+
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'locations'

--- a/locations/migrations/0001_adopt_inventory_location.py
+++ b/locations/migrations/0001_adopt_inventory_location.py
@@ -1,0 +1,86 @@
+"""Adopt the existing location table into the locations app.
+
+The model moves out of `inventory` because stock is not the only thing that
+stands somewhere: trays and individual plants use the same physical places.
+Nothing about the table changes here, so the whole migration is state-only —
+`db_table` still names the inventory table and the unique constraint keeps its
+original name. `0002` renames the table once every app agrees who owns it.
+"""
+
+import django.db.models.deletion
+import workspaces.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Take ownership of the location model without touching the database."""
+
+    initial = True
+
+    dependencies = [
+        ("workspaces", "0002_workspace_override_tolerance_floor_and_more"),
+        ("inventory", "0006_stockreceipt_price_includes_tax"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="Location",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        ("name", models.CharField(max_length=255)),
+                        ("code", models.CharField(max_length=64)),
+                        (
+                            "location_type",
+                            models.CharField(
+                                choices=[
+                                    ("receiving", "Receiving"),
+                                    ("storage", "Storage"),
+                                    ("growing", "Nursery or growing area"),
+                                    ("dispatch", "Customer dispatch"),
+                                    ("quarantine", "Quarantine"),
+                                    ("adjustment", "Adjustment"),
+                                    ("seed_packet", "Seed packet"),
+                                ],
+                                max_length=16,
+                            ),
+                        ),
+                        ("active", models.BooleanField(default=True)),
+                        ("notes", models.TextField(blank=True, default="")),
+                        ("created", models.DateTimeField(auto_now_add=True)),
+                        ("updated", models.DateTimeField(auto_now=True)),
+                        (
+                            "workspace",
+                            models.ForeignKey(
+                                default=workspaces.models.get_default_workspace_id,
+                                editable=False,
+                                on_delete=django.db.models.deletion.PROTECT,
+                                related_name="+",
+                                to="workspaces.workspace",
+                            ),
+                        ),
+                    ],
+                    options={
+                        "ordering": ["name", "pk"],
+                        "db_table": "inventory_inventorylocation",
+                    },
+                ),
+                migrations.AddConstraint(
+                    model_name="location",
+                    constraint=models.UniqueConstraint(
+                        fields=("workspace", "code"),
+                        name="inventory_location_workspace_code_unique",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/locations/migrations/0002_rename_location_table.py
+++ b/locations/migrations/0002_rename_location_table.py
@@ -1,0 +1,23 @@
+"""Rename the location table to match the app that now owns it.
+
+Deliberately separate from `0001`: that migration moved ownership without
+touching the database, so if this rename has to be rolled back on a live
+deployment the model move survives it.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Move the table from inventory_inventorylocation to locations_location."""
+
+    dependencies = [
+        ("locations", "0001_adopt_inventory_location"),
+        ("inventory", "0007_point_stock_at_the_locations_app"),
+    ]
+
+    operations = [
+        # Passing no table name restores Django's default, which is exactly
+        # what the model declares, so `makemigrations --check` stays quiet.
+        migrations.AlterModelTable(name="location", table=None),
+    ]

--- a/locations/models.py
+++ b/locations/models.py
@@ -1,0 +1,57 @@
+"""The catalog of physical places a workspace uses.
+
+One record describes one physical place, whatever is standing in it. Stock,
+serialized assets such as seed trays, and individual plants all refer to the
+same row rather than each keeping a private idea of where things are, so a
+bench cannot exist twice under two names that drift apart.
+"""
+
+# The timestamp, ordering, and workspace-unique-code tail is shared with the
+# other workspace-owned catalogs; it is convention, not copied logic.
+# pylint: disable=duplicate-code
+
+from django.db import models
+
+from workspaces.models import WorkspaceOwnedModel
+
+
+class Location(WorkspaceOwnedModel):
+    """A physical or operational place that can hold stock."""
+
+    class LocationType(models.TextChoices):
+        """Controlled location roles used by stock workflows."""
+
+        RECEIVING = 'receiving', 'Receiving'
+        STORAGE = 'storage', 'Storage'
+        GROWING = 'growing', 'Nursery or growing area'
+        DISPATCH = 'dispatch', 'Customer dispatch'
+        QUARANTINE = 'quarantine', 'Quarantine'
+        ADJUSTMENT = 'adjustment', 'Adjustment'
+        SEED_PACKET = 'seed_packet', 'Seed packet'
+
+    name = models.CharField(max_length=255)
+    code = models.CharField(max_length=64)
+    location_type = models.CharField(max_length=16, choices=LocationType.choices)
+    active = models.BooleanField(default=True)
+    notes = models.TextField(blank=True, default='')
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ['name', 'pk']
+        constraints = [
+            # Named for the app this model used to live in. The constraint is
+            # the one already on the table, so keeping the name means moving
+            # the model rewrites no indexes on a live database.
+            models.UniqueConstraint(
+                fields=['workspace', 'code'],
+                name='inventory_location_workspace_code_unique',
+            ),
+        ]
+
+    def __str__(self):
+        return self.name
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)

--- a/locations/rest.py
+++ b/locations/rest.py
@@ -1,0 +1,98 @@
+"""REST resources for the shared physical location catalog."""
+
+from django.db.models import ProtectedError
+from rest_framework import routers, serializers, viewsets
+from rest_framework.exceptions import ValidationError
+
+from inventory.rest_query import parse_boolean
+from workspaces.scoping import CurrentWorkspaceViewSetMixin
+
+from .models import Location
+
+
+#: The migration-era holding location for trays whose real place is unknown.
+LEGACY_TRAY_CODE = 'SYSTEM-TRAY-UNKNOWN'
+
+
+def is_system_managed(location):
+    """Return whether a workflow rather than an operator owns this location."""
+    if location is None:
+        return False
+    seed_packet = location.location_type == Location.LocationType.SEED_PACKET
+    return seed_packet or location.code == LEGACY_TRAY_CODE
+
+
+class LocationSerializer(serializers.ModelSerializer):
+    """Serialize one current-workspace physical location."""
+
+    class Meta:
+        model = Location
+        fields = [
+            'pk',
+            'name',
+            'code',
+            'location_type',
+            'active',
+            'notes',
+            'created',
+            'updated',
+        ]
+        read_only_fields = ['created', 'updated']
+
+    def validate(self, attrs):
+        """Reserve packet-container locations for the seed workflow."""
+        if self.instance and self.instance.code == LEGACY_TRAY_CODE:
+            raise ValidationError({
+                'location': 'The legacy tray location is system-managed.',
+            })
+        current_type = getattr(self.instance, 'location_type', None)
+        requested_type = attrs.get('location_type', current_type)
+        if requested_type == Location.LocationType.SEED_PACKET:
+            raise ValidationError({
+                'location_type': 'Seed packet locations are system-managed.',
+            })
+        return attrs
+
+
+class LocationViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Configure active physical locations without deleting used history."""
+
+    queryset = Location.objects.all()
+    serializer_class = LocationSerializer
+    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        active = parse_boolean(self.request.query_params.get('active'), 'active')
+        if active is not None:
+            queryset = queryset.filter(active=active)
+        location_type = self.request.query_params.get('location_type')
+        if location_type:
+            if location_type not in Location.LocationType.values:
+                raise ValidationError(
+                    {'location_type': 'Select a valid location type.'},
+                )
+            queryset = queryset.filter(location_type=location_type)
+        return queryset
+
+    def perform_destroy(self, instance):
+        if is_system_managed(instance):
+            raise ValidationError({
+                'location': 'This location is system-managed.',
+            })
+        try:
+            instance.delete()
+        except ProtectedError as exc:
+            raise ValidationError(
+                {'location': 'Used locations must be deactivated, not deleted.'},
+            ) from exc
+
+
+# The app serves one resource mounted at its own prefix, so the viewset takes
+# the empty prefix and the router must not add an API-root view: that root sits
+# at the same path as the list route and would shadow it.
+router = routers.SimpleRouter()
+router.register(r'', LocationViewSet)

--- a/locations/tests.py
+++ b/locations/tests.py
@@ -1,0 +1,116 @@
+"""Contract tests for the shared physical location catalog."""
+
+from seeds.services import ensure_packet_inventory_identity
+from tests.api import RESTContractTestCase
+from tests.factories import make_location, make_seed_packet, make_stock_lot
+from workspaces.models import get_current_workspace
+
+from .models import Location
+
+
+class LocationRestTests(RESTContractTestCase):
+    """The catalog is workspace-scoped, filterable, and safe to retire."""
+
+    url = '/locations/'
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+
+    def test_authentication_is_required(self):
+        """The catalog names a workspace's real premises, so it is not public."""
+        self.assert_authentication_required([self.url])
+
+    def test_a_location_round_trips_through_the_api(self):
+        """An operator can name a place and read back what they named."""
+        self.assert_create_retrieve(
+            self.url,
+            {
+                'name': 'Temporary receiving',
+                'code': 'TEMP-RECV',
+                'location_type': Location.LocationType.RECEIVING,
+            },
+        )
+
+    def test_locations_filter_by_status_and_type(self):
+        """Pickers ask for the places a workflow can actually use."""
+        growing = make_location(
+            workspace=self.workspace,
+            location_type=Location.LocationType.GROWING,
+        )
+        make_location(
+            workspace=self.workspace,
+            location_type=Location.LocationType.STORAGE,
+        )
+        retired = make_location(
+            workspace=self.workspace,
+            location_type=Location.LocationType.GROWING,
+            active=False,
+        )
+
+        response = self.client.get(
+            self.url,
+            {'active': 'true', 'location_type': 'growing'},
+        )
+        self.assertEqual(response.status_code, 200)
+        returned = [location['pk'] for location in response.data]
+        self.assertEqual(returned, [growing.pk])
+        self.assertNotIn(retired.pk, returned)
+
+    def test_an_unused_location_is_deletable(self):
+        """A place that never held anything leaves no history worth keeping."""
+        location = make_location(workspace=self.workspace)
+        response = self.client.delete(f'{self.url}{location.pk}/')
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Location.objects.filter(pk=location.pk).exists())
+
+    def test_a_used_location_must_be_deactivated_rather_than_deleted(self):
+        """Deleting a place stock passed through would orphan the ledger."""
+        location = make_location(workspace=self.workspace)
+        make_stock_lot(workspace=self.workspace, location=location)
+
+        response = self.client.delete(f'{self.url}{location.pk}/')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('location', response.data)
+
+        deactivated = self.client.patch(
+            f'{self.url}{location.pk}/',
+            {'active': False},
+            format='json',
+        )
+        self.assertEqual(deactivated.status_code, 200, deactivated.data)
+        self.assertFalse(deactivated.data['active'])
+
+    def test_seed_packet_containers_stay_under_the_seed_workflow(self):
+        """A packet's container is created and retired with the packet itself."""
+        packet = make_seed_packet(workspace=self.workspace)
+        ensure_packet_inventory_identity(packet)
+        packet.refresh_from_db()
+        container = packet.storage_location
+        self.assertIsNotNone(container)
+
+        rejected = self.client.patch(
+            f'{self.url}{container.pk}/',
+            {'name': 'Renamed by hand'},
+            format='json',
+        )
+        self.assertEqual(rejected.status_code, 400)
+        self.assertIn('location_type', rejected.data)
+
+        deleted = self.client.delete(f'{self.url}{container.pk}/')
+        self.assertEqual(deleted.status_code, 400)
+        self.assertIn('location', deleted.data)
+
+    def test_a_new_location_cannot_claim_the_packet_type(self):
+        """Only the seed workflow may mint packet containers."""
+        response = self.client.post(
+            self.url,
+            {
+                'name': 'Hand-made packet',
+                'code': 'HAND-PACKET',
+                'location_type': Location.LocationType.SEED_PACKET,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('location_type', response.data)

--- a/locations/urls.py
+++ b/locations/urls.py
@@ -1,0 +1,10 @@
+"""URL routing for the shared physical location catalog."""
+
+from django.urls import include, path
+
+from .rest import router
+
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/plantings/test_sowing_inventory.py
+++ b/plantings/test_sowing_inventory.py
@@ -14,11 +14,11 @@ from rest_framework.test import APITestCase
 
 from inventory.ledger import OpeningBalanceRequest, post_opening_balance
 from inventory.models import (
-    InventoryLocation,
     QuantityCertainty,
     StockMovement,
 )
 from inventory.units import UnitCode
+from locations.models import Location
 from seeds.models import SeedPacket, Seeds
 from seeds.services import (
     create_seed_inventory_item,
@@ -283,11 +283,11 @@ class ConcurrentSowingInventoryTests(TransactionTestCase):
         item = create_seed_inventory_item(workspace, seeds, UnitCode.SEED)
         seeds.inventory_item = item
         seeds.save(update_fields=['inventory_item'])
-        location = InventoryLocation.objects.create(
+        location = Location.objects.create(
             workspace=workspace,
             name='Concurrent packet',
             code='CONCURRENT-SEED-PACKET',
-            location_type=InventoryLocation.LocationType.SEED_PACKET,
+            location_type=Location.LocationType.SEED_PACKET,
         )
         lot, _movement = post_opening_balance(
             workspace,

--- a/seeds/migrations/0007_point_packets_at_the_locations_app.py
+++ b/seeds/migrations/0007_point_packets_at_the_locations_app.py
@@ -1,0 +1,43 @@
+"""Point a packet's storage location at the locations app.
+
+State-only: the column and its constraint already reference the same table.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Record that a packet's container is a locations.Location."""
+
+    dependencies = [
+        ("seeds", "0006_map_legacy_packets_to_inventory"),
+        ("locations", "0001_adopt_inventory_location"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="seedpacket",
+                    name="storage_location",
+                    field=models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="seed_packet",
+                        to="locations.location",
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="seedpacketreceiptdraft",
+                    name="storage_location",
+                    field=models.OneToOneField(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="seed_packet_draft",
+                        to="locations.location",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/seeds/models.py
+++ b/seeds/models.py
@@ -9,7 +9,6 @@ from django.db import models
 
 from inventory.models import (
     InventoryItem,
-    InventoryLocation,
     QUANTITY_DECIMAL_PLACES,
     QUANTITY_MAX_DIGITS,
     QuantityCertainty,
@@ -17,6 +16,7 @@ from inventory.models import (
     StockMovement,
     StockReceipt,
 )
+from locations.models import Location
 from plants.models import PlantVariety
 from supplies.models import Supplier
 from workspaces.models import WorkspaceOwnedModel
@@ -56,7 +56,7 @@ class SeedPacket(WorkspaceOwnedModel):
         related_name='seed_packet',
     )
     storage_location = models.OneToOneField(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -85,7 +85,7 @@ class SeedPacketReceiptDraft(WorkspaceOwnedModel):
         related_name='seed_packet_draft',
     )
     storage_location = models.OneToOneField(
-        InventoryLocation,
+        Location,
         on_delete=models.PROTECT,
         related_name='seed_packet_draft',
     )

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -18,7 +18,6 @@ from inventory.ledger import (
 )
 from inventory.models import (
     InventoryItem,
-    InventoryLocation,
     QuantityCertainty,
     StockMovement,
     StockReceipt,
@@ -27,6 +26,7 @@ from inventory.models import (
 )
 from inventory.units import UnitCode
 
+from locations.models import Location
 from .models import (
     SeedPacket,
     SeedPacketQuantityReconciliation,
@@ -63,11 +63,11 @@ def set_seed_inventory_unit(seeds, base_unit):
 
 def _packet_location(workspace):
     token = uuid4().hex.upper()
-    return InventoryLocation.objects.create(
+    return Location.objects.create(
         workspace=workspace,
         name=f'Seed packet {token[:8]}',
         code=f'SEED-PACKET-{token}',
-        location_type=InventoryLocation.LocationType.SEED_PACKET,
+        location_type=Location.LocationType.SEED_PACKET,
         notes='System-managed seed packet container.',
     )
 

--- a/seedtrays/generation_rest.py
+++ b/seedtrays/generation_rest.py
@@ -19,8 +19,8 @@ from rest_framework.response import Response
 from rest_framework_nested import routers
 
 from inventory.ledger import quantize_quantity
-from inventory.models import InventoryLocation
 from inventory.rest_query import parse_integer
+from locations.models import Location
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
 from .generation_costs import generation_cost_breakdown
@@ -99,7 +99,7 @@ class SeedDispositionSerializer(CurrentWorkspaceSerializerMixin, ActionSerialize
     disposition = serializers.CharField()
     reason = serializers.CharField(required=False, allow_blank=True, default='')
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
         required=False,
         allow_null=True,
         default=None,
@@ -116,7 +116,7 @@ class MediaDispositionSerializer(CurrentWorkspaceSerializerMixin, ActionSerializ
     disposition = serializers.CharField()
     reason = serializers.CharField(required=False, allow_blank=True, default='')
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
         required=False,
         allow_null=True,
         default=None,

--- a/seedtrays/rest.py
+++ b/seedtrays/rest.py
@@ -16,12 +16,12 @@ from rest_framework_nested import routers
 from inventory.ledger import post_receipt, unit_is_in_use, unit_physical_state
 from inventory.models import (
     InventoryItem,
-    InventoryLocation,
     StockReceipt,
     StockReceiptLine,
 )
 from inventory.serialized_rest import InventoryUnitSerializer
 from inventory.units import UnitCode
+from locations.models import Location
 from supplies.models import Supplier
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
@@ -127,7 +127,7 @@ class SeedTrayReceiptSerializer(
         min_value=Decimal('0'),
     )
     destination = serializers.PrimaryKeyRelatedField(
-        queryset=InventoryLocation.objects.all(),
+        queryset=Location.objects.all(),
     )
     tax_rate = serializers.DecimalField(
         max_digits=7,

--- a/seedtrays/test_generation_models.py
+++ b/seedtrays/test_generation_models.py
@@ -20,7 +20,7 @@ from plantings.models import SeedTrayPlanting
 from seeds.services import ensure_packet_inventory_identity
 from tests.factories import (
     make_batch_for_packet,
-    make_inventory_location,
+    make_location,
     make_seed_packet,
     make_seed_tray,
     make_seed_tray_cell,
@@ -266,7 +266,7 @@ class SeedTrayGenerationResidualTests(TestCase):
                             lot=self.lot,
                             movement_type=StockMovement.MovementType.ADJUSTMENT_GAIN,
                             quantity=Decimal('1'),
-                            destination=make_inventory_location(),
+                            destination=make_location(),
                             occurred_at=timezone.now(),
                         ),
                     ),

--- a/seedtrays/test_generation_rest.py
+++ b/seedtrays/test_generation_rest.py
@@ -25,7 +25,7 @@ from tests.api import RESTContractTestCase
 from tests.factories import (
     make_batch_for_packet,
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_seed_packet,
     make_seed_tray,
     make_seed_tray_cell,
@@ -171,7 +171,7 @@ class GenerationCleanContractTests(GenerationRESTTestCase):
 
     def setUp(self):
         super().setUp()
-        self.location = make_inventory_location()
+        self.location = make_location()
         self.media_item = make_inventory_item(
             base_unit=UnitCode.LITRE,
             default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,

--- a/seedtrays/test_generations.py
+++ b/seedtrays/test_generations.py
@@ -29,7 +29,7 @@ from seeds.services import ensure_packet_inventory_identity
 from tests.factories import (
     make_batch_for_packet,
     make_inventory_item,
-    make_inventory_location,
+    make_location,
     make_seed_packet,
     make_seed_tray,
     make_seed_tray_cell,
@@ -185,7 +185,7 @@ class GenerationContentsTestCase(TestCase):  # pylint: disable=too-many-instance
         super().setUp()
         self.workspace = Workspace.objects.get(pk=1)
         self.user = get_user_model().objects.create_user('cleaner', password='x')
-        self.location = make_inventory_location()
+        self.location = make_location()
         self.media_item = make_inventory_item(
             base_unit=UnitCode.LITRE,
             default_usage_basis=InventoryItem.UsageBasis.CELL_VOLUME,

--- a/seedtrays/tests.py
+++ b/seedtrays/tests.py
@@ -7,7 +7,8 @@ import json
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from inventory.models import InventoryLocation, InventoryUnit, StockMovement
+from inventory.models import InventoryUnit, StockMovement
+from locations.models import Location
 from plantings.models import SeedTrayPlanting
 from tests.api import RESTContractTestCase
 from tests.factories import (
@@ -63,10 +64,10 @@ class SeedTrayRESTContractTests(RESTContractTestCase):
             },
         )
         supplier = make_supplier()
-        location = InventoryLocation.objects.create(
+        location = Location.objects.create(
             name='Receipt store',
             code='RECEIPT-STORE',
-            location_type=InventoryLocation.LocationType.STORAGE,
+            location_type=Location.LocationType.STORAGE,
         )
         response = self.client.post(
             f"/seedtrays/seedtraymodels/{tray_model['pk']}/receive/",
@@ -162,10 +163,10 @@ class SeedTrayCellIntegrityTests(TestCase):
         self.tray = make_seed_tray(model=self.tray_model)
         self.other_tray = make_seed_tray(model=self.other_model)
         self.supplier = make_supplier()
-        self.location = InventoryLocation.objects.create(
+        self.location = Location.objects.create(
             name='Tray receiving',
             code='TRAY-RECEIVING',
-            location_type=InventoryLocation.LocationType.RECEIVING,
+            location_type=Location.LocationType.RECEIVING,
         )
 
     def test_detail_view_requires_login(self):
@@ -258,10 +259,10 @@ class SeedTrayCellIntegrityTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('unit', response.data)
 
-        destination = InventoryLocation.objects.create(
+        destination = Location.objects.create(
             name='Growing bench',
             code='GROWING-BENCH',
-            location_type=InventoryLocation.LocationType.GROWING,
+            location_type=Location.LocationType.GROWING,
         )
         response = self.client.post(
             f'/inventory/serialized-units/{unit.pk}/transfer/',

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,12 +17,12 @@ from garden.models import (
 )
 from inventory.models import (
     InventoryItem,
-    InventoryLocation,
     InventoryUnit,
     StockLot,
     StockMovement,
 )
 from inventory.units import UnitCode
+from locations.models import Location
 from plantings.models import (
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
@@ -126,15 +126,15 @@ def make_seed_packet(**overrides):
     return SeedPacket.objects.create(**values)
 
 
-def make_inventory_location(**overrides):
-    """Create a stock location that can hold and issue inventory."""
+def make_location(**overrides):
+    """Create a physical location that can hold stock, trays, or plants."""
     values = {
         'name': _next_name('Location'),
         'code': _next_name('LOC').replace(' ', '-').upper(),
-        'location_type': InventoryLocation.LocationType.STORAGE,
+        'location_type': Location.LocationType.STORAGE,
     }
     values.update(overrides)
-    return InventoryLocation.objects.create(**values)
+    return Location.objects.create(**values)
 
 
 def make_inventory_item(**overrides):
@@ -172,7 +172,7 @@ def make_stock_lot(**overrides):
     values.setdefault('currency_code', workspace.currency_code)
     lot = StockLot.objects.create(**values)
     if location is None:
-        location = make_inventory_location(workspace=workspace)
+        location = make_location(workspace=workspace)
     StockMovement.objects.create(
         workspace=workspace,
         lot=lot,
@@ -278,12 +278,12 @@ def make_seed_tray(**overrides):
     values.update(overrides)
     tray_model = values['model']
     workspace = values.get('workspace', tray_model.workspace)
-    location, _created = InventoryLocation.objects.get_or_create(
+    location, _created = Location.objects.get_or_create(
         workspace=workspace,
         code='TEST-TRAY-STOCK',
         defaults={
             'name': 'Test tray stock',
-            'location_type': InventoryLocation.LocationType.STORAGE,
+            'location_type': Location.LocationType.STORAGE,
         },
     )
     lot = StockLot.objects.create(


### PR DESCRIPTION
Stock is not the only thing that stands somewhere. Seed trays already carry a location through their serialized unit, and individual plants are about to need one, so the model has outgrown the app it was named for.

Move InventoryLocation to a new locations app as Location. The move is state-only: db_table still names the inventory table, the workspace-unique constraint keeps its original name, and a separate migration performs the one real rename afterwards, so the ownership change survives on its own if the rename has to be rolled back.

The REST route moves with it, from /inventory/locations/ to /locations/, along with the tests that covered it. locations depends only on workspaces; inventory, seeds, seedtrays, applications, and plantings now depend on it, which is the direction the dependency should have run all along.

## Summary by Sourcery

Extract the shared physical location model and API into a dedicated locations app and retarget all inventory, seeds, seedtrays, applications, costing, and frontend code to depend on it.

New Features:
- Introduce a locations app exposing a workspace-scoped REST API for managing physical locations used by stock, trays, and plants.
- Add frontend types, API client, and query keys for the new locations endpoint and wire them into seed tray and inventory receipt UIs.

Enhancements:
- Refactor inventory, seeds, applications, seedtrays, plantings, costing, tests, and factories to reference the new shared Location model instead of the inventory-specific InventoryLocation.
- Update balance and serialized inventory APIs to resolve locations through the new app while preserving existing workspace and protection semantics.
- Document the locations service and app in the README and include the new app in linting and Django settings.

Build:
- Extend linting script to cover the new locations app.

Documentation:
- Describe the new /locations/ API and locations app in the README.

Tests:
- Add contract tests for the locations REST API, including filtering, deletion semantics, and seed-packet location protections.
- Adjust existing tests to use the new locations app and shared factory helpers for creating locations.