### PR TITLE
feat(labels): expose print and scan APIs

### DIFF
--- a/gp/urls.py
+++ b/gp/urls.py
@@ -33,4 +33,5 @@ urlpatterns = [
     path("seedtrays/", include('seedtrays.urls')),
     path("applications/", include('applications.urls')),
     path("costing/", include('costing.urls')),
+    path("labels/", include('labels.urls')),
 ]

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -146,12 +146,15 @@ def _resolution(code, workspace):
 
 
 class LabelTemplateSerializer(serializers.ModelSerializer):
+    """Validate reusable physical label layout configuration."""
+
     class Meta:
         model = LabelTemplate
         fields = ['pk', 'name', 'format', 'payload_mode', 'layout', 'fields', 'dimensions', 'built_in', 'active', 'created', 'updated']
         read_only_fields = ['pk', 'built_in', 'created', 'updated']
 
     def validate_fields(self, value):
+        """Require known fields once each in their desired display order."""
         if not isinstance(value, list) or not value or len(value) != len(set(value)):
             raise serializers.ValidationError('Choose a non-empty ordered list without duplicates.')
         unknown = set(value) - LABEL_FIELDS
@@ -160,6 +163,7 @@ class LabelTemplateSerializer(serializers.ModelSerializer):
         return value
 
     def validate_dimensions(self, value):
+        """Require positive label dimensions and non-negative page spacing."""
         if not isinstance(value, dict):
             raise serializers.ValidationError('Dimensions must be an object.')
         unknown = set(value) - DIMENSION_FIELDS
@@ -185,7 +189,12 @@ class LabelTemplateSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class LabelTemplateViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+class LabelTemplateViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Manage current-workspace print templates without deleting built-ins."""
+
     queryset = LabelTemplate.objects.all()
     serializer_class = LabelTemplateSerializer
 
@@ -197,6 +206,8 @@ class LabelTemplateViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
 
 
 class PrintTargetSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Validate the identities and template selected for one print operation."""
+
     identities = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False, max_length=5000)
     template = serializers.PrimaryKeyRelatedField(queryset=LabelTemplate.objects.all())
     payload_mode = serializers.ChoiceField(choices=LabelTemplate.PayloadMode.choices, required=False)
@@ -266,7 +277,12 @@ def _print_response(snapshot, items, job=None):
     }
 
 
-class LabelPrintJobViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):
+class LabelPrintJobViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Preview, initiate, and inspect immutable physical print jobs."""
+
     queryset = LabelPrintJob.objects.prefetch_related('items')
 
     def list(self, request, *args, **kwargs):  # pylint: disable=unused-argument
@@ -283,6 +299,7 @@ class LabelPrintJobViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelV
 
     @action(detail=False, methods=['post'])
     def preview(self, request):
+        """Render print data without creating an audit record."""
         serializer = PrintTargetSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         snapshot, items = _print_items(request, serializer.validated_data)
@@ -290,6 +307,7 @@ class LabelPrintJobViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelV
 
     @transaction.atomic
     def create(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        """Freeze one print job and every code and target value it contains."""
         serializer = PrintTargetSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         values = serializer.validated_data
@@ -306,6 +324,7 @@ class LabelPrintJobViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelV
 
     @action(detail=True, methods=['post'])
     def printed(self, request, pk=None):  # pylint: disable=unused-argument
+        """Record the first time the operator initiates the browser print dialog."""
         job = self.get_object()
         if job.printed_at is None:
             job.printed_at = timezone.now()
@@ -314,10 +333,17 @@ class LabelPrintJobViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelV
 
 
 class ReasonSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Require an audit explanation for retiring a physical code."""
+
     reason = serializers.CharField(trim_whitespace=True, allow_blank=False)
 
 
