### PR TITLE
feat(plantings): add audited cohort operations

### DIFF
--- a/labels/rest.py
+++ b/labels/rest.py
@@ -26,6 +26,7 @@ LABEL_FIELDS = {
     'batch',
     'sowing_date',
     'expected_ready',
+    'quantity',
     'code',
     'print_date',
 }
@@ -39,6 +40,7 @@ DIMENSION_FIELDS = {
 }
 TARGET_ROUTES = {
     ('plantings', 'specificplant'): '/plantings/plants/{pk}',
+    ('plantings', 'plantcohort'): '/plantings/cohorts/{pk}',
     ('seedtrays', 'seedtray'): '/seedtrays/{pk}',
     ('plantings', 'productionbatch'): '/plantings/batches/{pk}',
     ('locations', 'location'): '/locations',
@@ -71,13 +73,13 @@ def _target_values(identity, code=None):
         return values
     key = _key(identity)
     if key == ('plantings', 'specificplant'):
-        planting = target.cell_planting.seed_tray_planting
-        variety = planting.batch.variety
+        planting = target.cell_planting.seed_tray_planting if target.cell_planting_id else None
+        variety = target.batch.variety if target.batch_id else planting.batch.variety
         values.update({
             'display': f'{variety.plant.name} — {variety.name}',
             'variety': variety.name,
-            'batch': planting.batch.code,
-            'sowing_date': planting.planted.date().isoformat(),
+            'batch': target.batch.code if target.batch_id else planting.batch.code,
+            'sowing_date': planting.planted.date().isoformat() if planting else None,
         })
         minimum = variety.maturity_days_min or variety.plant.maturity_days_min
         maximum = variety.maturity_days_max or variety.plant.maturity_days_max
@@ -88,6 +90,14 @@ def _target_values(identity, code=None):
         ]
         if ready_dates:
             values['expected_ready'] = ready_dates[0] if len(set(ready_dates)) == 1 else f'{ready_dates[0]} – {ready_dates[-1]}'
