### PR TITLE
feat(frontend): add nursery production planning workspace

### DIFF
--- a/frontend/js/api/plantings.ts
+++ b/frontend/js/api/plantings.ts
@@ -45,7 +45,12 @@ import {
   CohortObservation,
   CohortPage,
   PlantCohort,
-  GrowthCatalogValue
+  GrowthCatalogValue,
+  NurseryPlanDemand,
+  NurseryPlanVariance,
+  NurseryPlanningAssumption,
+  NurseryPlanningStageAssumption,
+  NurseryProductionPlan
 } from '../types/plantings'
 
 interface ProductionBatchFilters {
@@ -217,6 +222,38 @@ function saveGrowthCatalog(kind: 'growth-stages' | 'plant-grades', value: Partia
   return request.then((response) => response.json() as Promise<GrowthCatalogValue>)
 }
 
+function getPlanningAssumptions(signal?: AbortSignal): Promise<Array<NurseryPlanningAssumption>> {
+  return fetchAsJson<Array<NurseryPlanningAssumption>>('/plantings/planning-assumptions/', signal)
+}
+
+function addPlanningAssumption(data: object): Promise<NurseryPlanningAssumption> {
+  return csrfPost('/plantings/planning-assumptions/', data).then((response) => response.json() as Promise<NurseryPlanningAssumption>)
+}
+
+function addPlanningStageAssumption(data: object): Promise<NurseryPlanningStageAssumption> {
+  return csrfPost('/plantings/planning-stage-assumptions/', data).then((response) => response.json() as Promise<NurseryPlanningStageAssumption>)
+}
+
+function getProductionPlans(signal?: AbortSignal): Promise<Array<NurseryProductionPlan>> {
+  return fetchAsJson<Array<NurseryProductionPlan>>('/plantings/production-plans/', signal)
+}
+
+function addProductionPlan(data: object): Promise<NurseryProductionPlan> {
+  return csrfPost('/plantings/production-plans/', data).then((response) => response.json() as Promise<NurseryProductionPlan>)
+}
+
+function addPlanDemand(data: object): Promise<NurseryPlanDemand> {
+  return csrfPost('/plantings/production-plan-demand/', data).then((response) => response.json() as Promise<NurseryPlanDemand>)
+}
+
+function postPlanAction(planPk: number, actionName: 'calculate' | 'approve' | 'revise'): Promise<NurseryProductionPlan> {
+  return csrfPost(`/plantings/production-plans/${planPk}/${actionName}/`, {}).then((response) => response.json() as Promise<NurseryProductionPlan>)
+}
+
+function getPlanVariance(planPk: number, signal?: AbortSignal): Promise<Array<NurseryPlanVariance>> {
+  return fetchAsJson<Array<NurseryPlanVariance>>(`/plantings/production-plans/${planPk}/variance/`, signal)
+}
+
 function harvestQuery(filters: HarvestFilters | HarvestReportFilters): string {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(filters)) {
@@ -345,6 +382,14 @@ export {
   getGrowthStages,
   getPlantGrades,
   saveGrowthCatalog,
+  getPlanningAssumptions,
+  addPlanningAssumption,
+  addPlanningStageAssumption,
+  getProductionPlans,
+  addProductionPlan,
+  addPlanDemand,
+  postPlanAction,
+  getPlanVariance,
   getHarvests,
   getHarvest,
   addHarvest,

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -28,6 +28,7 @@ import { NurseryRegisterView } from './plantings/register.js'
 import { PlantDetailView } from './plantings/plant_detail.js'
 import { CohortDetailView, CohortRegisterView } from './plantings/cohorts.js'
 import { GrowthCatalogsView } from './plantings/growth_catalogs.js'
+import { ProductionPlanningView } from './plantings/production_planning.js'
 import { LabelsView, ScannerView } from './labels.js'
 
 function SeedTrayDetailsRoute() {
@@ -136,6 +137,14 @@ function FrontEndPage() {
           element={
             <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
               <GrowthCatalogsView />
+            </WorkspaceModeRoute>
+          }
+        />
+        <Route
+          path="/plantings/production-planning"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <ProductionPlanningView />
             </WorkspaceModeRoute>
           }
         />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -63,6 +63,9 @@ function GPTopBar({ workspace }: GPTopBarProps) {
                 <NavDropdown.Item as={NavLink} to="/plantings/growth-setup">
                   Growth stages and grades
                 </NavDropdown.Item>
+                <NavDropdown.Item as={NavLink} to="/plantings/production-planning">
+                  Production planning
+                </NavDropdown.Item>
               </>
             )}
             <NavDropdown.Item as={NavLink} to="/plantings/batches">

--- a/frontend/js/plantings/production_planning.tsx
+++ b/frontend/js/plantings/production_planning.tsx
@@ -1,0 +1,503 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Accordion, Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+
+import { getLocations } from '../api/locations'
+import {
+  addPlanDemand,
+  addPlanningAssumption,
+  addPlanningStageAssumption,
+  addProductionPlan,
+  getGrowthStages,
+  getPlanningAssumptions,
+  getPlanVariance,
+  getProductionPlans,
+  postPlanAction
+} from '../api/plantings'
+import { getPlantVarieties } from '../api/plants'
+import { queryKeys } from '../query'
+import { NurseryPlanningAssumption, NurseryProductionPlan } from '../types/plantings'
+import { PlantVariety } from '../types/plants'
+
+function AssumptionForm({ varieties }: { varieties: Array<PlantVariety> }) {
+  const cache = useQueryClient()
+  const [variety, setVariety] = React.useState('')
+  const [effectiveFrom, setEffectiveFrom] = React.useState('')
+  const [germinationRate, setGerminationRate] = React.useState('0.85')
+  const [seedsPerCluster, setSeedsPerCluster] = React.useState('1')
+  const [trayDensity, setTrayDensity] = React.useState('50')
+  const create = useMutation({
+    mutationFn: () =>
+      addPlanningAssumption({
+        variety: Number(variety),
+        effective_from: effectiveFrom,
+        germination_rate: germinationRate,
+        seeds_per_cluster: Number(seedsPerCluster),
+        tray_density: Number(trayDensity)
+      }),
+    onSuccess: () => {
+      setVariety('')
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.planningAssumptions })
+    }
+  })
+  return (
+    <Form
+      onSubmit={(event) => {
+        event.preventDefault()
+        create.mutate()
+      }}
+    >
+      <Row className="g-2 align-items-end">
+        <Col md={3}>
+          <Form.Label>Variety</Form.Label>
+          <Form.Select required value={variety} onChange={(event) => setVariety(event.target.value)}>
+            <option value="">Choose…</option>
+            {varieties.map((value) => (
+              <option key={value.pk} value={value.pk}>
+                {value.name}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={2}>
+          <Form.Label>Effective from</Form.Label>
+          <Form.Control required type="date" value={effectiveFrom} onChange={(event) => setEffectiveFrom(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Germination rate</Form.Label>
+          <Form.Control required type="number" min="0.000001" max="1" step="0.01" value={germinationRate} onChange={(event) => setGerminationRate(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Seeds / cluster</Form.Label>
+          <Form.Control required type="number" min="1" value={seedsPerCluster} onChange={(event) => setSeedsPerCluster(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Clusters / tray</Form.Label>
+          <Form.Control required type="number" min="1" value={trayDensity} onChange={(event) => setTrayDensity(event.target.value)} />
+        </Col>
+        <Col md="auto">
+          <Button type="submit" disabled={create.isPending}>
+            Add
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  )
+}
+
+function StageAssumptionForm({ assumption }: { assumption: NurseryPlanningAssumption }) {
+  const cache = useQueryClient()
+  const stages = useQuery({ queryKey: ['growth-stages'], queryFn: ({ signal }) => getGrowthStages(signal) })
+  const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+  const [stage, setStage] = React.useState('')
+  const [leadDays, setLeadDays] = React.useState('7')
+  const [lossRate, setLossRate] = React.useState('0.05')
+  const [location, setLocation] = React.useState('')
+  const [basis, setBasis] = React.useState('plants')
+  const create = useMutation({
+    mutationFn: () =>
+      addPlanningStageAssumption({
+        assumption: assumption.pk,
+        stage: Number(stage),
+        sequence: assumption.stages.length + 1,
+        lead_days: Number(leadDays),
+        loss_rate: lossRate,
+        location: location ? Number(location) : null,
+        capacity_basis: basis,
+        capacity_per_plant: '1'
+      }),
+    onSuccess: () => cache.invalidateQueries({ queryKey: queryKeys.plantings.planningAssumptions })
+  })
+  const used = new Set(assumption.stages.map((row) => row.stage))
+  return (
+    <Form
+      className="border-top pt-2 mt-2"
+      onSubmit={(event) => {
+        event.preventDefault()
+        create.mutate()
+      }}
+    >
+      <Row className="g-2 align-items-end">
+        <Col md={3}>
+          <Form.Label>Add stage</Form.Label>
+          <Form.Select required value={stage} onChange={(event) => setStage(event.target.value)}>
+            <option value="">Choose…</option>
+            {(stages.data ?? [])
+              .filter((value) => !used.has(value.pk))
+              .map((value) => (
+                <option key={value.pk} value={value.pk}>
+                  {value.name}
+                </option>
+              ))}
+          </Form.Select>
+        </Col>
+        <Col md={2}>
+          <Form.Label>Lead days</Form.Label>
+          <Form.Control required type="number" min="0" value={leadDays} onChange={(event) => setLeadDays(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Loss rate</Form.Label>
+          <Form.Control required type="number" min="0" max="0.999999" step="0.01" value={lossRate} onChange={(event) => setLossRate(event.target.value)} />
+        </Col>
+        <Col md={3}>
+          <Form.Label>Location</Form.Label>
+          <Form.Select value={location} onChange={(event) => setLocation(event.target.value)}>
+            <option value="">Not assigned</option>
+            {(locations.data ?? []).map((value) => (
+              <option key={value.pk} value={value.pk}>
+                {value.full_name}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={1}>
+          <Form.Label>Basis</Form.Label>
+          <Form.Select value={basis} onChange={(event) => setBasis(event.target.value)}>
+            <option value="plants">Plants</option>
+            <option value="trays">Trays</option>
+            <option value="containers">Pots</option>
+            <option value="area">Area</option>
+          </Form.Select>
+        </Col>
+        <Col md="auto">
+          <Button type="submit" size="sm" disabled={create.isPending}>
+            Add
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  )
+}
+
+function Assumptions({ values, varieties }: { values: Array<NurseryPlanningAssumption>; varieties: Array<PlantVariety> }) {
+  return (
+    <Card className="mb-3">
+      <Card.Header>Yield and stage assumptions</Card.Header>
+      <Card.Body>
+        <AssumptionForm varieties={varieties} />
+        <Accordion className="mt-3">
+          {values.map((value) => (
+            <Accordion.Item eventKey={String(value.pk)} key={value.pk}>
+              <Accordion.Header>
+                {value.variety_name} · from {value.effective_from} · {Number(value.germination_rate) * 100}% germination
+              </Accordion.Header>
+              <Accordion.Body>
+                <div>
+                  {value.seeds_per_cluster} seed(s) per cluster · {value.tray_density} clusters per tray
+                </div>
+                {value.stages.length === 0 ? (
+                  <Alert variant="warning" className="mt-2 mb-0">
+                    Add at least one stage before calculating demand.
+                  </Alert>
+                ) : (
+                  <Table size="sm" className="mt-2 mb-0">
+                    <thead>
+                      <tr>
+                        <th>Stage</th>
+                        <th>Lead</th>
+                        <th>Loss</th>
+                        <th>Location</th>
+                        <th>Capacity</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {value.stages.map((stage) => (
+                        <tr key={stage.pk}>
+                          <td>{stage.stage_name}</td>
+                          <td>{stage.lead_days} days</td>
+                          <td>{Number(stage.loss_rate) * 100}%</td>
+                          <td>{stage.location_name ?? 'Not assigned'}</td>
+                          <td>
+                            {stage.capacity_per_plant} {stage.capacity_basis} / plant
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                )}
+                <StageAssumptionForm assumption={value} />
+              </Accordion.Body>
+            </Accordion.Item>
+          ))}
+        </Accordion>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function NewPlanForm() {
+  const cache = useQueryClient()
+  const [code, setCode] = React.useState('')
+  const [direction, setDirection] = React.useState('backward')
+  const [sowingDate, setSowingDate] = React.useState('')
+  const create = useMutation({
+    mutationFn: () => addProductionPlan({ code, direction, sowing_date: direction === 'forward' ? sowingDate : null }),
+    onSuccess: () => {
+      setCode('')
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.productionPlans })
+    }
+  })
+  return (
+    <Card className="mb-3">
+      <Card.Header>New plan</Card.Header>
+      <Card.Body>
+        <Form
+          onSubmit={(event) => {
+            event.preventDefault()
+            create.mutate()
+          }}
+        >
+          <Row className="g-2 align-items-end">
+            <Col md={4}>
+              <Form.Label>Plan code</Form.Label>
+              <Form.Control required value={code} onChange={(event) => setCode(event.target.value)} />
+            </Col>
+            <Col md={3}>
+              <Form.Label>Schedule</Form.Label>
+              <Form.Select value={direction} onChange={(event) => setDirection(event.target.value)}>
+                <option value="backward">Backward from ready date</option>
+                <option value="forward">Forward from sowing date</option>
+              </Form.Select>
+            </Col>
+            {direction === 'forward' && (
+              <Col md={3}>
+                <Form.Label>Sowing date</Form.Label>
+                <Form.Control required type="date" value={sowingDate} onChange={(event) => setSowingDate(event.target.value)} />
+              </Col>
+            )}
+            <Col md="auto">
+              <Button type="submit" disabled={create.isPending}>
+                Create plan
+              </Button>
+            </Col>
+          </Row>
+        </Form>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function DemandForm({ plan, varieties }: { plan: NurseryProductionPlan; varieties: Array<PlantVariety> }) {
+  const cache = useQueryClient()
+  const [variety, setVariety] = React.useState('')
+  const [quantity, setQuantity] = React.useState('')
+  const [readyFrom, setReadyFrom] = React.useState('')
+  const [readyUntil, setReadyUntil] = React.useState('')
+  const [source, setSource] = React.useState('manual')
+  const [orderReference, setOrderReference] = React.useState('')
+  const create = useMutation({
+    mutationFn: () =>
+      addPlanDemand({
+        plan: plan.pk,
+        variety: Number(variety),
+        target_quantity: Number(quantity),
+        ready_from: readyFrom,
+        ready_until: readyUntil,
+        source,
+        priority: 20,
+        order_reference: orderReference
+      }),
+    onSuccess: () => {
+      setQuantity('')
+      cache.invalidateQueries({ queryKey: queryKeys.plantings.productionPlans })
+    }
+  })
+  return (
+    <Form
+      className="border-top pt-3"
+      onSubmit={(event) => {
+        event.preventDefault()
+        create.mutate()
+      }}
+    >
+      <Row className="g-2 align-items-end">
+        <Col md={3}>
+          <Form.Label>Variety</Form.Label>
+          <Form.Select required value={variety} onChange={(event) => setVariety(event.target.value)}>
+            <option value="">Choose…</option>
+            {varieties.map((value) => (
+              <option key={value.pk} value={value.pk}>
+                {value.name}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={1}>
+          <Form.Label>Quantity</Form.Label>
+          <Form.Control required type="number" min="1" value={quantity} onChange={(event) => setQuantity(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Ready from</Form.Label>
+          <Form.Control
+            required
+            type="date"
+            value={readyFrom}
+            onChange={(event) => {
+              setReadyFrom(event.target.value)
+              if (!readyUntil) setReadyUntil(event.target.value)
+            }}
+          />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Ready until</Form.Label>
+          <Form.Control required type="date" min={readyFrom} value={readyUntil} onChange={(event) => setReadyUntil(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Label>Source</Form.Label>
+          <Form.Select value={source} onChange={(event) => setSource(event.target.value)}>
+            <option value="manual">Manual</option>
+            <option value="forecast">Forecast</option>
+            <option value="confirmed_order">Confirmed order</option>
+          </Form.Select>
+        </Col>
+        {source === 'confirmed_order' && (
+          <Col md={2}>
+            <Form.Label>Order reference</Form.Label>
+            <Form.Control required value={orderReference} onChange={(event) => setOrderReference(event.target.value)} />
+          </Col>
+        )}
+        <Col md="auto">
+          <Button size="sm" type="submit" disabled={create.isPending}>
+            Add demand
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  )
+}
+
+function PlanVariance({ plan }: { plan: NurseryProductionPlan }) {
+  const variance = useQuery({
+    queryKey: queryKeys.plantings.productionPlanVariance(plan.pk),
+    queryFn: ({ signal }) => getPlanVariance(plan.pk, signal),
+    enabled: plan.status === 'approved'
+  })
+  if (plan.status !== 'approved' || !variance.data?.length) return null
+  return (
+    <Table size="sm" className="mt-3">
+      <thead>
+        <tr>
+          <th>Batch</th>
+          <th>Seeds planned / actual</th>
+          <th>Output planned / current</th>
+          <th>Start planned / actual</th>
+        </tr>
+      </thead>
+      <tbody>
+        {variance.data.map((row) => (
+          <tr key={row.demand}>
+            <td>
+              {row.batch ?? '—'} ({row.batch_status})
+            </td>
+            <td>
+              {row.planned_seeds} / {row.actual_seeds}
+            </td>
+            <td>
+              {row.planned_output} / {row.current_output}
+            </td>
+            <td>
+              {row.planned_sowing_date} / {row.actual_sowing_date ?? 'not started'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+function PlanCard({ plan, varieties }: { plan: NurseryProductionPlan; varieties: Array<PlantVariety> }) {
+  const cache = useQueryClient()
+  const action = useMutation({
+    mutationFn: (name: 'calculate' | 'approve' | 'revise') => postPlanAction(plan.pk, name),
+    onSuccess: () => cache.invalidateQueries({ queryKey: queryKeys.plantings.productionPlans })
+  })
+  return (
+    <Card className="mb-3">
+      <Card.Header className="d-flex justify-content-between align-items-center">
+        <span>
+          {plan.code} v{plan.version} <Badge bg={plan.status === 'approved' ? 'success' : 'secondary'}>{plan.status}</Badge>
+        </span>
+        <span>
+          {plan.status === 'draft' ? (
+            <>
+              <Button size="sm" variant="outline-primary" className="me-2" disabled={action.isPending || plan.demand_lines.length === 0} onClick={() => action.mutate('calculate')}>
+                Calculate
+              </Button>
+              <Button size="sm" variant="success" disabled={action.isPending || plan.demand_lines.some((line) => !line.requirement)} onClick={() => action.mutate('approve')}>
+                Approve
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="outline-primary" disabled={action.isPending} onClick={() => action.mutate('revise')}>
+              New version
+            </Button>
+          )}
+        </span>
+      </Card.Header>
+      <Card.Body>
+        {plan.issues.map((issue) => (
+          <Alert key={issue.pk} variant="warning" className="py-2">
+            {issue.kind}: {issue.message}
+          </Alert>
+        ))}
+        {plan.demand_lines.length > 0 && (
+          <Table responsive size="sm">
+            <thead>
+              <tr>
+                <th>Demand</th>
+                <th>Ready</th>
+                <th>Source</th>
+                <th>Seeds / trays</th>
+                <th>Milestones</th>
+                <th>Batch</th>
+              </tr>
+            </thead>
+            <tbody>
+              {plan.demand_lines.map((line) => (
+                <tr key={line.pk}>
+                  <td>
+                    {line.target_quantity} × {line.variety_name}
+                  </td>
+                  <td>
+                    {line.ready_from}–{line.ready_until}
+                  </td>
+                  <td>{line.source.replace('_', ' ')}</td>
+                  <td>{line.requirement ? `${line.requirement.required_seeds} / ${line.requirement.required_trays}` : 'Calculate plan'}</td>
+                  <td>
+                    {line.requirement?.milestones.map((milestone) => (
+                      <div key={milestone.pk}>
+                        {milestone.planned_date}: {milestone.stage_name} ({milestone.input_quantity} → {milestone.expected_output})
+                      </div>
+                    ))}
+                  </td>
+                  <td>{line.requirement?.batch ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+        {plan.status === 'draft' && <DemandForm plan={plan} varieties={varieties} />}
+        <PlanVariance plan={plan} />
+      </Card.Body>
+    </Card>
+  )
+}
+
+function ProductionPlanningView() {
+  const varieties = useQuery({ queryKey: queryKeys.plants.varieties, queryFn: ({ signal }) => getPlantVarieties(signal) })
+  const assumptions = useQuery({ queryKey: queryKeys.plantings.planningAssumptions, queryFn: ({ signal }) => getPlanningAssumptions(signal) })
+  const plans = useQuery({ queryKey: queryKeys.plantings.productionPlans, queryFn: ({ signal }) => getProductionPlans(signal) })
+  return (
+    <main className="container py-3">
+      <h1>Nursery production planning</h1>
+      <p>Turn committed, forecast, and manual demand into reviewed sowing, stage, stock, and capacity requirements.</p>
+      <Assumptions values={assumptions.data ?? []} varieties={varieties.data ?? []} />
+      <NewPlanForm />
+      {(plans.data ?? []).map((plan) => (
+        <PlanCard key={plan.pk} plan={plan} varieties={varieties.data ?? []} />
+      ))}
+    </main>
+  )
+}
+
+export { ProductionPlanningView }

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -91,6 +91,9 @@ const queryKeys = {
     cohorts: (filters: CohortFilters) => ['plantings', 'cohorts', filters] as const,
     cohort: (cohortPk: number) => ['plantings', 'cohorts', 'detail', cohortPk] as const,
     cohortAvailability: (filters: CohortFilters) => ['plantings', 'cohorts', 'availability', filters] as const,
+    planningAssumptions: ['plantings', 'planningAssumptions'] as const,
+    productionPlans: ['plantings', 'productionPlans'] as const,
+    productionPlanVariance: (planPk: number) => ['plantings', 'productionPlans', planPk, 'variance'] as const,
     harvestReportAll: ['plantings', 'harvestReport'] as const,
     harvestReport: (groupBy: string, batch: number | '', variety: number | '', from: string, to: string) =>
       ['plantings', 'harvestReport', groupBy, batch, variety, from, to] as const

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -750,6 +750,128 @@ interface CohortMerge {
   idempotency_key: string
 }
 
+type NurseryPlanStatus = 'draft' | 'approved'
+type NurseryPlanDirection = 'backward' | 'forward'
+type NurseryDemandSource = 'confirmed_order' | 'forecast' | 'manual'
+
+interface NurseryPlanMilestone {
+  pk: number
+  stage: number
+  stage_name: string
+  sequence: number
+  planned_date: string
+  input_quantity: number
+  expected_output: number
+  location: number | null
+  location_name: string | null
+  capacity_basis: string
+  capacity_required: string
+}
+
+interface NurseryPlanRequirement {
+  pk: number
+  assumption: number
+  required_seeds: number
+  required_clusters: number
+  required_trays: number
+  expected_finished: number
+  sowing_date: string
+  expected_ready_from: string
+  expected_ready_until: string
+  assumption_snapshot: Record<string, unknown>
+  batch: number | null
+  milestones: Array<NurseryPlanMilestone>
+  inputs: Array<{ pk: number; item: number; item_name: string; quantity: string; base_unit: string }>
+}
+
+interface NurseryPlanDemand {
+  pk: number
+  plan: number
+  variety: number
+  variety_name: string
+  product_reference: string
+  target_quantity: number
+  ready_from: string
+  ready_until: string
+  source: NurseryDemandSource
+  priority: number
+  customer_reference: string
+  order_reference: string
+  source_line_reference: string
+  notes: string
+  requirement: NurseryPlanRequirement | null
+}
+
+interface NurseryPlanIssue {
+  pk: number
+  demand: number | null
+  kind: 'seed' | 'input' | 'tray' | 'capacity' | 'assumption'
+  message: string
+  required_quantity: string | null
+  available_quantity: string | null
+}
+
+interface NurseryProductionPlan {
+  pk: number
+  code: string
+  version: number
+  status: NurseryPlanStatus
+  direction: NurseryPlanDirection
+  sowing_date: string | null
+  supersedes: number | null
+  notes: string
+  approved_at: string | null
+  approved_by: number | null
+  created_by: number | null
+  created: string
+  updated: string
+  demand_lines: Array<NurseryPlanDemand>
+  issues: Array<NurseryPlanIssue>
+}
+
+interface NurseryPlanningStageAssumption {
+  pk: number
+  assumption: number
+  stage: number
+  stage_name: string
+  sequence: number
+  lead_days: number
+  loss_rate: string
+  location: number | null
+  location_name: string | null
+  capacity_basis: string
+  capacity_per_plant: string
+}
+
+interface NurseryPlanningAssumption {
+  pk: number
+  variety: number
+  variety_name: string
+  effective_from: string
+  effective_until: string | null
+  germination_rate: string
+  seeds_per_cluster: number
+  tray_density: number
+  notes: string
+  stages: Array<NurseryPlanningStageAssumption>
+  inputs: Array<{ pk: number; item: number; item_name: string; quantity_per_plant: string; base_unit: string }>
+  created: string
+}
+
+interface NurseryPlanVariance {
+  demand: number
+  batch: number | null
+  planned_sowing_date: string
+  actual_sowing_date: string | null
+  planned_seeds: number
+  actual_seeds: number
+  seed_variance: number
+  planned_output: number
+  current_output: number
+  output_variance: number
+  batch_status: ProductionBatchStatus | null
+}
+
 export {
   BatchAction,
   BulkPlantOutcome,
@@ -823,5 +945,16 @@ export {
   CohortObservation,
   CohortPage,
   CohortTotals,
-  PlantCohort
+  PlantCohort,
+  NurseryDemandSource,
+  NurseryPlanDirection,
+  NurseryPlanStatus,
+  NurseryPlanDemand,
+  NurseryPlanIssue,
+  NurseryPlanMilestone,
+  NurseryPlanRequirement,
+  NurseryPlanVariance,
+  NurseryPlanningAssumption,
+  NurseryPlanningStageAssumption,
+  NurseryProductionPlan
 }


### PR DESCRIPTION
Operators need to review planning assumptions, demand certainty, shortages, milestones, approval versions, and actual variance without scripting API calls. Add a nursery-only planning screen and navigation with typed query and mutation support.

## Summary by Sourcery

Introduce a nursery-only production planning workspace to manage assumptions, demand, plans, and variances.

New Features:
- Add typed nursery production planning types for plans, assumptions, demand, issues, and variance.
- Expose new nursery planning and production plan API helpers for assumptions, plans, demand, actions, and variance queries.
- Add a nursery production planning React workspace with forms for assumptions, demand entry, plan management, and variance review.
- Wire the nursery production planning view into routing and navigation for the nursery workspace.

Enhancements:
- Extend React Query key registry to cover nursery planning assumptions, production plans, and variance data.