### PR TITLE
feat(frontend): print and scan physical labels

### DIFF
--- a/frontend/js/api/labels.ts
+++ b/frontend/js/api/labels.ts
@@ -1,0 +1,28 @@
+import { csrfPost, fetchAsJson } from '../utils'
+import { LabelIdentity, LabelPayloadMode, LabelPrintJob, LabelResolution, LabelTemplate } from '../types/labels'
+
+function getLabelIdentities(signal?: AbortSignal): Promise<Array<LabelIdentity>> {
+  return fetchAsJson<Array<LabelIdentity>>('/labels/identities/', signal)
+}
+
+function getLabelTemplates(signal?: AbortSignal): Promise<Array<LabelTemplate>> {
+  return fetchAsJson<Array<LabelTemplate>>('/labels/templates/', signal)
+}
+
+function resolveLabel(value: string, signal?: AbortSignal): Promise<LabelResolution> {
+  return fetchAsJson<LabelResolution>(`/labels/resolve/?value=${encodeURIComponent(value)}`, signal)
+}
+
+function previewLabels(template: number, identities: Array<number>, payloadMode: LabelPayloadMode): Promise<LabelPrintJob> {
+  return csrfPost('/labels/print-jobs/preview/', { template, identities, payload_mode: payloadMode }).then((response) => response.json() as Promise<LabelPrintJob>)
+}
+
+function createLabelPrintJob(template: number, identities: Array<number>, payloadMode: LabelPayloadMode): Promise<LabelPrintJob> {
+  return csrfPost('/labels/print-jobs/', { template, identities, payload_mode: payloadMode }).then((response) => response.json() as Promise<LabelPrintJob>)
+}
+
+function markLabelPrintJobPrinted(job: number): Promise<{ pk: number; printed_at: string }> {
+  return csrfPost(`/labels/print-jobs/${job}/printed/`, {}).then((response) => response.json() as Promise<{ pk: number; printed_at: string }>)
+}
+
+export { createLabelPrintJob, getLabelIdentities, getLabelTemplates, markLabelPrintJobPrinted, previewLabels, resolveLabel }

