### PR TITLE
feat(plantings): expose production planning workflow

### DIFF
--- a/plantings/planning.py
+++ b/plantings/planning.py
@@ -27,6 +27,13 @@ from .models import (
     NurseryPlanningAssumption,
     NurseryProductionPlan,
     PlantCohort,
+    ProductionBatch,
+)
+
+
+OPEN_BATCH_STATUSES = (
+    ProductionBatch.Status.PLANNED,
+    ProductionBatch.Status.ACTIVE,
 )
 
 
@@ -141,23 +148,43 @@ def _add_issue(plan, demand, kind, message, required=None, available=None):
 
 def _stock_issues(plan, demand, requirement, assumption):
     seed_available = _seed_balance(plan.workspace, demand.variety)
-    if seed_available < requirement.required_seeds:
+    seed_required = NurseryPlanRequirement.objects.filter(
+        demand__plan=plan, demand__variety=demand.variety,
+    ).aggregate(total=Sum('required_seeds'))['total'] or 0
+    seed_required += NurseryPlanRequirement.objects.filter(
+        demand__plan__workspace=plan.workspace,
+        demand__plan__status=NurseryProductionPlan.Status.APPROVED,
+        demand__variety=demand.variety,
+        batch__status__in=OPEN_BATCH_STATUSES,
+    ).exclude(demand__plan=plan).aggregate(total=Sum('required_seeds'))['total'] or 0
+    if seed_available < seed_required:
         _add_issue(
             plan, demand, NurseryPlanIssue.Kind.SEED,
             f'Only {seed_available} seeds are recorded as available.',
-            requirement.required_seeds, seed_available,
+            seed_required, seed_available,
         )
     for row in assumption.inputs.all():
         quantity = Decimal(requirement.required_clusters) * row.quantity_per_plant
         NurseryPlanInputRequirement.objects.create(
             requirement=requirement, item=row.item, quantity=quantity,
         )
+        required = NurseryPlanInputRequirement.objects.filter(
+            requirement__demand__plan=plan, item=row.item,
+        ).aggregate(total=Sum('quantity'))['total'] or Decimal('0')
+        required += NurseryPlanInputRequirement.objects.filter(
+            requirement__demand__plan__workspace=plan.workspace,
+            requirement__demand__plan__status=NurseryProductionPlan.Status.APPROVED,
+            requirement__batch__status__in=OPEN_BATCH_STATUSES,
+            item=row.item,
+        ).exclude(requirement__demand__plan=plan).aggregate(
+            total=Sum('quantity'),
+        )['total'] or Decimal('0')
         available = _item_balance(plan.workspace, row.item)
-        if available < quantity:
+        if available < required:
             _add_issue(
                 plan, demand, NurseryPlanIssue.Kind.INPUT,
                 f'Only {available} {row.item.base_unit} of {row.item.name} is available.',
-                quantity, available,
+                required, available,
             )
 
 
@@ -172,17 +199,18 @@ def _tray_issue(plan, demand, requirement):
             not unit_is_in_use(tray.inventory_unit),
         ))
     )
-    other_planned = NurseryPlanRequirement.objects.filter(
+    planned = NurseryPlanRequirement.objects.filter(
         demand__plan__workspace=plan.workspace,
-        demand__plan__status=NurseryProductionPlan.Status.APPROVED,
         sowing_date=requirement.sowing_date,
-    ).exclude(demand__plan=plan).aggregate(total=Sum('required_trays'))['total'] or 0
-    available -= other_planned
-    if available < requirement.required_trays:
+    ).filter(Q(demand__plan=plan) | Q(
+        demand__plan__status=NurseryProductionPlan.Status.APPROVED,
+        batch__status__in=OPEN_BATCH_STATUSES,
+    )).aggregate(total=Sum('required_trays'))['total'] or 0
+    if available < planned:
         _add_issue(
             plan, demand, NurseryPlanIssue.Kind.TRAY,
-            f'Only {max(available, 0)} unallocated trays are available on the sowing date.',
-            requirement.required_trays, max(available, 0),
+            f'Only {available} trays are available on the sowing date.',
+            planned, available,
         )
 
 
