### PR TITLE
feat(locations): count occupancy and enforce capacity

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -820,6 +820,31 @@ def _latest_effective_unit_movement(unit):
     )
 
 
+def _check_unit_destination_capacity(unit, destination, reason):
+    """Refuse to put a tray somewhere that has no room left for it.
+
+    Only trays occupy growing space; any other serialized asset simply sits
+    where it is put. The plants riding in the tray count too, because a bench
+    measured in plants is just as full whether they arrived loose or in a tray.
+
+    An overrun is allowed when the caller gave a reason, which the movement
+    already records — that is the audited override, not a separate field.
+    """
+    from locations.occupancy import check_capacity, tray_contribution  # pylint: disable=import-outside-toplevel
+
+    try:
+        tray = unit.seed_tray
+    except ObjectDoesNotExist:
+        return
+    from plantings.models import SpecificPlantLocation  # pylint: disable=import-outside-toplevel
+
+    riding = SpecificPlantLocation.objects.filter(
+        seed_tray_cell__tray=tray,
+        ended__isnull=True,
+    ).count()
+    check_capacity(destination, tray_contribution(riding), reason)
+
+
 @transaction.atomic
 def post_unit_movement(workspace, user, request):  # pylint: disable=too-many-branches
     """Post one physical action against an exact locked serialized unit."""
@@ -872,6 +897,8 @@ def post_unit_movement(workspace, user, request):  # pylint: disable=too-many-br
         if not destination:
             raise ValidationError({'destination': 'A return destination is required.'})
         source = None
