### PR TITLE
feat(frontend): review and confirm bulk plant actions

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -1,6 +1,9 @@
 import { fetchAsJson, csrfPatch, csrfPost } from '../utils'
 import {
   BatchAction,
+  BulkPlantOperation,
+  BulkPlantOperationRequest,
+  BulkPlantPreview,
   BulkPlantOutcome,
   Harvest,
   HarvestCreate,
@@ -184,6 +187,14 @@ function postBulkPlantOutcome(data: BulkPlantOutcome): Promise<Array<PlantLifecy
   return csrfPost('/plantings/specificplants/bulk-outcome/', data).then((response) => response.json() as Promise<Array<PlantLifecycleEvent>>)
 }
 
+function previewBulkPlantOperation(data: BulkPlantOperationRequest): Promise<BulkPlantPreview> {
+  return csrfPost('/plantings/bulk-operations/preview/', data).then((response) => response.json() as Promise<BulkPlantPreview>)
+}
+
+function postBulkPlantOperation(data: BulkPlantOperationRequest): Promise<BulkPlantOperation> {
+  return csrfPost('/plantings/bulk-operations/', data).then((response) => response.json() as Promise<BulkPlantOperation>)
+}
+
 function harvestQuery(filters: HarvestFilters | HarvestReportFilters): string {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(filters)) {
@@ -275,6 +286,8 @@ export {
   postSpecificPlantOutcome,
   reverseSpecificPlantEvent,
   postBulkPlantOutcome,
+  previewBulkPlantOperation,
+  postBulkPlantOperation,
   getHarvests,
   getHarvest,
   addHarvest,

--- a/frontend/js/plantings/bulk_operations.tsx
+++ b/frontend/js/plantings/bulk_operations.tsx
@@ -1,0 +1,309 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+
+import { getGardenSquares } from '../api/garden'
+import { getNurseryRegisterSelection, postBulkPlantOperation, previewBulkPlantOperation } from '../api/plantings'
+import { getSeedTrayCells, getSeedTrays } from '../api/seedtrays'
+import { queryKeys } from '../query'
+import { Location } from '../types/locations'
+import { BulkPlantAction, BulkPlantAtomicity, BulkPlantOperationRequest, BulkPlantPreview, NurseryRegisterFilters } from '../types/plantings'
+import { localDatetimeInputValue, parseLocalDatetimeInput } from '../utils'
+import { EMPTY_SELECTION, RegisterSelection } from './register_list'
+
+const ACTIONS: Array<{ value: BulkPlantAction; label: string }> = [
+  { value: 'move', label: 'Move or transplant' },
+  { value: 'ready', label: 'Mark ready' },
+  { value: 'retain', label: 'Retain' },
+  { value: 'donate', label: 'Donate' },
+  { value: 'fail', label: 'Record failed' },
+  { value: 'cull', label: 'Cull' },
+  { value: 'finish_harvest', label: 'Finish harvest' }
+]
+
+type DestinationType = 'location' | 'garden_square' | 'seed_tray_cell'
+
+interface BulkOperationPanelProps {
+  selection: RegisterSelection
+  filters: NurseryRegisterFilters
+  locations: Array<Location>
+  setSelection: (selection: RegisterSelection) => void
+}
+
+function BulkOperationPanel({ selection, filters, locations, setSelection }: BulkOperationPanelProps) {
+  const cache = useQueryClient()
+  const [action, setAction] = React.useState<BulkPlantAction>('move')
+  const [atomicity, setAtomicity] = React.useState<BulkPlantAtomicity | ''>('')
+  const [occurredAt, setOccurredAt] = React.useState(localDatetimeInputValue())
+  const [reason, setReason] = React.useState('')
+  const [destinationType, setDestinationType] = React.useState<DestinationType>('location')
+  const [destination, setDestination] = React.useState<number | ''>('')
+  const [tray, setTray] = React.useState<number | ''>('')
+  const [overrideReason, setOverrideReason] = React.useState('')
+  const [request, setRequest] = React.useState<BulkPlantOperationRequest>()
+  const [preview, setPreview] = React.useState<BulkPlantPreview>()
+
+  const gardenSquaresQuery = useQuery({ queryKey: queryKeys.garden.squares, queryFn: ({ signal }) => getGardenSquares(signal) })
+  const traysQuery = useQuery({ queryKey: queryKeys.seedTrays.trays, queryFn: ({ signal }) => getSeedTrays(signal) })
+  const cellsQuery = useQuery({
+    queryKey: queryKeys.seedTrays.cells(tray || 0),
+    queryFn: ({ signal }) => getSeedTrayCells(tray as number, signal),
+    enabled: destinationType === 'seed_tray_cell' && tray !== ''
+  })
+
+  function invalidateReview() {
+    setPreview(undefined)
+    setRequest(undefined)
+  }
+
+  function actionPayload(): Record<string, unknown> {
+    if (action !== 'move') return {}
+    if (destinationType === 'location') {
+      return { location_type: destinationType, location: destination, override_reason: overrideReason }
+    }
+    if (destinationType === 'garden_square') {
+      return { location_type: destinationType, garden_square: destination }
+    }
+    return { location_type: destinationType, seed_tray_cell: destination }
+  }
+
+  const previewMutation = useMutation({
+    mutationFn: previewBulkPlantOperation,
+    onSuccess: (review, reviewedRequest) => {
+      setPreview(review)
+      setRequest(reviewedRequest)
+    }
+  })
+  const executeMutation = useMutation({
+    mutationFn: postBulkPlantOperation,
+    onSuccess: () => {
+      setSelection(EMPTY_SELECTION)
+      setPreview(undefined)
+      setRequest(undefined)
+      return Promise.all([
+        cache.invalidateQueries({ queryKey: queryKeys.plantings.registerAll }),
+        cache.invalidateQueries({ queryKey: queryKeys.plantings.specificPlantsAll }),
+        cache.invalidateQueries({ queryKey: queryKeys.plantings.batchesAll }),
+        cache.invalidateQueries({ queryKey: queryKeys.locations.all })
+      ])
+    }
+  })
+
+  async function review() {
+    const parsed = parseLocalDatetimeInput(occurredAt)
+    if (!parsed) return
+    const resolved = selection.mode === 'filter' ? await getNurseryRegisterSelection(filters) : { plants: selection.ids, count: selection.ids.length }
+    const reviewedRequest: BulkPlantOperationRequest = {
+      idempotency_key: globalThis.crypto.randomUUID(),
+      action,
+      atomicity: atomicity || 'all_or_nothing',
+      occurred_at: parsed.toISOString(),
+      reason,
+      plants: resolved.plants,
+      selection_source: selection.mode === 'filter' ? { mode: 'filter', filters } : { mode: 'ids' },
+      action_payload: actionPayload()
+    }
+    previewMutation.mutate(reviewedRequest)
+  }
+
+  const moveIncomplete = action === 'move' && destination === ''
+  return (
+    <Card className="mb-3">
+      <Card.Body>
+        <Card.Title>Bulk action</Card.Title>
+        <Row className="g-2">
+          <Col md={3}>
+            <Form.Label>Action</Form.Label>
+            <Form.Select
+              value={action}
+              onChange={(event) => {
+                setAction(event.target.value as BulkPlantAction)
+                invalidateReview()
+              }}
+            >
+              {ACTIONS.map((entry) => (
+                <option key={entry.value} value={entry.value}>
+                  {entry.label}
+                </option>
+              ))}
+            </Form.Select>
+          </Col>
+          <Col md={3}>
+            <Form.Label>When</Form.Label>
+            <Form.Control
+              type="datetime-local"
+              value={occurredAt}
+              onChange={(event) => {
+                setOccurredAt(event.target.value)
+                invalidateReview()
+              }}
+            />
+          </Col>
+          <Col md={6}>
+            <Form.Label>Reason or notes</Form.Label>
+            <Form.Control
+              value={reason}
+              onChange={(event) => {
+                setReason(event.target.value)
+                invalidateReview()
+              }}
+            />
+          </Col>
+        </Row>
+
+        {action === 'move' && (
+          <Row className="g-2 mt-1">
+            <Col md={3}>
+              <Form.Label>Destination kind</Form.Label>
+              <Form.Select
+                value={destinationType}
+                onChange={(event) => {
+                  setDestinationType(event.target.value as DestinationType)
+                  setDestination('')
+                  setTray('')
+                  invalidateReview()
+                }}
+              >
+                <option value="location">Nursery location</option>
+                <option value="garden_square">Garden square</option>
+                <option value="seed_tray_cell">Seed tray cell</option>
+              </Form.Select>
+            </Col>
+            {destinationType === 'seed_tray_cell' && (
+              <Col md={3}>
+                <Form.Label>Tray</Form.Label>
+                <Form.Select
+                  value={tray}
+                  onChange={(event) => {
+                    setTray(event.target.value ? Number(event.target.value) : '')
+                    setDestination('')
+                    invalidateReview()
+                  }}
+                >
+                  <option value="">Select tray</option>
+                  {(traysQuery.data ?? []).map((entry) => (
+                    <option key={entry.pk} value={entry.pk}>
+                      Tray #{entry.pk}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Col>
+            )}
+            <Col md={3}>
+              <Form.Label>Destination</Form.Label>
+              <Form.Select
+                value={destination}
+                onChange={(event) => {
+                  setDestination(event.target.value ? Number(event.target.value) : '')
+                  invalidateReview()
+                }}
+              >
+                <option value="">Select destination</option>
+                {destinationType === 'location' &&
+                  locations.map((entry) => (
+                    <option key={entry.pk} value={entry.pk}>
+                      {entry.full_name}
+                    </option>
+                  ))}
+                {destinationType === 'garden_square' &&
+                  (gardenSquaresQuery.data ?? []).map((entry) => (
+                    <option key={entry.pk} value={entry.pk}>
+                      {entry.name}
+                    </option>
+                  ))}
+                {destinationType === 'seed_tray_cell' &&
+                  (cellsQuery.data ?? []).map((entry) => (
+                    <option key={entry.pk} value={entry.pk}>
+                      ({entry.x_position},{entry.y_position})
+                    </option>
+                  ))}
+              </Form.Select>
+            </Col>
+            {destinationType === 'location' && (
+              <Col md={3}>
+                <Form.Label>Capacity override reason</Form.Label>
+                <Form.Control
+                  value={overrideReason}
+                  onChange={(event) => {
+                    setOverrideReason(event.target.value)
+                    invalidateReview()
+                  }}
+                  placeholder="Leave blank to enforce capacity"
+                />
+              </Col>
+            )}
+          </Row>
+        )}
+
+        <Button className="mt-3" variant="outline-primary" disabled={moveIncomplete || previewMutation.isPending} onClick={review}>
+          {previewMutation.isPending ? 'Reviewing…' : 'Review changes'}
+        </Button>
+
+        {preview && request && (
+          <div className="mt-3">
+            <Alert variant={preview.conflicts ? 'warning' : 'success'}>
+              {preview.eligible} of {preview.selected} plants are eligible; {preview.conflicts} have conflicts.
+            </Alert>
+            {preview.capacity.length > 0 && (
+              <p className="small text-muted">Capacity checked at {preview.capacity.map((entry) => `${entry.used} used / ${entry.capacity} ${entry.basis}`).join(', ')}.</p>
+            )}
+            {preview.plants.length > 0 && (
+              <Table size="sm" responsive>
+                <thead>
+                  <tr>
+                    <th>Plant</th>
+                    <th>Current</th>
+                    <th>After</th>
+                    <th>Review</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.plants.slice(0, 100).map((row) => (
+                    <tr key={row.plant}>
+                      <td>#{row.plant}</td>
+                      <td>{row.before.lifecycle_state}</td>
+                      <td>
+                        {row.after.lifecycle_state}
+                        {row.after.location_type ? ` at ${row.after.location_type.replaceAll('_', ' ')}` : ''}
+                      </td>
+                      <td>{row.eligible ? 'Eligible' : row.conflicts.join(' ')}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            )}
+            {preview.plants.length > 100 && <p className="text-muted small">Showing the first 100 of {preview.plants.length} reviewed plants.</p>}
+            <Form.Label>How should conflicts be handled?</Form.Label>
+            <div>
+              <Form.Check
+                inline
+                type="radio"
+                name="bulk-atomicity"
+                label="Apply nothing if any conflict remains"
+                checked={atomicity === 'all_or_nothing'}
+                onChange={() => setAtomicity('all_or_nothing')}
+              />
+              <Form.Check
+                inline
+                type="radio"
+                name="bulk-atomicity"
+                label="Apply eligible plants only"
+                checked={atomicity === 'eligible_only'}
+                onChange={() => setAtomicity('eligible_only')}
+              />
+            </div>
+            <Button
+              className="mt-2"
+              disabled={!atomicity || executeMutation.isPending || (atomicity === 'all_or_nothing' && preview.conflicts > 0)}
+              onClick={() => executeMutation.mutate({ ...request, atomicity: atomicity as BulkPlantAtomicity })}
+            >
+              {executeMutation.isPending ? 'Applying…' : 'Confirm bulk action'}
+            </Button>
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
+
+export { BulkOperationPanel }

--- a/frontend/js/plantings/register.tsx
+++ b/frontend/js/plantings/register.tsx
@@ -5,10 +5,12 @@ import { Alert, Badge, Button, ButtonGroup, Card, Col, Form, Row } from 'react-b
 import { getLocations } from '../api/locations'
 import { getNurseryRegister, getProductionBatches } from '../api/plantings'
 import { getPlantVarieties } from '../api/plants'
+import { getSeedTrayGenerations, getSeedTrays } from '../api/seedtrays'
 import { queryKeys } from '../query'
 import { NurseryRegisterFilters, NurseryRegisterOrdering, NurseryRegisterTotals, PlantLifecycleState } from '../types/plantings'
 import { STATE_LABELS } from './lifecycle'
 import { EMPTY_SELECTION, RegisterSelection, RegisterTable } from './register_list'
+import { BulkOperationPanel } from './bulk_operations'
 
 const PAGE_SIZE = 50
 
@@ -99,6 +101,8 @@ function NurseryRegisterView() {
   const [states, setStates] = React.useState<Array<PlantLifecycleState>>([])
   const [locationType, setLocationType] = React.useState<NurseryRegisterFilters['location_type'] | ''>('')
   const [location, setLocation] = React.useState<number | ''>('')
+  const [seedTray, setSeedTray] = React.useState<number | ''>('')
+  const [generation, setGeneration] = React.useState<number | ''>('')
   const [germinatedFrom, setGerminatedFrom] = React.useState('')
   const [germinatedTo, setGerminatedTo] = React.useState('')
   const [ordering, setOrdering] = React.useState<NurseryRegisterOrdering>('-age')
@@ -112,6 +116,8 @@ function NurseryRegisterView() {
     state: states.length > 0 ? states : undefined,
     location_type: locationType === '' ? undefined : locationType,
     location: location === '' ? undefined : location,
+    seed_tray: seedTray === '' ? undefined : seedTray,
+    generation: generation === '' ? undefined : generation,
     germinated_from: germinatedFrom || undefined,
     germinated_to: germinatedTo || undefined,
     ordering,
@@ -141,6 +147,15 @@ function NurseryRegisterView() {
     queryKey: queryKeys.locations.list('active'),
     queryFn: ({ signal }) => getLocations(signal, true)
   })
+  const { data: seedTrays = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.trays,
+    queryFn: ({ signal }) => getSeedTrays(signal)
+  })
+  const { data: generations = [] } = useQuery({
+    queryKey: queryKeys.seedTrays.generations(seedTray || 0),
+    queryFn: ({ signal }) => getSeedTrayGenerations(seedTray as number, signal),
+    enabled: seedTray !== ''
+  })
   const { data: register, isPending } = useQuery({
     queryKey: queryKeys.plantings.register(filters),
     queryFn: ({ signal }) => getNurseryRegister(filters, signal)
@@ -162,6 +177,38 @@ function NurseryRegisterView() {
           <Form.Group controlId="register-search">
             <Form.Label>Search</Form.Label>
             <Form.Control type="search" placeholder="Plant number, batch code, or crop" value={search} onChange={(event) => narrow(setSearch)(event.target.value)} />
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-seed-tray">
+            <Form.Label>Tray</Form.Label>
+            <Form.Select
+              value={seedTray}
+              onChange={(event) => {
+                narrow(setSeedTray)(event.target.value === '' ? '' : Number(event.target.value))
+                setGeneration('')
+              }}
+            >
+              <option value="">Any tray</option>
+              {seedTrays.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  Tray #{entry.pk}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Group controlId="register-generation">
+            <Form.Label>Tray fill</Form.Label>
+            <Form.Select value={generation} disabled={seedTray === ''} onChange={(event) => narrow(setGeneration)(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Any fill</option>
+              {generations.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.code}
+                </option>
+              ))}
+            </Form.Select>
           </Form.Group>
         </Col>
         <Col md={3}>
@@ -256,6 +303,9 @@ function NurseryRegisterView() {
 
       {register !== undefined && <RegisterTotals totals={register.totals} />}
       {register !== undefined && <SelectionBar selection={selection} matching={register.count} setSelection={setSelection} />}
+      {(selection.mode === 'filter' || selection.ids.length > 0) && (
+        <BulkOperationPanel selection={selection} filters={filters} locations={locations} setSelection={setSelection} />
+      )}
 
       {isPending ? (
         <div>Loading plants…</div>

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -25,12 +25,13 @@ import {
 } from '../api/seedtrays'
 import { GenerationCleanForm, GenerationCostPanel } from './generation_clean'
 import { Alert, Button, Card, Form, Table } from 'react-bootstrap'
-import { PlantLifecycleEvent, PlantOutcomeAction, SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
+import { BulkPlantOperationRequest, PlantLifecycleEvent, PlantOutcomeAction, SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
 import {
   getPlantingSeedTray,
   getSpecificPlantsBySeedTray,
   getSpecificPlantLifecycleEvents,
-  addSpecificPlant,
+  postBulkPlantOperation,
+  previewBulkPlantOperation,
   moveSpecificPlant,
   postSpecificPlantOutcome,
   reverseSpecificPlantEvent
@@ -263,17 +264,24 @@ const PlantLifecycleRow: React.FC<PlantLifecycleRowProps> = ({ plant, locationLa
 
 type GerminationFormProps = {
   cellPlantingPk: number
+  quantity: number
   date: string
   notes: string
   onChangeDate: (value: string) => void
+  onChangeQuantity: (value: number) => void
   onChangeNotes: (value: string) => void
   onSave: () => void
   onCancel: () => void
 }
 
-const GerminationForm: React.FC<GerminationFormProps> = ({ cellPlantingPk, date, notes, onChangeDate, onChangeNotes, onSave, onCancel }) => (
+const GerminationForm: React.FC<GerminationFormProps> = ({ cellPlantingPk, quantity, date, notes, onChangeDate, onChangeQuantity, onChangeNotes, onSave, onCancel }) => (
   <div style={{ marginTop: 16, padding: 12, border: '1px solid #ccc', maxWidth: 400 }}>
     <h5>Record Germination (cell planting #{cellPlantingPk})</h5>
+    <div>
+      <label>
+        Quantity: <input type="number" min={1} max={5000} value={quantity} onChange={(e) => onChangeQuantity(Number(e.target.value))} />
+      </label>
+    </div>
     <div>
       <label>
         Date: <input type="datetime-local" value={date} onChange={(e) => onChangeDate(e.target.value)} />
@@ -285,8 +293,8 @@ const GerminationForm: React.FC<GerminationFormProps> = ({ cellPlantingPk, date,
       </label>
     </div>
     <div style={{ marginTop: 8 }}>
-      <Button variant="success" onClick={onSave} disabled={!date}>
-        Save
+      <Button variant="success" onClick={onSave} disabled={!date || quantity < 1}>
+        Review and save
       </Button>{' '}
       <Button variant="secondary" onClick={onCancel}>
         Cancel
@@ -515,6 +523,7 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   const cache = useQueryClient()
   const [germinatingCellPlantingPk, setGerminatingCellPlantingPk] = React.useState<number>()
   const [germinationDate, setGerminationDate] = React.useState(localDatetimeInputValue())
+  const [germinationQuantity, setGerminationQuantity] = React.useState(1)
   const [germinationNotes, setGerminationNotes] = React.useState('')
   const [moveForm, setMoveForm] = React.useState<MoveForm>()
   const [inventoryAction, setInventoryAction] = React.useState<InventoryAction>()
@@ -583,7 +592,7 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     enabled: Boolean(moveTrayPk)
   })
   const germinationMutation = useMutation({
-    mutationFn: addSpecificPlant,
+    mutationFn: postBulkPlantOperation,
     onSuccess: () =>
       Promise.all([
         cache.invalidateQueries({ queryKey: queryKeys.plantings.specificPlants(seedTrayPk) }),
@@ -681,12 +690,29 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     if (!germinatingCellPlantingPk) return
     const parsedDate = parseLocalDatetimeInput(germinationDate)
     if (!parsedDate) return
-    await germinationMutation.mutateAsync({
-      cell_planting: germinatingCellPlantingPk,
-      germinated: parsedDate.toISOString(),
-      notes: germinationNotes || undefined
-    })
+    const request: BulkPlantOperationRequest = {
+      idempotency_key: globalThis.crypto.randomUUID(),
+      action: 'germinate',
+      atomicity: 'all_or_nothing',
+      occurred_at: parsedDate.toISOString(),
+      reason: germinationNotes,
+      plants: [],
+      selection_source: { mode: 'cell_planting', cell_planting: germinatingCellPlantingPk },
+      action_payload: {
+        cell_planting: germinatingCellPlantingPk,
+        quantity: germinationQuantity,
+        notes: germinationNotes
+      }
+    }
+    const review = await previewBulkPlantOperation(request)
+    if (review.conflicts > 0) {
+      globalThis.alert(review.source?.conflicts.join(' ') || 'This germination cannot be recorded.')
+      return
+    }
+    if (!globalThis.confirm(`Create ${review.eligible} individually tracked plant${review.eligible === 1 ? '' : 's'}?`)) return
+    await germinationMutation.mutateAsync(request)
     setGerminatingCellPlantingPk(undefined)
+    setGerminationQuantity(1)
     setGerminationNotes('')
   }
 
@@ -1092,9 +1118,11 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
       {germinatingCellPlantingPk && (
         <GerminationForm
           cellPlantingPk={germinatingCellPlantingPk}
+          quantity={germinationQuantity}
           date={germinationDate}
           notes={germinationNotes}
           onChangeDate={setGerminationDate}
+          onChangeQuantity={setGerminationQuantity}
           onChangeNotes={setGerminationNotes}
           onSave={handleRecordGermination}
           onCancel={() => setGerminatingCellPlantingPk(undefined)}

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -355,6 +355,7 @@ interface NurseryRegisterFilters {
   germinated_to?: string
   location_type?: PlantPlacementType | 'none'
   seed_tray?: number
+  generation?: number
   garden_square?: number
   // Matches the location or anything below it, so a greenhouse answers for
   // the bays inside it.
@@ -382,6 +383,70 @@ interface NurseryRegisterPage {
 interface NurseryRegisterSelection {
   count: number
   plants: Array<number>
+}
+
+type BulkPlantAction = 'germinate' | 'move' | 'ready' | 'retain' | 'donate' | 'fail' | 'cull' | 'finish_harvest'
+type BulkPlantAtomicity = 'all_or_nothing' | 'eligible_only'
+
+interface BulkPlantOperationRequest {
+  idempotency_key?: string
+  action: BulkPlantAction
+  atomicity: BulkPlantAtomicity
+  occurred_at: string
+  reason?: string
+  plants: Array<number>
+  selection_source?: Record<string, unknown>
+  action_payload?: Record<string, unknown>
+}
+
+interface BulkPlantPreviewRow {
+  plant: number
+  eligible: boolean
+  conflicts: Array<string>
+  before: { lifecycle_state: PlantLifecycleState }
+  after: { lifecycle_state: PlantLifecycleState; location_type: PlantPlacementType | null }
+}
+
+interface BulkPlantPreview {
+  action: BulkPlantAction
+  selected: number
+  eligible: number
+  conflicts: number
+  plants: Array<BulkPlantPreviewRow>
+  capacity: Array<{
+    location: number
+    basis: string
+    capacity: string
+    used: number
+    available: number
+  }>
+  source?: {
+    cell_planting: number
+    quantity: number
+    conflicts: Array<string>
+  }
+}
+
+interface BulkPlantOperationResult {
+  plant: number
+  status: 'applied' | 'skipped'
+  errors: Array<string>
+  lifecycle_event: number | null
+  location: number | null
+}
+
+interface BulkPlantOperation {
+  pk: number
+  idempotency_key: string
+  action: BulkPlantAction
+  atomicity: BulkPlantAtomicity
+  occurred_at: string
+  reason: string
+  selection_source: Record<string, unknown>
+  action_payload: Record<string, unknown>
+  created_by: number | null
+  created: string
+  results: Array<BulkPlantOperationResult>
 }
 
 // The five units a yield may be measured in. The backend rejects the seed and
@@ -523,6 +588,11 @@ export {
   NurseryRegisterPage,
   NurseryRegisterRow,
   NurseryRegisterSelection,
+  BulkPlantAction,
+  BulkPlantAtomicity,
+  BulkPlantOperationRequest,
+  BulkPlantPreview,
+  BulkPlantOperation,
   NurseryRegisterTotals,
   Planting,
   ProductionBatch,


### PR DESCRIPTION
Register selections now need an operational path from rows or filters to a frozen, reviewed request. Add capacity and state previews, explicit atomicity, stable retry keys, tray-fill filters, all supported move destinations, and quantity germination from the tray screen.

## Summary by Sourcery

Introduce a bulk plant operations workflow in the nursery register and seed tray views, including review and confirmation of bulk actions before applying them.

New Features:
- Add bulk operation types, preview, and execution APIs and models for plant actions such as move, readiness, retain, donate, fail, cull, and finish harvest.
- Add a bulk action panel to the nursery register allowing users to review eligibility, conflicts, and capacity for filter- or selection-based bulk plant changes.
- Enable germination from the seed tray screen via bulk operation requests with quantity input, preview of conflicts, and confirmation before creating individually tracked plants.
- Add tray and tray-fill (generation) filters to the nursery register to target plants originating from specific seed trays and generations.

Enhancements:
- Invalidate relevant nursery, plant, batch, and location queries after bulk operations to keep register views and related data in sync.