@@ -193,11 +221,13 @@ def _capacity_issue(plan, demand, milestone):
     occupied = location_occupancy(milestone.location, subtree=True).of(basis)
     planned = NurseryPlanMilestone.objects.filter(
         requirement__demand__plan__workspace=plan.workspace,
-        requirement__demand__plan__status=NurseryProductionPlan.Status.APPROVED,
         location=milestone.location,
         planned_date=milestone.planned_date,
         capacity_basis=basis,
-    ).exclude(requirement__demand__plan=plan).aggregate(
+    ).filter(Q(requirement__demand__plan=plan) | Q(
+        requirement__demand__plan__status=NurseryProductionPlan.Status.APPROVED,
+        requirement__batch__status__in=OPEN_BATCH_STATUSES,
+    )).exclude(pk=milestone.pk).aggregate(
         total=Sum('capacity_required'),
     )['total'] or Decimal('0')
     available = milestone.location.capacity_value - Decimal(occupied) - planned

--- a/plantings/planning_rest.py
+++ b/plantings/planning_rest.py
@@ -1,0 +1,279 @@
+"""Nursery production assumptions, demand, plan actions, and projections."""
+
+# DRF viewsets and serializers use framework-defined small method signatures.
+# pylint: disable=too-many-ancestors,missing-class-docstring,missing-function-docstring,duplicate-code,unused-argument
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from workspaces.models import Workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+    RequireWorkspaceModeMixin,
+)
+
+from .models import (
+    NurseryPlanDemand,
+    NurseryPlanInputRequirement,
+    NurseryPlanIssue,
+    NurseryPlanMilestone,
+    NurseryPlanRequirement,
+    NurseryPlanningAssumption,
+    NurseryPlanningInputAssumption,
+    NurseryPlanningStageAssumption,
+    NurseryProductionPlan,
+)
+from .planning import approve_plan, calculate_plan, plan_variance, revise_plan
+
+
+def _errors(error):
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+class PlanningStageAssumptionSerializer(
+        CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    stage_name = serializers.CharField(source='stage.name', read_only=True)
+    location_name = serializers.CharField(source='location.name', read_only=True, allow_null=True)
+
+    class Meta:
+        model = NurseryPlanningStageAssumption
+        fields = [
+            'pk', 'assumption', 'stage', 'stage_name', 'sequence', 'lead_days',
+            'loss_rate', 'location', 'location_name', 'capacity_basis',
+            'capacity_per_plant',
+        ]
+
+    workspace_field_lookups = {
+        'assumption': 'workspace',
+        'stage': 'workspace',
+        'location': 'workspace',
+    }
+
+
+class PlanningInputAssumptionSerializer(
+        CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    item_name = serializers.CharField(source='item.name', read_only=True)
+    base_unit = serializers.CharField(source='item.base_unit', read_only=True)
+
+    class Meta:
+        model = NurseryPlanningInputAssumption
+        fields = [
+            'pk', 'assumption', 'item', 'item_name', 'quantity_per_plant', 'base_unit',
+        ]
+
+    workspace_field_lookups = {
+        'assumption': 'workspace',
+        'item': 'workspace',
+    }
+
+
+class PlanningAssumptionSerializer(
+        CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    variety_name = serializers.CharField(source='variety.name', read_only=True)
+    stages = PlanningStageAssumptionSerializer(many=True, read_only=True)
+    inputs = PlanningInputAssumptionSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = NurseryPlanningAssumption
+        fields = [
+            'pk', 'variety', 'variety_name', 'effective_from', 'effective_until',
+            'germination_rate', 'seeds_per_cluster', 'tray_density', 'notes',
+            'stages', 'inputs', 'created',
+        ]
+
+    workspace_field_lookups = {'variety': 'workspace'}
+
+
+class PlanMilestoneSerializer(serializers.ModelSerializer):
+    stage_name = serializers.CharField(source='stage.name', read_only=True)
+    location_name = serializers.CharField(source='location.name', read_only=True, allow_null=True)
+
+    class Meta:
+        model = NurseryPlanMilestone
+        fields = [
+            'pk', 'stage', 'stage_name', 'sequence', 'planned_date',
+            'input_quantity', 'expected_output', 'location', 'location_name',
+            'capacity_basis', 'capacity_required',
+        ]
+
+
+class PlanInputRequirementSerializer(serializers.ModelSerializer):
+    item_name = serializers.CharField(source='item.name', read_only=True)
+    base_unit = serializers.CharField(source='item.base_unit', read_only=True)
+
+    class Meta:
+        model = NurseryPlanInputRequirement
+        fields = ['pk', 'item', 'item_name', 'quantity', 'base_unit']
+
+
+class PlanRequirementSerializer(serializers.ModelSerializer):
+    milestones = PlanMilestoneSerializer(many=True, read_only=True)
+    inputs = PlanInputRequirementSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = NurseryPlanRequirement
+        fields = [
+            'pk', 'assumption', 'required_seeds', 'required_clusters',
+            'required_trays', 'expected_finished', 'sowing_date',
+            'expected_ready_from', 'expected_ready_until', 'assumption_snapshot',
+            'batch', 'milestones', 'inputs',
+        ]
+
+
+class PlanDemandSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    variety_name = serializers.CharField(source='variety.name', read_only=True)
+    requirement = PlanRequirementSerializer(read_only=True)
+
+    class Meta:
+        model = NurseryPlanDemand
+        fields = [
+            'pk', 'plan', 'variety', 'variety_name', 'product_reference',
+            'target_quantity', 'ready_from', 'ready_until', 'source', 'priority',
+            'customer_reference', 'order_reference', 'source_line_reference',
+            'notes', 'requirement',
+        ]
+
+    workspace_field_lookups = {'plan': 'workspace', 'variety': 'workspace'}
+
+    def validate(self, attrs):
+        plan = attrs.get('plan', self.instance.plan if self.instance else None)
+        if plan and plan.status == NurseryProductionPlan.Status.APPROVED:
+            raise serializers.ValidationError({'plan': 'Approved plan demand is immutable.'})
+        return attrs
+
+
+class PlanIssueSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = NurseryPlanIssue
+        fields = [
+            'pk', 'demand', 'kind', 'message', 'required_quantity',
+            'available_quantity',
+        ]
+
+
+class ProductionPlanSerializer(serializers.ModelSerializer):
+    demand_lines = PlanDemandSerializer(many=True, read_only=True)
+    issues = PlanIssueSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = NurseryProductionPlan
+        fields = [
+            'pk', 'code', 'version', 'status', 'direction', 'sowing_date',
+            'supersedes', 'notes', 'approved_at', 'approved_by', 'created_by',
+            'created', 'updated', 'demand_lines', 'issues',
+        ]
+        read_only_fields = [
+            'version', 'status', 'supersedes', 'approved_at', 'approved_by',
+            'created_by', 'created', 'updated',
+        ]
+
+    def validate(self, attrs):
+        if self.instance and self.instance.status == NurseryProductionPlan.Status.APPROVED:
+            raise serializers.ValidationError({'status': 'Approved plans are immutable.'})
+        return attrs
+
+
+class NurseryPlanningViewSetMixin(
+        RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin):
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
+
+
+class PlanningAssumptionViewSet(
+        NurseryPlanningViewSetMixin, viewsets.ModelViewSet):
+    queryset = NurseryPlanningAssumption.objects.select_related('variety').prefetch_related(
+        'stages__stage', 'stages__location', 'inputs__item',
+    )
+    serializer_class = PlanningAssumptionSerializer
+
+
+class PlanningStageAssumptionViewSet(
+        NurseryPlanningViewSetMixin, viewsets.ModelViewSet):
+    queryset = NurseryPlanningStageAssumption.objects.select_related(
+        'assumption', 'stage', 'location',
+    )
+    serializer_class = PlanningStageAssumptionSerializer
+    workspace_lookup = 'assumption__workspace'
+    bind_workspace_on_create = False
+
+
+class PlanningInputAssumptionViewSet(
+        NurseryPlanningViewSetMixin, viewsets.ModelViewSet):
+    queryset = NurseryPlanningInputAssumption.objects.select_related('assumption', 'item')
+    serializer_class = PlanningInputAssumptionSerializer
+    workspace_lookup = 'assumption__workspace'
+    bind_workspace_on_create = False
+
+
+class PlanDemandViewSet(NurseryPlanningViewSetMixin, viewsets.ModelViewSet):
+    queryset = NurseryPlanDemand.objects.select_related('plan', 'variety').prefetch_related(
+        'requirement__milestones__stage', 'requirement__inputs__item',
+    )
+    serializer_class = PlanDemandSerializer
+    workspace_lookup = 'plan__workspace'
+    bind_workspace_on_create = False
+
+    def destroy(self, request, *args, **kwargs):
+        if self.get_object().plan.status == NurseryProductionPlan.Status.APPROVED:
+            return Response(
+                {'plan': ['Approved plan demand is immutable.']},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return super().destroy(request, *args, **kwargs)
+
+
+class ProductionPlanViewSet(NurseryPlanningViewSetMixin, viewsets.ModelViewSet):
+    queryset = NurseryProductionPlan.objects.select_related(
+        'supersedes', 'approved_by', 'created_by',
+    ).prefetch_related(
+        'demand_lines__variety',
+        'demand_lines__requirement__milestones__stage',
+        'demand_lines__requirement__inputs__item',
+        'issues',
+    )
+    serializer_class = ProductionPlanSerializer
+    http_method_names = ['get', 'post', 'patch', 'head', 'options']
+
+    def perform_create(self, serializer):
+        serializer.save(
+            workspace=self.get_current_workspace(),
+            created_by=self.request.user,
+        )
+
+    def _run(self, operation):
+        try:
+            result = operation(self.get_object())
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(_errors(exc)) from exc
+        return result
+
+    @action(detail=True, methods=['post'])
+    def calculate(self, request, pk=None):
+        self._run(calculate_plan)
+        plan = self.get_queryset().get(pk=self.get_object().pk)
+        return Response(self.get_serializer(plan).data)
+
+    @action(detail=True, methods=['post'])
+    def approve(self, request, pk=None):
+        plan = self._run(lambda current: approve_plan(current, request.user))
+        return Response(self.get_serializer(plan).data)
+
+    @action(detail=True, methods=['post'])
+    def revise(self, request, pk=None):
+        revision = self._run(lambda current: revise_plan(current, request.user))
+        return Response(self.get_serializer(revision).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get'])
+    def variance(self, request, pk=None):
+        return Response(plan_variance(self.get_object()))
+
+
+def register_planning_routes(router):
+    router.register(r'planning-assumptions', PlanningAssumptionViewSet)
+    router.register(r'planning-stage-assumptions', PlanningStageAssumptionViewSet)
+    router.register(r'planning-input-assumptions', PlanningInputAssumptionViewSet)
+    router.register(r'production-plan-demand', PlanDemandViewSet)
+    router.register(r'production-plans', ProductionPlanViewSet)

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -28,6 +28,7 @@ from .lifecycle_rest import PlantLifecycleEventSerializer, PlantLifecycleSeriali
 from .models import GardenRowDirectSowPlanting, GardenSquareDirectSowPlanting, NurseryObservation, SeedTrayPlanting, GardenSquareTransplant, SeedTrayCellPlanting, SpecificPlant, SpecificPlantLocation
 from .register_rest import register_register_routes
 from .growth_rest import NurseryObservationSerializer, register_growth_routes
+from .planning_rest import register_planning_routes
 from .growth import current_growth
 from .cohort_rest import register_cohort_routes
 from .sowing import correct_sowing_consumption, post_sowing_consumption
@@ -1077,6 +1078,7 @@ register_harvest_routes(router)
 register_register_routes(router)
 register_growth_routes(router)
 register_cohort_routes(router)
+register_planning_routes(router)
 
 
 def _register_bulk_routes():

--- a/plantings/test_planning.py
+++ b/plantings/test_planning.py
@@ -137,6 +137,27 @@ class NurseryPlanningTests(TestCase):
         self.assertEqual(calculate_plan(plan).count(), 2)
         self.assertEqual(plan.demand_lines.count(), 2)
 
+    def test_demand_lines_share_capacity_and_stock_availability(self):
+        self.location.capacity_value = Decimal('150')
+        self.location.save()
+        plan = self._plan()
+        NurseryPlanDemand.objects.create(
+            plan=plan,
+            variety=self.variety,
+            target_quantity=72,
+            ready_from=date(2026, 4, 30),
+            ready_until=date(2026, 5, 2),
+            source=NurseryPlanDemand.Source.MANUAL,
+        )
+
+        calculate_plan(plan)
+
+        capacity = plan.issues.filter(kind=NurseryPlanIssue.Kind.CAPACITY).first()
+        seed = plan.issues.filter(kind=NurseryPlanIssue.Kind.SEED).last()
+        self.assertEqual(capacity.required_quantity, Decimal('100'))
+        self.assertEqual(capacity.available_quantity, Decimal('50'))
+        self.assertEqual(seed.required_quantity, Decimal('448'))
+
     def test_approval_creates_planned_batches_without_sowings_or_stock(self):
         plan = self._plan()
         requirement = calculate_plan(plan).get()

--- a/plantings/test_planning_rest.py
+++ b/plantings/test_planning_rest.py
@@ -1,0 +1,126 @@
+"""REST contract for nursery production planning."""
+
+# Test names state the behavior more clearly than repeated method docstrings.
+# pylint: disable=missing-function-docstring
+
+from datetime import date
+from decimal import Decimal
+
+from tests.api import RESTContractTestCase
+from tests.factories import make_location, make_plant_variety
+from workspaces.models import Workspace
+
+from .models import (
+    GrowthStage,
+    NurseryPlanningAssumption,
+    NurseryPlanningStageAssumption,
+    NurseryProductionPlan,
+    ProductionBatch,
+)
+
+
+class NurseryPlanningRESTTests(RESTContractTestCase):
+    """Plans expose reviewed calculation and approval actions in nursery mode."""
+
+    def setUp(self):
+        super().setUp()
+        self.variety = make_plant_variety()
+        self.workspace = self.variety.workspace
+        Workspace.objects.filter(pk=self.workspace.pk).update(mode=Workspace.Mode.NURSERY)
+        self.workspace.refresh_from_db()
+        self.location = make_location(
+            workspace=self.workspace,
+            capacity_basis='plants',
+            capacity_value=Decimal('1000'),
+        )
+        stage = GrowthStage.objects.create(
+            workspace=self.workspace, code='finish', name='Finish', display_order=1,
+        )
+        assumption = NurseryPlanningAssumption.objects.create(
+            workspace=self.workspace,
+            variety=self.variety,
+            effective_from=date(2026, 1, 1),
+            germination_rate=Decimal('0.8'),
+            seeds_per_cluster=1,
+            tray_density=50,
+        )
+        NurseryPlanningStageAssumption.objects.create(
+            assumption=assumption,
+            stage=stage,
+            sequence=1,
+            lead_days=10,
+            loss_rate=Decimal('0.2'),
+            location=self.location,
+        )
+
+    def test_plan_workflow_calculates_approves_revises_and_reports_variance(self):
+        created = self.client.post('/plantings/production-plans/', {
+            'code': 'AUTUMN',
+            'direction': NurseryProductionPlan.Direction.BACKWARD,
+            'notes': 'Retail availability',
+        }, format='json')
+        self.assertEqual(created.status_code, 201, created.data)
+        plan_id = created.data['pk']
+        demand = self.client.post('/plantings/production-plan-demand/', {
+            'plan': plan_id,
+            'variety': self.variety.pk,
+            'target_quantity': 80,
+            'ready_from': '2026-05-20',
+            'ready_until': '2026-05-22',
+            'source': 'confirmed_order',
+            'priority': 30,
+            'order_reference': 'ORDER-9',
+            'source_line_reference': 'ORDER-9-L1',
+        }, format='json')
+        self.assertEqual(demand.status_code, 201, demand.data)
+
+        calculated = self.client.post(f'/plantings/production-plans/{plan_id}/calculate/')
+        self.assertEqual(calculated.status_code, 200, calculated.data)
+        requirement = calculated.data['demand_lines'][0]['requirement']
+        self.assertEqual(requirement['required_clusters'], 125)
+        self.assertEqual(requirement['required_trays'], 3)
+        self.assertEqual(requirement['sowing_date'], '2026-05-10')
+
+        approved = self.client.post(f'/plantings/production-plans/{plan_id}/approve/')
+        self.assertEqual(approved.status_code, 200, approved.data)
+        self.assertEqual(approved.data['status'], NurseryProductionPlan.Status.APPROVED)
+        batch = ProductionBatch.objects.get(planning_requirement__demand__plan_id=plan_id)
+        self.assertEqual(batch.status, ProductionBatch.Status.PLANNED)
+
+        rejected = self.client.patch(
+            f'/plantings/production-plans/{plan_id}/', {'notes': 'silent rewrite'},
+            format='json',
+        )
+        self.assertEqual(rejected.status_code, 400)
+        rejected = self.client.patch(
+            f'/plantings/production-plan-demand/{demand.data["pk"]}/',
+            {'target_quantity': 1}, format='json',
+        )
+        self.assertEqual(rejected.status_code, 400)
+
+        variance = self.client.get(f'/plantings/production-plans/{plan_id}/variance/')
+        self.assertEqual(variance.status_code, 200)
+        self.assertEqual(variance.data[0]['planned_seeds'], 125)
+        self.assertEqual(variance.data[0]['actual_seeds'], 0)
+
+        revision = self.client.post(f'/plantings/production-plans/{plan_id}/revise/')
+        self.assertEqual(revision.status_code, 201, revision.data)
+        self.assertEqual(revision.data['version'], 2)
+        self.assertEqual(revision.data['supersedes'], plan_id)
+        self.assertEqual(revision.data['demand_lines'][0]['target_quantity'], 80)
+
+    def test_routes_require_authentication_and_nursery_profile(self):
+        urls = [
+            '/plantings/planning-assumptions/',
+            '/plantings/planning-stage-assumptions/',
+            '/plantings/planning-input-assumptions/',
+            '/plantings/production-plan-demand/',
+            '/plantings/production-plans/',
+        ]
+        self.assert_authentication_required(urls)
+        self.assert_list_contract(urls)
+
+        Workspace.objects.filter(pk=self.workspace.pk).update(mode=Workspace.Mode.GARDEN)
+        for url in urls:
+            with self.subTest(url=url):
+                self.assertEqual(self.client.get(url).status_code, 403)


### PR DESCRIPTION
Nursery operators need a review boundary around plan calculations and approval. Add workspace-scoped assumption, demand, and plan endpoints with calculate, approve, revise, and variance actions, reject approved-version edits, and aggregate conflicts across draft and open approved production.

## Summary by Sourcery

Expose nursery production planning workflow over REST with workspace-scoped assumptions, demand, and plan actions, including calculation, approval, revision, and variance reporting.

New Features:
- Add REST endpoints for nursery planning assumptions, stage assumptions, input assumptions, production plan demand, and production plans scoped to nursery workspaces.
- Provide calculate, approve, revise, and variance actions on production plans to support reviewed planning workflows.

Bug Fixes:
- Ensure capacity, seed, and input availability calculations aggregate requirements across all demand lines in a workspace, including open approved production batches.

Enhancements:
- Make approved production plans and their demand lines immutable via REST to enforce a review boundary around plan changes.

Tests:
- Add REST contract tests covering nursery planning endpoints, workflow actions, authorization, and workspace mode restrictions.
- Extend planning tests to assert shared capacity and stock availability across multiple demand lines in a plan.