### PR TITLE
feat(plantings): filter the register by where a plant is standing

### DIFF
--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -324,11 +324,16 @@ interface NurseryRegisterRow {
   sellable: boolean
   final_outcome: PlantLifecycleEventType | null
   final_outcome_at: string | null
-  location_type: 'seed_tray_cell' | 'garden_square' | null
+  location_type: PlantPlacementType | null
   location_label: string
   seed_tray: number | null
   seed_tray_cell: number | null
   garden_square: number | null
+  location: number | null
+  // Where the plant is physically standing. For a plant in a tray that is
+  // wherever the tray has been wheeled, which is why it differs from location.
+  standing_at: number | null
+  standing_at_label: string
   located_since: string | null
   // Projected from the crop's maturity range, not an observed readiness date.
   expected_ready_early: string | null
@@ -337,7 +342,8 @@ interface NurseryRegisterRow {
   currency_code: string
 }
 
-type NurseryRegisterOrdering = 'age' | '-age' | 'variety' | '-variety' | 'location' | '-location' | 'cost' | '-cost' | 'state' | '-state' | 'batch' | '-batch'
+type NurseryRegisterOrdering =
+  'age' | '-age' | 'variety' | '-variety' | 'location' | '-location' | 'standing_at' | '-standing_at' | 'cost' | '-cost' | 'state' | '-state' | 'batch' | '-batch'
 
 // Keys are the query-parameter names the register endpoint validates.
 interface NurseryRegisterFilters {
@@ -347,9 +353,12 @@ interface NurseryRegisterFilters {
   sellable?: boolean
   germinated_from?: string
   germinated_to?: string
-  location_type?: 'seed_tray_cell' | 'garden_square' | 'none'
+  location_type?: PlantPlacementType | 'none'
   seed_tray?: number
   garden_square?: number
+  // Matches the location or anything below it, so a greenhouse answers for
+  // the bays inside it.
+  location?: number
   search?: string
   ordering?: NurseryRegisterOrdering
   page?: number

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -6,9 +6,9 @@ mutable plant table. Every row is derived from the source records, and one
 filter parser feeds both the rows and the whole-filter totals so a screen can
 never report counts that its own list disagrees with.
 
-Filters for growth stage, grade, container, nursery location, reservation, and
-quarantine are deliberately absent: nothing records those facts yet, and tasks
-54, 51, 44, and 56 each add their filter here when they add their model.
+Filters for growth stage, grade, container, reservation, and quarantine are
+deliberately absent: nothing records those facts yet, and tasks 54, 44, and 56
+each add their filter here when they add their model.
 """
 
 from typing import NamedTuple
@@ -19,6 +19,7 @@ from rest_framework.exceptions import ValidationError
 
 from costing.models import CostAllocation
 from inventory.rest_query import parse_boolean, parse_datetime, parse_integer
+from locations.models import Location
 
 from .lifecycle import FINAL_STATES, LifecycleState, with_lifecycle_state
 from .models import SpecificPlant, SpecificPlantLocation
@@ -28,6 +29,7 @@ from .models import SpecificPlant, SpecificPlantLocation
 LOCATION_TYPES = {
     SpecificPlantLocation.SEED_TRAY_CELL,
     SpecificPlantLocation.GARDEN_SQUARE,
+    SpecificPlantLocation.LOCATION,
 }
 UNPLACED = 'none'
 
@@ -37,6 +39,7 @@ ORDERINGS = {
     'age': ('germinated', 'pk'),
     'variety': ('variety_name', 'plant_name', 'pk'),
     'location': ('current_location_label', 'pk'),
+    'standing_at': ('standing_at_label', 'pk'),
     'cost': ('cost', 'pk'),
     'state': ('lifecycle_state', 'pk'),
     'batch': ('batch_code', 'pk'),
@@ -45,6 +48,10 @@ ORDERINGS = {
 DEFAULT_ORDERING = '-age'
 
 _BATCH = 'cell_planting__seed_tray_planting__batch'
+
+#: A tray stands somewhere as a serialized asset, and the plants in its cells
+#: stand there with it.
+_TRAY_LOCATION = 'seed_tray_cell__tray__inventory_unit__current_location'
 
 
 class RegisterFilters(NamedTuple):
@@ -59,6 +66,7 @@ class RegisterFilters(NamedTuple):
     location_type: object = None
     seed_tray: object = None
     garden_square: object = None
+    location: object = None
     search: str = ''
     ordering: str = DEFAULT_ORDERING
 
@@ -91,6 +99,7 @@ def parse_register_filters(query_params):
         location_type=location_type,
         seed_tray=parse_integer(query_params.get('seed_tray'), 'seed_tray'),
         garden_square=parse_integer(query_params.get('garden_square'), 'garden_square'),
+        location=parse_integer(query_params.get('location'), 'location'),
         search=(query_params.get('search') or '').strip(),
         ordering=ordering,
     )
@@ -149,10 +158,34 @@ def register_projection(workspace):
         current_garden_square_label=_current_location('garden_square__name'),
         located_since=_current_location('started'),
         cost=_plant_cost(),
+        direct_location=_current_location('location'),
+        direct_location_name=_current_location('location__name'),
+        direct_location_path=_current_location('location__path'),
+        tray_location=_current_location(_TRAY_LOCATION),
+        tray_location_name=_current_location(f'{_TRAY_LOCATION}__name'),
+        tray_location_path=_current_location(f'{_TRAY_LOCATION}__path'),
     ).annotate(
         current_location_label=Coalesce(
             'current_garden_square_label',
             'current_seed_tray_label',
+            'direct_location_name',
+            Value(''),
+            output_field=TextField(),
+        ),
+        # Where the plant is physically standing, which for a plant in a tray
+        # is wherever the tray has been wheeled. The tray's placement is the
+        # only record of that, so it is resolved here rather than copied onto
+        # every plant it carries.
+        standing_at=Coalesce('direct_location', 'tray_location'),
+        standing_at_label=Coalesce(
+            'direct_location_name',
+            'tray_location_name',
+            Value(''),
+            output_field=TextField(),
+        ),
+        standing_at_path=Coalesce(
+            'direct_location_path',
+            'tray_location_path',
             Value(''),
             output_field=TextField(),
         ),
@@ -198,9 +231,30 @@ def register_queryset(workspace, filters):
         queryset = queryset.filter(current_seed_tray=filters.seed_tray)
     if filters.garden_square is not None:
         queryset = queryset.filter(current_garden_square=filters.garden_square)
+    if filters.location is not None:
+        queryset = _standing_in(queryset, workspace, filters.location)
     if filters.search:
         queryset = _apply_search(queryset, filters.search)
     return queryset.order_by(*_ordering_fields(filters.ordering))
+
+
+def _standing_in(queryset, workspace, location_id):
+    """Select the plants standing at a location or anywhere below it.
+
+    Asking about a greenhouse means asking about its benches and their bays;
+    an operator standing in the doorway does not think of those as elsewhere.
+    Unknown ids match nothing rather than everything, because an empty path
+    prefix would select the whole register.
+    """
+    path = (
+        Location.objects
+        .filter(pk=location_id, workspace=workspace)
+        .values_list('path', flat=True)
+        .first()
+    )
+    if not path:
+        return queryset.none()
+    return queryset.filter(standing_at_path__startswith=path)
 
 
 def _ordering_fields(ordering):

--- a/plantings/register_rest.py
+++ b/plantings/register_rest.py
@@ -103,6 +103,13 @@ class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abst
         read_only=True,
         allow_null=True,
     )
+    location = serializers.IntegerField(
+        source='direct_location',
+        read_only=True,
+        allow_null=True,
+    )
+    standing_at = serializers.IntegerField(read_only=True, allow_null=True)
+    standing_at_label = serializers.CharField(read_only=True)
     located_since = serializers.DateTimeField(read_only=True, allow_null=True)
     expected_ready_early = serializers.SerializerMethodField()
     expected_ready_late = serializers.SerializerMethodField()

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_garden_square,
+    make_location,
     make_plant_variety,
     make_production_batch,
     make_seed_packet,
@@ -29,6 +30,7 @@ from tests.factories import (
     make_specific_plant,
     make_specific_plant_location,
 )
+from locations.models import Location
 from workspaces.models import Workspace, get_current_workspace
 
 from .lifecycle import (
@@ -135,6 +137,41 @@ class RegisterContractTests(RegisterTestCase):
         self.assertEqual(row['variety_name'], batch.variety.name)
         self.assertEqual(row['lifecycle_state'], LifecycleState.GROWING)
         self.assertEqual(row['age_days'], 40)
+
+    def test_the_row_carries_exactly_the_fields_the_screen_reads(self):
+        """This repository has no JavaScript test runner, so the contract that
+        `frontend/js/types/plantings.ts` describes is pinned here instead. A
+        field renamed on either side fails this rather than rendering as
+        undefined.
+        """
+        self.make_plant()
+        self.assertEqual(sorted(self.page()['results'][0]), [
+            'age_days',
+            'batch',
+            'batch_code',
+            'cost',
+            'currency_code',
+            'expected_ready_early',
+            'expected_ready_late',
+            'final_outcome',
+            'final_outcome_at',
+            'garden_square',
+            'germinated',
+            'lifecycle_state',
+            'located_since',
+            'location',
+            'location_label',
+            'location_type',
+            'pk',
+            'plant_name',
+            'seed_tray',
+            'seed_tray_cell',
+            'sellable',
+            'standing_at',
+            'standing_at_label',
+            'variety',
+            'variety_name',
+        ])
 
     def test_a_garden_workspace_cannot_reach_the_register(self):
         """The Garden profile has plants but no nursery to run them through."""
@@ -296,6 +333,74 @@ class RegisterFilterTests(RegisterTestCase):
         self.assertEqual(self.row_ids(payload), [wanted.pk])
         self.assertEqual(payload['totals']['available'], 1)
 
+    def test_a_plant_standing_on_a_bench_is_found_under_it(self):
+        """A potted plant set down on a bench is standing on that bench."""
+        bench = make_location(location_type=Location.LocationType.BENCH)
+        standing = self.make_plant()
+        make_specific_plant_location(
+            specific_plant=standing,
+            location_type=SpecificPlantLocation.LOCATION,
+            seed_tray_cell=None,
+            location=bench,
+            started=self.start,
+        )
+        self.make_plant()
+
+        payload = self.assert_filter_agrees(location=bench.pk)
+        self.assertEqual(self.row_ids(payload), [standing.pk])
+
+    def test_a_plant_in_a_tray_is_found_under_the_bench_the_tray_stands_on(self):
+        """The register answers what is standing there, not what is in a tray."""
+        bench = make_location(location_type=Location.LocationType.BENCH)
+        tray = make_seed_tray()
+        tray.inventory_unit.current_location = bench
+        tray.inventory_unit.save()
+        in_tray = self.make_plant(tray=tray)
+        make_specific_plant_location(
+            specific_plant=in_tray,
+            seed_tray_cell=in_tray.cell_planting.cell,
+            started=self.start,
+        )
+        self.make_plant()
+
+        payload = self.assert_filter_agrees(location=bench.pk)
+        self.assertEqual(self.row_ids(payload), [in_tray.pk])
+        self.assertEqual(payload['results'][0]['standing_at'], bench.pk)
+
+    def test_a_greenhouse_answers_for_the_bays_inside_it(self):
+        """Someone in the doorway does not think of its own bays as elsewhere."""
+        greenhouse = make_location(location_type=Location.LocationType.GREENHOUSE)
+        bay = make_location(
+            location_type=Location.LocationType.BAY,
+            parent=greenhouse,
+        )
+        deep = self.make_plant()
+        make_specific_plant_location(
+            specific_plant=deep,
+            location_type=SpecificPlantLocation.LOCATION,
+            seed_tray_cell=None,
+            location=bay,
+            started=self.start,
+        )
+
+        payload = self.assert_filter_agrees(location=greenhouse.pk)
+        self.assertEqual(self.row_ids(payload), [deep.pk])
+
+    def test_an_unknown_location_selects_nothing_rather_than_everything(self):
+        """An empty path prefix would match the whole register."""
+        self.make_plant()
+        payload = self.assert_filter_agrees(location=99999)
+        self.assertEqual(self.row_ids(payload), [])
+
+    def test_another_workspace_s_location_selects_nothing(self):
+        """A location filter is scoped like every other read."""
+        other = Workspace.objects.create(name='Other nursery')
+        outsider = make_location(workspace=other)
+        self.make_plant()
+
+        payload = self.assert_filter_agrees(location=outsider.pk)
+        self.assertEqual(self.row_ids(payload), [])
+
     def test_bad_filter_values_blame_the_parameter_that_carried_them(self):
         """A typo in a query string should say which one it was."""
         for params, field in (
@@ -303,7 +408,7 @@ class RegisterFilterTests(RegisterTestCase):
             ({'state': 'sprouting'}, 'state'),
             ({'sellable': 'maybe'}, 'sellable'),
             ({'germinated_from': 'last week'}, 'germinated_from'),
-            ({'location_type': 'bench'}, 'location_type'),
+            ({'location_type': 'wheelbarrow'}, 'location_type'),
             ({'ordering': 'whim'}, 'ordering'),
         ):
             with self.subTest(params=params):


### PR DESCRIPTION
Task 50 shipped the register with a location filter that meant seed-tray cell, garden square, or nowhere at all. It could not answer the question a nursery day starts with: what is standing on that bench.

The register now resolves where a plant physically is. A plant standing at a location gives its own answer; a plant in a tray inherits wherever the tray has been wheeled, resolved through the tray's placement rather than copied onto every plant it carries. Filtering by a greenhouse reaches its benches and their bays, because someone in the doorway does not think of those as elsewhere.

An unknown or out-of-workspace location selects nothing rather than everything: the filter is a path prefix, and an empty prefix would match the whole register.

The row payload is now pinned key-for-key against the TypeScript contract, the way the costing suite does it. This repository has no JavaScript test runner, so a field renamed on either side had until now been free to render as undefined.

## Summary by Sourcery

Add location-aware filtering and ordering to the nursery register so it can answer where plants are physically standing, including plants in trays and hierarchical locations.

New Features:
- Expose physical standing location (and label) for each plant in the nursery register, distinguishing direct placement from tray placement.
- Allow filtering the register by a location hierarchy so a parent location (e.g. greenhouse) matches plants in its child locations (e.g. bays and benches).
- Support ordering nursery register rows by the physical standing location field in addition to existing sort options.

Enhancements:
- Align nursery register row payload fields exactly with the TypeScript NurseryRegisterRow contract and broaden location_type and filters to share PlantPlacementType.
- Extend register projections to compute and expose both logical location and tray-resolved standing location paths for downstream use.
- Tighten location-type filter validation by updating test coverage for invalid values.

Tests:
- Add tests pinning the register row payload to the TypeScript contract and covering new standing-location semantics, including trays, hierarchical locations, and workspace scoping.