+    if destination is not None:
+        _check_unit_destination_capacity(unit, destination, request.reason)
     movement = _create_movement(MovementEntry(
         workspace=workspace,
         user=user,

--- a/locations/occupancy.py
+++ b/locations/occupancy.py
@@ -1,0 +1,157 @@
+"""What is standing in a location, and whether one more thing fits.
+
+Occupancy is measured in every dimension a location can express — trays,
+plants, containers — and only the one dimension a location declares as its
+capacity basis is compared against its limit. Unlike dimensions are never
+compared: a bench counted in trays says nothing about how many loose pots fit
+on it.
+
+This module reaches back into `plantings` and `seedtrays` from function bodies
+rather than at import time, so the `locations` app itself keeps depending only
+on `workspaces`. It is the same one-way-at-load pattern `inventory.ledger`
+already uses for `unit_is_in_use`, and the reason `.pylintrc` turns
+`cyclic-import` off.
+"""
+
+from typing import NamedTuple
+
+from django.core.exceptions import ValidationError
+
+from .models import Location
+
+
+class Occupancy(NamedTuple):
+    """What a location holds, counted in each dimension that can measure it."""
+
+    trays: int = 0
+    plants: int = 0
+    containers: int = 0
+
+    def of(self, basis):
+        """Return the count in the dimension a capacity basis measures."""
+        return getattr(self, basis, 0)
+
+    def __add__(self, other):
+        return Occupancy(
+            trays=self.trays + other.trays,
+            plants=self.plants + other.plants,
+            containers=self.containers + other.containers,
+        )
+
+    @property
+    def is_empty(self):
+        """Return whether nothing at all is standing here."""
+        return not (self.trays or self.plants or self.containers)
+
+
+#: What one placement adds to a location, per kind of thing being placed. A
+#: tray of seedlings really is that many plants on the bench, so it counts in
+#: both dimensions; it is not a container, and a loose pot is not a tray.
+def tray_contribution(plant_count):
+    """Return what placing one tray holding `plant_count` plants adds."""
+    return Occupancy(trays=1, plants=plant_count, containers=0)
+
+
+def plant_contribution():
+    """Return what standing one plant somewhere adds.
+
+    One directly placed plant counts as one container until task 54 records
+    real containers and a single pot can hold several plants.
+    """
+    return Occupancy(trays=0, plants=1, containers=1)
+
+
+def location_occupancy(location, subtree=False):
+    """Count what is standing in a location, optionally including its children."""
+    from plantings.models import SpecificPlantLocation  # pylint: disable=import-outside-toplevel
+    from seedtrays.models import SeedTray  # pylint: disable=import-outside-toplevel
+
+    if subtree:
+        lookup, value = 'in', list(location.subtree().values_list('pk', flat=True))
+    else:
+        lookup, value = 'exact', location.pk
+
+    trays = SeedTray.objects.filter(
+        **{f'inventory_unit__current_location__{lookup}': value},
+    )
+    tray_count = trays.count()
+    plants_in_trays = SpecificPlantLocation.objects.filter(
+        ended__isnull=True,
+        **{f'seed_tray_cell__tray__inventory_unit__current_location__{lookup}': value},
+    ).count()
+    standing_plants = SpecificPlantLocation.objects.filter(
+        ended__isnull=True,
+        **{f'location__{lookup}': value},
+    ).count()
+
+    return Occupancy(
+        trays=tray_count,
+        plants=plants_in_trays + standing_plants,
+        containers=standing_plants,
+    )
+
+
+def capacity_chain(location):
+    """Return the location and its ancestors that actually limit anything.
+
+    Ordered outermost first, which is also ascending primary-key order along a
+    path, so callers that lock these rows always take them in the same order
+    and two placements racing into the same greenhouse cannot deadlock.
+    """
+    chain_ids = location.ancestor_ids + [location.pk]
+    return list(
+        Location.objects
+        .filter(pk__in=chain_ids)
+        .exclude(capacity_basis=Location.CapacityBasis.NONE)
+        .order_by('pk'),
+    )
+
+
+def check_capacity(destination, contribution, override_reason='', lock=True):
+    """Reject a placement that does not fit, or that the basis cannot measure.
+
+    Every capacitated ancestor is checked, so a greenhouse capped at 200 trays
+    caps its benches' total rather than only what stands directly in its aisle.
+    An overrun is refused unless the caller supplies a reason, which its own
+    record then keeps.
+    """
+    chain = capacity_chain(destination)
+    if lock and chain:
+        chain = list(
+            Location.objects
+            .select_for_update()
+            .filter(pk__in=[limit.pk for limit in chain])
+            .order_by('pk'),
+        )
+
+    for limit in chain:
+        basis = limit.capacity_basis
+        if basis not in Location.ENFORCED_BASES:
+            # `area` is recorded for planning; nothing measures a footprint to
+            # compare against it yet, so it limits nothing.
+            continue
+        adding = contribution.of(basis)
+        if not adding:
+            raise ValidationError({
+                'destination': (
+                    f'{limit.name} is measured in {limit.get_capacity_basis_display().lower()}, '
+                    'which this does not occupy.'
+                ),
+            })
+        if override_reason:
+            continue
+        used = location_occupancy(limit, subtree=True).of(basis)
+        if used + adding > limit.capacity_value:
+            raise ValidationError({
+                'destination': (
+                    f'{limit.name} holds {limit.capacity_value:g} '
+                    f'{limit.get_capacity_basis_display().lower()} and already has {used}. '
+                    'Record a reason to place this anyway.'
+                ),
+            })
+
+
+def blocking_occupancy(location):
+    """Return what still stands in a location's subtree, or None when empty."""
+    occupancy = location_occupancy(location, subtree=True)
+    return None if occupancy.is_empty else occupancy

--- a/locations/rest.py
+++ b/locations/rest.py
@@ -2,7 +2,9 @@
 
 from django.db.models import ProtectedError
 from rest_framework import routers, serializers, viewsets
+from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
 
 from inventory.rest_query import parse_boolean
 from workspaces.scoping import (
@@ -11,6 +13,7 @@ from workspaces.scoping import (
 )
 
 from .models import Location, location_full_name
+from .occupancy import blocking_occupancy, location_occupancy
 
 
 #: The migration-era holding location for trays whose real place is unknown.
@@ -79,7 +82,7 @@ class LocationSerializer(
         return len(location.ancestor_ids)
 
     def validate(self, attrs):
-        """Reserve packet-container locations for the seed workflow."""
+        """Reserve packet locations, and keep an occupied place open."""
         if self.instance and self.instance.code == LEGACY_TRAY_CODE:
             raise ValidationError({
                 'location': 'The legacy tray location is system-managed.',
@@ -90,7 +93,29 @@ class LocationSerializer(
             raise ValidationError({
                 'location_type': 'Seed packet locations are system-managed.',
             })
+        if self.instance and attrs.get('active') is False and self.instance.active:
+            self._reject_occupied_retirement()
         return attrs
+
+    def _reject_occupied_retirement(self):
+        """Refuse to retire a place while anything is still standing in it.
+
+        Retiring an occupied bench would leave trays and plants recorded at a
+        location no picker offers any more, which is how stock goes missing on
+        paper while sitting in plain sight.
+        """
+        still_there = blocking_occupancy(self.instance)
+        if still_there is not None:
+            raise ValidationError({
+                'active': (
+                    f'{self.instance.name} still holds {still_there.trays} trays and '
+                    f'{still_there.plants} plants. Move them before retiring it.'
+                ),
+            })
+        if self.instance.descendants().filter(active=True).exists():
+            raise ValidationError({
+                'active': 'Retire the locations inside this one first.',
+            })
 
 
 class LocationViewSet(
@@ -116,6 +141,29 @@ class LocationViewSet(
                 )
             queryset = queryset.filter(location_type=location_type)
         return queryset
+
+    @action(detail=True)
+    def occupancy(self, request, pk=None):  # pylint: disable=unused-argument
+        """Report what stands here, and what remains of any capacity.
+
+        Both the location itself and its whole subtree are reported, because a
+        greenhouse's own aisle and everything on its benches are different
+        answers to "what is in here" and an operator needs each of them.
+        """
+        location = self.get_object()
+        here = location_occupancy(location)
+        below = location_occupancy(location, subtree=True)
+        remaining = None
+        if location.capacity_basis in Location.ENFORCED_BASES:
+            remaining = location.capacity_value - below.of(location.capacity_basis)
+        return Response({
+            'location': location.pk,
+            'capacity_basis': location.capacity_basis,
+            'capacity_value': location.capacity_value,
+            'here': here._asdict(),
+            'subtree': below._asdict(),
+            'remaining': remaining,
+        })
 
     def perform_destroy(self, instance):
         if is_system_managed(instance):

--- a/locations/test_capacity.py
+++ b/locations/test_capacity.py
@@ -1,0 +1,396 @@
+"""Counting what stands in a location, and refusing what will not fit."""
+
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections, transaction
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+
+from inventory.ledger import UnitMovementRequest, post_unit_movement
+from inventory.models import StockMovement
+from plantings.models import SpecificPlantLocation
+from tests.factories import (
+    make_location,
+    make_seed_tray,
+    make_seed_tray_cell,
+    make_seed_tray_cell_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import Location
+from .occupancy import (
+    check_capacity,
+    location_occupancy,
+    plant_contribution,
+    tray_contribution,
+)
+
+
+class OccupancyFixture(TestCase):
+    """Shared helpers for putting known things in known places."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+
+    def bench(self, basis=Location.CapacityBasis.NONE, value=None, parent=None):
+        """Create one bench with an optional capacity."""
+        return make_location(
+            workspace=self.workspace,
+            location_type=Location.LocationType.BENCH,
+            capacity_basis=basis,
+            capacity_value=value,
+            parent=parent,
+        )
+
+    def stand_plant(self, location):
+        """Stand one plant directly at a location."""
+        return make_specific_plant_location(
+            location_type=SpecificPlantLocation.LOCATION,
+            seed_tray_cell=None,
+            location=location,
+        )
+
+    def stocked_tray(self, plant_count=0):
+        """Create a tray standing where the ledger says it was received.
+
+        Its unit keeps the opening movement the factory posts, so it can be
+        transferred through the real ledger rather than teleported.
+        """
+        tray = make_seed_tray(workspace=self.workspace)
+        for index in range(plant_count):
+            cell = make_seed_tray_cell(tray=tray, x_position=index, y_position=0)
+            planting = make_seed_tray_cell_planting(cell=cell)
+            make_specific_plant_location(
+                specific_plant=make_specific_plant(cell_planting=planting),
+                seed_tray_cell=cell,
+            )
+        return tray
+
+    def tray_at(self, location, plant_count=0):
+        """Put one tray at a location, optionally holding growing plants.
+
+        Sets the unit's location directly: these tests are about counting what
+        is standing somewhere, not about how it got there.
+        """
+        tray = self.stocked_tray(plant_count)
+        tray.inventory_unit.current_location = location
+        tray.inventory_unit.save()
+        return tray
+
+
+class OccupancyCountingTests(OccupancyFixture):
+    """Occupancy is measured in every dimension that can describe it."""
+
+    def test_a_loose_plant_counts_as_one_plant_and_one_container(self):
+        """Until containers are recorded, a standing plant is its own pot."""
+        bench = self.bench()
+        self.stand_plant(bench)
+
+        occupancy = location_occupancy(bench)
+        self.assertEqual(occupancy.plants, 1)
+        self.assertEqual(occupancy.containers, 1)
+        self.assertEqual(occupancy.trays, 0)
+
+    def test_a_tray_counts_as_one_tray_and_all_the_plants_riding_in_it(self):
+        """A bench measured in plants is just as full whether they came in a tray."""
+        bench = self.bench()
+        self.tray_at(bench, plant_count=3)
+
+        occupancy = location_occupancy(bench)
+        self.assertEqual(occupancy.trays, 1)
+        self.assertEqual(occupancy.plants, 3)
+        self.assertEqual(occupancy.containers, 0)
+
+    def test_a_parent_reports_what_stands_on_its_benches(self):
+        """"What is in this greenhouse" includes everything below it."""
+        greenhouse = self.bench()
+        bench = self.bench(parent=greenhouse)
+        self.tray_at(bench, plant_count=2)
+        self.stand_plant(greenhouse)
+
+        self.assertEqual(location_occupancy(greenhouse).plants, 1)
+        below = location_occupancy(greenhouse, subtree=True)
+        self.assertEqual(below.plants, 3)
+        self.assertEqual(below.trays, 1)
+
+    def test_a_departed_plant_stops_occupying_the_bench_it_left(self):
+        """Only open placements describe the present."""
+        bench = self.bench()
+        placement = self.stand_plant(bench)
+        placement.ended = placement.started
+        placement.save(update_fields=['ended'])
+
+        self.assertEqual(location_occupancy(bench).plants, 0)
+
+
+class CapacityBasisTests(OccupancyFixture):
+    """Only the dimension a location declares is compared against its limit."""
+
+    def test_a_plants_bench_admits_a_loose_plant_within_its_limit(self):
+        """The ordinary case: room remains, so the plant goes down."""
+        bench = self.bench(Location.CapacityBasis.PLANTS, Decimal('2'))
+        self.stand_plant(bench)
+
+        check_capacity(bench, plant_contribution(), lock=False)
+
+    def test_a_plants_bench_refuses_the_plant_that_overfills_it(self):
+        """A bench with two spaces does not hold three plants."""
+        bench = self.bench(Location.CapacityBasis.PLANTS, Decimal('2'))
+        self.stand_plant(bench)
+        self.stand_plant(bench)
+
+        with self.assertRaises(ValidationError) as caught:
+            check_capacity(bench, plant_contribution(), lock=False)
+        self.assertIn('destination', caught.exception.message_dict)
+
+    def test_a_plants_bench_counts_a_whole_tray_against_its_limit(self):
+        """Seventy-two seedlings take seventy-two spaces, tray or no tray."""
+        bench = self.bench(Location.CapacityBasis.PLANTS, Decimal('5'))
+
+        with self.assertRaises(ValidationError):
+            check_capacity(bench, tray_contribution(6), lock=False)
+        check_capacity(bench, tray_contribution(5), lock=False)
+
+    def test_a_trays_bench_refuses_a_loose_plant_as_unmeasurable(self):
+        """A pot is not a tray, so a tray count cannot describe it."""
+        bench = self.bench(Location.CapacityBasis.TRAYS, Decimal('4'))
+
+        with self.assertRaises(ValidationError) as caught:
+            check_capacity(bench, plant_contribution(), lock=False)
+        self.assertIn('destination', caught.exception.message_dict)
+
+    def test_a_trays_bench_admits_trays_up_to_its_limit(self):
+        """The dimension matches, so the comparison is meaningful."""
+        bench = self.bench(Location.CapacityBasis.TRAYS, Decimal('1'))
+
+        check_capacity(bench, tray_contribution(20), lock=False)
+        self.tray_at(bench)
+        with self.assertRaises(ValidationError):
+            check_capacity(bench, tray_contribution(20), lock=False)
+
+    def test_a_containers_bench_refuses_a_tray_as_unmeasurable(self):
+        """A tray is not a container, and counting it as one would be a guess."""
+        bench = self.bench(Location.CapacityBasis.CONTAINERS, Decimal('10'))
+
+        with self.assertRaises(ValidationError) as caught:
+            check_capacity(bench, tray_contribution(4), lock=False)
+        self.assertIn('destination', caught.exception.message_dict)
+
+    def test_a_containers_bench_admits_potted_plants(self):
+        """One standing plant is one container until task 54 records real ones."""
+        bench = self.bench(Location.CapacityBasis.CONTAINERS, Decimal('1'))
+
+        check_capacity(bench, plant_contribution(), lock=False)
+        self.stand_plant(bench)
+        with self.assertRaises(ValidationError):
+            check_capacity(bench, plant_contribution(), lock=False)
+
+    def test_an_area_bench_limits_nothing_yet(self):
+        """Nothing records a footprint, so area is planning data, not a rule."""
+        bench = self.bench(Location.CapacityBasis.AREA, Decimal('0.5'))
+
+        check_capacity(bench, plant_contribution(), lock=False)
+        check_capacity(bench, tray_contribution(400), lock=False)
+
+    def test_an_untracked_bench_admits_anything(self):
+        """A place with no declared measure limits nothing."""
+        bench = self.bench()
+
+        check_capacity(bench, plant_contribution(), lock=False)
+        check_capacity(bench, tray_contribution(999), lock=False)
+
+    def test_an_override_reason_lets_an_overrun_through(self):
+        """Physical reality sometimes wins; it must be explained, not silent."""
+        bench = self.bench(Location.CapacityBasis.PLANTS, Decimal('1'))
+        self.stand_plant(bench)
+
+        with self.assertRaises(ValidationError):
+            check_capacity(bench, plant_contribution(), lock=False)
+        check_capacity(bench, plant_contribution(), 'Bench extended for the week', lock=False)
+
+
+class CapacityChainTests(OccupancyFixture):
+    """A limit on a greenhouse caps its benches' total, not just its aisle."""
+
+    def test_an_ancestor_limit_blocks_a_bench_that_has_room(self):
+        """The bench is not full; the greenhouse holding it is."""
+        greenhouse = self.bench(Location.CapacityBasis.TRAYS, Decimal('2'))
+        bench = self.bench(Location.CapacityBasis.TRAYS, Decimal('50'), parent=greenhouse)
+        self.tray_at(bench)
+        self.tray_at(bench)
+
+        with self.assertRaises(ValidationError) as caught:
+            check_capacity(bench, tray_contribution(0), lock=False)
+        self.assertIn(greenhouse.name, str(caught.exception.message_dict['destination']))
+
+    def test_an_uncapped_ancestor_is_not_consulted(self):
+        """Only locations that declare a limit take part in the decision."""
+        greenhouse = self.bench()
+        bench = self.bench(Location.CapacityBasis.TRAYS, Decimal('1'), parent=greenhouse)
+
+        check_capacity(bench, tray_contribution(0), lock=False)
+
+
+class DeactivationTests(OccupancyFixture):
+    """An occupied place cannot quietly disappear from the pickers."""
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(
+            get_user_model().objects.create_user(username='retirement-tester'),
+        )
+
+    def retire(self, location):
+        """Attempt to retire one location through the API."""
+        return self.client.patch(
+            f'/locations/{location.pk}/',
+            data='{"active": false}',
+            content_type='application/json',
+        )
+
+    def test_an_occupied_location_cannot_be_retired(self):
+        """Retiring it would strand its contents at an unofferable place."""
+        bench = self.bench()
+        self.stand_plant(bench)
+
+        response = self.retire(bench)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('active', response.json())
+
+    def test_a_location_holding_a_tray_below_it_cannot_be_retired(self):
+        """A greenhouse is occupied when anything on its benches is."""
+        greenhouse = self.bench()
+        bench = self.bench(parent=greenhouse)
+        self.tray_at(bench)
+
+        response = self.retire(greenhouse)
+        self.assertEqual(response.status_code, 400)
+
+    def test_an_active_child_must_be_retired_first(self):
+        """An active bench inside a retired greenhouse is a contradiction."""
+        greenhouse = self.bench()
+        self.bench(parent=greenhouse)
+
+        response = self.retire(greenhouse)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('active', response.json())
+
+    def test_an_empty_location_retires_cleanly(self):
+        """Nothing is standing there, so nothing is stranded."""
+        bench = self.bench()
+
+        response = self.retire(bench)
+        self.assertEqual(response.status_code, 200, response.json())
+        bench.refresh_from_db()
+        self.assertFalse(bench.active)
+
+
+class TrayTransferCapacityTests(OccupancyFixture):
+    """Wheeling a tray somewhere goes through the same limit as a plant."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='tray-mover')
+
+    def transfer(self, tray, destination, reason=''):
+        """Transfer one tray's unit to a destination."""
+        return post_unit_movement(
+            self.workspace,
+            self.user,
+            UnitMovementRequest(
+                unit=tray.inventory_unit,
+                movement_type=StockMovement.MovementType.TRANSFER,
+                destination=destination,
+                occurred_at=None,
+                reason=reason,
+                reference='',
+            ),
+        )
+
+    def test_a_tray_cannot_be_wheeled_onto_a_full_bench(self):
+        """The bench holds one tray and already has it."""
+        bench = self.bench(Location.CapacityBasis.TRAYS, Decimal('1'))
+        self.tray_at(bench)
+        moving = self.stocked_tray()
+
+        with self.assertRaises(ValidationError) as caught:
+            self.transfer(moving, bench)
+        self.assertIn('destination', caught.exception.message_dict)
+
+    def test_a_reason_lets_a_full_bench_take_one_more_tray(self):
+        """The movement already records a reason; that is the audited override."""
+        bench = self.bench(Location.CapacityBasis.TRAYS, Decimal('1'))
+        self.tray_at(bench)
+        moving = self.stocked_tray()
+
+        movement = self.transfer(moving, bench, reason='Overflow for one afternoon')
+        self.assertEqual(movement.reason, 'Overflow for one afternoon')
+        moving.inventory_unit.refresh_from_db()
+        self.assertEqual(moving.inventory_unit.current_location_id, bench.pk)
+
+    def test_the_plants_riding_in_a_tray_count_against_a_plants_bench(self):
+        """Two seedlings arriving in a tray fill two of the bench's spaces."""
+        bench = self.bench(Location.CapacityBasis.PLANTS, Decimal('1'))
+        moving = self.stocked_tray(plant_count=2)
+
+        with self.assertRaises(ValidationError):
+            self.transfer(moving, bench)
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentPlacementTests(TransactionTestCase):
+    """Two plants racing for the last space must not both take it."""
+
+    def _post_teardown(self):
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(pk=settings.CURRENT_WORKSPACE_ID, name='My Garden')
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.bench = make_location(
+            workspace=self.workspace,
+            location_type=Location.LocationType.BENCH,
+            capacity_basis=Location.CapacityBasis.PLANTS,
+            capacity_value=Decimal('1'),
+        )
+
+    def place(self):
+        """Take the last space if it is still free, reporting which happened."""
+        try:
+            with transaction.atomic():
+                check_capacity(self.bench, plant_contribution())
+                make_specific_plant_location(
+                    location_type=SpecificPlantLocation.LOCATION,
+                    seed_tray_cell=None,
+                    location=self.bench,
+                )
+            return 'placed'
+        except ValidationError:
+            return 'rejected'
+        finally:
+            close_old_connections()
+
+    def test_only_one_of_two_racing_placements_takes_the_last_space(self):
+        """Counting without locking would let both read the bench as free."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(future.result() for future in [
+                pool.submit(self.place),
+                pool.submit(self.place),
+            ])
+
+        self.assertEqual(results, ['placed', 'rejected'])
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                location=self.bench,
+                ended__isnull=True,
+            ).count(),
+            1,
+        )

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from locations.occupancy import check_capacity, plant_contribution
 from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
 
@@ -676,6 +677,22 @@ def is_active_location_integrity_error(exc):
     return names_constraint or names_sqlite_column
 
 
+def _check_destination_capacity(destination, override_reason):
+    """Refuse a bench that is full, or that cannot measure a single plant.
+
+    Locks the destination and every capacitated ancestor before counting, so
+    two plants racing for the last space cannot both read it as free.
+    """
+    if not destination.active:
+        raise serializers.ValidationError({'location': 'The location is inactive.'})
+    try:
+        check_capacity(destination, plant_contribution(), override_reason)
+    except DjangoValidationError as exc:
+        raise serializers.ValidationError(
+            {'location': _model_errors(exc).get('destination', exc.messages)},
+        ) from exc
+
+
 def move_specific_plant(plant, move_data, user=None):
     """
     Move a plant by ending its active location and creating the new one atomically.
@@ -688,12 +705,15 @@ def move_specific_plant(plant, move_data, user=None):
     started = move_data.get('started') or timezone.now()
     move_payload = {**move_data, 'started': started}
     planted_out = move_payload.get('location_type') == SpecificPlantLocation.GARDEN_SQUARE
+    destination = move_payload.get('location')
     with transaction.atomic():
         plant = get_object_or_404(
             SpecificPlant.objects.select_for_update(),
             pk=plant.pk,
             workspace=plant.workspace,
         )
+        if destination is not None:
+            _check_destination_capacity(destination, move_payload.get('override_reason', ''))
         if planted_out:
             try:
                 record_transplant_event(plant, user, started)


### PR DESCRIPTION
A bench that is already full should refuse the next tray rather than let an operator discover the problem carrying it.

Occupancy is counted in every dimension a location can express, and only the one dimension a location declares as its basis is compared against its limit. A tray of seedlings really is that many plants on the bench, so it counts in both trays and plants; it is not a container, and a loose pot is not a tray, so those combinations are refused as unmeasurable rather than guessed at.

Every capacitated ancestor is checked, so a greenhouse capped at 200 trays caps its benches' total and not merely its own aisle. The chain is locked in primary-key order, which along a path is also outermost-first, so two placements racing into the same greenhouse cannot deadlock — and the racing test proves only one of them takes the last space.

An overrun needs a reason. Plant moves record it on the placement; tray transfers reuse the reason the movement already carries, so the audit trail is the one that already existed.

Retiring a location is refused while anything still stands in its subtree or an active location sits inside it, because a retired place no picker offers is how stock goes missing on paper while sitting in plain sight.

## Summary by Sourcery

Introduce occupancy tracking and capacity enforcement for locations, integrating it into plant moves, tray transfers, and location lifecycle, with concurrent-safety guarantees.

New Features:
- Expose a location occupancy API endpoint that reports current contents and remaining capacity for the location and its subtree.
- Add capacity checks when moving plants and transferring seed trays so benches and ancestors cannot be overfilled without an explicit override reason.

Bug Fixes:
- Prevent retiring locations that still hold stock or have active child locations to avoid stranding inventory at unpickable places.

Enhancements:
- Implement a shared occupancy and capacity model that counts trays, plants, and containers appropriately and enforces declared capacity bases across ancestor chains.
- Ensure capacity checks lock capacitated locations in a consistent order to avoid deadlocks and race conditions when multiple placements compete for the last space.

Tests:
- Add comprehensive tests covering occupancy counting, capacity basis behavior, ancestor capacity enforcement, location retirement rules, tray transfer limits, and concurrent placement race conditions.