### PR TITLE
feat(plantings): execute reviewed bulk plant work

### DIFF
--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -197,10 +197,11 @@ def _plant_preview(workspace, request, lock=False):
     capacity = []
     slots = None
     capacity_error = []
-    moves_to_location = all((
-        request.action == BulkPlantOperation.Action.MOVE,
-        request.action_payload['location_type'] == SpecificPlantLocation.LOCATION,
-    ))
+    moves_to_location = False
+    if request.action == BulkPlantOperation.Action.MOVE:
+        moves_to_location = (
+            request.action_payload['location_type'] == SpecificPlantLocation.LOCATION
+        )
     if moves_to_location:
         slots, capacity_error, capacity = _capacity_slots(
             request.action_payload['location'],

--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -1,0 +1,428 @@
+"""Reviewed, idempotent bulk work over individually identified plants."""
+
+from dataclasses import dataclass
+from decimal import ROUND_FLOOR
+from hashlib import sha256
+import json
+
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, models, transaction
+from django.utils import timezone
+
+from locations.models import Location
+from locations.occupancy import capacity_chain, location_occupancy
+
+from .batches import lock_batch_with_plants
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_germination_event,
+    record_lifecycle_event,
+    validate_outcome,
+)
+from .models import (
+    BulkPlantOperation,
+    BulkPlantOperationResult,
+    SeedTrayCellPlanting,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
+
+
+ACTION_EVENTS = {
+    BulkPlantOperation.Action.READY: EventType.READY,
+    BulkPlantOperation.Action.RETAIN: EventType.RETAINED,
+    BulkPlantOperation.Action.DONATE: EventType.DONATED,
+    BulkPlantOperation.Action.FAIL: EventType.FAILED,
+    BulkPlantOperation.Action.CULL: EventType.CULLED,
+    BulkPlantOperation.Action.FINISH_HARVEST: EventType.HARVEST_FINISHED,
+}
+
+
+@dataclass(frozen=True)
+class BulkOperationRequest:
+    """One validated preview or confirmed bulk-operation request."""
+
+    action: str
+    atomicity: str
+    occurred_at: object
+    reason: str
+    plants: tuple = ()
+    selection_source: dict = None
+    action_payload: dict = None
+    idempotency_key: object = None
+
+
+class BulkOperationConflict(Exception):
+    """A confirmed plan had no permitted set of writes."""
+
+    def __init__(self, preview):
+        super().__init__('The bulk operation has conflicts.')
+        self.preview = preview
+
+
+def _errors(error):
+    """Flatten a domain validation error into operator-readable messages."""
+    if hasattr(error, 'message_dict'):
+        return [str(message) for messages in error.message_dict.values() for message in messages]
+    return [str(message) for message in error.messages]
+
+
+def _json_value(value):
+    """Turn validated model/date values into a stable JSON audit value."""
+    if isinstance(value, models.Model):
+        return value.pk
+    if hasattr(value, 'isoformat'):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _json_value(entry) for key, entry in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(entry) for entry in value]
+    return value
+
+
+def request_digest(request):
+    """Hash every part of a request whose reuse must mean the same work."""
+    content = {
+        'action': request.action,
+        'atomicity': request.atomicity,
+        'occurred_at': _json_value(request.occurred_at),
+        'reason': request.reason,
+        'plants': sorted(set(request.plants)),
+        'selection_source': _json_value(request.selection_source or {}),
+        'action_payload': _json_value(request.action_payload or {}),
+    }
+    encoded = json.dumps(content, sort_keys=True, separators=(',', ':')).encode()
+    return sha256(encoded).hexdigest()
+
+
+def _plant_conflicts(plant, request):
+    """Return conflicts independent of aggregate destination capacity."""
+    try:
+        if request.action in ACTION_EVENTS:
+            validate_outcome(plant, ACTION_EVENTS[request.action], request.occurred_at)
+        elif request.action == BulkPlantOperation.Action.MOVE:
+            active = (
+                SpecificPlantLocation.objects
+                .filter(specific_plant=plant, ended__isnull=True)
+                .first()
+            )
+            if active is not None and request.occurred_at < active.started:
+                raise ValidationError({'occurred_at': 'Move cannot start before the active location.'})
+            if request.action_payload['location_type'] == SpecificPlantLocation.GARDEN_SQUARE:
+                validate_outcome(plant, EventType.TRANSPLANTED, request.occurred_at)
+    except ValidationError as exc:
+        return _errors(exc)
+    return []
+
+
+def _lock_capacity_chain(destination):
+    """Lock capacity rows in the same deterministic order as single moves."""
+    limits = capacity_chain(destination)
+    if not limits:
+        return []
+    return list(
+        Location.objects
+        .select_for_update()
+        .filter(pk__in=[limit.pk for limit in limits])
+        .order_by('pk')
+    )
+
+
+def _capacity_slots(destination, override_reason, lock):
+    """Return how many directly placed plants fit and any category conflict."""
+    if not destination.active:
+        return 0, ['The destination location is inactive.'], []
+    limits = _lock_capacity_chain(destination) if lock else capacity_chain(destination)
+    slots = None
+    capacity = []
+    for limit in limits:
+        basis = limit.capacity_basis
+        if basis not in Location.ENFORCED_BASES:
+            continue
+        if basis not in {Location.CapacityBasis.PLANTS, Location.CapacityBasis.CONTAINERS}:
+            if limit.pk == destination.pk:
+                return 0, [f'{limit.name} is measured in {basis}, which a plant does not occupy.'], capacity
+            continue
+        used = location_occupancy(limit, subtree=True).of(basis)
+        remaining = limit.capacity_value - used
+        available = max(0, int(remaining.to_integral_value(rounding=ROUND_FLOOR)))
+        capacity.append({
+            'location': limit.pk,
+            'basis': basis,
+            'capacity': str(limit.capacity_value),
+            'used': used,
+            'available': available,
+        })
+        if not override_reason:
+            slots = available if slots is None else min(slots, available)
+    return slots, [], capacity
+
+
+def _load_plants(workspace, plant_ids, lock):
+    """Resolve an explicit selection without admitting another workspace."""
+    wanted = sorted(set(plant_ids))
+    if not wanted:
+        raise ValidationError({'plants': 'Select at least one plant.'})
+    queryset = SpecificPlant.objects.filter(workspace=workspace, pk__in=wanted).order_by('pk')
+    if lock:
+        queryset = queryset.select_for_update()
+    plants = list(queryset)
+    known = {plant.pk for plant in plants}
+    missing = [plant_id for plant_id in wanted if plant_id not in known]
+    if missing:
+        raise ValidationError({'plants': f'No such plants in this workspace: {missing}.'})
+    return plants
+
+
+def _projected_state(request):
+    """Return the state an eligible lifecycle action leaves behind."""
+    event = ACTION_EVENTS.get(request.action)
+    return {
+        EventType.READY: LifecycleState.AVAILABLE,
+        EventType.RETAINED: LifecycleState.RETAINED,
+        EventType.DONATED: LifecycleState.DONATED,
+        EventType.FAILED: LifecycleState.FAILED,
+        EventType.CULLED: LifecycleState.CULLED,
+        EventType.HARVEST_FINISHED: LifecycleState.HARVESTED,
+    }.get(event)
+
+
+def _plant_preview(workspace, request, lock=False):
+    """Plan one action over concrete plants, optionally under execution locks."""
+    plants = _load_plants(workspace, request.plants, lock)
+    capacity = []
+    slots = None
+    capacity_error = []
+    moves_to_location = all((
+        request.action == BulkPlantOperation.Action.MOVE,
+        request.action_payload['location_type'] == SpecificPlantLocation.LOCATION,
+    ))
+    if moves_to_location:
+        slots, capacity_error, capacity = _capacity_slots(
+            request.action_payload['location'],
+            request.action_payload.get('override_reason', ''),
+            lock,
+        )
+
+    rows = []
+    capacity_used = 0
+    for plant in plants:
+        summary = plant_lifecycle_summary(plant)
+        conflicts = _plant_conflicts(plant, request)
+        if not conflicts and capacity_error:
+            conflicts = list(capacity_error)
+        if not conflicts and slots is not None:
+            if capacity_used >= slots:
+                conflicts = ['The destination does not have capacity for this plant.']
+            else:
+                capacity_used += 1
+        after_state = _projected_state(request) or summary.state
+        rows.append({
+            'plant': plant.pk,
+            'eligible': not conflicts,
+            'conflicts': conflicts,
+            'before': {'lifecycle_state': summary.state},
+            'after': {
+                'lifecycle_state': after_state,
+                'location_type': (
+                    request.action_payload.get('location_type')
+                    if request.action == BulkPlantOperation.Action.MOVE else None
+                ),
+            },
+        })
+    eligible = sum(row['eligible'] for row in rows)
+    return {
+        'action': request.action,
+        'selected': len(rows),
+        'eligible': eligible,
+        'conflicts': len(rows) - eligible,
+        'plants': rows,
+        'capacity': capacity,
+    }
+
+
+def _germination_preview(workspace, request, lock=False):
+    """Validate the source allocation for a quantity germination."""
+    allocation = request.action_payload['cell_planting']
+    queryset = SeedTrayCellPlanting.objects.filter(pk=allocation.pk)
+    if lock:
+        queryset = queryset.select_for_update()
+    allocation = queryset.select_related('seed_tray_planting__batch').first()
+    conflicts = []
+    if allocation is None or allocation.seed_tray_planting.workspace_id != workspace.pk:
+        conflicts.append('The cell allocation is unavailable in this workspace.')
+    return {
+        'action': request.action,
+        'selected': request.action_payload['quantity'],
+        'eligible': 0 if conflicts else request.action_payload['quantity'],
+        'conflicts': len(conflicts),
+        'plants': [],
+        'capacity': [],
+        'source': {
+            'cell_planting': request.action_payload['cell_planting'].pk,
+            'quantity': request.action_payload['quantity'],
+            'conflicts': conflicts,
+        },
+    }
+
+
+def preview_bulk_operation(workspace, request, lock=False):
+    """Return eligibility and projected effects without changing a plant."""
+    if request.action == BulkPlantOperation.Action.GERMINATE:
+        return _germination_preview(workspace, request, lock)
+    return _plant_preview(workspace, request, lock)
+
+
+def _create_operation(workspace, user, request, digest):
+    """Claim the idempotency key before any domain writes occur."""
+    return BulkPlantOperation.objects.create(
+        workspace=workspace,
+        idempotency_key=request.idempotency_key,
+        request_digest=digest,
+        action=request.action,
+        atomicity=request.atomicity,
+        occurred_at=request.occurred_at,
+        reason=request.reason,
+        selection_source=_json_value(request.selection_source or {}),
+        action_payload=_json_value(request.action_payload or {}),
+        created_by=user if user is not None and user.is_authenticated else None,
+    )
+
+
+def _move_data(request):
+    """Build the existing single-plant move service payload."""
+    return {
+        **request.action_payload,
+        'started': request.occurred_at,
+        'notes': request.reason,
+    }
+
+
+def _apply_plant_operation(operation, user, request, preview):
+    """Apply eligible plan rows and append one result for every selection member."""
+    from .rest import move_specific_plant  # pylint: disable=import-outside-toplevel
+
+    rows = {row['plant']: row for row in preview['plants']}
+    plants = {
+        plant.pk: plant
+        for plant in SpecificPlant.objects.filter(pk__in=rows).order_by('pk')
+    }
+    for plant_id, row in rows.items():
+        plant = plants[plant_id]
+        if not row['eligible']:
+            BulkPlantOperationResult.objects.create(
+                workspace=operation.workspace,
+                operation=operation,
+                plant=plant,
+                status=BulkPlantOperationResult.Status.SKIPPED,
+                errors=row['conflicts'],
+            )
+            continue
+        event = None
+        location = None
+        if request.action == BulkPlantOperation.Action.MOVE:
+            location = move_specific_plant(plant, _move_data(request), user=user)
+        else:
+            event = record_lifecycle_event(
+                plant,
+                user,
+                OutcomeRequest(
+                    ACTION_EVENTS[request.action],
+                    occurred_at=request.occurred_at,
+                    reason=request.reason,
+                    reference=f'bulk-operation:{operation.pk}',
+                ),
+            )
+        BulkPlantOperationResult.objects.create(
+            workspace=operation.workspace,
+            operation=operation,
+            plant=plant,
+            status=BulkPlantOperationResult.Status.APPLIED,
+            lifecycle_event=event,
+            location=location,
+        )
+
+
+def _apply_germination(operation, user, request):
+    """Create individually auditable plants and reallocate their batch once."""
+    allocation = SeedTrayCellPlanting.objects.select_for_update().get(
+        pk=request.action_payload['cell_planting'].pk,
+    )
+    batch = lock_batch_with_plants(allocation.seed_tray_planting.batch)
+    notes = request.action_payload.get('notes', '')
+    for _index in range(request.action_payload['quantity']):
+        plant = SpecificPlant.objects.create(
+            cell_planting=allocation,
+            germinated=request.occurred_at,
+            notes=notes,
+        )
+        location = SpecificPlantLocation.objects.create(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+            seed_tray_cell=allocation.cell,
+            started=request.occurred_at,
+        )
+        event = record_germination_event(plant, user)
+        BulkPlantOperationResult.objects.create(
+            workspace=operation.workspace,
+            operation=operation,
+            plant=plant,
+            status=BulkPlantOperationResult.Status.APPLIED,
+            lifecycle_event=event,
+            location=location,
+        )
+
+    from costing.services import reallocate_batch  # pylint: disable=import-outside-toplevel
+
+    reallocate_batch(batch, user, 'bulk-germination')
+
+
+@transaction.atomic
+def _execute(workspace, user, request, digest):
+    """Execute a new request atomically; callers handle idempotent races."""
+    operation = _create_operation(workspace, user, request, digest)
+    preview = preview_bulk_operation(workspace, request, lock=True)
+    has_conflicts = preview['conflicts'] > 0
+    if has_conflicts and request.atomicity == BulkPlantOperation.Atomicity.ALL_OR_NOTHING:
+        raise BulkOperationConflict(preview)
+    if preview['eligible'] == 0:
+        raise BulkOperationConflict(preview)
+    if request.action == BulkPlantOperation.Action.GERMINATE:
+        _apply_germination(operation, user, request)
+    else:
+        _apply_plant_operation(operation, user, request, preview)
+    return operation, False
+
+
+def execute_bulk_operation(workspace, user, request):
+    """Execute once, replaying an identical completed request after retries."""
+    digest = request_digest(request)
+    existing = (
+        BulkPlantOperation.objects
+        .filter(workspace=workspace, idempotency_key=request.idempotency_key)
+        .first()
+    )
+    if existing is not None:
+        if existing.request_digest != digest:
+            raise ValidationError({'idempotency_key': 'That key was used for different work.'})
+        return existing, True
+    try:
+        return _execute(workspace, user, request, digest)
+    except IntegrityError:
+        existing = BulkPlantOperation.objects.get(
+            workspace=workspace,
+            idempotency_key=request.idempotency_key,
+        )
+        if existing.request_digest != digest:
+            raise ValidationError({'idempotency_key': 'That key was used for different work.'})
+        return existing, True
+
+
+def concrete_request(**values):
+    """Fill the one action time shared by every selected plant."""
+    values['occurred_at'] = values.get('occurred_at') or timezone.now()
+    values['plants'] = tuple(values.get('plants') or ())
+    return BulkOperationRequest(**values)