-class LabelCodeViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):
+class LabelCodeViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Resolve code history and expose explicit replacement or void actions."""
+
     queryset = LabelCode.objects.select_related('identity', 'identity__target_content_type', 'replacement')
 
     def retrieve(self, request, *args, **kwargs):  # pylint: disable=unused-argument
@@ -335,15 +361,20 @@ class LabelCodeViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewS
 
     @action(detail=True, methods=['post'])
     def replace(self, request, pk=None):  # pylint: disable=unused-argument
+        """Retire an active code and return its newly issued successor."""
         return self._retire(request, replace_code)
 
     @action(detail=True, methods=['post'])
     def void(self, request, pk=None):  # pylint: disable=unused-argument
+        """Retire an active code without issuing a successor."""
         return self._retire(request, void_code)
 
 
 class ResolveLabelView(APIView):
+    """Resolve a typed code or QR deep link inside the current workspace."""
+
     def get(self, request):
+        """Return an explicit safe outcome for every scanner input."""
         raw = request.query_params.get('value', '')
         parsed = urlparse(raw)
         if parsed.fragment:

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -1,0 +1,368 @@
+"""REST resources for label templates, printing, and scan resolution."""
+
+from urllib.parse import unquote, urlparse
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from plantings.lifecycle import derive_state
+from workspaces.models import get_current_workspace
+from workspaces.scoping import CurrentWorkspaceViewSetMixin
+
+from .models import LabelCode, LabelIdentity, LabelPrintItem, LabelPrintJob, LabelTemplate
+from .services import normalize_code, replace_code, void_code
+
+
+LABEL_FIELDS = {
+    'display',
+    'variety',
+    'batch',
+    'sowing_date',
+    'expected_ready',
+    'code',
+    'print_date',
+}
+DIMENSION_FIELDS = {
+    'label_width_mm',
+    'label_height_mm',
+    'page_width_mm',
+    'page_height_mm',
+    'margin_mm',
+    'gap_mm',
+}
+TARGET_ROUTES = {
+    ('plantings', 'specificplant'): '/plantings/plants/{pk}',
+    ('seedtrays', 'seedtray'): '/seedtrays/{pk}',
+    ('plantings', 'productionbatch'): '/plantings/batches/{pk}',
+    ('locations', 'location'): '/locations',
+    ('garden', 'gardenarea'): '/gardens/{pk}',
+}
+
+
+def _model_error(error):
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _key(identity):
+    return (identity.target_content_type.app_label, identity.target_content_type.model)
+
+
+def _active_code(identity):
+    return identity.codes.filter(status=LabelCode.Status.ACTIVE).first()
+
+
+def _target_values(identity, code=None):
+    """Project useful label fields without making them a second source of truth."""
+    target = identity.target
+    values = dict(identity.target_snapshot)
+    values['target_type'] = identity.target_content_type.model
+    values['object_id'] = identity.target_object_id
+    values['code'] = code.code if code else None
+    values['print_date'] = timezone.localdate().isoformat()
+    if target is None:
+        return values
+    key = _key(identity)
+    if key == ('plantings', 'specificplant'):
+        planting = target.cell_planting.seed_tray_planting
+        variety = planting.batch.variety
+        values.update({
+            'display': f'{variety.plant.name} — {variety.name}',
+            'variety': variety.name,
+            'batch': planting.batch.code,
+            'sowing_date': planting.planted.date().isoformat(),
+        })
+    elif key == ('plantings', 'productionbatch'):
+        values.update({
+            'display': target.code,
+            'variety': target.variety.name,
+            'batch': target.code,
+            'sowing_date': target.actual_start.date().isoformat() if target.actual_start else target.planned_start,
+        })
+    elif key == ('seedtrays', 'seedtray'):
+        open_generation = target.generations.filter(status='open').first()
+        values['display'] = f'Tray {target.pk} — {target.model.identifier}'
+        if open_generation:
+            sowings = list(open_generation.sowings.select_related('batch__variety'))
+            batches = sorted({sowing.batch.code for sowing in sowings})
+            varieties = sorted({sowing.batch.variety.name for sowing in sowings})
+            dates = sorted({sowing.planted.date().isoformat() for sowing in sowings})
+            values['batch'] = batches[0] if len(batches) == 1 else ('Mixed' if batches else None)
+            values['variety'] = varieties[0] if len(varieties) == 1 else ('Mixed' if varieties else None)
+            values['sowing_date'] = dates[0] if len(dates) == 1 else ('Mixed' if dates else None)
+    elif key == ('locations', 'location'):
+        values['display'] = target.name
+    elif key == ('garden', 'gardenarea'):
+        values['display'] = target.name
+    return values
+
+
+def _target_active(identity):
+    target = identity.target
+    if not identity.active or target is None:
+        return False
+    key = _key(identity)
+    if key == ('locations', 'location'):
+        return target.active
+    if key == ('seedtrays', 'seedtray'):
+        return target.inventory_unit.active
+    return True
+
+
+def _resolution(code, workspace):
+    """Build the safe scan contract for a code visible to this workspace."""
+    if code.workspace_id != workspace.pk:
+        return {'status': 'wrong_workspace', 'message': 'This code belongs to another workspace.'}
+    identity = code.identity
+    current = _active_code(identity)
+    resolution_status = code.status
+    if code.status == LabelCode.Status.VOID or not _target_active(identity):
+        resolution_status = 'inactive'
+    key = _key(identity)
+    route = TARGET_ROUTES.get(key)
+    capabilities = ['inspect', 'print'] if resolution_status == LabelCode.Status.ACTIVE else ['inspect']
+    if resolution_status == LabelCode.Status.ACTIVE and key == ('plantings', 'specificplant'):
+        summary = derive_state(identity.target.lifecycle_events.all())
+        if summary.state in ('growing', 'available', 'retained'):
+            capabilities.append('bulk_select')
+    return {
+        'status': resolution_status,
+        'message': {
+            'active': 'Code resolved.',
+            'replaced': 'This label was replaced; use the current code.',
+            'inactive': 'This label is inactive.',
+        }[resolution_status],
+        'code': code.code,
+        'current_code': current.code if current else None,
+        'target': _target_values(identity, current or code),
+        'deep_link': route.format(pk=identity.target_object_id) if route else None,
+        'capabilities': capabilities,
+    }
+
+
+class LabelTemplateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LabelTemplate
+        fields = ['pk', 'name', 'format', 'payload_mode', 'layout', 'fields', 'dimensions', 'built_in', 'active', 'created', 'updated']
+        read_only_fields = ['pk', 'built_in', 'created', 'updated']
+
+    def validate_fields(self, value):
+        if not isinstance(value, list) or not value or len(value) != len(set(value)):
+            raise serializers.ValidationError('Choose a non-empty ordered list without duplicates.')
+        unknown = set(value) - LABEL_FIELDS
+        if unknown:
+            raise serializers.ValidationError(f'Unknown label fields: {", ".join(sorted(unknown))}.')
+        return value
+
+    def validate_dimensions(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError('Dimensions must be an object.')
+        unknown = set(value) - DIMENSION_FIELDS
+        if unknown:
+            raise serializers.ValidationError(f'Unknown dimensions: {", ".join(sorted(unknown))}.')
+        for required in ('label_width_mm', 'label_height_mm'):
+            if required not in value or not isinstance(value[required], (int, float)) or value[required] <= 0:
+                raise serializers.ValidationError(f'{required} must be a positive number.')
+        for key, number in value.items():
+            if not isinstance(number, (int, float)) or number < 0:
+                raise serializers.ValidationError(f'{key} must be a non-negative number.')
+        return value
+
+    def validate(self, attrs):
+        format_name = attrs.get('format', getattr(self.instance, 'format', None))
+        payload_mode = attrs.get('payload_mode', getattr(self.instance, 'payload_mode', None))
+        if format_name == LabelTemplate.Format.CODE128 and payload_mode != LabelTemplate.PayloadMode.CODE:
+            raise serializers.ValidationError({'payload_mode': 'Code 128 labels always contain the bare code.'})
+        if self.instance and self.instance.built_in:
+            editable = set(attrs) - {'active'}
+            if editable:
+                raise serializers.ValidationError('Clone a built-in template before changing it.')
+        return attrs
+
+
+class LabelTemplateViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    queryset = LabelTemplate.objects.all()
+    serializer_class = LabelTemplateSerializer
+
+    def perform_destroy(self, instance):
+        if instance.built_in:
+            raise ValidationError({'template': 'Built-in templates cannot be deleted.'})
+        instance.active = False
+        instance.save(update_fields=['active', 'updated'])
+
+
+class PrintTargetSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    identities = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False, max_length=5000)
+    template = serializers.PrimaryKeyRelatedField(queryset=LabelTemplate.objects.all())
+    payload_mode = serializers.ChoiceField(choices=LabelTemplate.PayloadMode.choices, required=False)
+
+    def validate(self, attrs):
+        workspace = get_current_workspace()
+        template = attrs['template']
+        if template.workspace_id != workspace.pk:
+            raise serializers.ValidationError({'template': 'The template belongs to another workspace.'})
+        if template.format == LabelTemplate.Format.CODE128 and attrs.get('payload_mode', template.payload_mode) != LabelTemplate.PayloadMode.CODE:
+            raise serializers.ValidationError({'payload_mode': 'Code 128 labels always contain the bare code.'})
+        identities = list(LabelIdentity.objects.filter(workspace=workspace, pk__in=attrs['identities']).select_related('target_content_type'))
+        if len(identities) != len(set(attrs['identities'])):
+            raise serializers.ValidationError({'identities': 'One or more identities are unavailable or duplicated.'})
+        attrs['identities'] = identities
+        return attrs
+
+
+def _template_snapshot(template, payload_mode):
+    return {
+        'name': template.name,
+        'format': template.format,
+        'payload_mode': payload_mode,
+        'layout': template.layout,
+        'fields': template.fields,
+        'dimensions': template.dimensions,
+    }
+
+
+def _print_items(request, values):
+    template = values['template']
+    payload_mode = values.get('payload_mode', template.payload_mode)
+    base_url = request.build_absolute_uri('/').rstrip('/')
+    items = []
+    for position, identity in enumerate(values['identities']):
+        code = _active_code(identity)
+        if code is None or not _target_active(identity):
+            raise ValidationError({'identities': f'Identity {identity.pk} has no active printable code.'})
+        payload = code.code if payload_mode == 'code' else f'{base_url}/#/scan/{code.code}'
+        items.append({
+            'position': position,
+            'identity': identity,
+            'code': code,
+            'payload': payload,
+            'target_snapshot': _target_values(identity, code),
+            'is_reprint': LabelPrintItem.objects.filter(identity=identity, job__printed_at__isnull=False).exists(),
+        })
+    return _template_snapshot(template, payload_mode), items
+
+
+def _print_response(snapshot, items, job=None):
+    return {
+        'job': job.pk if job else None,
+        'printed_at': job.printed_at if job else None,
+        'template': snapshot,
+        'items': [
+            {
+                'position': item['position'],
+                'identity': item['identity'].pk,
+                'code': item['code'].code,
+                'payload': item['payload'],
+                'target': item['target_snapshot'],
+                'is_reprint': item['is_reprint'],
+            }
+            for item in items
+        ],
+    }
+
+
+class LabelPrintJobViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    queryset = LabelPrintJob.objects.prefetch_related('items')
+
+    def list(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        jobs = self.get_queryset()[:100]
+        return Response([{'pk': job.pk, 'created': job.created, 'printed_at': job.printed_at, 'items': job.items.count()} for job in jobs])
+
+    def retrieve(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        job = self.get_object()
+        items = [
+            {'position': item.position, 'identity': item.identity, 'code': item.code, 'payload': item.payload, 'target_snapshot': item.target_snapshot, 'is_reprint': item.is_reprint}
+            for item in job.items.select_related('identity', 'code')
+        ]
+        return Response(_print_response(job.template_snapshot, items, job))
+
+    @action(detail=False, methods=['post'])
+    def preview(self, request):
+        serializer = PrintTargetSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        snapshot, items = _print_items(request, serializer.validated_data)
+        return Response(_print_response(snapshot, items))
+
+    @transaction.atomic
+    def create(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        serializer = PrintTargetSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        snapshot, items = _print_items(request, values)
+        job = LabelPrintJob.objects.create(
+            workspace=self.get_current_workspace(),
+            template=values['template'],
+            template_snapshot=snapshot,
+            created_by=request.user,
+        )
+        for item in items:
+            LabelPrintItem.objects.create(job=job, **item)
+        return Response(_print_response(snapshot, items, job), status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'])
+    def printed(self, request, pk=None):  # pylint: disable=unused-argument
+        job = self.get_object()
+        if job.printed_at is None:
+            job.printed_at = timezone.now()
+            job.save(update_fields=['printed_at'])
+        return Response({'pk': job.pk, 'printed_at': job.printed_at})
+
+
+class ReasonSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    reason = serializers.CharField(trim_whitespace=True, allow_blank=False)
+
+
+class LabelCodeViewSet(CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    queryset = LabelCode.objects.select_related('identity', 'identity__target_content_type', 'replacement')
+
+    def retrieve(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        code = self.get_object()
+        return Response(_resolution(code, self.get_current_workspace()))
+
+    def _retire(self, request, service):
+        serializer = ReasonSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            result = service(self.get_object(), request.user, serializer.validated_data['reason'])
+        except DjangoValidationError as exc:
+            raise ValidationError(_model_error(exc)) from exc
+        return Response(_resolution(result, self.get_current_workspace()))
+
+    @action(detail=True, methods=['post'])
+    def replace(self, request, pk=None):  # pylint: disable=unused-argument
+        return self._retire(request, replace_code)
+
+    @action(detail=True, methods=['post'])
+    def void(self, request, pk=None):  # pylint: disable=unused-argument
+        return self._retire(request, void_code)
+
+
+class ResolveLabelView(APIView):
+    def get(self, request):
+        raw = request.query_params.get('value', '')
+        parsed = urlparse(raw)
+        if parsed.fragment:
+            candidate = parsed.fragment.rstrip('/').split('/')[-1]
+        else:
+            candidate = parsed.path.rstrip('/').split('/')[-1] if '://' in raw else raw
+        code_value = normalize_code(unquote(candidate))
+        if not code_value:
+            raise ValidationError({'value': 'Enter or scan a label code.'})
+        workspace = get_current_workspace()
+        code = LabelCode.objects.select_related('identity', 'identity__target_content_type').filter(workspace=workspace, code=code_value).first()
+        if code:
+            return Response(_resolution(code, workspace))
+        if LabelCode.objects.filter(code=code_value).exists():
+            return Response({'status': 'wrong_workspace', 'message': 'This code belongs to another workspace.'})
+        return Response({'status': 'unknown', 'message': 'No label uses this code.'})
+
+
+router = routers.SimpleRouter()
+router.register(r'templates', LabelTemplateViewSet, basename='label-template')
+router.register(r'print-jobs', LabelPrintJobViewSet, basename='label-print-job')
+router.register(r'codes', LabelCodeViewSet, basename='label-code')

--- a/labels/services.py
+++ b/labels/services.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from .models import LabelCode, LabelIdentity
+from .models import LabelCode, LabelIdentity, LabelTemplate
 
 
 ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
@@ -18,11 +18,33 @@ TARGET_PREFIXES = {
     ('locations', 'location'): 'LOC',
     ('garden', 'gardenarea'): 'GAR',
 }
+DEFAULT_TEMPLATES = (
+    ('Single QR 100 × 50 mm', 'qr', 'url', 'single', {'label_width_mm': 100, 'label_height_mm': 50}),
+    ('A4 sheet QR 63.5 × 38.1 mm', 'qr', 'url', 'sheet', {'label_width_mm': 63.5, 'label_height_mm': 38.1, 'page_width_mm': 210, 'page_height_mm': 297, 'margin_mm': 7, 'gap_mm': 2}),
+    ('Roll Code 128 50 × 30 mm', 'code128', 'code', 'roll', {'label_width_mm': 50, 'label_height_mm': 30}),
+)
 
 
 def normalize_code(value):
     """Normalize scanner and keyboard input without accepting embedded spaces."""
     return str(value).strip().upper()
+
+
+def ensure_default_templates(workspace):
+    """Create the built-in presets for a newly added workspace."""
+    for name, format_name, payload_mode, layout, dimensions in DEFAULT_TEMPLATES:
+        LabelTemplate.objects.get_or_create(
+            workspace=workspace,
+            name=name,
+            defaults={
+                'format': format_name,
+                'payload_mode': payload_mode,
+                'layout': layout,
+                'fields': ['display', 'variety', 'batch', 'sowing_date', 'expected_ready', 'code', 'print_date'],
+                'dimensions': dimensions,
+                'built_in': True,
+            },
+        )
 
 
 def code_checksum(value):

--- a/labels/signals.py
+++ b/labels/signals.py
@@ -7,12 +7,20 @@ from garden.models import GardenArea
 from locations.models import Location
 from plantings.models import ProductionBatch, SpecificPlant
 from seedtrays.models import SeedTray
+from workspaces.models import Workspace
 
 from .models import LabelIdentity
-from .services import ensure_identity, target_key
+from .services import ensure_default_templates, ensure_identity, target_key
 
 
 SUPPORTED_MODELS = (SpecificPlant, SeedTray, ProductionBatch, Location, GardenArea)
+
+
+@receiver(post_save, sender=Workspace)
+def create_workspace_label_templates(sender, instance, created, raw=False, **kwargs):  # pylint: disable=unused-argument
+    """Give every new workspace the same useful starting print layouts."""
+    if created and not raw:
+        ensure_default_templates(instance)
 
 
 @receiver(post_save, sender=SpecificPlant)

--- a/labels/test_rest.py
+++ b/labels/test_rest.py
@@ -1,0 +1,93 @@
+"""REST contract tests for label resolution and print auditing."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from tests.factories import make_garden_area, make_specific_plant
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import LabelCode, LabelPrintJob, LabelTemplate
+from .services import ensure_identity, replace_code, void_code
+
+
+class LabelResolutionTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('labels', password='secret')
+        self.client.force_login(self.user)
+        self.workspace = get_current_workspace()
+        self.identity = ensure_identity(make_specific_plant())
+        self.code = self.identity.codes.get(status=LabelCode.Status.ACTIVE)
+
+    def resolve(self, value):
+        return self.client.get('/labels/resolve/', {'value': value})
+
+    def test_bare_code_and_deep_link_resolve_to_the_same_plant(self):
+        bare = self.resolve(self.code.code)
+        linked = self.resolve(f'https://example.test/#/scan/{self.code.code}')
+        self.assertEqual(bare.status_code, 200)
+        self.assertEqual(linked.status_code, 200)
+        self.assertEqual(bare.data['status'], 'active')
+        self.assertEqual(bare.data['target']['object_id'], self.identity.target_object_id)
+        self.assertIn('bulk_select', bare.data['capabilities'])
+        self.assertEqual(linked.data['code'], bare.data['code'])
+
+    def test_unknown_replaced_void_and_wrong_workspace_are_explicit(self):
+        self.assertEqual(self.resolve('PLT-NOT-A-CODE').data['status'], 'unknown')
+        old = self.code.code
+        replacement = replace_code(self.code, self.user, 'Unreadable')
+        replaced = self.resolve(old)
+        self.assertEqual(replaced.data['status'], 'replaced')
+        self.assertEqual(replaced.data['current_code'], replacement.code)
+        void_code(replacement, self.user, 'No longer used')
+        self.assertEqual(self.resolve(replacement.code).data['status'], 'inactive')
+
+        other = Workspace.objects.create(name='Other labels')
+        foreign = ensure_identity(make_garden_area(workspace=other)).codes.get()
+        wrong = self.resolve(foreign.code)
+        self.assertEqual(wrong.data, {
+            'status': 'wrong_workspace',
+            'message': 'This code belongs to another workspace.',
+        })
+
+
+class LabelPrintJobTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('printer', password='secret')
+        self.client.force_login(self.user)
+        self.identity = ensure_identity(make_garden_area())
+        self.template = LabelTemplate.objects.get(
+            workspace=get_current_workspace(),
+            name='Single QR 100 × 50 mm',
+        )
+
+    def request(self):
+        return {'template': self.template.pk, 'identities': [self.identity.pk], 'payload_mode': 'url'}
+
+    def test_preview_is_not_audit_but_print_job_and_print_click_are(self):
+        preview = self.client.post('/labels/print-jobs/preview/', self.request(), content_type='application/json')
+        self.assertEqual(preview.status_code, 200)
+        self.assertIsNone(preview.data['job'])
+        self.assertEqual(LabelPrintJob.objects.count(), 0)
+
+        created = self.client.post('/labels/print-jobs/', self.request(), content_type='application/json')
+        self.assertEqual(created.status_code, 201)
+        self.assertIn('/#/scan/', created.data['items'][0]['payload'])
+        printed = self.client.post(f"/labels/print-jobs/{created.data['job']}/printed/", {}, content_type='application/json')
+        self.assertEqual(printed.status_code, 200)
+        self.assertIsNotNone(printed.data['printed_at'])
+
+        reprint = self.client.post('/labels/print-jobs/preview/', self.request(), content_type='application/json')
+        self.assertTrue(reprint.data['items'][0]['is_reprint'])
+
+    def test_code128_rejects_a_url_payload(self):
+        template = LabelTemplate.objects.get(
+            workspace=get_current_workspace(),
+            name='Roll Code 128 50 × 30 mm',
+        )
+        response = self.client.post(
+            '/labels/print-jobs/preview/',
+            {'template': template.pk, 'identities': [self.identity.pk], 'payload_mode': 'url'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('payload_mode', response.data)

--- a/labels/test_rest.py
+++ b/labels/test_rest.py
@@ -11,6 +11,8 @@ from .services import ensure_identity, replace_code, void_code
 
 
 class LabelResolutionTests(TestCase):
+    """Scans resolve safely without leaking records across workspaces."""
+
     def setUp(self):
         self.user = get_user_model().objects.create_user('labels', password='secret')
         self.client.force_login(self.user)
@@ -19,9 +21,11 @@ class LabelResolutionTests(TestCase):
         self.code = self.identity.codes.get(status=LabelCode.Status.ACTIVE)
 
     def resolve(self, value):
+        """Resolve one scanner value through the public endpoint."""
         return self.client.get('/labels/resolve/', {'value': value})
 
     def test_bare_code_and_deep_link_resolve_to_the_same_plant(self):
+        """Hardware scanners and phone cameras reach the same identity."""
         bare = self.resolve(self.code.code)
         linked = self.resolve(f'https://example.test/#/scan/{self.code.code}')
         self.assertEqual(bare.status_code, 200)
@@ -32,6 +36,7 @@ class LabelResolutionTests(TestCase):
         self.assertEqual(linked.data['code'], bare.data['code'])
 
     def test_unknown_replaced_void_and_wrong_workspace_are_explicit(self):
+        """Every unusable scan explains its condition without target leakage."""
         self.assertEqual(self.resolve('PLT-NOT-A-CODE').data['status'], 'unknown')
         old = self.code.code
         replacement = replace_code(self.code, self.user, 'Unreadable')
@@ -51,6 +56,8 @@ class LabelResolutionTests(TestCase):
 
 
 class LabelPrintJobTests(TestCase):
+    """Print previews and initiated jobs have distinct audit behavior."""
+
     def setUp(self):
         self.user = get_user_model().objects.create_user('printer', password='secret')
         self.client.force_login(self.user)
@@ -61,9 +68,11 @@ class LabelPrintJobTests(TestCase):
         )
 
     def request(self):
+        """Return one valid QR print selection."""
         return {'template': self.template.pk, 'identities': [self.identity.pk], 'payload_mode': 'url'}
 
     def test_preview_is_not_audit_but_print_job_and_print_click_are(self):
+        """Only initiated physical work enters immutable print history."""
         preview = self.client.post('/labels/print-jobs/preview/', self.request(), content_type='application/json')
         self.assertEqual(preview.status_code, 200)
         self.assertIsNone(preview.data['job'])
@@ -80,6 +89,7 @@ class LabelPrintJobTests(TestCase):
         self.assertTrue(reprint.data['items'][0]['is_reprint'])
 
     def test_code128_rejects_a_url_payload(self):
+        """Linear labels remain compact enough for practical scanners."""
         template = LabelTemplate.objects.get(
             workspace=get_current_workspace(),
             name='Roll Code 128 50 × 30 mm',

--- a/labels/urls.py
+++ b/labels/urls.py
@@ -1,0 +1,11 @@
+"""URL routes for labels and scanning."""
+
+from django.urls import include, path
+
+from .rest import ResolveLabelView, router
+
+
+urlpatterns = [
+    path('resolve/', ResolveLabelView.as_view(), name='resolve-label'),
+    path('', include(router.urls)),
+]

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -15,11 +15,13 @@ from typing import NamedTuple
 
 from django.db.models import Count, DecimalField, F, OuterRef, Q, Subquery, Sum, TextField, Value
 from django.db.models.functions import Coalesce
+from django.contrib.contenttypes.models import ContentType
 from rest_framework.exceptions import ValidationError
 
 from costing.models import CostAllocation
 from inventory.rest_query import parse_boolean, parse_datetime, parse_integer
 from locations.models import Location
+from labels.models import LabelCode
 
 from .lifecycle import FINAL_STATES, LifecycleState, with_lifecycle_state
 from .models import SpecificPlant, SpecificPlantLocation
@@ -144,6 +146,13 @@ def _plant_cost():
 
 def register_projection(workspace):
     """Return every plant in the workspace with its register columns."""
+    plant_content_type = ContentType.objects.get_for_model(SpecificPlant)
+    active_label = LabelCode.objects.filter(
+        workspace=workspace,
+        status=LabelCode.Status.ACTIVE,
+        identity__target_content_type=plant_content_type,
+        identity__target_object_id=OuterRef('pk'),
+    ).values('code')[:1]
     return with_lifecycle_state(
         SpecificPlant.objects
         .filter(workspace=workspace)
@@ -160,6 +169,7 @@ def register_projection(workspace):
         current_garden_square_label=_current_location('garden_square__name'),
         located_since=_current_location('started'),
         cost=_plant_cost(),
+        label_code=Subquery(active_label),
         direct_location=_current_location('location'),
         direct_location_name=_current_location('location__name'),
         direct_location_path=_current_location('location__path'),
@@ -202,7 +212,7 @@ def _apply_search(queryset, search):
     number wants that plant, not every crop whose catalog name happens to
     contain the same digit. Label codes join this once task 18 issues them.
     """
-    matches = Q(batch_code__icontains=search)
+    matches = Q(batch_code__icontains=search) | Q(label_code__iexact=search)
     if search.isdigit():
         matches |= Q(pk=int(search))
     else:

--- a/plantings/register_rest.py
+++ b/plantings/register_rest.py
@@ -74,6 +74,7 @@ class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abst
         read_only=True,
     )
     batch_code = serializers.CharField(read_only=True)
+    label_code = serializers.CharField(read_only=True, allow_null=True)
     variety = serializers.IntegerField(
         source='cell_planting.seed_tray_planting.batch.variety_id',
         read_only=True,

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -473,6 +473,7 @@ class SpecificPlantSerializer(PlantLifecycleSerializerMixin, CurrentWorkspaceSer
     sellable = serializers.SerializerMethodField()
     final_outcome = serializers.SerializerMethodField()
     final_outcome_at = serializers.SerializerMethodField()
+    label_code = serializers.SerializerMethodField()
 
     class Meta:
         model = SpecificPlant
@@ -482,12 +483,20 @@ class SpecificPlantSerializer(PlantLifecycleSerializerMixin, CurrentWorkspaceSer
             'batch',
             'germinated',
             'notes',
+            'label_code',
             'locations',
         ] + PlantLifecycleSerializerMixin.LIFECYCLE_FIELDS
 
     workspace_field_lookups = {
         'cell_planting': 'seed_tray_planting__workspace',
     }
+
+    def get_label_code(self, plant):
+        """Return the immutable physical label code currently in use."""
+        from labels.services import ensure_identity  # pylint: disable=import-outside-toplevel
+
+        identity = ensure_identity(plant)
+        return identity.codes.get(status='active').code
 
     def validate(self, data):  # pylint: disable=arguments-renamed
         """Keep a plant attached to the cell allocation it germinated from."""

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -158,6 +158,7 @@ class RegisterContractTests(RegisterTestCase):
             'final_outcome_at',
             'garden_square',
             'germinated',
+            'label_code',
             'lifecycle_state',
             'located_since',
             'location',
@@ -173,6 +174,11 @@ class RegisterContractTests(RegisterTestCase):
             'variety',
             'variety_name',
         ])
+
+    def test_label_code_search_finds_the_identified_plant(self):
+        plant = self.make_plant()
+        code = self.page()['results'][0]['label_code']
+        self.assertEqual(self.row_ids(self.page(search=code)), [plant.pk])
 
     def test_a_garden_workspace_cannot_reach_the_register(self):
         """The Garden profile has plants but no nursery to run them through."""

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -176,6 +176,7 @@ class RegisterContractTests(RegisterTestCase):
         ])
 
     def test_label_code_search_finds_the_identified_plant(self):
+        """The code from a plant's physical label resolves in ordinary search."""
         plant = self.make_plant()
         code = self.page()['results'][0]['label_code']
         self.assertEqual(self.row_ids(self.page(search=code)), [plant.pk])


### PR DESCRIPTION
Operators need workspace-safe code resolution, reusable print settings, and auditable print initiation before a browser UI can reliably produce or consume physical labels. The plant register now resolves the same code through its existing search path.

## Summary by Sourcery

Introduce REST APIs and workspace defaults for label templates, printing, and scan resolution, and integrate label codes into plant register and serialization.

New Features:
- Expose label template management, print job preview/creation, print auditing, and label code resolution via new REST endpoints and URL routes.
- Provide default built-in label templates automatically for each new workspace.
- Surface the current physical label code on specific plants in both the plant register projection and plant REST serializer, including search by label code.

Enhancements:
- Record print jobs and items with template snapshots and reprint detection to support auditability of label printing.
- Extend plant register search to resolve plants by exact label code as well as batch code.

Tests:
- Add REST contract tests covering label resolution status cases and print job preview/creation/auditing, including payload validation for Code 128 templates.
- Update plant register tests to assert presence of label_code in rows and support searching plants by their label code.