+    elif key == ('plantings', 'plantcohort'):
+        values.update({
+            'display': f'{target.batch.variety.name} — {target.quantity}',
+            'variety': target.batch.variety.name,
+            'batch': target.batch.code,
+            'sowing_date': target.source_sowing.planted.date().isoformat() if target.source_sowing else None,
+            'quantity': target.quantity,
+        })
     elif key == ('plantings', 'productionbatch'):
         values.update({
             'display': target.code,
@@ -141,6 +151,11 @@ def _resolution(code, workspace):
         summary = derive_state(identity.target.lifecycle_events.all())
         if summary.state in ('growing', 'available', 'retained'):
             capabilities.append('bulk_select')
+    active_cohort = resolution_status == LabelCode.Status.ACTIVE
+    active_cohort = active_cohort and key == ('plantings', 'plantcohort')
+    active_cohort = active_cohort and identity.target.quantity > 0
+    if active_cohort:
+        capabilities.append('cohort_operation')
     return {
         'status': resolution_status,
         'message': {

--- a/labels/services.py
+++ b/labels/services.py
@@ -13,6 +13,7 @@ from .models import LabelCode, LabelIdentity, LabelTemplate
 ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 TARGET_PREFIXES = {
     ('plantings', 'specificplant'): 'PLT',
+    ('plantings', 'plantcohort'): 'COH',
     ('seedtrays', 'seedtray'): 'TRY',
     ('plantings', 'productionbatch'): 'BAT',
     ('locations', 'location'): 'LOC',

--- a/labels/signals.py
+++ b/labels/signals.py
@@ -5,7 +5,7 @@ from django.dispatch import receiver
 
 from garden.models import GardenArea
 from locations.models import Location
-from plantings.models import ProductionBatch, SpecificPlant
+from plantings.models import PlantCohort, ProductionBatch, SpecificPlant
 from seedtrays.models import SeedTray
 from workspaces.models import Workspace
 
@@ -13,7 +13,7 @@ from .models import LabelIdentity
 from .services import ensure_default_templates, ensure_identity, target_key
 
 
-SUPPORTED_MODELS = (SpecificPlant, SeedTray, ProductionBatch, Location, GardenArea)
+SUPPORTED_MODELS = (SpecificPlant, PlantCohort, SeedTray, ProductionBatch, Location, GardenArea)
 
 
 @receiver(post_save, sender=Workspace)
@@ -24,6 +24,7 @@ def create_workspace_label_templates(sender, instance, created, raw=False, **kwa
 
 
 @receiver(post_save, sender=SpecificPlant)
+@receiver(post_save, sender=PlantCohort)
 @receiver(post_save, sender=SeedTray)
 @receiver(post_save, sender=ProductionBatch)
 @receiver(post_save, sender=Location)
@@ -35,6 +36,7 @@ def issue_label_identity(sender, instance, created, raw=False, **kwargs):  # pyl
 
 
 @receiver(pre_delete, sender=SpecificPlant)
+@receiver(pre_delete, sender=PlantCohort)
 @receiver(pre_delete, sender=SeedTray)
 @receiver(pre_delete, sender=ProductionBatch)
 @receiver(pre_delete, sender=Location)

--- a/locations/occupancy.py
+++ b/locations/occupancy.py
@@ -61,9 +61,14 @@ def plant_contribution():
     return Occupancy(trays=0, plants=1, containers=1)
 
 
+def cohort_contribution(quantity):
+    """Return the measurable footprint of anonymous nursery stock."""
+    return Occupancy(trays=0, plants=quantity, containers=0)
+
+
 def location_occupancy(location, subtree=False):
     """Count what is standing in a location, optionally including its children."""
-    from plantings.models import SpecificPlantLocation  # pylint: disable=import-outside-toplevel
+    from plantings.models import PlantCohort, SpecificPlantLocation  # pylint: disable=import-outside-toplevel
     from seedtrays.models import SeedTray  # pylint: disable=import-outside-toplevel
 
     if subtree:
@@ -83,10 +88,16 @@ def location_occupancy(location, subtree=False):
         ended__isnull=True,
         **{f'location__{lookup}': value},
     ).count()
+    cohort_plants = sum(
+        PlantCohort.objects.filter(
+            quantity__gt=0,
+            **{f'location__{lookup}': value},
+        ).values_list('quantity', flat=True)
+    )
 
     return Occupancy(
         trays=tray_count,
-        plants=plants_in_trays + standing_plants,
+        plants=plants_in_trays + standing_plants + cohort_plants,
         containers=standing_plants,
     )
 

--- a/plantings/cohort_rest.py
+++ b/plantings/cohort_rest.py
@@ -1,0 +1,316 @@
+"""Nursery cohort register and transactional operation endpoints."""
+
+# DRF calls detail actions with a `pk` keyword even when `get_object()` resolves
+# it, so the required method signatures intentionally retain that argument.
+# pylint: disable=unused-argument
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import Sum
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+from workspaces.models import Workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+    RequireWorkspaceModeMixin,
+)
+
+from .cohorts import (
+    change_cohort,
+    merge_cohorts,
+    observe_cohort,
+    promote_cohort,
+    split_cohort,
+)
+from .models import CohortEvent, CohortOperation, PlantCohort
+
+
+class CohortPagination(PageNumberPagination):
+    """Bound cohort register pages while totals continue to describe the filter."""
+
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+
+def _errors(error):
+    if hasattr(error, 'message_dict'):
+        return error.message_dict
+    return error.messages
+
+
+class CohortEventSerializer(serializers.ModelSerializer):
+    """Expose immutable quantity, state, location, and lineage history."""
+
+    source_cohorts = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    action = serializers.CharField(source='operation.action', read_only=True)
+    occurred_at = serializers.DateTimeField(source='operation.occurred_at', read_only=True)
+    reason = serializers.CharField(source='operation.reason', read_only=True)
+
+    class Meta:
+        model = CohortEvent
+        fields = [
+            'pk', 'action', 'occurred_at', 'reason', 'quantity_before',
+            'quantity_delta', 'quantity_after', 'state_before', 'state_after',
+            'location_before', 'location_after', 'source_cohorts', 'created',
+        ]
+
+
+class PlantCohortSerializer(serializers.ModelSerializer):
+    """Current cohort register row with batch-derived crop identity."""
+
+    batch_code = serializers.CharField(source='batch.code', read_only=True)
+    variety = serializers.IntegerField(source='batch.variety_id', read_only=True)
+    variety_name = serializers.CharField(source='batch.variety.name', read_only=True)
+    plant_name = serializers.CharField(source='batch.variety.plant.name', read_only=True)
+    location_name = serializers.CharField(source='location.name', read_only=True, allow_null=True)
+    label_code = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PlantCohort
+        fields = [
+            'pk', 'batch', 'batch_code', 'variety', 'variety_name', 'plant_name',
+            'source_sowing', 'quantity', 'lifecycle_state', 'location',
+            'location_name', 'observed_at', 'revision', 'notes', 'label_code',
+            'created', 'updated',
+        ]
+        read_only_fields = [
+            'quantity', 'lifecycle_state', 'observed_at', 'revision', 'created', 'updated',
+        ]
+
+    def get_label_code(self, cohort):
+        """Return the active physical identity issued for this cohort."""
+        from labels.services import ensure_identity  # pylint: disable=import-outside-toplevel
+
+        return ensure_identity(cohort).codes.get(status='active').code
+
+
+class CohortDetailSerializer(PlantCohortSerializer):
+    """Add the cohort's append-only history and promoted plant IDs."""
+
+    events = CohortEventSerializer(many=True, read_only=True)
+    promoted_plants = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+
+    class Meta(PlantCohortSerializer.Meta):
+        fields = PlantCohortSerializer.Meta.fields + ['events', 'promoted_plants']
+
+
+class ObserveCohortSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.Serializer,
+):  # pylint: disable=abstract-method
+    """Validate one initial cohort observation."""
+
+    batch = serializers.PrimaryKeyRelatedField(queryset=PlantCohort._meta.get_field('batch').remote_field.model.objects.all())
+    source_sowing = serializers.PrimaryKeyRelatedField(
+        queryset=PlantCohort._meta.get_field('source_sowing').remote_field.model.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    quantity = serializers.IntegerField(min_value=1)
+    location = serializers.PrimaryKeyRelatedField(
+        queryset=PlantCohort._meta.get_field('location').remote_field.model.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    occurred_at = serializers.DateTimeField(required=False)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    idempotency_key = serializers.UUIDField()
+    workspace_field_lookups = {
+        'batch': 'workspace',
+        'source_sowing': 'workspace',
+        'location': 'workspace',
+    }
+
+
+class CohortActionSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.Serializer,
+):  # pylint: disable=abstract-method
+    """Shared request envelope for a confirmed cohort command."""
+
+    expected_revision = serializers.IntegerField(min_value=1)
+    idempotency_key = serializers.UUIDField()
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+    quantity = serializers.IntegerField(required=False, min_value=0)
+    location = serializers.PrimaryKeyRelatedField(
+        queryset=PlantCohort._meta.get_field('location').remote_field.model.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    disposition = serializers.ChoiceField(
+        choices=('failed', 'culled', 'donated', 'other'),
+        required=False,
+    )
+    workspace_field_lookups = {'location': 'workspace'}
+
+
+class MergeCohortSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Validate a compatible many-to-one merge request."""
+
+    target = serializers.IntegerField(min_value=1)
+    sources = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False)
+    revisions = serializers.DictField(child=serializers.IntegerField(min_value=1))
+    idempotency_key = serializers.UUIDField()
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=False)
+
+
+class PlantCohortViewSet(
+    RequireWorkspaceModeMixin,
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ReadOnlyModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """Search cohorts and route all writes through audited domain commands."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    queryset = PlantCohort.objects.select_related(
+        'batch__variety__plant', 'source_sowing', 'location',
+    ).prefetch_related('events__operation', 'events__source_cohorts', 'promoted_plants')
+    pagination_class = CohortPagination
+
+    def get_serializer_class(self):
+        return CohortDetailSerializer if self.action == 'retrieve' else PlantCohortSerializer
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        params = self.request.query_params
+        for name in ('batch', 'location', 'source_sowing'):
+            if params.get(name):
+                queryset = queryset.filter(**{f'{name}_id': params[name]})
+        if params.get('variety'):
+            queryset = queryset.filter(batch__variety_id=params['variety'])
+        if params.get('state'):
+            queryset = queryset.filter(lifecycle_state=params['state'])
+        if params.get('active') == 'true':
+            queryset = queryset.filter(quantity__gt=0)
+        if params.get('search'):
+            search = params['search'].strip()
+            queryset = queryset.filter(batch__code__icontains=search)
+        return queryset
+
+    def list(self, request, *args, **kwargs):
+        """Return one page plus quantity totals for the complete filter."""
+        response = super().list(request, *args, **kwargs)
+        queryset = self.filter_queryset(self.get_queryset()).order_by()
+        totals = {
+            'cohort_count': queryset.count(),
+            'quantity': queryset.aggregate(total=Sum('quantity'))['total'] or 0,
+        }
+        for state_name, _label in PlantCohort.LifecycleState.choices:
+            totals[state_name] = (
+                queryset.filter(lifecycle_state=state_name).aggregate(total=Sum('quantity'))['total'] or 0
+            )
+        response.data['cohort_totals'] = totals
+        return response
+
+    @action(detail=False, methods=['post'])
+    def observe(self, request):
+        """Record an initial anonymous quantity through the domain service."""
+        serializer = ObserveCohortSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            cohort, _operation_row = observe_cohort(
+                self.get_current_workspace(), request.user, **serializer.validated_data,
+            )
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_errors(exc)) from exc
+        return Response(CohortDetailSerializer(cohort).data, status=status.HTTP_201_CREATED)
+
+    def _change(self, request, cohort, operation_action):
+        """Validate and dispatch one single-cohort state or quantity command."""
+        serializer = CohortActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        disposition = values.pop('disposition', None)
+        try:
+            changed, _operation_row = change_cohort(
+                self.get_current_workspace(), request.user,
+                cohort_id=cohort.pk,
+                action=operation_action,
+                payload_extra={'disposition': disposition} if disposition else None,
+                **values,
+            )
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_errors(exc)) from exc
+        return Response(CohortDetailSerializer(changed).data)
+
+    @action(detail=True, methods=['post'])
+    def adjust(self, request, pk=None):
+        """Reconcile the cohort to a physical count."""
+        return self._change(request, self.get_object(), CohortOperation.Action.ADJUST)
+
+    @action(detail=True, methods=['post'])
+    def loss(self, request, pk=None):
+        """Remove an explained lost quantity from the cohort."""
+        return self._change(request, self.get_object(), CohortOperation.Action.LOSS)
+
+    @action(detail=True, methods=['post'])
+    def move(self, request, pk=None):
+        """Move the complete cohort to a capacity-checked location."""
+        return self._change(request, self.get_object(), CohortOperation.Action.MOVE)
+
+    @action(detail=True, methods=['post'])
+    def ready(self, request, pk=None):
+        """Make a growing cohort commercially available."""
+        return self._change(request, self.get_object(), CohortOperation.Action.READY)
+
+    @action(detail=True, methods=['post'])
+    def retain(self, request, pk=None):
+        """Remove a growing or available cohort from sale stock."""
+        return self._change(request, self.get_object(), CohortOperation.Action.RETAIN)
+
+    @action(detail=True, methods=['post'])
+    def split(self, request, pk=None):
+        """Create a separately identified child quantity."""
+        serializer = CohortActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        values.pop('disposition', None)
+        try:
+            child, _operation_row = split_cohort(
+                self.get_current_workspace(), request.user,
+                cohort_id=self.get_object().pk, **values,
+            )
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_errors(exc)) from exc
+        return Response(CohortDetailSerializer(child).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'])
+    def promote(self, request, pk=None):
+        """Replace part of a cohort with concrete plant identities."""
+        serializer = CohortActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        values.pop('location', None)
+        values.pop('disposition', None)
+        try:
+            plants, operation = promote_cohort(
+                self.get_current_workspace(), request.user,
+                cohort_id=self.get_object().pk, **values,
+            )
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_errors(exc)) from exc
+        return Response({'operation': operation.pk, 'plants': [plant.pk for plant in plants]})
+
+    @action(detail=False, methods=['post'])
+    def merge(self, request):
+        """Fold compatible source cohorts into the selected target."""
+        serializer = MergeCohortSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            cohort, _operation_row = merge_cohorts(
+                self.get_current_workspace(), request.user, **serializer.validated_data,
+            )
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_errors(exc)) from exc
+        return Response(CohortDetailSerializer(cohort).data)
+
+
+def register_cohort_routes(router):
+    """Attach the cohort inventory contract to the plantings API."""
+    router.register(r'cohorts', PlantCohortViewSet, basename='plant-cohorts')

