### PR TITLE
feat(plantings): complete cohort operational workflows

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -41,6 +41,7 @@ import {
   CohortAction,
   CohortAvailability,
   CohortFilters,
+  CohortMerge,
   CohortObservation,
   CohortPage,
   PlantCohort
@@ -288,6 +289,10 @@ function postCohortAction(cohortPk: number, actionName: string, data: CohortActi
   return csrfPost(`/plantings/cohorts/${cohortPk}/${actionName}/`, data).then((response) => response.json() as Promise<PlantCohort | { operation: number; plants: Array<number> }>)
 }
 
+function mergeCohorts(data: CohortMerge): Promise<PlantCohort> {
+  return csrfPost('/plantings/cohorts/merge/', data).then((response) => response.json() as Promise<PlantCohort>)
+}
+
 export {
   ProductionBatchFilters,
   getProductionBatches,
@@ -333,5 +338,6 @@ export {
   getCohort,
   getCohortAvailability,
   observeCohort,
-  postCohortAction
+  postCohortAction,
+  mergeCohorts
 }

--- a/frontend/js/plantings/cohorts.tsx
+++ b/frontend/js/plantings/cohorts.tsx
@@ -4,7 +4,7 @@ import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstr
 import { Link } from 'react-router'
 
 import { getLocations } from '../api/locations'
-import { getCohort, getCohortAvailability, getCohorts, getProductionBatches, observeCohort, postCohortAction } from '../api/plantings'
+import { getCohort, getCohortAvailability, getCohorts, getProductionBatches, mergeCohorts, observeCohort, postCohortAction } from '../api/plantings'
 import { queryClient, queryKeys } from '../query'
 import { CohortAction, CohortFilters, CohortLifecycleState, PlantCohort } from '../types/plantings'
 
@@ -122,10 +122,20 @@ function CohortRegisterView() {
   const [search, setSearch] = React.useState('')
   const [state, setState] = React.useState<CohortLifecycleState | ''>('')
   const [page, setPage] = React.useState(1)
+  const [selected, setSelected] = React.useState<Array<number>>([])
+  const [mergeReason, setMergeReason] = React.useState('')
   const filters: CohortFilters = { search: search || undefined, state: state || undefined, page, page_size: 50 }
   const { data, isPending } = useQuery({
     queryKey: queryKeys.plantings.cohorts(filters),
     queryFn: ({ signal }) => getCohorts(filters, signal)
+  })
+  const mergeMutation = useMutation({
+    mutationFn: mergeCohorts,
+    onSuccess: () => {
+      setSelected([])
+      setMergeReason('')
+      void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.cohortsAll })
+    }
   })
   return (
     <main className="container py-3">
@@ -148,6 +158,30 @@ function CohortRegisterView() {
           </Form.Select>
         </Col>
       </Row>
+      {selected.length >= 2 && (
+        <Alert variant="light" className="d-flex gap-2 align-items-end">
+          <div className="flex-grow-1">
+            <strong>Merge {selected.length} cohorts</strong>
+            <div className="small text-muted">Cohort #{selected[0]} will keep the identity. Compatibility is rechecked when applied.</div>
+            <Form.Control className="mt-2" placeholder="Reason for merge" value={mergeReason} onChange={(event) => setMergeReason(event.target.value)} />
+          </div>
+          <Button
+            disabled={!mergeReason.trim() || mergeMutation.isPending}
+            onClick={() => {
+              const rows = data?.results.filter((entry) => selected.includes(entry.pk)) ?? []
+              mergeMutation.mutate({
+                target: selected[0],
+                sources: selected.slice(1),
+                revisions: Object.fromEntries(rows.map((entry) => [String(entry.pk), entry.revision])),
+                reason: mergeReason,
+                idempotency_key: crypto.randomUUID()
+              })
+            }}
+          >
+            Merge
+          </Button>
+        </Alert>
+      )}
       {isPending ? (
         <div>Loading cohorts…</div>
       ) : (
@@ -155,6 +189,7 @@ function CohortRegisterView() {
           <Table responsive hover>
             <thead>
               <tr>
+                <th aria-label="Select" />
                 <th>Cohort</th>
                 <th>Crop</th>
                 <th>Batch</th>
@@ -167,6 +202,14 @@ function CohortRegisterView() {
             <tbody>
               {data?.results.map((cohort) => (
                 <tr key={cohort.pk}>
+                  <td>
+                    <Form.Check
+                      aria-label={`Select cohort ${cohort.pk}`}
+                      disabled={cohort.quantity === 0}
+                      checked={selected.includes(cohort.pk)}
+                      onChange={(event) => setSelected(event.target.checked ? [...selected, cohort.pk] : selected.filter((pk) => pk !== cohort.pk))}
+                    />
+                  </td>
                   <td>
                     <Link to={`/plantings/cohorts/${cohort.pk}`}>#{cohort.pk}</Link>
                   </td>
@@ -202,6 +245,7 @@ function CohortActionPanel({ cohort }: { cohort: PlantCohort }) {
   const [actionName, setActionName] = React.useState('adjust')
   const [quantity, setQuantity] = React.useState(cohort.quantity)
   const [reason, setReason] = React.useState('')
+  const [location, setLocation] = React.useState<number | ''>(cohort.location ?? '')
   const [message, setMessage] = React.useState('')
   const mutation = useMutation({
     mutationFn: (payload: CohortAction) => postCohortAction(cohort.pk, actionName, payload),
@@ -211,6 +255,10 @@ function CohortActionPanel({ cohort }: { cohort: PlantCohort }) {
       void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.cohortsAll })
       void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.cohort(cohort.pk) })
     }
+  })
+  const { data: locations = [] } = useQuery({
+    queryKey: queryKeys.locations.list('active'),
+    queryFn: ({ signal }) => getLocations(signal, true)
   })
   const needsQuantity = ['adjust', 'loss', 'split', 'promote'].includes(actionName)
   return (
@@ -224,6 +272,7 @@ function CohortActionPanel({ cohort }: { cohort: PlantCohort }) {
             expected_revision: cohort.revision,
             idempotency_key: crypto.randomUUID(),
             quantity: needsQuantity ? quantity : undefined,
+            location: actionName === 'move' && location !== '' ? location : undefined,
             reason
           })
         }}
@@ -238,12 +287,26 @@ function CohortActionPanel({ cohort }: { cohort: PlantCohort }) {
               <option value="promote">Promote to plant IDs</option>
               <option value="ready">Mark available</option>
               <option value="retain">Retain</option>
+              <option value="move">Move</option>
             </Form.Select>
           </Col>
           {needsQuantity && (
             <Col md={2}>
               <Form.Label>Quantity</Form.Label>
               <Form.Control type="number" min={actionName === 'adjust' ? 0 : 1} value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+            </Col>
+          )}
+          {actionName === 'move' && (
+            <Col md={3}>
+              <Form.Label>Destination</Form.Label>
+              <Form.Select value={location} required onChange={(event) => setLocation(event.target.value === '' ? '' : Number(event.target.value))}>
+                <option value="">Select location</option>
+                {locations.map((entry) => (
+                  <option key={entry.pk} value={entry.pk}>
+                    {entry.full_name}
+                  </option>
+                ))}
+              </Form.Select>
             </Col>
           )}
           <Col md={5}>
@@ -298,6 +361,12 @@ function CohortDetailView({ cohortPk }: { cohortPk: number }) {
           <Card body>
             <div className="text-muted">Label</div>
             <div>{cohort.label_code}</div>
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card body>
+            <div className="text-muted">Production cost</div>
+            <div>{cohort.cost === null ? 'Unknown' : `${cohort.currency_code} ${cohort.cost}`}</div>
           </Card>
         </Col>
       </Row>

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -597,6 +597,8 @@ interface PlantCohort {
   revision: number
   notes: string
   label_code: string
+  cost: string | null
+  currency_code: string
   created: string
   updated: string
   events?: Array<CohortEvent>
@@ -653,6 +655,14 @@ interface CohortAction {
   location?: number | null
   disposition?: 'failed' | 'culled' | 'donated' | 'other'
   reason?: string
+}
+
+interface CohortMerge {
+  target: number
+  sources: Array<number>
+  revisions: Record<string, number>
+  reason: string
+  idempotency_key: string
 }
 
 export {
@@ -721,6 +731,7 @@ export {
   CohortEvent,
   CohortFilters,
   CohortLifecycleState,
+  CohortMerge,
   CohortObservation,
   CohortPage,
   CohortTotals,

--- a/plantings/cohort_rest.py
+++ b/plantings/cohort_rest.py
@@ -69,6 +69,8 @@ class PlantCohortSerializer(serializers.ModelSerializer):
     plant_name = serializers.CharField(source='batch.variety.plant.name', read_only=True)
     location_name = serializers.CharField(source='location.name', read_only=True, allow_null=True)
     label_code = serializers.SerializerMethodField()
+    cost = serializers.SerializerMethodField()
+    currency_code = serializers.CharField(source='workspace.currency_code', read_only=True)
 
     class Meta:
         model = PlantCohort
@@ -76,6 +78,7 @@ class PlantCohortSerializer(serializers.ModelSerializer):
             'pk', 'batch', 'batch_code', 'variety', 'variety_name', 'plant_name',
             'source_sowing', 'quantity', 'lifecycle_state', 'location',
             'location_name', 'observed_at', 'revision', 'notes', 'label_code',
+            'cost', 'currency_code',
             'created', 'updated',
         ]
         read_only_fields = [
@@ -87,6 +90,16 @@ class PlantCohortSerializer(serializers.ModelSerializer):
         from labels.services import ensure_identity  # pylint: disable=import-outside-toplevel
 
         return ensure_identity(cohort).codes.get(status='active').code
+
+    def get_cost(self, cohort):
+        """Sum effective cohort layers while preserving unknown as unknown."""
+        rows = cohort.cost_allocations.filter(
+            reversal_of__isnull=True,
+            reversal__isnull=True,
+        )
+        if rows.filter(amount__isnull=True).exists():
+            return None
+        return rows.aggregate(total=Sum('amount'))['total']
 
 
 class CohortDetailSerializer(PlantCohortSerializer):

--- a/plantings/test_cohorts.py
+++ b/plantings/test_cohorts.py
@@ -1,9 +1,12 @@
 """Cohort quantity, lineage, promotion, and REST contract tests."""
 
+from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 from django.utils import timezone
 
 from tests.api import RESTContractTestCase
@@ -189,3 +192,58 @@ class CohortRESTTests(RESTContractTestCase):
         register = self.client.get('/plantings/register/', {'batch': self.batch.pk})
         self.assertEqual(register.status_code, 200, register.data)
         self.assertEqual(register.data['count'], 2)
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class CohortConcurrencyTests(TransactionTestCase):
+    """A stale writer cannot spend the same anonymous quantity twice."""
+
+    reset_sequences = True
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional test flushing."""
+        super()._post_teardown()
+        Workspace.objects.get_or_create(
+            pk=settings.CURRENT_WORKSPACE_ID,
+            defaults={'name': 'My Garden'},
+        )
+
+    def setUp(self):
+        """Create one positive cohort whose initial revision both writers read."""
+        self.workspace = Workspace.objects.get()
+        batch = make_production_batch()
+        self.cohort, _operation = observe_cohort(
+            self.workspace,
+            None,
+            batch=batch,
+            quantity=10,
+            idempotency_key=uuid4(),
+        )
+
+    def split(self):
+        """Attempt one concurrent split on an isolated database connection."""
+        close_old_connections()
+        try:
+            split_cohort(
+                self.workspace,
+                None,
+                cohort_id=self.cohort.pk,
+                expected_revision=self.cohort.revision,
+                quantity=6,
+                idempotency_key=uuid4(),
+                reason='Concurrent split.',
+            )
+            return True
+        except ValidationError:
+            return False
+        finally:
+            close_old_connections()
+
+    def test_only_one_racing_split_uses_the_loaded_revision(self):
+        """Row locking admits one writer and makes the other revision stale."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _index: self.split(), range(2)))
+        self.assertEqual(sorted(results), [False, True])
+        self.cohort.refresh_from_db()
+        self.assertEqual(self.cohort.quantity, 4)
+        self.assertEqual(sum(PlantCohort.objects.values_list('quantity', flat=True)), 10)


### PR DESCRIPTION
Daily nursery work needs reviewed movement and merge controls, visible cohort value, and an explicit record of the delivered contract. This completes the UI operations, adds stale-writer concurrency coverage, and documents the task 54 boundary.

## Summary by Sourcery

Complete cohort operational workflows in the nursery UI and backend, including merge, move, and cost visibility, plus concurrency safeguards.

New Features:
- Add cohort merge controls to the inventory view, allowing selection of multiple cohorts with a documented merge reason.
- Introduce a move action for cohorts with explicit destination selection from active locations.
- Expose production cost and currency for cohorts in the detail view based on cost allocation data.

Enhancements:
- Extend cohort REST serializers and frontend types to carry cost and currency metadata.
- Wire new merge endpoint into the frontend API client and query invalidation for cohort lists.

Tests:
- Add transactional concurrency tests to ensure row locking prevents stale writers from double-spending cohort quantities.