--- a/frontend/js/labels.css
+++ b/frontend/js/labels.css
@@ -1,0 +1,67 @@
+.label-sheet {
+  display: grid;
+  align-content: start;
+  gap: var(--label-gap, 2mm);
+}
+
+.physical-label {
+  box-sizing: border-box;
+  overflow: hidden;
+  border: 1px dashed #adb5bd;
+  padding: 2mm;
+  display: grid;
+  grid-template-columns: minmax(20mm, 38%) 1fr;
+  gap: 2mm;
+  break-inside: avoid;
+  background: white;
+  color: black;
+}
+
+.physical-label svg {
+  width: 100%;
+  height: 100%;
+  max-height: 35mm;
+}
+
+.label-values {
+  min-width: 0;
+  font-size: 10pt;
+  line-height: 1.15;
+}
+
+.label-code {
+  font-family: monospace;
+  overflow-wrap: anywhere;
+}
+
+.scanner-video {
+  width: 100%;
+  max-height: 55vh;
+  background: #111;
+  border-radius: 0.375rem;
+}
+
+@media print {
+  body * {
+    visibility: hidden;
+  }
+
+  .label-print-area,
+  .label-print-area * {
+    visibility: visible;
+  }
+
+  .label-print-area {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+  }
+
+  .physical-label {
+    border: 0;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+}

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -1,0 +1,298 @@
+import React from 'react'
+import bwipjs from 'bwip-js/browser'
+import { BrowserMultiFormatReader, IScannerControls } from '@zxing/browser'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+import { Link, useParams } from 'react-router'
+
+import { createLabelPrintJob, getLabelIdentities, getLabelTemplates, markLabelPrintJobPrinted, previewLabels, resolveLabel } from './api/labels'
+import { getLocations } from './api/locations'
+import { queryKeys } from './query'
+import { LabelFormat, LabelPrintJob, LabelResolution } from './types/labels'
+import { BulkOperationPanel } from './plantings/bulk_operations'
+
+import './labels.css'
+
+function Barcode({ format, payload }: { format: LabelFormat; payload: string }) {
+  const svg = bwipjs.toSVG({ bcid: format === 'qr' ? 'qrcode' : 'code128', text: payload, scale: 2, includetext: false })
+  return <div aria-label={`${format === 'qr' ? 'QR' : 'Code 128'} code`} dangerouslySetInnerHTML={{ __html: svg }} />
+}
+
+function PrintArea({ job }: { job: LabelPrintJob }) {
+  const dimensions = job.template.dimensions
+  const width = `${dimensions.label_width_mm}mm`
+  const height = `${dimensions.label_height_mm}mm`
+  const columns = job.template.layout === 'sheet' ? `repeat(auto-fill, ${width})` : width
+  return (
+    <div className="label-print-area label-sheet" style={{ gridTemplateColumns: columns, ['--label-gap' as string]: `${dimensions.gap_mm ?? 0}mm` }}>
+      {job.items.map((item) => (
+        <article className="physical-label" key={`${item.identity}:${item.position}`} style={{ width, height }}>
+          <Barcode format={job.template.format} payload={item.payload} />
+          <div className="label-values">
+            {job.template.fields.map((field) => {
+              const value = item.target[field]
+              if (value === undefined || value === null || value === '') return null
+              return (
+                <div key={field} className={field === 'code' ? 'label-code' : undefined}>
+                  {field === 'display' ? <strong>{String(value)}</strong> : `${field.replaceAll('_', ' ')}: ${String(value)}`}
+                </div>
+              )
+            })}
+            {item.is_reprint && <small>Reprint</small>}
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function LabelsView() {
+  const [selected, setSelected] = React.useState<Array<number>>([])
+  const [templatePk, setTemplatePk] = React.useState<number | ''>('')
+  const [payloadMode, setPayloadMode] = React.useState<'code' | 'url'>('url')
+  const [preview, setPreview] = React.useState<LabelPrintJob>()
+  const identities = useQuery({ queryKey: ['labels', 'identities'], queryFn: ({ signal }) => getLabelIdentities(signal) })
+  const templates = useQuery({ queryKey: ['labels', 'templates'], queryFn: ({ signal }) => getLabelTemplates(signal) })
+  const selectedTemplate = templates.data?.find((entry) => entry.pk === templatePk)
+  const previewMutation = useMutation({ mutationFn: () => previewLabels(templatePk as number, selected, payloadMode), onSuccess: setPreview })
+  const printMutation = useMutation({
+    mutationFn: () => createLabelPrintJob(templatePk as number, selected, payloadMode),
+    onSuccess: async (job) => {
+      setPreview(job)
+      if (job.job !== null) {
+        await markLabelPrintJobPrinted(job.job)
+        window.setTimeout(() => window.print(), 0)
+      }
+    }
+  })
+
+  React.useEffect(() => {
+    if (templatePk === '' && templates.data?.length) setTemplatePk(templates.data[0].pk)
+  }, [templatePk, templates.data])
+
+  React.useEffect(() => {
+    if (selectedTemplate?.format === 'code128') setPayloadMode('code')
+    else if (selectedTemplate) setPayloadMode(selectedTemplate.payload_mode)
+    setPreview(undefined)
+  }, [selectedTemplate])
+
+  function toggle(identity: number) {
+    setSelected(selected.includes(identity) ? selected.filter((entry) => entry !== identity) : [...selected, identity])
+    setPreview(undefined)
+  }
+
+  return (
+    <main className="container py-3">
+      <div className="no-print">
+        <h1>Labels</h1>
+        <p>Select physical records, preview their durable labels, then initiate a browser print job.</p>
+        <Row className="g-2 mb-3">
+          <Col md={6}>
+            <Form.Label>Template</Form.Label>
+            <Form.Select value={templatePk} onChange={(event) => setTemplatePk(Number(event.target.value))}>
+              {(templates.data ?? [])
+                .filter((entry) => entry.active)
+                .map((entry) => (
+                  <option value={entry.pk} key={entry.pk}>
+                    {entry.name}
+                  </option>
+                ))}
+            </Form.Select>
+          </Col>
+          <Col md={3}>
+            <Form.Label>QR payload</Form.Label>
+            <Form.Select value={payloadMode} disabled={selectedTemplate?.format === 'code128'} onChange={(event) => setPayloadMode(event.target.value as 'code' | 'url')}>
+              <option value="url">App deep link</option>
+              <option value="code">Bare code</option>
+            </Form.Select>
+          </Col>
+        </Row>
+        <Table responsive hover size="sm">
+          <thead>
+            <tr>
+              <th>Select</th>
+              <th>Type</th>
+              <th>Record</th>
+              <th>Code</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(identities.data ?? []).map((identity) => (
+              <tr key={identity.identity}>
+                <td>
+                  <Form.Check aria-label={`Select ${identity.display}`} checked={selected.includes(identity.identity)} onChange={() => toggle(identity.identity)} />
+                </td>
+                <td>{identity.target_type}</td>
+                <td>{identity.display}</td>
+                <td className="font-monospace">{identity.code}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+        <div className="d-flex gap-2 mb-3">
+          <Button variant="outline-primary" disabled={!templatePk || selected.length === 0 || previewMutation.isPending} onClick={() => previewMutation.mutate()}>
+            Preview
+          </Button>
+          <Button disabled={!templatePk || selected.length === 0 || printMutation.isPending} onClick={() => printMutation.mutate()}>
+            Print {selected.length} label{selected.length === 1 ? '' : 's'}
+          </Button>
+        </div>
+      </div>
+      {preview && <PrintArea job={preview} />}
+    </main>
+  )
+}
+
+function ScanResult({ result }: { result: LabelResolution }) {
+  const variant = result.status === 'active' ? 'success' : result.status === 'unknown' || result.status === 'wrong_workspace' ? 'danger' : 'warning'
+  return (
+    <Alert variant={variant}>
+      <strong>{result.message}</strong>
+      {result.target && (
+        <div>
+          {result.target.display} <span className="font-monospace">{result.current_code ?? result.code}</span>
+        </div>
+      )}
+      {result.deep_link && (
+        <Link to={result.deep_link}>
+          <Button className="mt-2" size="lg">
+            Open record
+          </Button>
+        </Link>
+      )}
+    </Alert>
+  )
+}
+
+function ScannerView() {
+  const { code } = useParams()
+  const [value, setValue] = React.useState(code ?? '')
+  const [result, setResult] = React.useState<LabelResolution>()
+  const [cameraError, setCameraError] = React.useState('')
+  const [scanned, setScanned] = React.useState<Array<{ id: number; code: string; display: string }>>([])
+  const video = React.useRef<HTMLVideoElement>(null)
+  const controls = React.useRef<IScannerControls | undefined>(undefined)
+  const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+
+  const resolveMutation = useMutation({
+    mutationFn: (input: string) => resolveLabel(input),
+    onSuccess: (resolved) => {
+      setResult(resolved)
+      if (resolved.status === 'active' && resolved.target && resolved.capabilities?.includes('bulk_select')) {
+        const target = resolved.target
+        setScanned((current) =>
+          current.some((entry) => entry.id === target.object_id)
+            ? current
+            : [...current, { id: target.object_id, code: resolved.current_code ?? resolved.code ?? '', display: target.display }]
+        )
+      }
+    }
+  })
+
+  function submit(next = value) {
+    const clean = next.trim()
+    if (clean) resolveMutation.mutate(clean)
+  }
+
+  async function startCamera() {
+    setCameraError('')
+    try {
+      const reader = new BrowserMultiFormatReader()
+      controls.current = await reader.decodeFromVideoDevice(undefined, video.current ?? undefined, (decoded) => {
+        if (decoded) {
+          const text = decoded.getText()
+          setValue(text)
+          submit(text)
+        }
+      })
+    } catch (error) {
+      setCameraError(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  React.useEffect(() => {
+    if (code) submit(code)
+    return () => controls.current?.stop()
+  }, [])
+
+  const ids = scanned.map((entry) => entry.id)
+  return (
+    <main className="container py-3">
+      <h1>Scan labels</h1>
+      <Row className="g-3">
+        <Col lg={6}>
+          <Card body>
+            <video ref={video} className="scanner-video" muted playsInline />
+            <div className="d-flex gap-2 mt-2">
+              <Button size="lg" onClick={startCamera}>
+                Start camera
+              </Button>
+              <Button size="lg" variant="outline-secondary" onClick={() => controls.current?.stop()}>
+                Stop
+              </Button>
+            </div>
+            {cameraError && (
+              <Alert variant="warning" className="mt-2">
+                Camera unavailable: {cameraError}. Enter the code below or use a hardware scanner.
+              </Alert>
+            )}
+            <Form
+              className="mt-3"
+              onSubmit={(event) => {
+                event.preventDefault()
+                submit()
+              }}
+            >
+              <Form.Label>Label code or QR URL</Form.Label>
+              <div className="d-flex gap-2">
+                <Form.Control size="lg" autoFocus value={value} onChange={(event) => setValue(event.target.value)} />
+                <Button size="lg" type="submit">
+                  Resolve
+                </Button>
+              </div>
+            </Form>
+          </Card>
+          {result && (
+            <div className="mt-3">
+              <ScanResult result={result} />
+            </div>
+          )}
+        </Col>
+        <Col lg={6}>
+          <h2>
+            Plant selection <Badge bg="secondary">{scanned.length}</Badge>
+          </h2>
+          {scanned.length === 0 ? (
+            <p className="text-muted">Active plant labels scanned here will build a reviewed bulk selection.</p>
+          ) : (
+            <>
+              <ul className="list-group mb-3">
+                {scanned.map((entry) => (
+                  <li className="list-group-item d-flex justify-content-between" key={entry.id}>
+                    <span>
+                      {entry.display}
+                      <br />
+                      <small className="font-monospace">{entry.code}</small>
+                    </span>
+                    <Button variant="outline-danger" onClick={() => setScanned(scanned.filter((item) => item.id !== entry.id))}>
+                      Remove
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+              <BulkOperationPanel
+                selection={{ mode: 'ids', ids }}
+                filters={{}}
+                locations={locations.data ?? []}
+                setSelection={() => setScanned([])}
+                sourceLabels={scanned.map((entry) => entry.code)}
+              />
+            </>
+          )}
+        </Col>
+      </Row>
+    </main>
+  )
+}
+
+export { LabelsView, ScannerView }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -26,6 +26,7 @@ import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/bat
 import { HarvestsView, YieldReportView } from './plantings/harvests.js'
 import { NurseryRegisterView } from './plantings/register.js'
 import { PlantDetailView } from './plantings/plant_detail.js'
+import { LabelsView, ScannerView } from './labels.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -111,6 +112,9 @@ function FrontEndPage() {
         <Route path="/inventory" element={<InventoryCatalog />} />
         <Route path="/inventory/receipts" element={<InventoryReceiptsView />} />
         <Route path="/applications" element={<InputApplicationsView />} />
+        <Route path="/labels" element={<LabelsView />} />
+        <Route path="/scan" element={<ScannerView />} />
+        <Route path="/scan/:code" element={<ScannerView />} />
         <Route
           path="/settings"
           element={

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -90,6 +90,12 @@ function GPTopBar({ workspace }: GPTopBarProps) {
           <Nav.Link as={NavLink} to="/settings">
             Settings
           </Nav.Link>
+          <Nav.Link as={NavLink} to="/labels">
+            Labels
+          </Nav.Link>
+          <Nav.Link as={NavLink} to="/scan">
+            Scan
+          </Nav.Link>
         </Nav>
       </Navbar.Collapse>
     </Navbar>

--- a/frontend/js/plantings/bulk_operations.tsx
+++ b/frontend/js/plantings/bulk_operations.tsx
@@ -28,9 +28,10 @@ interface BulkOperationPanelProps {
   filters: NurseryRegisterFilters
   locations: Array<Location>
   setSelection: (selection: RegisterSelection) => void
+  sourceLabels?: Array<string>
 }
 
-function BulkOperationPanel({ selection, filters, locations, setSelection }: BulkOperationPanelProps) {
+function BulkOperationPanel({ selection, filters, locations, setSelection, sourceLabels }: BulkOperationPanelProps) {
   const cache = useQueryClient()
   const [action, setAction] = React.useState<BulkPlantAction>('move')
   const [atomicity, setAtomicity] = React.useState<BulkPlantAtomicity | ''>('')
@@ -100,7 +101,7 @@ function BulkOperationPanel({ selection, filters, locations, setSelection }: Bul
       occurred_at: parsed.toISOString(),
       reason,
       plants: resolved.plants,
-      selection_source: selection.mode === 'filter' ? { mode: 'filter', filters } : { mode: 'ids' },
+      selection_source: sourceLabels ? { mode: 'scan', labels: sourceLabels } : selection.mode === 'filter' ? { mode: 'filter', filters } : { mode: 'ids' },
       action_payload: actionPayload()
     }
     previewMutation.mutate(reviewedRequest)

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -3,6 +3,11 @@ import { QueryClient } from '@tanstack/react-query'
 import { NurseryRegisterFilters } from './types/plantings'
 
 const queryKeys = {
+  labels: {
+    all: ['labels'] as const,
+    identities: ['labels', 'identities'] as const,
+    templates: ['labels', 'templates'] as const
+  },
   workspace: {
     all: ['workspace'] as const,
     current: ['workspace', 'current'] as const

--- a/frontend/js/types/labels.ts
+++ b/frontend/js/types/labels.ts
@@ -1,0 +1,56 @@
+type LabelFormat = 'qr' | 'code128'
+type LabelPayloadMode = 'code' | 'url'
+type LabelLayout = 'single' | 'sheet' | 'roll'
+type LabelResolutionStatus = 'active' | 'inactive' | 'replaced' | 'wrong_workspace' | 'unknown'
+
+interface LabelIdentity {
+  identity: number
+  target_type: string
+  object_id: number
+  display: string
+  code: string
+  variety?: string | null
+  batch?: string | null
+  sowing_date?: string | null
+  expected_ready?: string | null
+}
+
+interface LabelTemplate {
+  pk: number
+  name: string
+  format: LabelFormat
+  payload_mode: LabelPayloadMode
+  layout: LabelLayout
+  fields: Array<string>
+  dimensions: Record<string, number>
+  built_in: boolean
+  active: boolean
+}
+
+interface LabelPrintItem {
+  position: number
+  identity: number
+  code: string
+  payload: string
+  target: LabelIdentity & Record<string, unknown>
+  is_reprint: boolean
+}
+
+interface LabelPrintJob {
+  job: number | null
+  printed_at: string | null
+  template: Omit<LabelTemplate, 'pk' | 'built_in' | 'active'>
+  items: Array<LabelPrintItem>
+}
+
+interface LabelResolution {
+  status: LabelResolutionStatus
+  message: string
+  code?: string
+  current_code?: string | null
+  target?: LabelIdentity
+  deep_link?: string | null
+  capabilities?: Array<string>
+}
+
+export { LabelFormat, LabelIdentity, LabelLayout, LabelPayloadMode, LabelPrintItem, LabelPrintJob, LabelResolution, LabelResolutionStatus, LabelTemplate }

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -282,6 +282,7 @@ interface ReversePlantEvent {
 
 interface SpecificPlant {
   pk: number
+  label_code: string
   cell_planting: number
   batch: number
   germinated: string
@@ -313,6 +314,7 @@ interface SowingCorrection {
 // row carries where a plant is now rather than everywhere it has been.
 interface NurseryRegisterRow {
   pk: number
+  label_code: string | null
   batch: number
   batch_code: string
   variety: number

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote, urlparse
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.utils import timezone
-from rest_framework import routers, serializers, status, viewsets
+from rest_framework import mixins, routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -61,6 +61,7 @@ def _target_values(identity, code=None):
     """Project useful label fields without making them a second source of truth."""
     target = identity.target
     values = dict(identity.target_snapshot)
+    values['identity'] = identity.pk
     values['target_type'] = identity.target_content_type.model
     values['object_id'] = identity.target_object_id
     values['code'] = code.code if code else None
@@ -203,6 +204,24 @@ class LabelTemplateViewSet(
             raise ValidationError({'template': 'Built-in templates cannot be deleted.'})
         instance.active = False
         instance.save(update_fields=['active', 'updated'])
+
+
+class LabelIdentityViewSet(CurrentWorkspaceViewSetMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+    """List printable identities without exposing generic target internals."""
+
+    queryset = LabelIdentity.objects.select_related('target_content_type').prefetch_related('codes')
+
+    def list(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        queryset = self.get_queryset().filter(active=True)
+        target_type = request.query_params.get('target_type')
+        if target_type:
+            queryset = queryset.filter(target_content_type__model=target_type)
+        rows = []
+        for identity in queryset:
+            code = _active_code(identity)
+            if code:
+                rows.append(_target_values(identity, code))
+        return Response(rows)
 
 
 class PrintTargetSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -394,6 +413,7 @@ class ResolveLabelView(APIView):
 
 
 router = routers.SimpleRouter()
+router.register(r'identities', LabelIdentityViewSet, basename='label-identity')
 router.register(r'templates', LabelTemplateViewSet, basename='label-template')
 router.register(r'print-jobs', LabelPrintJobViewSet, basename='label-print-job')
 router.register(r'codes', LabelCodeViewSet, basename='label-code')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
+        "@zxing/browser": "^0.2.1",
         "bootstrap": "^5.3.3",
+        "bwip-js": "^4.11.2",
         "esbuild": "^0.28.0",
         "esbuild-config": "^1.0.1",
         "js-cookie": "^3.0.5",
@@ -1473,6 +1475,41 @@
         "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
+    "node_modules/@zxing/browser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.2.1.tgz",
+      "integrity": "sha512-92pVfVDUXbc15xu9vIEmhNyqIEASMEkDF92CwT6T+7sg2EHXJRktH9CQKoQSXe51UtbNsj+Fm09H/JBWHMs/Sw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.23.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.23.0.tgz",
+      "integrity": "sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1759,6 +1796,15 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bwip-js": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/bwip-js/-/bwip-js-4.11.2.tgz",
+      "integrity": "sha512-gAjZvO0a8n6NmzbtqRY5gLrYO4vNWtbmUXfyWG/NMG8/qJE66ahbzA8J0MvBkWnYY69zx3qfJQq4q9qu3Bm3FQ==",
+      "license": "MIT",
+      "bin": {
+        "bwip-js": "bin/bwip-js.js"
       }
     },
     "node_modules/call-bind": {
@@ -4572,6 +4618,16 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "description": "",
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
+    "@zxing/browser": "^0.2.1",
     "bootstrap": "^5.3.3",
+    "bwip-js": "^4.11.2",
     "esbuild": "^0.28.0",
     "esbuild-config": "^1.0.1",
     "js-cookie": "^3.0.5",


### PR DESCRIPTION
Nursery work needs a mobile path from physical QR and Code 128 labels into existing records and reviewed plant operations. This adds printable layouts, audited print initiation, camera and manual scanning, explicit scan feedback, and duplicate-free scan selections.

## Summary by Sourcery

Introduce frontend and backend support for printing physical labels and scanning them to drive bulk plant operations.

New Features:
- Add labels navigation and routes for printing labels and scanning label codes in the frontend.
- Provide a labels view to select printable identities, preview rendered labels, and initiate audited print jobs using QR or Code 128 payloads.
- Add a scanner view that resolves scanned or manually entered label codes, deep-links into records, and accumulates plant selections for bulk actions.

Enhancements:
- Expose active label identities via a dedicated API endpoint without revealing target internals.
- Extend bulk plant operations to record label-based scan selections as a distinct selection source.
- Add label-related type definitions and query keys to support the new frontend flows.
- Style printable label layouts and scan UI for browser-based printing and camera usage.

Build:
- Add barcode generation and browser-based scanning libraries to the frontend dependencies.