### PR TITLE
feat(frontend): add cohort register and operations

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -37,7 +37,13 @@ import {
   SpecificPlantDetail,
   SpecificPlantLocationCreate,
   SpecificPlantMove,
-  SowingCorrection
+  SowingCorrection,
+  CohortAction,
+  CohortAvailability,
+  CohortFilters,
+  CohortObservation,
+  CohortPage,
+  PlantCohort
 } from '../types/plantings'
 
 interface ProductionBatchFilters {
@@ -254,6 +260,34 @@ function getNurseryRegisterSelection(filters: NurseryRegisterFilters = {}, signa
   return fetchAsJson<NurseryRegisterSelection>(`/plantings/register/ids/${registerQuery(filters)}`, signal)
 }
 
+function cohortQuery(filters: CohortFilters): string {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== '') query.set(key, String(value))
+  }
+  return query.size > 0 ? `?${query.toString()}` : ''
+}
+
+function getCohorts(filters: CohortFilters = {}, signal?: AbortSignal): Promise<CohortPage> {
+  return fetchAsJson<CohortPage>(`/plantings/cohorts/${cohortQuery(filters)}`, signal)
+}
+
+function getCohort(cohortPk: number, signal?: AbortSignal): Promise<PlantCohort> {
+  return fetchAsJson<PlantCohort>(`/plantings/cohorts/${cohortPk}/`, signal)
+}
+
+function getCohortAvailability(filters: CohortFilters = {}, signal?: AbortSignal): Promise<CohortAvailability> {
+  return fetchAsJson<CohortAvailability>(`/plantings/cohorts/availability/${cohortQuery(filters)}`, signal)
+}
+
+function observeCohort(data: CohortObservation): Promise<PlantCohort> {
+  return csrfPost('/plantings/cohorts/observe/', data).then((response) => response.json() as Promise<PlantCohort>)
+}
+
+function postCohortAction(cohortPk: number, actionName: string, data: CohortAction): Promise<PlantCohort | { operation: number; plants: Array<number> }> {
+  return csrfPost(`/plantings/cohorts/${cohortPk}/${actionName}/`, data).then((response) => response.json() as Promise<PlantCohort | { operation: number; plants: Array<number> }>)
+}
+
 export {
   ProductionBatchFilters,
   getProductionBatches,
@@ -294,5 +328,10 @@ export {
   reverseHarvest,
   getHarvestReport,
   getNurseryRegister,
-  getNurseryRegisterSelection
+  getNurseryRegisterSelection,
+  getCohorts,
+  getCohort,
+  getCohortAvailability,
+  observeCohort,
+  postCohortAction
 }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -26,6 +26,7 @@ import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/bat
 import { HarvestsView, YieldReportView } from './plantings/harvests.js'
 import { NurseryRegisterView } from './plantings/register.js'
 import { PlantDetailView } from './plantings/plant_detail.js'
+import { CohortDetailView, CohortRegisterView } from './plantings/cohorts.js'
 import { LabelsView, ScannerView } from './labels.js'
 
 function SeedTrayDetailsRoute() {
@@ -59,6 +60,13 @@ function PlantDetailRoute({ workspace }: { workspace: Workspace }) {
   }
 
   return <PlantDetailView plantPk={plantPk} workspace={workspace} />
+}
+
+function CohortDetailRoute() {
+  const { cohortId } = useParams()
+  const cohortPk = Number(cohortId)
+  if (!cohortId || !Number.isInteger(cohortPk) || cohortPk <= 0) return <div>Cohort not found.</div>
+  return <CohortDetailView cohortPk={cohortPk} />
 }
 
 function FrontEndPage() {
@@ -106,6 +114,22 @@ function FrontEndPage() {
           }
         />
         <Route path="/plantings/plants/:plantId" element={<PlantDetailRoute workspace={workspace} />} />
+        <Route
+          path="/plantings/cohorts"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <CohortRegisterView />
+            </WorkspaceModeRoute>
+          }
+        />
+        <Route
+          path="/plantings/cohorts/:cohortId"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <CohortDetailRoute />
+            </WorkspaceModeRoute>
+          }
+        />
         <Route path="/plantings/harvests" element={<HarvestsView />} />
         <Route path="/plantings/yield" element={<YieldReportView />} />
         <Route path="/locations" element={<LocationsCatalog />} />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -53,9 +53,14 @@ function GPTopBar({ workspace }: GPTopBarProps) {
           </NavDropdown>
           <NavDropdown title="Planting" active={plantingActive}>
             {workspace.mode === 'nursery' && (
-              <NavDropdown.Item as={NavLink} to="/plantings/register">
-                Plant register
-              </NavDropdown.Item>
+              <>
+                <NavDropdown.Item as={NavLink} to="/plantings/register">
+                  Plant register
+                </NavDropdown.Item>
+                <NavDropdown.Item as={NavLink} to="/plantings/cohorts">
+                  Cohort inventory
+                </NavDropdown.Item>
+              </>
             )}
             <NavDropdown.Item as={NavLink} to="/plantings/batches">
               Batches

--- a/frontend/js/plantings/cohorts.tsx
+++ b/frontend/js/plantings/cohorts.tsx
@@ -1,0 +1,346 @@
+import React from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+import { Link } from 'react-router'
+
+import { getLocations } from '../api/locations'
+import { getCohort, getCohortAvailability, getCohorts, getProductionBatches, observeCohort, postCohortAction } from '../api/plantings'
+import { queryClient, queryKeys } from '../query'
+import { CohortAction, CohortFilters, CohortLifecycleState, PlantCohort } from '../types/plantings'
+
+const STATE_LABELS: Record<CohortLifecycleState, string> = {
+  growing: 'Growing',
+  available: 'Available',
+  retained: 'Retained',
+  depleted: 'Depleted'
+}
+
+function CohortTotals({ filters }: { filters: CohortFilters }) {
+  const { data } = useQuery({
+    queryKey: queryKeys.plantings.cohortAvailability(filters),
+    queryFn: ({ signal }) => getCohortAvailability(filters, signal)
+  })
+  if (!data) return null
+  return (
+    <Row className="g-2 mb-3">
+      {[
+        ['Available cohorts', data.cohort_quantity],
+        ['Available identified plants', data.individual_count],
+        ['Combined availability', data.combined_total]
+      ].map(([label, value]) => (
+        <Col key={label} md={4}>
+          <Card body className="py-2">
+            <div className="text-muted small">{label}</div>
+            <div className="fs-5">{value}</div>
+          </Card>
+        </Col>
+      ))}
+    </Row>
+  )
+}
+
+function ObserveCohortForm() {
+  const [batch, setBatch] = React.useState<number | ''>('')
+  const [quantity, setQuantity] = React.useState(1)
+  const [location, setLocation] = React.useState<number | ''>('')
+  const [notes, setNotes] = React.useState('')
+  const { data: batches = [] } = useQuery({
+    queryKey: queryKeys.plantings.batches('active', '', '', false),
+    queryFn: ({ signal }) => getProductionBatches({ status: 'active' }, signal)
+  })
+  const { data: locations = [] } = useQuery({
+    queryKey: queryKeys.locations.list('active'),
+    queryFn: ({ signal }) => getLocations(signal, true)
+  })
+  const mutation = useMutation({
+    mutationFn: observeCohort,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.cohortsAll })
+      setQuantity(1)
+      setNotes('')
+    }
+  })
+  return (
+    <Card body className="mb-3">
+      <h2 className="h5">Observe a cohort</h2>
+      <Form
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (batch === '') return
+          mutation.mutate({
+            batch,
+            quantity,
+            location: location === '' ? null : location,
+            notes,
+            idempotency_key: crypto.randomUUID()
+          })
+        }}
+      >
+        <Row className="g-2 align-items-end">
+          <Col md={4}>
+            <Form.Label>Production batch</Form.Label>
+            <Form.Select value={batch} required onChange={(event) => setBatch(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Select batch</option>
+              {batches.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.code}
+                </option>
+              ))}
+            </Form.Select>
+          </Col>
+          <Col md={2}>
+            <Form.Label>Count</Form.Label>
+            <Form.Control type="number" min={1} value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+          </Col>
+          <Col md={3}>
+            <Form.Label>Location</Form.Label>
+            <Form.Select value={location} onChange={(event) => setLocation(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Not placed</option>
+              {locations.map((entry) => (
+                <option key={entry.pk} value={entry.pk}>
+                  {entry.full_name}
+                </option>
+              ))}
+            </Form.Select>
+          </Col>
+          <Col md={3}>
+            <Form.Label>Notes</Form.Label>
+            <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </Col>
+          <Col>
+            <Button type="submit" disabled={mutation.isPending || batch === ''}>
+              Record cohort
+            </Button>
+          </Col>
+        </Row>
+      </Form>
+    </Card>
+  )
+}
+
+function CohortRegisterView() {
+  const [search, setSearch] = React.useState('')
+  const [state, setState] = React.useState<CohortLifecycleState | ''>('')
+  const [page, setPage] = React.useState(1)
+  const filters: CohortFilters = { search: search || undefined, state: state || undefined, page, page_size: 50 }
+  const { data, isPending } = useQuery({
+    queryKey: queryKeys.plantings.cohorts(filters),
+    queryFn: ({ signal }) => getCohorts(filters, signal)
+  })
+  return (
+    <main className="container py-3">
+      <h1>Cohort inventory</h1>
+      <p>Homogeneous nursery stock tracked by quantity until individual identity is useful.</p>
+      <CohortTotals filters={{ search: filters.search }} />
+      <ObserveCohortForm />
+      <Row className="g-2 mb-3">
+        <Col md={4}>
+          <Form.Control type="search" placeholder="Batch code" value={search} onChange={(event) => setSearch(event.target.value)} />
+        </Col>
+        <Col md={3}>
+          <Form.Select value={state} onChange={(event) => setState(event.target.value as CohortLifecycleState | '')}>
+            <option value="">All states</option>
+            {Object.entries(STATE_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+      </Row>
+      {isPending ? (
+        <div>Loading cohorts…</div>
+      ) : (
+        <>
+          <Table responsive hover>
+            <thead>
+              <tr>
+                <th>Cohort</th>
+                <th>Crop</th>
+                <th>Batch</th>
+                <th>State</th>
+                <th>Quantity</th>
+                <th>Location</th>
+                <th>Label</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.results.map((cohort) => (
+                <tr key={cohort.pk}>
+                  <td>
+                    <Link to={`/plantings/cohorts/${cohort.pk}`}>#{cohort.pk}</Link>
+                  </td>
+                  <td>
+                    {cohort.plant_name} — {cohort.variety_name}
+                  </td>
+                  <td>{cohort.batch_code}</td>
+                  <td>
+                    <Badge bg={cohort.lifecycle_state === 'available' ? 'success' : 'secondary'}>{STATE_LABELS[cohort.lifecycle_state]}</Badge>
+                  </td>
+                  <td>{cohort.quantity}</td>
+                  <td>{cohort.location_name || 'Not placed'}</td>
+                  <td>{cohort.label_code}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+          <div className="d-flex gap-2">
+            <Button variant="outline-secondary" disabled={!data?.previous} onClick={() => setPage(Math.max(1, page - 1))}>
+              Previous
+            </Button>
+            <Button variant="outline-secondary" disabled={!data?.next} onClick={() => setPage(page + 1)}>
+              Next
+            </Button>
+          </div>
+        </>
+      )}
+    </main>
+  )
+}
+
+function CohortActionPanel({ cohort }: { cohort: PlantCohort }) {
+  const [actionName, setActionName] = React.useState('adjust')
+  const [quantity, setQuantity] = React.useState(cohort.quantity)
+  const [reason, setReason] = React.useState('')
+  const [message, setMessage] = React.useState('')
+  const mutation = useMutation({
+    mutationFn: (payload: CohortAction) => postCohortAction(cohort.pk, actionName, payload),
+    onSuccess: (result) => {
+      const promoted = 'plants' in result ? ` Promoted plants: ${result.plants.join(', ')}.` : ''
+      setMessage(`Operation applied.${promoted}`)
+      void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.cohortsAll })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.cohort(cohort.pk) })
+    }
+  })
+  const needsQuantity = ['adjust', 'loss', 'split', 'promote'].includes(actionName)
+  return (
+    <Card body className="mb-3">
+      <h2 className="h5">Review an operation</h2>
+      {message && <Alert variant="success">{message}</Alert>}
+      <Form
+        onSubmit={(event) => {
+          event.preventDefault()
+          mutation.mutate({
+            expected_revision: cohort.revision,
+            idempotency_key: crypto.randomUUID(),
+            quantity: needsQuantity ? quantity : undefined,
+            reason
+          })
+        }}
+      >
+        <Row className="g-2 align-items-end">
+          <Col md={3}>
+            <Form.Label>Action</Form.Label>
+            <Form.Select value={actionName} onChange={(event) => setActionName(event.target.value)}>
+              <option value="adjust">Reconcile count</option>
+              <option value="split">Split cohort</option>
+              <option value="loss">Record loss</option>
+              <option value="promote">Promote to plant IDs</option>
+              <option value="ready">Mark available</option>
+              <option value="retain">Retain</option>
+            </Form.Select>
+          </Col>
+          {needsQuantity && (
+            <Col md={2}>
+              <Form.Label>Quantity</Form.Label>
+              <Form.Control type="number" min={actionName === 'adjust' ? 0 : 1} value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+            </Col>
+          )}
+          <Col md={5}>
+            <Form.Label>Reason</Form.Label>
+            <Form.Control value={reason} onChange={(event) => setReason(event.target.value)} />
+          </Col>
+          <Col md={2}>
+            <Button type="submit" disabled={mutation.isPending || cohort.quantity === 0}>
+              Apply
+            </Button>
+          </Col>
+        </Row>
+      </Form>
+    </Card>
+  )
+}
+
+function CohortDetailView({ cohortPk }: { cohortPk: number }) {
+  const { data: cohort, isPending } = useQuery({
+    queryKey: queryKeys.plantings.cohort(cohortPk),
+    queryFn: ({ signal }) => getCohort(cohortPk, signal)
+  })
+  if (isPending) return <main className="container py-3">Loading cohort…</main>
+  if (!cohort) return <main className="container py-3">Cohort not found.</main>
+  return (
+    <main className="container py-3">
+      <Link to="/plantings/cohorts">← Cohort inventory</Link>
+      <h1>Cohort #{cohort.pk}</h1>
+      <p>
+        {cohort.plant_name} — {cohort.variety_name}, batch {cohort.batch_code}
+      </p>
+      <Row className="g-2 mb-3">
+        <Col md={3}>
+          <Card body>
+            <div className="text-muted">Quantity</div>
+            <div className="fs-4">{cohort.quantity}</div>
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card body>
+            <div className="text-muted">State</div>
+            <div>{STATE_LABELS[cohort.lifecycle_state]}</div>
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card body>
+            <div className="text-muted">Location</div>
+            <div>{cohort.location_name || 'Not placed'}</div>
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card body>
+            <div className="text-muted">Label</div>
+            <div>{cohort.label_code}</div>
+          </Card>
+        </Col>
+      </Row>
+      <CohortActionPanel cohort={cohort} />
+      <h2>History</h2>
+      <Table responsive>
+        <thead>
+          <tr>
+            <th>When</th>
+            <th>Action</th>
+            <th>Quantity</th>
+            <th>State</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cohort.events?.map((event) => (
+            <tr key={event.pk}>
+              <td>{new Date(event.occurred_at).toLocaleString()}</td>
+              <td>{event.action}</td>
+              <td>
+                {event.quantity_before} → {event.quantity_after}
+              </td>
+              <td>
+                {STATE_LABELS[event.state_before]} → {STATE_LABELS[event.state_after]}
+              </td>
+              <td>{event.reason}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+      {(cohort.promoted_plants?.length ?? 0) > 0 && (
+        <p>
+          Promoted plants:{' '}
+          {cohort.promoted_plants?.map((plantPk) => (
+            <Link key={plantPk} className="me-2" to={`/plantings/plants/${plantPk}`}>
+              #{plantPk}
+            </Link>
+          ))}
+        </p>
+      )}
+    </main>
+  )
+}
+
+export { CohortDetailView, CohortRegisterView }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query'
 
-import { NurseryRegisterFilters } from './types/plantings'
+import { CohortFilters, NurseryRegisterFilters } from './types/plantings'
 
 const queryKeys = {
   labels: {
@@ -87,6 +87,10 @@ const queryKeys = {
     registerAll: ['plantings', 'register'] as const,
     register: (filters: NurseryRegisterFilters) => ['plantings', 'register', filters] as const,
     registerSelection: (filters: NurseryRegisterFilters) => ['plantings', 'register', 'ids', filters] as const,
+    cohortsAll: ['plantings', 'cohorts'] as const,
+    cohorts: (filters: CohortFilters) => ['plantings', 'cohorts', filters] as const,
+    cohort: (cohortPk: number) => ['plantings', 'cohorts', 'detail', cohortPk] as const,
+    cohortAvailability: (filters: CohortFilters) => ['plantings', 'cohorts', 'availability', filters] as const,
     harvestReportAll: ['plantings', 'harvestReport'] as const,
     harvestReport: (groupBy: string, batch: number | '', variety: number | '', from: string, to: string) =>
       ['plantings', 'harvestReport', groupBy, batch, variety, from, to] as const

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -563,6 +563,98 @@ interface HarvestReportFilters {
   harvested_to?: string
 }
 
+type CohortLifecycleState = 'growing' | 'available' | 'retained' | 'depleted'
+
+interface CohortEvent {
+  pk: number
+  action: string
+  occurred_at: string
+  reason: string
+  quantity_before: number
+  quantity_delta: number
+  quantity_after: number
+  state_before: CohortLifecycleState
+  state_after: CohortLifecycleState
+  location_before: number | null
+  location_after: number | null
+  source_cohorts: Array<number>
+  created: string
+}
+
+interface PlantCohort {
+  pk: number
+  batch: number
+  batch_code: string
+  variety: number
+  variety_name: string
+  plant_name: string
+  source_sowing: number | null
+  quantity: number
+  lifecycle_state: CohortLifecycleState
+  location: number | null
+  location_name: string | null
+  observed_at: string
+  revision: number
+  notes: string
+  label_code: string
+  created: string
+  updated: string
+  events?: Array<CohortEvent>
+  promoted_plants?: Array<number>
+}
+
+interface CohortTotals {
+  cohort_count: number
+  quantity: number
+  growing: number
+  available: number
+  retained: number
+  depleted: number
+}
+
+interface CohortPage {
+  count: number
+  next: string | null
+  previous: string | null
+  results: Array<PlantCohort>
+  cohort_totals: CohortTotals
+}
+
+interface CohortFilters {
+  search?: string
+  batch?: number
+  variety?: number
+  location?: number
+  state?: CohortLifecycleState
+  active?: boolean
+  page?: number
+  page_size?: number
+}
+
+interface CohortAvailability {
+  cohort_quantity: number
+  individual_count: number
+  combined_total: number
+}
+
+interface CohortObservation {
+  batch: number
+  source_sowing?: number | null
+  quantity: number
+  location?: number | null
+  notes?: string
+  idempotency_key: string
+}
+
+interface CohortAction {
+  expected_revision: number
+  idempotency_key: string
+  quantity?: number
+  location?: number | null
+  disposition?: 'failed' | 'culled' | 'donated' | 'other'
+  reason?: string
+}
+
 export {
   BatchAction,
   BulkPlantOutcome,
@@ -623,5 +715,14 @@ export {
   SpecificPlantLocation,
   SpecificPlantLocationCreate,
   SpecificPlantMove,
-  SowingCorrection
+  SowingCorrection,
+  CohortAction,
+  CohortAvailability,
+  CohortEvent,
+  CohortFilters,
+  CohortLifecycleState,
+  CohortObservation,
+  CohortPage,
+  CohortTotals,
+  PlantCohort
 }

--- a/plantings/batch_rest.py
+++ b/plantings/batch_rest.py
@@ -169,7 +169,7 @@ def _batch_sowings(batch):
 def _current_locations(batch):
     """Describe where this batch's individual plants are living now."""
     locations = SpecificPlantLocation.objects.filter(
-        specific_plant__cell_planting__seed_tray_planting__batch=batch,
+        specific_plant__batch=batch,
         ended__isnull=True,
     ).select_related('seed_tray_cell', 'garden_square', 'location').order_by('pk')
     return [

--- a/plantings/batches.py
+++ b/plantings/batches.py
@@ -84,9 +84,7 @@ def batch_open_sowings(batch):
 
 def batch_specific_plants(batch):
     """Return every individual plant observed from this batch's sowings."""
-    return SpecificPlant.objects.filter(
-        cell_planting__seed_tray_planting__batch=batch,
-    )
+    return SpecificPlant.objects.filter(batch=batch)
 
 
 def batch_plants_with_active_location(batch):
@@ -181,7 +179,7 @@ def lock_batch_with_plants(batch):
     list(
         SpecificPlant.objects
         .select_for_update(of=('self',))
-        .filter(cell_planting__seed_tray_planting__batch=batch)
+        .filter(batch=batch)
         .order_by('pk')
     )
     return lock_batch(batch)

--- a/plantings/cohort_rest.py
+++ b/plantings/cohort_rest.py
@@ -26,6 +26,7 @@ from .cohorts import (
     split_cohort,
 )
 from .models import CohortEvent, CohortOperation, PlantCohort
+from .register import parse_register_filters, register_queryset
 
 
 class CohortPagination(PageNumberPagination):
@@ -181,7 +182,17 @@ class PlantCohortViewSet(
         params = self.request.query_params
         for name in ('batch', 'location', 'source_sowing'):
             if params.get(name):
-                queryset = queryset.filter(**{f'{name}_id': params[name]})
+                if name == 'location':
+                    location_model = PlantCohort._meta.get_field('location').remote_field.model
+                    path = location_model.objects.filter(
+                        workspace=self.get_current_workspace(), pk=params[name],
+                    ).values_list('path', flat=True).first()
+                    queryset = (
+                        queryset.filter(location__path__startswith=path)
+                        if path else queryset.none()
+                    )
+                else:
+                    queryset = queryset.filter(**{f'{name}_id': params[name]})
         if params.get('variety'):
             queryset = queryset.filter(batch__variety_id=params['variety'])
         if params.get('state'):
@@ -207,6 +218,26 @@ class PlantCohortViewSet(
             )
         response.data['cohort_totals'] = totals
         return response
+
+    @action(detail=False, methods=['get'])
+    def availability(self, request):
+        """Report anonymous and identified available stock under shared filters."""
+        cohorts = self.get_queryset().filter(
+            lifecycle_state=PlantCohort.LifecycleState.AVAILABLE,
+            quantity__gt=0,
+        )
+        params = request.query_params.copy()
+        params.setlist('state', ['available'])
+        individuals = register_queryset(
+            self.get_current_workspace(), parse_register_filters(params),
+        )
+        cohort_quantity = cohorts.aggregate(total=Sum('quantity'))['total'] or 0
+        individual_count = individuals.count()
+        return Response({
+            'cohort_quantity': cohort_quantity,
+            'individual_count': individual_count,
+            'combined_total': cohort_quantity + individual_count,
+        })
 
     @action(detail=False, methods=['post'])
     def observe(self, request):

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -774,7 +774,7 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
 
     def plant_batch_id(self):
         """Return the batch that raised this event's plant."""
-        return self.plant.batch_id
+        return self.plant.batch_id or self.plant.cell_planting.seed_tray_planting.batch_id
 
     def save(self, *args, **kwargs):
         if self.pk:

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -49,7 +49,7 @@ ORDERINGS = {
 }
 DEFAULT_ORDERING = '-age'
 
-_BATCH = 'cell_planting__seed_tray_planting__batch'
+_BATCH = 'batch'
 
 #: A tray stands somewhere as a serialized asset, and the plants in its cells
 #: stand there with it.

--- a/plantings/register_rest.py
+++ b/plantings/register_rest.py
@@ -70,13 +70,13 @@ class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abst
 
     pk = serializers.IntegerField(read_only=True)
     batch = serializers.IntegerField(
-        source='cell_planting.seed_tray_planting.batch_id',
+        source='batch_id',
         read_only=True,
     )
     batch_code = serializers.CharField(read_only=True)
     label_code = serializers.CharField(read_only=True, allow_null=True)
     variety = serializers.IntegerField(
-        source='cell_planting.seed_tray_planting.batch.variety_id',
+        source='batch.variety_id',
         read_only=True,
     )
     variety_name = serializers.CharField(read_only=True)
@@ -141,7 +141,7 @@ class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abst
     @staticmethod
     def _expected_ready(plant, field):
         """Offset germination by the variety's days, falling back to the crop."""
-        variety = plant.cell_planting.seed_tray_planting.batch.variety
+        variety = plant.batch.variety
         days = getattr(variety, field) or getattr(variety.plant, field)
         if days is None:
             return None

--- a/plantings/test_cohorts.py
+++ b/plantings/test_cohorts.py
@@ -155,3 +155,37 @@ class CohortRESTTests(RESTContractTestCase):
         self.assertEqual(adjusted.status_code, 200, adjusted.data)
         self.assertEqual(adjusted.data['quantity'], 8)
         self.assertEqual(len(adjusted.data['events']), 2)
+
+    def test_combined_availability_counts_promoted_plants_once(self):
+        """Moving units to concrete IDs leaves the combined total unchanged."""
+        observed = self.client.post('/plantings/cohorts/observe/', {
+            'batch': self.batch.pk,
+            'quantity': 9,
+            'location': self.location.pk,
+            'idempotency_key': str(uuid4()),
+        }, format='json')
+        cohort_id = observed.data['pk']
+        ready = self.client.post(f'/plantings/cohorts/{cohort_id}/ready/', {
+            'expected_revision': observed.data['revision'],
+            'idempotency_key': str(uuid4()),
+        }, format='json')
+        promoted = self.client.post(f'/plantings/cohorts/{cohort_id}/promote/', {
+            'expected_revision': ready.data['revision'],
+            'quantity': 2,
+            'reason': 'Give selected stock individual labels.',
+            'idempotency_key': str(uuid4()),
+        }, format='json')
+        self.assertEqual(promoted.status_code, 200, promoted.data)
+
+        availability = self.client.get('/plantings/cohorts/availability/', {
+            'batch': self.batch.pk,
+            'location': self.location.pk,
+        })
+        self.assertEqual(availability.data, {
+            'cohort_quantity': 7,
+            'individual_count': 2,
+            'combined_total': 9,
+        })
+        register = self.client.get('/plantings/register/', {'batch': self.batch.pk})
+        self.assertEqual(register.status_code, 200, register.data)
+        self.assertEqual(register.data['count'], 2)


### PR DESCRIPTION
Nursery staff need a quantity-first view alongside the individual plant register. The new register, detail history, reviewed actions, and combined availability projection expose cohort stock while promoted plants continue through the existing plant workflows.

## Summary by Sourcery

Add cohort-based nursery inventory views and operations, including quantity tracking, combined availability reporting, and routing/menu integration alongside the existing individual plant register.

New Features:
- Introduce cohort domain types and REST/frontend APIs for listing, viewing, and updating plant cohorts with lifecycle and location metadata.
- Add a cohort inventory UI with filters, availability totals, and a form to observe new cohorts, plus a cohort detail view with history and operations review.
- Expose a combined availability endpoint that reports cohort and identified plant stock under shared filters, and surface these totals in the frontend.
- Wire cohort inventory and detail routes into the frontend router and planting menu for nursery workspaces.

Bug Fixes:
- Ensure individual plant queries and register serializers use the plant batch relationship directly instead of traversing via seed tray plantings, preserving correct batch and variety resolution.
- Guard plant event batch resolution by falling back to the legacy cell-planting-based batch when the direct batch is not set.

Enhancements:
- Extend cohort filtering to treat location filters hierarchically via location path matching.
- Adjust batch plant and location helpers to work off the plant batch field, simplifying queries and aligning with promoted plants.
- Add dedicated query keys for cohort lists, details, and availability in the frontend React Query client.

Tests:
- Add a regression test ensuring combined cohort availability counts promoted plants exactly once and remains consistent with the nursery register.