--- a/plantings/cohorts.py
+++ b/plantings/cohorts.py
@@ -1,0 +1,342 @@
+"""Transactional commands for quantity-based nursery plant cohorts."""
+
+# Cohort commands deliberately expose the complete audited request at their
+# boundary; grouping those values into untyped dictionaries would obscure the
+# contract and merely move the same branching and local state elsewhere.
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from locations.occupancy import check_capacity, cohort_contribution
+
+from .lifecycle import EventType, OutcomeRequest, record_germination_event, record_lifecycle_event
+from .models import (
+    CohortEvent,
+    CohortOperation,
+    PlantCohort,
+    ProductionBatch,
+    SpecificPlant,
+    SpecificPlantLocation,
+)
+
+
+def _actor(user):
+    return user if user is not None and user.is_authenticated else None
+
+
+def _require_reason(reason):
+    if not reason or not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+
+
+def _existing(workspace, idempotency_key, action, payload):
+    operation = CohortOperation.objects.filter(
+        workspace=workspace,
+        idempotency_key=idempotency_key,
+    ).first()
+    recorded_request = {
+        key: operation.payload.get(key)
+        for key in payload
+    } if operation else None
+    if operation and (operation.action != action or recorded_request != payload):
+        raise ValidationError({'idempotency_key': 'This key was already used for different work.'})
+    return operation
+
+
+def _operation(workspace, user, action, idempotency_key, occurred_at, reason, payload):
+    return CohortOperation.objects.create(
+        workspace=workspace,
+        created_by=_actor(user),
+        action=action,
+        idempotency_key=idempotency_key,
+        occurred_at=occurred_at or timezone.now(),
+        reason=reason,
+        payload=payload,
+    )
+
+
+def _event(operation, cohort, before, sources=()):
+    event = CohortEvent.objects.create(
+        workspace=cohort.workspace,
+        operation=operation,
+        cohort=cohort,
+        quantity_before=before['quantity'],
+        quantity_delta=cohort.quantity - before['quantity'],
+        quantity_after=cohort.quantity,
+        state_before=before['state'],
+        state_after=cohort.lifecycle_state,
+        location_before_id=before['location'],
+        location_after=cohort.location,
+    )
+    if sources:
+        event.source_cohorts.add(*sources)
+    return event
+
+
+def _snapshot(cohort):
+    return {
+        'quantity': cohort.quantity,
+        'state': cohort.lifecycle_state,
+        'location': cohort.location_id,
+    }
+
+
+def _lock(cohort_id, workspace, expected_revision):
+    cohort = PlantCohort.objects.select_for_update().get(pk=cohort_id, workspace=workspace)
+    if cohort.revision != expected_revision:
+        raise ValidationError({'revision': 'The cohort changed after it was loaded.'})
+    return cohort
+
+
+def _save(cohort):
+    cohort.revision += 1
+    cohort.full_clean()
+    cohort.save(update_fields=['quantity', 'lifecycle_state', 'location', 'revision', 'updated'])
+
+
+@transaction.atomic
+def observe_cohort(workspace, user, *, batch, quantity, idempotency_key,
+                   source_sowing=None, location=None, occurred_at=None, notes=''):
+    """Record one initial homogeneous quantity and its optional sowing lineage."""
+    payload = {
+        'batch': batch.pk,
+        'source_sowing': source_sowing.pk if source_sowing else None,
+        'quantity': quantity,
+        'location': location.pk if location else None,
+        'notes': notes,
+    }
+    existing = _existing(workspace, idempotency_key, CohortOperation.Action.OBSERVE, payload)
+    if existing:
+        return existing.events.get().cohort, existing
+    if quantity <= 0:
+        raise ValidationError({'quantity': 'Quantity must be greater than zero.'})
+    batch = ProductionBatch.objects.select_for_update().get(pk=batch.pk, workspace=workspace)
+    if source_sowing and (source_sowing.workspace_id != workspace.pk or source_sowing.batch_id != batch.pk):
+        raise ValidationError({'source_sowing': 'The sowing is not part of this batch.'})
+    if location:
+        check_capacity(location, cohort_contribution(quantity))
+    cohort = PlantCohort.objects.create(
+        workspace=workspace,
+        batch=batch,
+        source_sowing=source_sowing,
+        quantity=quantity,
+        location=location,
+        observed_at=occurred_at or timezone.now(),
+        notes=notes,
+        created_by=_actor(user),
+    )
+    operation = _operation(
+        workspace, user, CohortOperation.Action.OBSERVE,
+        idempotency_key, occurred_at, '', payload,
+    )
+    _event(operation, cohort, {
+        'quantity': 0,
+        'state': PlantCohort.LifecycleState.GROWING,
+        'location': None,
+    })
+    return cohort, operation
+
+
+@transaction.atomic
+def change_cohort(workspace, user, *, cohort_id, expected_revision, action,
+                  idempotency_key, occurred_at=None, reason='', quantity=None,
+                  location=None, payload_extra=None):
+    """Apply an adjustment, loss, lifecycle change, or whole-cohort move."""
+    payload = {
+        'cohort': cohort_id,
+        'expected_revision': expected_revision,
+        'quantity': quantity,
+        'location': location.pk if location else None,
+        **(payload_extra or {}),
+    }
+    existing = _existing(workspace, idempotency_key, action, payload)
+    if existing:
+        return existing.events.get().cohort, existing
+    cohort = _lock(cohort_id, workspace, expected_revision)
+    before = _snapshot(cohort)
+    if action == CohortOperation.Action.ADJUST:
+        _require_reason(reason)
+        if quantity is None or quantity < 0:
+            raise ValidationError({'quantity': 'Counted quantity must be zero or greater.'})
+        cohort.quantity = quantity
+    elif action == CohortOperation.Action.LOSS:
+        _require_reason(reason)
+        if quantity is None or quantity <= 0 or quantity > cohort.quantity:
+            raise ValidationError({'quantity': 'Loss must be within the current quantity.'})
+        cohort.quantity -= quantity
+    elif action == CohortOperation.Action.MOVE:
+        if location is None:
+            raise ValidationError({'location': 'A destination is required.'})
+        check_capacity(location, cohort_contribution(cohort.quantity))
+        cohort.location = location
+    elif action == CohortOperation.Action.READY:
+        if cohort.lifecycle_state != PlantCohort.LifecycleState.GROWING:
+            raise ValidationError({'action': 'Only a growing cohort can be made available.'})
+        cohort.lifecycle_state = PlantCohort.LifecycleState.AVAILABLE
+    elif action == CohortOperation.Action.RETAIN:
+        retainable = (
+            PlantCohort.LifecycleState.GROWING,
+            PlantCohort.LifecycleState.AVAILABLE,
+        )
+        if cohort.lifecycle_state not in retainable:
+            raise ValidationError({'action': 'This cohort cannot be retained.'})
+        cohort.lifecycle_state = PlantCohort.LifecycleState.RETAINED
+    else:
+        raise ValidationError({'action': 'Select a supported cohort action.'})
+    if cohort.quantity == 0:
+        cohort.lifecycle_state = PlantCohort.LifecycleState.DEPLETED
+    _save(cohort)
+    operation = _operation(workspace, user, action, idempotency_key, occurred_at, reason, payload)
+    _event(operation, cohort, before)
+    return cohort, operation
+
+
+@transaction.atomic
+def split_cohort(workspace, user, *, cohort_id, expected_revision, quantity,
+                 idempotency_key, occurred_at=None, reason='', location=None):
+    """Move part of a cohort into a new identity, optionally at a new location."""
+    _require_reason(reason)
+    payload = {
+        'cohort': cohort_id,
+        'expected_revision': expected_revision,
+        'quantity': quantity,
+        'location': location.pk if location else None,
+    }
+    existing = _existing(workspace, idempotency_key, CohortOperation.Action.SPLIT, payload)
+    if existing:
+        return existing.events.order_by('pk').last().cohort, existing
+    source = _lock(cohort_id, workspace, expected_revision)
+    if quantity <= 0 or quantity >= source.quantity:
+        raise ValidationError({'quantity': 'Split quantity must be less than the cohort quantity.'})
+    destination = location or source.location
+    if destination != source.location:
+        check_capacity(destination, cohort_contribution(quantity))
+    source_before = _snapshot(source)
+    source.quantity -= quantity
+    _save(source)
+    child = PlantCohort.objects.create(
+        workspace=workspace,
+        batch=source.batch,
+        source_sowing=source.source_sowing,
+        quantity=quantity,
+        lifecycle_state=source.lifecycle_state,
+        location=destination,
+        observed_at=source.observed_at,
+        notes=source.notes,
+        created_by=_actor(user),
+    )
+    operation = _operation(
+        workspace, user, CohortOperation.Action.SPLIT,
+        idempotency_key, occurred_at, reason, payload,
+    )
+    _event(operation, source, source_before)
+    _event(operation, child, {
+        'quantity': 0,
+        'state': child.lifecycle_state,
+        'location': None,
+    }, sources=(source,))
+    return child, operation
+
+
+@transaction.atomic
+def merge_cohorts(workspace, user, *, target_id, revisions, source_ids,
+                  idempotency_key, occurred_at=None, reason=''):
+    """Fold compatible sources into an existing target without losing ancestry."""
+    _require_reason(reason)
+    ids = sorted(set(source_ids) | {target_id})
+    payload = {'target': target_id, 'sources': sorted(set(source_ids)), 'revisions': revisions}
+    existing = _existing(workspace, idempotency_key, CohortOperation.Action.MERGE, payload)
+    if existing:
+        return existing.events.get(cohort_id=target_id).cohort, existing
+    cohorts = list(
+        PlantCohort.objects.select_for_update().filter(workspace=workspace, pk__in=ids).order_by('pk')
+    )
+    if len(cohorts) != len(ids) or target_id in source_ids:
+        raise ValidationError({'cohorts': 'Select one target and distinct source cohorts.'})
+    by_id = {cohort.pk: cohort for cohort in cohorts}
+    for cohort in cohorts:
+        if cohort.revision != int(revisions.get(str(cohort.pk), revisions.get(cohort.pk, -1))):
+            raise ValidationError({'revision': f'Cohort {cohort.pk} changed after it was loaded.'})
+    target = by_id[target_id]
+    signature = (target.batch_id, target.source_sowing_id, target.lifecycle_state, target.location_id)
+
+    def incompatible(row):
+        row_signature = (row.batch_id, row.source_sowing_id, row.lifecycle_state, row.location_id)
+        return row_signature != signature or row.quantity == 0
+
+    if any(incompatible(row) for row in cohorts):
+        raise ValidationError({'cohorts': 'Cohorts must share batch, lineage, state, and location.'})
+    snapshots = {row.pk: _snapshot(row) for row in cohorts}
+    target.quantity += sum(by_id[source_id].quantity for source_id in source_ids)
+    _save(target)
+    for source_id in source_ids:
+        source = by_id[source_id]
+        source.quantity = 0
+        source.lifecycle_state = PlantCohort.LifecycleState.DEPLETED
+        _save(source)
+    operation = _operation(
+        workspace, user, CohortOperation.Action.MERGE,
+        idempotency_key, occurred_at, reason, payload,
+    )
+    sources = [by_id[source_id] for source_id in source_ids]
+    _event(operation, target, snapshots[target.pk], sources=sources)
+    for source in sources:
+        _event(operation, source, snapshots[source.pk])
+    return target, operation
+
+
+@transaction.atomic
+def promote_cohort(workspace, user, *, cohort_id, expected_revision, quantity,
+                   idempotency_key, occurred_at=None, reason=''):
+    """Replace an anonymous quantity with the same number of concrete plant IDs."""
+    _require_reason(reason)
+    payload = {
+        'cohort': cohort_id,
+        'expected_revision': expected_revision,
+        'quantity': quantity,
+    }
+    existing = _existing(workspace, idempotency_key, CohortOperation.Action.PROMOTE, payload)
+    if existing:
+        return list(SpecificPlant.objects.filter(pk__in=existing.payload['plants'])), existing
+    cohort = _lock(cohort_id, workspace, expected_revision)
+    if quantity <= 0 or quantity > cohort.quantity:
+        raise ValidationError({'quantity': 'Promotion must be within the current quantity.'})
+    before = _snapshot(cohort)
+    promoted_at = occurred_at or timezone.now()
+    plants = []
+    for _index in range(quantity):
+        plant = SpecificPlant.objects.create(
+            workspace=workspace,
+            batch=cohort.batch,
+            promoted_from_cohort=cohort,
+            germinated=cohort.observed_at,
+        )
+        record_germination_event(plant, user)
+        if cohort.lifecycle_state == PlantCohort.LifecycleState.AVAILABLE:
+            record_lifecycle_event(
+                plant, user,
+                OutcomeRequest(EventType.READY, occurred_at=promoted_at, reason=reason),
+            )
+        if cohort.location_id:
+            SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                location_type=SpecificPlantLocation.LOCATION,
+                location=cohort.location,
+                started=promoted_at,
+                notes=f'Promoted from cohort {cohort.pk}.',
+            )
+        plants.append(plant)
+    cohort.quantity -= quantity
+    if cohort.quantity == 0:
+        cohort.lifecycle_state = PlantCohort.LifecycleState.DEPLETED
+    _save(cohort)
+    operation = _operation(
+        workspace, user, CohortOperation.Action.PROMOTE,
+        idempotency_key, promoted_at, reason, payload,
+    )
+    _event(operation, cohort, before)
+    operation.payload = {**payload, 'plants': [plant.pk for plant in plants]}
+    CohortOperation.objects.filter(pk=operation.pk).update(payload=operation.payload)
+    return plants, operation

