### PR TITLE
feat(labels): save custom print templates

### DIFF
--- a/frontend/js/api/labels.ts
+++ b/frontend/js/api/labels.ts
@@ -9,6 +9,10 @@ function getLabelTemplates(signal?: AbortSignal): Promise<Array<LabelTemplate>> 
   return fetchAsJson<Array<LabelTemplate>>('/labels/templates/', signal)
 }
 
+function createLabelTemplate(data: Omit<LabelTemplate, 'pk' | 'built_in' | 'active'>): Promise<LabelTemplate> {
+  return csrfPost('/labels/templates/', data).then((response) => response.json() as Promise<LabelTemplate>)
+}
+
 function resolveLabel(value: string, signal?: AbortSignal): Promise<LabelResolution> {
   return fetchAsJson<LabelResolution>(`/labels/resolve/?value=${encodeURIComponent(value)}`, signal)
 }
@@ -25,4 +29,4 @@ function markLabelPrintJobPrinted(job: number): Promise<{ pk: number; printed_at
   return csrfPost(`/labels/print-jobs/${job}/printed/`, {}).then((response) => response.json() as Promise<{ pk: number; printed_at: string }>)
 }
 
-export { createLabelPrintJob, getLabelIdentities, getLabelTemplates, markLabelPrintJobPrinted, previewLabels, resolveLabel }
+export { createLabelPrintJob, createLabelTemplate, getLabelIdentities, getLabelTemplates, markLabelPrintJobPrinted, previewLabels, resolveLabel }

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery } from '@tanstack/react-query'
 import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
 import { Link, useParams } from 'react-router'
 
-import { createLabelPrintJob, getLabelIdentities, getLabelTemplates, markLabelPrintJobPrinted, previewLabels, resolveLabel } from './api/labels'
+import { createLabelPrintJob, createLabelTemplate, getLabelIdentities, getLabelTemplates, markLabelPrintJobPrinted, previewLabels, resolveLabel } from './api/labels'
 import { getLocations } from './api/locations'
 import { queryKeys } from './query'
 import { LabelFormat, LabelPrintJob, LabelResolution } from './types/labels'
@@ -51,6 +51,9 @@ function LabelsView() {
   const [templatePk, setTemplatePk] = React.useState<number | ''>('')
   const [payloadMode, setPayloadMode] = React.useState<'code' | 'url'>('url')
   const [preview, setPreview] = React.useState<LabelPrintJob>()
+  const [templateName, setTemplateName] = React.useState('')
+  const [labelWidth, setLabelWidth] = React.useState('50')
+  const [labelHeight, setLabelHeight] = React.useState('30')
   const identities = useQuery({ queryKey: ['labels', 'identities'], queryFn: ({ signal }) => getLabelIdentities(signal) })
   const templates = useQuery({ queryKey: ['labels', 'templates'], queryFn: ({ signal }) => getLabelTemplates(signal) })
   const selectedTemplate = templates.data?.find((entry) => entry.pk === templatePk)
@@ -63,6 +66,22 @@ function LabelsView() {
         await markLabelPrintJobPrinted(job.job)
         window.setTimeout(() => window.print(), 0)
       }
+    }
+  })
+  const templateMutation = useMutation({
+    mutationFn: () =>
+      createLabelTemplate({
+        name: templateName,
+        format: 'qr',
+        payload_mode: 'url',
+        layout: 'roll',
+        fields: ['display', 'variety', 'batch', 'sowing_date', 'expected_ready', 'code', 'print_date'],
+        dimensions: { label_width_mm: Number(labelWidth), label_height_mm: Number(labelHeight) }
+      }),
+    onSuccess: async (created) => {
+      setTemplatePk(created.pk)
+      setTemplateName('')
+      await templates.refetch()
     }
   })
 
@@ -107,6 +126,31 @@ function LabelsView() {
             </Form.Select>
           </Col>
         </Row>
+        <Card body className="mb-3">
+          <Card.Title>Save a custom roll template</Card.Title>
+          <Row className="g-2 align-items-end">
+            <Col md={5}>
+              <Form.Label>Name</Form.Label>
+              <Form.Control value={templateName} onChange={(event) => setTemplateName(event.target.value)} />
+            </Col>
+            <Col md={2}>
+              <Form.Label>Width (mm)</Form.Label>
+              <Form.Control type="number" min="1" step="0.1" value={labelWidth} onChange={(event) => setLabelWidth(event.target.value)} />
+            </Col>
+            <Col md={2}>
+              <Form.Label>Height (mm)</Form.Label>
+              <Form.Control type="number" min="1" step="0.1" value={labelHeight} onChange={(event) => setLabelHeight(event.target.value)} />
+            </Col>
+            <Col md={3}>
+              <Button
+                disabled={!templateName.trim() || Number(labelWidth) <= 0 || Number(labelHeight) <= 0 || templateMutation.isPending}
+                onClick={() => templateMutation.mutate()}
+              >
+                Save template
+              </Button>
+            </Col>
+          </Row>
+        </Card>
         <Table responsive hover size="sm">
           <thead>
             <tr>

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -1,5 +1,6 @@
 """REST resources for label templates, printing, and scan resolution."""
 
+from datetime import timedelta
 from urllib.parse import unquote, urlparse
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -78,12 +79,21 @@ def _target_values(identity, code=None):
             'batch': planting.batch.code,
             'sowing_date': planting.planted.date().isoformat(),
         })
+        minimum = variety.maturity_days_min or variety.plant.maturity_days_min
+        maximum = variety.maturity_days_max or variety.plant.maturity_days_max
+        ready_dates = [
+            (target.germinated + timedelta(days=days)).date().isoformat()
+            for days in (minimum, maximum)
+            if days is not None
+        ]
+        if ready_dates:
+            values['expected_ready'] = ready_dates[0] if len(set(ready_dates)) == 1 else f'{ready_dates[0]} – {ready_dates[-1]}'
     elif key == ('plantings', 'productionbatch'):
         values.update({
             'display': target.code,
             'variety': target.variety.name,
             'batch': target.code,
-            'sowing_date': target.actual_start.date().isoformat() if target.actual_start else target.planned_start,
+            'sowing_date': target.actual_start.date().isoformat() if target.actual_start else (target.planned_start.isoformat() if target.planned_start else None),
         })
     elif key == ('seedtrays', 'seedtray'):
         open_generation = target.generations.filter(status='open').first()


### PR DESCRIPTION
Operators need reusable printer dimensions instead of re-entering physical settings for every job. The label projection also snapshots dates and projected readiness as portable strings so audited print items remain valid JSON.

## Summary by Sourcery

Add support for saving reusable custom roll label templates and enrich label payloads with audited readiness and sowing date data.

New Features:
- Allow operators to create and save custom roll label templates with name and physical dimensions from the labels UI.

Enhancements:
- Expose a backend endpoint and frontend API helper for creating label templates, integrating it into the labels workflow.
- Include projected readiness date range strings for plantings in label target values to support auditable print payloads.
- Ensure sowing dates in production batch label data are consistently serialized as ISO strings, including planned start dates.