### PR TITLE
feat(work): expose actionable nursery queue

### DIFF
--- a/gp/urls.py
+++ b/gp/urls.py
@@ -34,4 +34,5 @@ urlpatterns = [
     path("applications/", include('applications.urls')),
     path("costing/", include('costing.urls')),
     path("labels/", include('labels.urls')),
+    path("work/", include('work.urls')),
 ]

--- a/work/rest.py
+++ b/work/rest.py
@@ -1,0 +1,239 @@
+"""REST resources for rules, the combined work queue, and task actions."""
+
+# DRF viewsets and serializers have framework-defined small method signatures.
+# pylint: disable=too-many-ancestors,missing-function-docstring,missing-class-docstring,duplicate-code,abstract-method
+
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils import timezone
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from workspaces.models import Workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+    RequireWorkspaceModeMixin,
+)
+
+from .models import WorkTask, WorkTaskHistory, WorkTaskLink, WorkTaskRule, WorkTaskType
+from .projections import ProjectedTask, projected_tasks
+from .services import acknowledge_projection, act_on_task, create_manual_task
+
+
+def _errors(error):
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+class WorkRuleSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    class Meta:
+        model = WorkTaskRule
+        fields = [
+            'pk', 'code', 'name', 'task_type', 'trigger', 'active', 'priority',
+            'due_start_offset_days', 'due_end_offset_days', 'local_due_time',
+            'frequency', 'interval', 'weekdays', 'season_start', 'season_end',
+            'variety', 'stage', 'location', 'default_assignee', 'notes',
+            'created', 'updated',
+        ]
+        read_only_fields = ['created', 'updated']
+
+    workspace_field_lookups = {
+        'variety': 'workspace', 'stage': 'workspace', 'location': 'workspace',
+    }
+
+
+class HistorySerializer(serializers.ModelSerializer):
+    actor_name = serializers.CharField(source='actor.username', read_only=True, allow_null=True)
+
+    class Meta:
+        model = WorkTaskHistory
+        fields = ['pk', 'action', 'actor', 'actor_name', 'reason', 'changes', 'created']
+
+
+class LinkSerializer(serializers.ModelSerializer):
+    target_type = serializers.CharField(source='content_type.model', read_only=True)
+
+    class Meta:
+        model = WorkTaskLink
+        fields = ['role', 'target_type', 'object_id', 'label', 'url', 'snapshot']
+
+
+class WorkTaskSerializer(serializers.ModelSerializer):
+    assignee_name = serializers.CharField(source='assignee.username', read_only=True, allow_null=True)
+    links = LinkSerializer(many=True, read_only=True)
+    history = HistorySerializer(many=True, read_only=True)
+
+    class Meta:
+        model = WorkTask
+        fields = [
+            'pk', 'key', 'origin', 'rule', 'task_type', 'title', 'notes',
+            'priority', 'due_start', 'due_end', 'status', 'assignee',
+            'assignee_name', 'snoozed_until', 'completed_at', 'skipped_at',
+            'source_snapshot', 'recurrence', 'links', 'history', 'created', 'updated',
+        ]
+        read_only_fields = [
+            'pk', 'key', 'origin', 'rule', 'status', 'snoozed_until',
+            'completed_at', 'skipped_at', 'source_snapshot', 'created', 'updated',
+        ]
+
+
+class ManualTaskSerializer(serializers.Serializer):
+    task_type = serializers.ChoiceField(choices=WorkTaskType.choices)
+    title = serializers.CharField(max_length=255)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    priority = serializers.IntegerField(min_value=1, max_value=100, default=20)
+    due_start = serializers.DateTimeField()
+    due_end = serializers.DateTimeField()
+    assignee = serializers.PrimaryKeyRelatedField(
+        queryset=get_user_model().objects.filter(is_active=True), required=False,
+        allow_null=True,
+    )
+    recurrence = serializers.JSONField(required=False, default=dict)
+
+    def validate(self, attrs):
+        if attrs['due_end'] < attrs['due_start']:
+            raise serializers.ValidationError({'due_end': 'The due window cannot end before it starts.'})
+        recurrence = attrs['recurrence']
+        if recurrence and recurrence.get('frequency') not in {
+                WorkTaskRule.Frequency.DAILY, WorkTaskRule.Frequency.WEEKLY}:
+            raise serializers.ValidationError({'recurrence': 'Choose daily or weekly recurrence.'})
+        return attrs
+
+
+class TaskActionSerializer(serializers.Serializer):
+    action = serializers.ChoiceField(choices=['assign', 'claim', 'snooze', 'complete', 'skip', 'reopen'])
+    assignee = serializers.IntegerField(required=False, allow_null=True)
+    until = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+    results = serializers.ListField(child=serializers.DictField(), required=False, default=list)
+    idempotency_key = serializers.CharField(required=False, allow_blank=True, max_length=64, default='')
+
+
+def _projected_data(task):
+    return {
+        'pk': None, 'key': task.key, 'origin': task.origin, 'rule': task.rule.pk,
+        'task_type': task.task_type, 'title': task.title, 'notes': '',
+        'priority': task.priority, 'due_start': task.due_start,
+        'due_end': task.due_end, 'status': task.status,
+        'assignee': task.assignee.pk if task.assignee else None,
+        'assignee_name': task.assignee.username if task.assignee else None,
+        'snoozed_until': None, 'completed_at': None, 'skipped_at': None,
+        'source_snapshot': task.source_snapshot, 'recurrence': {},
+        'links': [{
+            'role': WorkTaskLink.Role.TARGET,
+            'target_type': row.target._meta.model_name,
+            'object_id': row.target.pk, 'label': row.label, 'url': row.url,
+            'snapshot': {},
+        } for row in task.targets],
+        'history': [], 'created': None, 'updated': None,
+    }
+
+
+def _effective_status(task, now):
+    if task.status == WorkTask.Status.SNOOZED and task.snoozed_until <= now:
+        return WorkTask.Status.OPEN
+    return task.status
+
+
+def _in_view(task, view, workspace, now):
+    effective = _effective_status(task, now)
+    local = now.astimezone(ZoneInfo(workspace.timezone))
+    day_start = local.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+    week_start = day_start - timedelta(days=day_start.weekday())
+    week_end = week_start + timedelta(days=7)
+    if view == 'completed':
+        return effective in {WorkTask.Status.COMPLETED, WorkTask.Status.SKIPPED}
+    if view == 'snoozed':
+        return effective == WorkTask.Status.SNOOZED
+    if effective != WorkTask.Status.OPEN:
+        return False
+    if view == 'overdue':
+        return task.due_end < now
+    if view == 'week':
+        return task.due_start < week_end and task.due_end >= week_start
+    return task.due_start < day_end and task.due_end >= day_start
+
+
+class NurseryWorkMixin(RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin):
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+
+
+class WorkRuleViewSet(NurseryWorkMixin, viewsets.ModelViewSet):
+    queryset = WorkTaskRule.objects.select_related('variety', 'stage', 'location', 'default_assignee')
+    serializer_class = WorkRuleSerializer
+
+    def perform_create(self, serializer):
+        serializer.save(workspace=self.get_current_workspace(), created_by=self.request.user)
+
+
+class WorkTaskViewSet(NurseryWorkMixin, viewsets.GenericViewSet):
+    queryset = WorkTask.objects.select_related('rule', 'assignee').prefetch_related(
+        'links__content_type', 'history__actor',
+    )
+    serializer_class = WorkTaskSerializer
+
+    def list(self, request):
+        workspace = self.get_current_workspace()
+        now = timezone.now()
+        view = request.query_params.get('view', 'today')
+        rows = list(self.get_queryset()) + list(projected_tasks(workspace))
+        rows = [row for row in rows if _in_view(row, view, workspace, now)]
+        for field in ('task_type', 'priority'):
+            value = request.query_params.get(field)
+            if value:
+                rows = [row for row in rows if str(getattr(row, field)) == value]
+        assignee = request.query_params.get('assignee')
+        if assignee:
+            rows = [row for row in rows if row.assignee and str(row.assignee.pk) == assignee]
+        rows.sort(key=lambda row: (row.due_end, -row.priority, row.key))
+        return Response([
+            _projected_data(row) if isinstance(row, ProjectedTask) else WorkTaskSerializer(row).data
+            for row in rows
+        ])
+
+    def create(self, request):
+        serializer = ManualTaskSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        assignee = values.pop('assignee', None)
+        task = create_manual_task(
+            self.get_current_workspace(), request.user,
+            {**values, 'assignee': assignee},
+        )
+        return Response(WorkTaskSerializer(task).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=['post'], url_path='acknowledge')
+    def acknowledge(self, request):
+        key = serializers.CharField().run_validation(request.data.get('key'))
+        try:
+            task = acknowledge_projection(self.get_current_workspace(), request.user, key)
+        except DjangoValidationError as error:
+            return Response(_errors(error), status=status.HTTP_409_CONFLICT)
+        return Response(WorkTaskSerializer(task).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'], url_path='act')
+    def act(self, request, pk=None):
+        serializer = TaskActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        action_name = values.pop('action')
+        try:
+            task = act_on_task(
+                self.get_current_workspace(), request.user, pk, action_name, values,
+            )
+        except DjangoValidationError as error:
+            return Response(_errors(error), status=status.HTTP_400_BAD_REQUEST)
+        return Response(WorkTaskSerializer(task).data)
+
+
+class AssigneeViewSet(NurseryWorkMixin, viewsets.ViewSet):
+    queryset = get_user_model().objects.none()
+
+    def list(self, request):
+        users = get_user_model().objects.filter(is_active=True).order_by('username', 'pk')
+        return Response([{'pk': user.pk, 'username': user.username} for user in users])

--- a/work/services.py
+++ b/work/services.py
@@ -1,0 +1,198 @@
+"""Transactional commands for acknowledging and acting on nursery work."""
+
+# Audit helpers carry actor, reason, change, and idempotency context together;
+# the action dispatcher deliberately keeps each supported transition visible.
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
+
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from .models import WorkTask, WorkTaskHistory, WorkTaskLink
+from .projections import next_recurrence, projected_tasks, target_identity
+
+
+def _actor(user):
+    return user if user is not None and user.is_authenticated else None
+
+
+def _history(task, action, user, reason='', changes=None, idempotency_key=''):
+    if idempotency_key:
+        existing = task.history.filter(idempotency_key=idempotency_key).first()
+        if existing:
+            return existing, False
+    return WorkTaskHistory.objects.create(
+        task=task, action=action, actor=_actor(user), reason=reason,
+        changes=changes or {}, idempotency_key=idempotency_key,
+    ), True
+
+
+def _link(task, role, target, label, url='', snapshot=None):
+    content_type, object_id = target_identity(target)
+    return WorkTaskLink.objects.create(
+        task=task, role=role, content_type=content_type, object_id=object_id,
+        label=label, url=url, snapshot=snapshot or {},
+    )
+
+
+@transaction.atomic
+def create_manual_task(workspace, user, values, targets=()):
+    """Create one manual task and its initial immutable history."""
+    task = WorkTask.objects.create(
+        workspace=workspace,
+        key=f'manual:{uuid4()}',
+        origin=WorkTask.Origin.MANUAL,
+        created_by=_actor(user),
+        **values,
+    )
+    for target, label, url in targets:
+        _link(task, WorkTaskLink.Role.TARGET, target, label, url)
+    _history(task, 'created', user)
+    return task
+
+
+@transaction.atomic
+def acknowledge_projection(workspace, user, key):
+    """Snapshot the current form of one generated occurrence exactly once."""
+    existing = WorkTask.objects.select_for_update().filter(workspace=workspace, key=key).first()
+    if existing:
+        return existing
+    projection = next((row for row in projected_tasks(workspace) if row.key == key), None)
+    if projection is None:
+        raise ValidationError({'key': 'This generated task changed or is no longer due.'})
+    try:
+        task = WorkTask.objects.create(
+            workspace=workspace, key=projection.key,
+            origin=WorkTask.Origin.GENERATED, rule=projection.rule,
+            task_type=projection.task_type, title=projection.title,
+            priority=projection.priority, due_start=projection.due_start,
+            due_end=projection.due_end, assignee=projection.assignee,
+            source_snapshot=projection.source_snapshot, created_by=_actor(user),
+        )
+    except IntegrityError:
+        return WorkTask.objects.select_for_update().get(workspace=workspace, key=key)
+    for target in projection.targets:
+        _link(task, WorkTaskLink.Role.TARGET, target.target, target.label, target.url)
+    _history(task, 'acknowledged', user)
+    return task
+
+
+def _result_target(workspace, values):
+    try:
+        content_type = ContentType.objects.get(
+            app_label=values['app_label'], model=values['model'],
+        )
+        target = content_type.get_object_for_this_type(pk=values['object_id'])
+    except (ContentType.DoesNotExist, ObjectDoesNotExist, KeyError, ValueError) as exc:
+        raise ValidationError({'results': 'A linked result does not exist.'}) from exc
+    target_workspace_id = getattr(target, 'workspace_id', None)
+    if target_workspace_id != workspace.pk:
+        raise ValidationError({'results': 'A linked result belongs to another workspace.'})
+    return target
+
+
+def _next_manual_occurrence(task, user):
+    recurrence = task.recurrence
+    if not recurrence:
+        return None
+    next_start = next_recurrence(
+        task.workspace, task.due_start, recurrence['frequency'],
+        recurrence.get('interval', 1), recurrence.get('weekdays', ()),
+    )
+    duration = task.due_end - task.due_start
+    key = f'{task.key}:next:{next_start.isoformat()}'
+    following, created = WorkTask.objects.get_or_create(
+        workspace=task.workspace, key=key,
+        defaults={
+            'origin': WorkTask.Origin.MANUAL,
+            'task_type': task.task_type,
+            'title': task.title,
+            'notes': task.notes,
+            'priority': task.priority,
+            'due_start': next_start,
+            'due_end': next_start + duration,
+            'assignee': task.assignee,
+            'recurrence': recurrence,
+            'parent': task,
+            'created_by': _actor(user),
+        },
+    )
+    if created:
+        for link in task.links.filter(role=WorkTaskLink.Role.TARGET):
+            WorkTaskLink.objects.create(
+                task=following, role=link.role, content_type=link.content_type,
+                object_id=link.object_id, label=link.label, url=link.url,
+                snapshot=link.snapshot,
+            )
+        _history(following, 'created', user, changes={'recurs_from': task.pk})
+    return following
+
+
+@transaction.atomic
+def act_on_task(workspace, user, task_id, action, values):  # pylint: disable=too-many-branches
+    """Apply one explicit idempotent state transition under a row lock."""
+    task = WorkTask.objects.select_for_update().filter(workspace=workspace, pk=task_id).first()
+    if task is None:
+        raise ValidationError({'task': 'The task does not belong to this workspace.'})
+    idempotency_key = values.get('idempotency_key', '')
+    if idempotency_key and task.history.filter(idempotency_key=idempotency_key).exists():
+        return task
+    now = timezone.now()
+    changes = {}
+    reason = values.get('reason', '').strip()
+    if action in {'complete', 'skip'} and task.status in {WorkTask.Status.COMPLETED, WorkTask.Status.SKIPPED}:
+        raise ValidationError({'status': 'This task is already closed.'})
+    if action == 'assign':
+        assignee_id = values.get('assignee')
+        assignee = None
+        if assignee_id is not None:
+            assignee = get_user_model().objects.filter(pk=assignee_id, is_active=True).first()
+            if assignee is None:
+                raise ValidationError({'assignee': 'Choose an active user.'})
+        task.assignee = assignee
+        changes['assignee'] = assignee.pk if assignee else None
+    elif action == 'claim':
+        task.assignee = user
+        changes['assignee'] = user.pk
+    elif action == 'snooze':
+        until = values.get('until')
+        if until is None or until <= now:
+            raise ValidationError({'until': 'Snooze until a future time.'})
+        task.status = WorkTask.Status.SNOOZED
+        task.snoozed_until = until
+        changes['until'] = until.isoformat()
+    elif action == 'complete':
+        task.status = WorkTask.Status.COMPLETED
+        task.completed_at = now
+        task.snoozed_until = None
+        for result in values.get('results', ()):
+            target = _result_target(workspace, result)
+            _link(
+                task, WorkTaskLink.Role.RESULT, target,
+                result.get('label') or str(target), result.get('url', ''),
+            )
+    elif action == 'skip':
+        if not reason:
+            raise ValidationError({'reason': 'Explain why this task was skipped.'})
+        task.status = WorkTask.Status.SKIPPED
+        task.skipped_at = now
+        task.snoozed_until = None
+    elif action == 'reopen':
+        if task.status not in {WorkTask.Status.COMPLETED, WorkTask.Status.SKIPPED}:
+            raise ValidationError({'status': 'Only completed or skipped work can be reopened.'})
+        if not reason:
+            raise ValidationError({'reason': 'Explain why this task was reopened.'})
+        task.status = WorkTask.Status.OPEN
+        task.completed_at = None
+        task.skipped_at = None
+    else:
+        raise ValidationError({'action': 'Choose a supported task action.'})
+    task.save()
+    _history(task, action, user, reason, changes, idempotency_key)
+    if action in {'complete', 'skip'}:
+        _next_manual_occurrence(task, user)
+    return task

--- a/work/test_rest.py
+++ b/work/test_rest.py
@@ -1,0 +1,77 @@
+"""REST contract tests for the nursery work queue."""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from workspaces.models import get_current_workspace
+
+from .models import WorkTask
+
+
+class WorkRESTTests(APITestCase):
+    """Operators can create, filter, and act on work through explicit actions."""
+
+    def setUp(self):
+        self.workspace = get_current_workspace()
+        self.workspace.mode = self.workspace.Mode.NURSERY
+        self.workspace.save()
+        self.user = get_user_model().objects.create_user(username='operator')
+        self.client.force_authenticate(self.user)
+
+    def _create(self, recurrence=None):
+        now = timezone.now()
+        response = self.client.post('/work/tasks/', {
+            'task_type': 'watering',
+            'title': 'Water propagation bench',
+            'due_start': (now - timedelta(minutes=5)).isoformat(),
+            'due_end': (now + timedelta(minutes=5)).isoformat(),
+            'recurrence': recurrence or {},
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def test_today_lists_manual_work(self):
+        """The default queue view contains work whose window intersects today."""
+        created = self._create()
+        response = self.client.get('/work/tasks/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(created['key'], [row['key'] for row in response.data])
+
+    def test_claim_snooze_complete_and_reopen_are_historical(self):
+        """Explicit actions update state and append readable audit rows."""
+        task = self._create()
+        response = self.client.post(f"/work/tasks/{task['pk']}/act/", {
+            'action': 'claim', 'idempotency_key': 'claim-1',
+        }, format='json')
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['assignee'], self.user.pk)
+        response = self.client.post(f"/work/tasks/{task['pk']}/act/", {
+            'action': 'complete', 'idempotency_key': 'complete-1',
+        }, format='json')
+        self.assertEqual(response.data['status'], WorkTask.Status.COMPLETED)
+        response = self.client.post(f"/work/tasks/{task['pk']}/act/", {
+            'action': 'reopen', 'reason': 'More work is needed.',
+        }, format='json')
+        self.assertEqual(response.data['status'], WorkTask.Status.OPEN)
+        self.assertEqual(len(response.data['history']), 4)
+
+    def test_skip_requires_a_reason(self):
+        """Skipping cannot erase the operational explanation."""
+        task = self._create()
+        response = self.client.post(f"/work/tasks/{task['pk']}/act/", {
+            'action': 'skip',
+        }, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(WorkTask.objects.get(pk=task['pk']).status, WorkTask.Status.OPEN)
+
+    def test_routes_require_authentication_and_nursery_mode(self):
+        """The queue is authenticated and belongs to the Nursery profile."""
+        self.client.force_authenticate(user=None)
+        self.assertEqual(self.client.get('/work/tasks/').status_code, 403)
+        self.client.force_authenticate(self.user)
+        self.workspace.mode = self.workspace.Mode.GARDEN
+        self.workspace.save()
+        self.assertEqual(self.client.get('/work/tasks/').status_code, 403)

--- a/work/urls.py
+++ b/work/urls.py
@@ -1,0 +1,13 @@
+"""REST routes for the nursery work queue."""
+
+from rest_framework import routers
+
+from .rest import AssigneeViewSet, WorkRuleViewSet, WorkTaskViewSet
+
+
+router = routers.DefaultRouter()
+router.register('rules', WorkRuleViewSet)
+router.register('tasks', WorkTaskViewSet)
+router.register('assignees', AssigneeViewSet, basename='work-assignee')
+
+urlpatterns = router.urls


### PR DESCRIPTION
Nursery operators need one authenticated queue that combines live projections with manual work and preserves every assignment, snooze, completion, skip, and reopen as an idempotent chronological action.

## Summary by Sourcery

Expose an authenticated nursery work queue API that combines rule-driven projections with manual tasks and explicit actions.

New Features:
- Add REST endpoints under /work/ for listing, creating, and filtering nursery work tasks, including projected and manual items.
- Expose rule management APIs for configuring nursery task generation within a workspace.
- Provide authenticated task action endpoints for assigning, claiming, snoozing, completing, skipping, reopening, and acknowledging projected work, with idempotent audit history.
- Add an assignee lookup API for active users to support task assignment in the nursery queue.

Enhancements:
- Restrict the work queue APIs to Nursery workspaces and integrate them into the global URL configuration.

Tests:
- Introduce API contract tests covering nursery work task creation, queue views, authenticated access, and workspace-mode enforcement.