--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -281,6 +281,8 @@ def _plant_events(plant):
 
 def _plant_batch(plant):
     """Return the batch that raised this plant."""
+    if plant.batch_id:
+        return plant.batch
     return plant.cell_planting.seed_tray_planting.batch
 
 

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -27,6 +27,7 @@ from .lifecycle import record_germination_event, record_transplant_event
 from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSerializerMixin, PlantOutcomeViewSetMixin, register_lifecycle_routes
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 from .register_rest import register_register_routes
+from .cohort_rest import register_cohort_routes
 from .sowing import correct_sowing_consumption, post_sowing_consumption
 
 
@@ -1039,6 +1040,7 @@ router.register(r'specificplants/(?P<specific_plant_pk>[^/.]+)/locations', Speci
 register_lifecycle_routes(router)
 register_harvest_routes(router)
 register_register_routes(router)
+register_cohort_routes(router)
 
 
 def _register_bulk_routes():

--- a/plantings/test_cohorts.py
+++ b/plantings/test_cohorts.py
@@ -1,0 +1,157 @@
+"""Cohort quantity, lineage, promotion, and REST contract tests."""
+
+from uuid import uuid4
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from tests.api import RESTContractTestCase
+from tests.factories import make_location, make_production_batch, make_seed_tray_planting
+from workspaces.models import Workspace
+
+from .cohorts import merge_cohorts, observe_cohort, promote_cohort, split_cohort
+from .models import CohortEvent, PlantCohort, PlantLifecycleEvent
+
+
+class CohortServiceTests(TestCase):
+    """Structural operations reconcile quantities and retain source history."""
+
+    def setUp(self):
+        """Build one batch and tray sowing shared by service scenarios."""
+        self.workspace = Workspace.objects.get()
+        self.batch = make_production_batch()
+        self.sowing = make_seed_tray_planting(batch=self.batch)
+
+    def observe(self, quantity=12):
+        """Create a cohort through the public service with a fresh identity."""
+        cohort, _operation = observe_cohort(
+            self.workspace,
+            None,
+            batch=self.batch,
+            source_sowing=self.sowing,
+            quantity=quantity,
+            idempotency_key=uuid4(),
+        )
+        return cohort
+
+    def test_split_and_merge_reconcile_and_preserve_lineage(self):
+        """A split followed by a compatible merge neither invents nor loses stock."""
+        source = self.observe()
+        child, _split = split_cohort(
+            self.workspace,
+            None,
+            cohort_id=source.pk,
+            expected_revision=source.revision,
+            quantity=5,
+            idempotency_key=uuid4(),
+            reason='Separate one sales block.',
+        )
+        source.refresh_from_db()
+        self.assertEqual((source.quantity, child.quantity), (7, 5))
+        self.assertEqual(list(child.events.get().source_cohorts.all()), [source])
+
+        merged, _merge = merge_cohorts(
+            self.workspace,
+            None,
+            target_id=source.pk,
+            source_ids=[child.pk],
+            revisions={str(source.pk): source.revision, str(child.pk): child.revision},
+            idempotency_key=uuid4(),
+            reason='Blocks are homogeneous again.',
+        )
+        child.refresh_from_db()
+        self.assertEqual(merged.quantity, 12)
+        self.assertEqual(child.quantity, 0)
+        self.assertEqual(child.lifecycle_state, PlantCohort.LifecycleState.DEPLETED)
+
+    def test_stale_revision_is_rejected_without_an_event(self):
+        """A stale expected revision leaves both quantity and audit untouched."""
+        cohort = self.observe()
+        before = CohortEvent.objects.count()
+        with self.assertRaises(ValidationError):
+            split_cohort(
+                self.workspace,
+                None,
+                cohort_id=cohort.pk,
+                expected_revision=cohort.revision + 1,
+                quantity=2,
+                idempotency_key=uuid4(),
+                reason='Stale request.',
+            )
+        self.assertEqual(CohortEvent.objects.count(), before)
+
+    def test_promotion_creates_individual_ids_without_double_counting(self):
+        """Promotion is idempotent and gives each plant the cohort's lineage."""
+        cohort = self.observe(quantity=4)
+        plants, operation = promote_cohort(
+            self.workspace,
+            None,
+            cohort_id=cohort.pk,
+            expected_revision=cohort.revision,
+            quantity=3,
+            idempotency_key=uuid4(),
+            occurred_at=timezone.now(),
+            reason='These plants need individual sale labels.',
+        )
+        cohort.refresh_from_db()
+        self.assertEqual(cohort.quantity, 1)
+        self.assertEqual(len(plants), 3)
+        self.assertTrue(all(plant.promoted_from_cohort_id == cohort.pk for plant in plants))
+        self.assertTrue(all(plant.batch_id == cohort.batch_id for plant in plants))
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(plant__in=plants, event_type='germinated').count(),
+            3,
+        )
+
+        replayed, same_operation = promote_cohort(
+            self.workspace,
+            None,
+            cohort_id=cohort.pk,
+            expected_revision=1,
+            quantity=3,
+            idempotency_key=operation.idempotency_key,
+            occurred_at=operation.occurred_at,
+            reason='These plants need individual sale labels.',
+        )
+        self.assertEqual(same_operation.pk, operation.pk)
+        self.assertEqual({plant.pk for plant in replayed}, {plant.pk for plant in plants})
+
+
+class CohortRESTTests(RESTContractTestCase):
+    """The register is Nursery-only, scoped, and returns quantity totals."""
+
+    def setUp(self):
+        """Enable Nursery routes and build valid batch/location choices."""
+        super().setUp()
+        self.workspace = Workspace.objects.get()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save(update_fields=['mode'])
+        self.batch = make_production_batch()
+        self.location = make_location()
+
+    def test_observe_list_and_adjust_round_trip(self):
+        """Observation, totals, and count reconciliation share one REST contract."""
+        response = self.client.post('/plantings/cohorts/observe/', {
+            'batch': self.batch.pk,
+            'quantity': 9,
+            'location': self.location.pk,
+            'idempotency_key': str(uuid4()),
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        cohort_id = response.data['pk']
+
+        listed = self.client.get('/plantings/cohorts/')
+        self.assertEqual(listed.status_code, 200, listed.data)
+        self.assertEqual(listed.data['cohort_totals']['quantity'], 9)
+        self.assertEqual(listed.data['results'][0]['quantity'], 9)
+
+        adjusted = self.client.post(f'/plantings/cohorts/{cohort_id}/adjust/', {
+            'expected_revision': response.data['revision'],
+            'quantity': 8,
+            'reason': 'Physical count found one missing plant.',
+            'idempotency_key': str(uuid4()),
+        }, format='json')
+        self.assertEqual(adjusted.status_code, 200, adjusted.data)
+        self.assertEqual(adjusted.data['quantity'], 8)
+        self.assertEqual(len(adjusted.data['events']), 2)


### PR DESCRIPTION
Nursery operators need safe quantity workflows that preserve lineage and reject stale changes. Transactional cohort commands now cover observation, reconciliation, lifecycle, movement, split, merge, loss, and promotion while occupancy and labels understand anonymous stock.

## Summary by Sourcery

Introduce audited, transactional operations and REST endpoints for managing quantity-based plant cohorts alongside existing specific-plant workflows.

New Features:
- Add cohort-based nursery inventory model with transactional commands for observation, adjustment, movement, lifecycle changes, splitting, merging, loss, and promotion to specific plants.
- Expose plant cohort register and operations via scoped REST API with paging, filtering, totals, and append-only event history, including promotion results.
- Issue labels and label metadata for plant cohorts, including new label capabilities for cohort operations and quantity display.
- Include cohort quantities in location occupancy calculations as anonymous nursery stock footprint.

Enhancements:
- Allow plants with direct batch links to resolve their production batch for lifecycle summaries.
- Extend label identity routing, prefixes, and signals to support plant cohorts and richer specific-plant label context.

Tests:
- Add service-level tests for cohort split, merge, and promotion behavior, including idempotency and lineage preservation.
- Add REST contract tests covering cohort observation, listing with totals, and adjustment workflows.