--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -42,6 +42,7 @@ ACTION_EVENTS = {
 
 
 @dataclass(frozen=True)
+# pylint: disable-next=too-many-instance-attributes
 class BulkOperationRequest:
     """One validated preview or confirmed bulk-operation request."""
 
@@ -411,13 +412,15 @@ def execute_bulk_operation(workspace, user, request):
         return existing, True
     try:
         return _execute(workspace, user, request, digest)
-    except IntegrityError:
+    except IntegrityError as exc:
         existing = BulkPlantOperation.objects.get(
             workspace=workspace,
             idempotency_key=request.idempotency_key,
         )
         if existing.request_digest != digest:
-            raise ValidationError({'idempotency_key': 'That key was used for different work.'})
+            raise ValidationError({
+                'idempotency_key': 'That key was used for different work.',
+            }) from exc
         return existing, True
 
 

--- a/plantings/bulk_rest.py
+++ b/plantings/bulk_rest.py
@@ -1,0 +1,212 @@
+"""REST preview, execution, and audit resources for bulk plant work."""
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from workspaces.models import Workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+    RequireWorkspaceModeMixin,
+)
+
+from .bulk_operations import (
+    ACTION_EVENTS,
+    BulkOperationConflict,
+    concrete_request,
+    execute_bulk_operation,
+    preview_bulk_operation,
+)
+from .models import (
+    BulkPlantOperation,
+    BulkPlantOperationResult,
+    SeedTrayCellPlanting,
+)
+from .rest import SpecificPlantMoveSerializer
+
+
+MAX_BULK_PLANTS = 5000
+
+
+class GerminationPayloadSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.Serializer,
+):  # pylint: disable=abstract-method
+    """Validate the tray-cell source and number of plants observed."""
+
+    cell_planting = serializers.PrimaryKeyRelatedField(
+        queryset=SeedTrayCellPlanting.objects.all(),
+    )
+    quantity = serializers.IntegerField(min_value=1, max_value=MAX_BULK_PLANTS)
+    notes = serializers.CharField(allow_blank=True, required=False, default='')
+    workspace_field_lookups = {
+        'cell_planting': 'seed_tray_planting__workspace',
+    }
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class BulkOperationRequestSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Validate both previews and confirmed requests."""
+
+    idempotency_key = serializers.UUIDField(required=False)
+    action = serializers.ChoiceField(choices=BulkPlantOperation.Action.choices)
+    atomicity = serializers.ChoiceField(choices=BulkPlantOperation.Atomicity.choices)
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=True, required=False, default='')
+    plants = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=True,
+        max_length=MAX_BULK_PLANTS,
+        required=False,
+        default=list,
+    )
+    selection_source = serializers.JSONField(required=False, default=dict)
+    action_payload = serializers.JSONField(required=False, default=dict)
+
+    def validate(self, attrs):
+        """Choose and validate the action-specific payload contract."""
+        action_name = attrs['action']
+        plants = attrs['plants']
+        payload = attrs['action_payload']
+        if action_name == BulkPlantOperation.Action.GERMINATE:
+            if plants:
+                raise ValidationError({'plants': 'Germination selects a cell allocation, not existing plants.'})
+            if attrs['atomicity'] != BulkPlantOperation.Atomicity.ALL_OR_NOTHING:
+                raise ValidationError({'atomicity': 'Germination is always all or nothing.'})
+            payload_serializer = GerminationPayloadSerializer(data=payload)
+        elif action_name == BulkPlantOperation.Action.MOVE:
+            if not plants:
+                raise ValidationError({'plants': 'Select at least one plant.'})
+            payload_serializer = SpecificPlantMoveSerializer(data=payload)
+        else:
+            if action_name not in ACTION_EVENTS:
+                raise ValidationError({'action': 'Select a supported action.'})
+            if not plants:
+                raise ValidationError({'plants': 'Select at least one plant.'})
+            if payload:
+                raise ValidationError({'action_payload': 'This action takes no additional fields.'})
+            attrs['action_payload'] = {}
+            return attrs
+        payload_serializer.is_valid(raise_exception=True)
+        attrs['action_payload'] = dict(payload_serializer.validated_data)
+        return attrs
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class BulkPlantOperationResultSerializer(serializers.ModelSerializer):
+    """One concrete plant's independently linked result."""
+
+    class Meta:
+        model = BulkPlantOperationResult
+        fields = [
+            'plant',
+            'status',
+            'errors',
+            'lifecycle_event',
+            'location',
+        ]
+        read_only_fields = fields
+
+
+class BulkPlantOperationSerializer(serializers.ModelSerializer):
+    """A completed bulk operation and every selected plant's result."""
+
+    results = BulkPlantOperationResultSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = BulkPlantOperation
+        fields = [
+            'pk',
+            'idempotency_key',
+            'action',
+            'atomicity',
+            'occurred_at',
+            'reason',
+            'selection_source',
+            'action_payload',
+            'created_by',
+            'created',
+            'results',
+        ]
+        read_only_fields = fields
+
+
+def _domain_error(error):
+    """Translate a model/service validation error into a REST error."""
+    if hasattr(error, 'message_dict'):
+        return ValidationError(error.message_dict)
+    return ValidationError(error.messages)
+
+
+class BulkPlantOperationViewSet(
+    RequireWorkspaceModeMixin,
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Preview, execute, and read immutable Nursery bulk operations."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    queryset = BulkPlantOperation.objects.prefetch_related('results')
+    serializer_class = BulkPlantOperationSerializer
+
+    def _request_values(self, request, require_key):
+        serializer = BulkOperationRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = dict(serializer.validated_data)
+        if require_key and 'idempotency_key' not in values:
+            raise ValidationError({'idempotency_key': 'This field is required.'})
+        return concrete_request(**values)
+
+    @action(detail=False, methods=['post'])
+    def preview(self, request):
+        """Resolve eligibility and effects without writing an audit or plant fact."""
+        operation_request = self._request_values(request, require_key=False)
+        try:
+            preview = preview_bulk_operation(
+                self.get_current_workspace(),
+                operation_request,
+            )
+        except DjangoValidationError as exc:
+            raise _domain_error(exc) from exc
+        return Response(preview)
+
+    def create(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        """Execute a confirmed plan once and replay completed retries."""
+        operation_request = self._request_values(request, require_key=True)
+        try:
+            operation, replayed = execute_bulk_operation(
+                self.get_current_workspace(),
+                request.user,
+                operation_request,
+            )
+        except BulkOperationConflict as exc:
+            return Response(
+                {'detail': 'The bulk operation has conflicts.', **exc.preview},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except DjangoValidationError as exc:
+            raise _domain_error(exc) from exc
+        response_status = status.HTTP_200_OK if replayed else status.HTTP_201_CREATED
+        return Response(self.get_serializer(operation).data, status=response_status)
+
+
+def register_bulk_operation_routes(router):
+    """Attach bulk execution and audit endpoints to the planting router."""
+    router.register(
+        r'bulk-operations',
+        BulkPlantOperationViewSet,
+        basename='bulk-plant-operation',
+    )

--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -316,7 +316,7 @@ def _require_chronology(events, occurred_at):
         })
 
 
-def _validate_outcome(plant, event_type, occurred_at):
+def validate_outcome(plant, event_type, occurred_at):
     """Check one plant admits a fact before anything is written."""
     events = _plant_events(plant)
     _require_chronology(events, occurred_at)
@@ -373,7 +373,7 @@ def record_lifecycle_event(plant, user, request):
     """Record one validated fact about a plant and close its location if final."""
     plant = _lock_plant(plant)
     request = request.at(timezone.now())
-    _validate_outcome(plant, request.event_type, request.occurred_at)
+    validate_outcome(plant, request.event_type, request.occurred_at)
     return _apply_outcome(plant, user, request)
 
 
@@ -395,7 +395,7 @@ def record_transplant_event(plant, user, occurred_at):
 
     Called from inside `move_specific_plant`, which already locks the plant.
     """
-    _validate_outcome(plant, EventType.TRANSPLANTED, occurred_at)
+    validate_outcome(plant, EventType.TRANSPLANTED, occurred_at)
     return _create_event(
         plant,
         user,
@@ -455,7 +455,7 @@ def record_bulk_outcome(plant_ids, user, request):
     errors = []
     for plant in plants:
         try:
-            _validate_outcome(plant, request.event_type, request.occurred_at)
+            validate_outcome(plant, request.event_type, request.occurred_at)
         except ValidationError as exc:
             errors.append(f'Plant {plant.pk}: {" ".join(exc.messages)}')
     if errors:

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -210,7 +210,7 @@ def _apply_search(queryset, search):
     return queryset.filter(matches)
 
 
-def register_queryset(workspace, filters):
+def register_queryset(workspace, filters):  # pylint: disable=too-many-branches
     """Return the plants one validated filter set selects, in its order."""
     queryset = register_projection(workspace)
     if filters.variety is not None:

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -65,6 +65,7 @@ class RegisterFilters(NamedTuple):
     germinated_to: object = None
     location_type: object = None
     seed_tray: object = None
+    generation: object = None
     garden_square: object = None
     location: object = None
     search: str = ''
@@ -98,6 +99,7 @@ def parse_register_filters(query_params):
         germinated_to=parse_datetime(query_params.get('germinated_to'), 'germinated_to'),
         location_type=location_type,
         seed_tray=parse_integer(query_params.get('seed_tray'), 'seed_tray'),
+        generation=parse_integer(query_params.get('generation'), 'generation'),
         garden_square=parse_integer(query_params.get('garden_square'), 'garden_square'),
         location=parse_integer(query_params.get('location'), 'location'),
         search=(query_params.get('search') or '').strip(),
@@ -229,6 +231,10 @@ def register_queryset(workspace, filters):
         queryset = queryset.filter(current_location_type=filters.location_type)
     if filters.seed_tray is not None:
         queryset = queryset.filter(current_seed_tray=filters.seed_tray)
+    if filters.generation is not None:
+        queryset = queryset.filter(
+            cell_planting__seed_tray_planting__generation_id=filters.generation,
+        )
     if filters.garden_square is not None:
         queryset = queryset.filter(current_garden_square=filters.garden_square)
     if filters.location is not None:

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -1033,3 +1033,13 @@ router.register(r'specificplants/(?P<specific_plant_pk>[^/.]+)/locations', Speci
 register_lifecycle_routes(router)
 register_harvest_routes(router)
 register_register_routes(router)
+
+
+def _register_bulk_routes():
+    """Import after the move serializer that bulk payload validation reuses."""
+    from .bulk_rest import register_bulk_operation_routes  # pylint: disable=import-outside-toplevel
+
+    register_bulk_operation_routes(router)
+
+
+_register_bulk_routes()

--- a/plantings/test_bulk_rest.py
+++ b/plantings/test_bulk_rest.py
@@ -1,0 +1,212 @@
+"""REST contract tests for reviewed bulk plant operations."""
+
+from uuid import uuid4
+
+from django.utils import timezone
+
+from locations.models import Location
+from tests.api import RESTContractTestCase
+from tests.factories import (
+    make_location,
+    make_seed_tray_cell_planting,
+    make_specific_plant,
+    make_specific_plant_location,
+)
+from workspaces.models import Workspace
+
+from .lifecycle import EventType, OutcomeRequest, record_lifecycle_event
+from .models import (
+    BulkPlantOperation,
+    PlantLifecycleEvent,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
+
+
+class BulkPlantOperationRESTTests(RESTContractTestCase):
+    """Confirmed actions retain one result and domain record per plant."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = Workspace.objects.get()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save(update_fields=['mode'])
+        self.plants = [make_specific_plant() for _index in range(3)]
+        for plant in self.plants:
+            make_specific_plant_location(specific_plant=plant)
+
+    def payload(self, action, plants=None, **overrides):
+        """Return one complete confirmed request with a fresh identity."""
+        values = {
+            'idempotency_key': str(uuid4()),
+            'action': action,
+            'atomicity': BulkPlantOperation.Atomicity.ALL_OR_NOTHING,
+            'occurred_at': timezone.now().isoformat(),
+            'reason': 'Routine nursery work.',
+            'plants': (
+                [plant.pk for plant in self.plants]
+                if plants is None else plants
+            ),
+            'selection_source': {'mode': 'ids'},
+            'action_payload': {},
+        }
+        values.update(overrides)
+        return values
+
+    def test_preview_reports_mixed_eligibility_without_writing(self):
+        """Review identifies conflicts but creates no audit or new facts."""
+        record_lifecycle_event(
+            self.plants[0],
+            self.user,
+            OutcomeRequest(EventType.FAILED),
+        )
+        before = PlantLifecycleEvent.objects.count()
+        response = self.client.post(
+            '/plantings/bulk-operations/preview/',
+            self.payload(BulkPlantOperation.Action.CULL),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['selected'], 3)
+        self.assertEqual(response.data['eligible'], 2)
+        self.assertEqual(response.data['conflicts'], 1)
+        self.assertEqual(PlantLifecycleEvent.objects.count(), before)
+        self.assertFalse(BulkPlantOperation.objects.exists())
+
+    def test_all_or_nothing_conflict_applies_and_audits_nothing(self):
+        """A rejected confirmed attempt is not retained as an operation."""
+        record_lifecycle_event(
+            self.plants[0],
+            self.user,
+            OutcomeRequest(EventType.FAILED),
+        )
+        response = self.client.post(
+            '/plantings/bulk-operations/',
+            self.payload(BulkPlantOperation.Action.CULL),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data['conflicts'], 1)
+        self.assertFalse(BulkPlantOperation.objects.exists())
+        self.assertFalse(
+            PlantLifecycleEvent.objects.filter(
+                plant__in=self.plants[1:],
+                event_type=EventType.CULLED,
+            ).exists(),
+        )
+
+    def test_eligible_only_records_applied_and_skipped_results(self):
+        """Mixed work remains reviewable without losing per-plant history."""
+        record_lifecycle_event(
+            self.plants[0],
+            self.user,
+            OutcomeRequest(EventType.FAILED),
+        )
+        response = self.client.post(
+            '/plantings/bulk-operations/',
+            self.payload(
+                BulkPlantOperation.Action.CULL,
+                atomicity=BulkPlantOperation.Atomicity.ELIGIBLE_ONLY,
+            ),
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        results = {entry['plant']: entry for entry in response.data['results']}
+        self.assertEqual(results[self.plants[0].pk]['status'], 'skipped')
+        for plant in self.plants[1:]:
+            self.assertEqual(results[plant.pk]['status'], 'applied')
+            self.assertIsNotNone(results[plant.pk]['lifecycle_event'])
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(event_type=EventType.CULLED).count(),
+            2,
+        )
+
+    def test_an_identical_retry_replays_but_changed_input_is_rejected(self):
+        """A lost response cannot double-post or repurpose its request key."""
+        payload = self.payload(BulkPlantOperation.Action.READY)
+        first = self.client.post('/plantings/bulk-operations/', payload, format='json')
+        second = self.client.post('/plantings/bulk-operations/', payload, format='json')
+        self.assertEqual(first.status_code, 201, first.data)
+        self.assertEqual(second.status_code, 200, second.data)
+        self.assertEqual(first.data, second.data)
+        self.assertEqual(BulkPlantOperation.objects.count(), 1)
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(event_type=EventType.READY).count(),
+            3,
+        )
+
+        payload['reason'] = 'Different work.'
+        changed = self.client.post('/plantings/bulk-operations/', payload, format='json')
+        self.assertEqual(changed.status_code, 400)
+        self.assertIn('idempotency_key', changed.data)
+
+    def test_move_preview_allocates_the_last_capacity_deterministically(self):
+        """Eligible-only review chooses plants by ID when only some fit."""
+        bench = make_location(
+            location_type=Location.LocationType.BENCH,
+            capacity_basis=Location.CapacityBasis.PLANTS,
+            capacity_value=1,
+        )
+        payload = self.payload(
+            BulkPlantOperation.Action.MOVE,
+            atomicity=BulkPlantOperation.Atomicity.ELIGIBLE_ONLY,
+            action_payload={
+                'location_type': SpecificPlantLocation.LOCATION,
+                'location': bench.pk,
+            },
+        )
+        preview = self.client.post(
+            '/plantings/bulk-operations/preview/',
+            payload,
+            format='json',
+        )
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(preview.data['eligible'], 1)
+        eligible = [row['plant'] for row in preview.data['plants'] if row['eligible']]
+        self.assertEqual(eligible, [min(plant.pk for plant in self.plants)])
+
+        response = self.client.post('/plantings/bulk-operations/', payload, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                specific_plant__in=self.plants,
+                location=bench,
+                ended__isnull=True,
+            ).count(),
+            1,
+        )
+
+    def test_bulk_germination_creates_independent_plants_and_facts(self):
+        """A quantity observation remains individual from its first record."""
+        allocation = make_seed_tray_cell_planting(quantity=2)
+        payload = self.payload(
+            BulkPlantOperation.Action.GERMINATE,
+            plants=[],
+            action_payload={
+                'cell_planting': allocation.pk,
+                'quantity': 3,
+                'notes': 'Multigerm cluster.',
+            },
+        )
+        response = self.client.post('/plantings/bulk-operations/', payload, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        plant_ids = [entry['plant'] for entry in response.data['results']]
+        self.assertEqual(len(plant_ids), 3)
+        self.assertEqual(
+            SpecificPlant.objects.filter(pk__in=plant_ids).count(),
+            3,
+        )
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(
+                plant_id__in=plant_ids,
+                event_type=EventType.GERMINATED,
+            ).count(),
+            3,
+        )
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                specific_plant_id__in=plant_ids,
+                ended__isnull=True,
+            ).count(),
+            3,
+        )

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -25,6 +25,7 @@ from tests.factories import (
     make_seed_tray,
     make_seed_tray_cell,
     make_seed_tray_cell_planting,
+    make_seed_tray_generation,
     make_seed_tray_model,
     make_seed_tray_planting,
     make_specific_plant,
@@ -288,6 +289,15 @@ class RegisterFilterTests(RegisterTestCase):
 
         nowhere = self.assert_filter_agrees(location_type='none')
         self.assertEqual(self.row_ids(nowhere), [unplaced.pk])
+
+    def test_a_generation_filter_selects_one_concrete_tray_fill(self):
+        """A reused tray does not make its previous fill part of today's work."""
+        generation = make_seed_tray_generation()
+        wanted = self.make_plant(tray=generation.tray)
+        self.make_plant()
+
+        payload = self.assert_filter_agrees(generation=generation.pk)
+        self.assertEqual(self.row_ids(payload), [wanted.pk])
 
     def test_a_finished_plant_leaves_its_location_behind(self):
         """An outcome that ends a location must stop reporting it as current."""


### PR DESCRIPTION
Nursery operators need to act on explicit plant selections without losing per-plant validation or audit history. Add previewed lifecycle and move actions, deterministic capacity planning, both atomicity modes, idempotent execution, quantity germination, and tray-fill register selection.

## Summary by Sourcery

Introduce reviewed bulk plant operations with preview, deterministic capacity planning, lifecycle-consistent validation, and idempotent execution, including quantity-based germination from tray-cell allocations and generation-aware tray-fill selection in the register.

New Features:
- Add REST endpoints and underlying services for previewing and executing reviewed bulk plant operations with idempotency and atomicity controls
- Support bulk germination from tray-cell allocations while creating individually auditable plants and lifecycle/location records

Enhancements:
- Expose generation-based tray-fill filtering in the plant register so reused trays only select the current fill
- Share lifecycle outcome validation between single-plant and bulk operations to keep rules consistent
- Integrate bulk operation routes into the existing plantings router

Tests:
- Add REST contract tests covering bulk operation preview, execution behaviour, idempotency, capacity handling, and bulk germination outcomes
- Extend register tests to cover generation-based tray-fill filtering