### PR TITLE
feat(frontend): add nursery work workspace

### DIFF
--- a/frontend/js/api/work.ts
+++ b/frontend/js/api/work.ts
@@ -1,0 +1,42 @@
+import { csrfPatch, csrfPost, fetchAsJson } from '../utils'
+import { WorkAssignee, WorkFilters, WorkRule, WorkTask } from '../types/work'
+
+function getWorkTasks(filters: WorkFilters, signal?: AbortSignal): Promise<Array<WorkTask>> {
+  const query = new URLSearchParams({ view: filters.view })
+  if (filters.task_type) query.set('task_type', filters.task_type)
+  if (filters.priority !== undefined) query.set('priority', String(filters.priority))
+  if (filters.assignee !== undefined) query.set('assignee', String(filters.assignee))
+  if (filters.batch !== undefined) query.set('batch', String(filters.batch))
+  if (filters.location !== undefined) query.set('location', String(filters.location))
+  return fetchAsJson<Array<WorkTask>>(`/work/tasks/?${query.toString()}`, signal)
+}
+
+function getWorkRules(signal?: AbortSignal): Promise<Array<WorkRule>> {
+  return fetchAsJson<Array<WorkRule>>('/work/rules/', signal)
+}
+
+function getWorkAssignees(signal?: AbortSignal): Promise<Array<WorkAssignee>> {
+  return fetchAsJson<Array<WorkAssignee>>('/work/assignees/', signal)
+}
+
+function addWorkTask(data: object): Promise<WorkTask> {
+  return csrfPost('/work/tasks/', data).then((response) => response.json() as Promise<WorkTask>)
+}
+
+function acknowledgeWorkTask(key: string): Promise<WorkTask> {
+  return csrfPost('/work/tasks/acknowledge/', { key }).then((response) => response.json() as Promise<WorkTask>)
+}
+
+function actOnWorkTask(pk: number, data: object): Promise<WorkTask> {
+  return csrfPost(`/work/tasks/${pk}/act/`, data).then((response) => response.json() as Promise<WorkTask>)
+}
+
+function addWorkRule(data: object): Promise<WorkRule> {
+  return csrfPost('/work/rules/', data).then((response) => response.json() as Promise<WorkRule>)
+}
+
+function updateWorkRule(pk: number, data: object): Promise<WorkRule> {
+  return csrfPatch(`/work/rules/${pk}/`, data).then((response) => response.json() as Promise<WorkRule>)
+}
+
+export { acknowledgeWorkTask, actOnWorkTask, addWorkRule, addWorkTask, getWorkAssignees, getWorkRules, getWorkTasks, updateWorkRule }

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -30,6 +30,7 @@ import { CohortDetailView, CohortRegisterView } from './plantings/cohorts.js'
 import { GrowthCatalogsView } from './plantings/growth_catalogs.js'
 import { ProductionPlanningView } from './plantings/production_planning.js'
 import { LabelsView, ScannerView } from './labels.js'
+import { WorkQueueView } from './work.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -157,6 +158,14 @@ function FrontEndPage() {
         <Route path="/labels" element={<LabelsView />} />
         <Route path="/scan" element={<ScannerView />} />
         <Route path="/scan/:code" element={<ScannerView />} />
+        <Route
+          path="/work"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <WorkQueueView />
+            </WorkspaceModeRoute>
+          }
+        />
         <Route
           path="/settings"
           element={

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -101,6 +101,11 @@ function GPTopBar({ workspace }: GPTopBarProps) {
           <Nav.Link as={NavLink} to="/settings">
             Settings
           </Nav.Link>
+          {workspace.mode === 'nursery' && (
+            <Nav.Link as={NavLink} to="/work">
+              Work
+            </Nav.Link>
+          )}
           <Nav.Link as={NavLink} to="/labels">
             Labels
           </Nav.Link>

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -1,8 +1,15 @@
 import { QueryClient } from '@tanstack/react-query'
 
 import { CohortFilters, NurseryRegisterFilters } from './types/plantings'
+import { WorkFilters } from './types/work'
 
 const queryKeys = {
+  work: {
+    all: ['work'] as const,
+    tasks: (filters: WorkFilters) => ['work', 'tasks', filters] as const,
+    rules: ['work', 'rules'] as const,
+    assignees: ['work', 'assignees'] as const
+  },
   labels: {
     all: ['labels'] as const,
     identities: ['labels', 'identities'] as const,

--- a/frontend/js/types/work.ts
+++ b/frontend/js/types/work.ts
@@ -1,0 +1,85 @@
+type WorkTaskStatus = 'open' | 'snoozed' | 'completed' | 'skipped'
+type WorkView = 'today' | 'week' | 'overdue' | 'snoozed' | 'completed'
+
+interface WorkLink {
+  role: 'target' | 'result'
+  target_type: string
+  object_id: number
+  label: string
+  url: string
+  snapshot: Record<string, unknown>
+}
+
+interface WorkHistory {
+  pk: number
+  action: string
+  actor: number | null
+  actor_name: string | null
+  reason: string
+  changes: Record<string, unknown>
+  created: string
+}
+
+interface WorkTask {
+  pk: number | null
+  key: string
+  origin: 'manual' | 'generated'
+  rule: number | null
+  task_type: string
+  title: string
+  notes: string
+  priority: number
+  due_start: string
+  due_end: string
+  status: WorkTaskStatus
+  assignee: number | null
+  assignee_name: string | null
+  snoozed_until: string | null
+  completed_at: string | null
+  skipped_at: string | null
+  source_snapshot: Record<string, unknown>
+  recurrence: Record<string, unknown>
+  links: Array<WorkLink>
+  history: Array<WorkHistory>
+  created: string | null
+  updated: string | null
+}
+
+interface WorkRule {
+  pk: number
+  code: string
+  name: string
+  task_type: string
+  trigger: string
+  active: boolean
+  priority: number
+  due_start_offset_days: number
+  due_end_offset_days: number
+  local_due_time: string
+  frequency: '' | 'daily' | 'weekly'
+  interval: number
+  weekdays: Array<number>
+  season_start: string
+  season_end: string
+  variety: number | null
+  stage: number | null
+  location: number | null
+  default_assignee: number | null
+  notes: string
+}
+
+interface WorkAssignee {
+  pk: number
+  username: string
+}
+
+interface WorkFilters {
+  view: WorkView
+  task_type?: string
+  priority?: number
+  assignee?: number
+  batch?: number
+  location?: number
+}
+
+export { WorkAssignee, WorkFilters, WorkHistory, WorkLink, WorkRule, WorkTask, WorkTaskStatus, WorkView }

--- a/frontend/js/work.tsx
+++ b/frontend/js/work.tsx
@@ -1,0 +1,371 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Badge, Button, Card, Col, Form, Nav, Row, Table } from 'react-bootstrap'
+import { NavLink } from 'react-router'
+
+import { acknowledgeWorkTask, actOnWorkTask, addWorkRule, addWorkTask, getWorkAssignees, getWorkRules, getWorkTasks, updateWorkRule } from './api/work'
+import { queryKeys } from './query'
+import { WorkFilters, WorkRule, WorkTask, WorkView } from './types/work'
+import { formatDateTime, localDatetimeInputValue, parseLocalDatetimeInput } from './utils'
+
+const TASK_TYPES = [
+  ['germination_check', 'Germination check'],
+  ['watering', 'Watering'],
+  ['feeding', 'Feeding'],
+  ['thinning', 'Thinning'],
+  ['spacing', 'Spacing'],
+  ['potting_on', 'Potting on'],
+  ['hardening', 'Hardening'],
+  ['ready_review', 'Ready-date review'],
+  ['harvest_review', 'Harvest review'],
+  ['stocktake', 'Stocktake'],
+  ['order_picking', 'Order picking'],
+  ['stage_review', 'Stage review'],
+  ['custom', 'Custom']
+]
+
+const VIEWS: Array<[WorkView, string]> = [
+  ['today', 'Today'],
+  ['week', 'This week'],
+  ['overdue', 'Overdue'],
+  ['snoozed', 'Snoozed'],
+  ['completed', 'Completed']
+]
+
+function ManualTaskForm() {
+  const cache = useQueryClient()
+  const [title, setTitle] = React.useState('')
+  const [taskType, setTaskType] = React.useState('custom')
+  const [dueStart, setDueStart] = React.useState(localDatetimeInputValue())
+  const [dueEnd, setDueEnd] = React.useState(localDatetimeInputValue(new Date(Date.now() + 60 * 60 * 1000)))
+  const [frequency, setFrequency] = React.useState('')
+  const mutation = useMutation({
+    mutationFn: addWorkTask,
+    onSuccess: () => {
+      setTitle('')
+      cache.invalidateQueries({ queryKey: queryKeys.work.all })
+    }
+  })
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault()
+    const start = parseLocalDatetimeInput(dueStart)
+    const end = parseLocalDatetimeInput(dueEnd)
+    if (!start || !end) return
+    mutation.mutate({
+      title,
+      task_type: taskType,
+      due_start: start.toISOString(),
+      due_end: end.toISOString(),
+      recurrence: frequency ? { frequency, interval: 1, weekdays: frequency === 'weekly' ? [new Date(start).getDay() === 0 ? 6 : new Date(start).getDay() - 1] : [] } : {}
+    })
+  }
+  return (
+    <Card className="mb-3">
+      <Card.Header>Schedule manual work</Card.Header>
+      <Card.Body>
+        <Form onSubmit={submit}>
+          <Row className="g-2">
+            <Col md={4}>
+              <Form.Control required placeholder="Work to do" value={title} onChange={(event) => setTitle(event.target.value)} />
+            </Col>
+            <Col md={2}>
+              <Form.Select value={taskType} onChange={(event) => setTaskType(event.target.value)}>
+                {TASK_TYPES.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </Form.Select>
+            </Col>
+            <Col md={2}>
+              <Form.Control required type="datetime-local" value={dueStart} onChange={(event) => setDueStart(event.target.value)} />
+            </Col>
+            <Col md={2}>
+              <Form.Control required type="datetime-local" value={dueEnd} onChange={(event) => setDueEnd(event.target.value)} />
+            </Col>
+            <Col md={1}>
+              <Form.Select aria-label="Recurrence" value={frequency} onChange={(event) => setFrequency(event.target.value)}>
+                <option value="">Once</option>
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+              </Form.Select>
+            </Col>
+            <Col md={1}>
+              <Button type="submit" disabled={mutation.isPending}>
+                Add
+              </Button>
+            </Col>
+          </Row>
+        </Form>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function TaskActions({ task }: { task: WorkTask }) {
+  const cache = useQueryClient()
+  const assignees = useQuery({ queryKey: queryKeys.work.assignees, queryFn: ({ signal }) => getWorkAssignees(signal) })
+  const mutation = useMutation({
+    mutationFn: async (data: Record<string, unknown>) => {
+      const acknowledged = task.pk === null ? await acknowledgeWorkTask(task.key) : task
+      return actOnWorkTask(acknowledged.pk as number, { ...data, idempotency_key: crypto.randomUUID() })
+    },
+    onSuccess: () => cache.invalidateQueries({ queryKey: queryKeys.work.all })
+  })
+  const reasoned = (action: 'skip' | 'reopen') => {
+    const reason = globalThis.prompt(`Reason to ${action} this task:`)
+    if (reason) mutation.mutate({ action, reason })
+  }
+  if (task.status === 'completed' || task.status === 'skipped') {
+    return (
+      <Button size="sm" variant="outline-secondary" onClick={() => reasoned('reopen')}>
+        Reopen
+      </Button>
+    )
+  }
+  return (
+    <div className="d-flex flex-wrap gap-1">
+      <Button size="sm" onClick={() => mutation.mutate({ action: 'claim' })}>
+        Claim
+      </Button>
+      <Form.Select
+        size="sm"
+        aria-label={`Assign ${task.title}`}
+        value={task.assignee ?? ''}
+        onChange={(event) => mutation.mutate({ action: 'assign', assignee: event.target.value ? Number(event.target.value) : null })}
+      >
+        <option value="">Unassigned</option>
+        {(assignees.data ?? []).map((user) => (
+          <option key={user.pk} value={user.pk}>
+            {user.username}
+          </option>
+        ))}
+      </Form.Select>
+      <Button size="sm" variant="outline-secondary" onClick={() => mutation.mutate({ action: 'snooze', until: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() })}>
+        Snooze 1 day
+      </Button>
+      <Button size="sm" variant="success" onClick={() => mutation.mutate({ action: 'complete' })}>
+        Complete
+      </Button>
+      <Button size="sm" variant="outline-danger" onClick={() => reasoned('skip')}>
+        Skip
+      </Button>
+    </div>
+  )
+}
+
+function TaskTable({ tasks }: { tasks: Array<WorkTask> }) {
+  return (
+    <Table responsive hover>
+      <thead>
+        <tr>
+          <th>Due</th>
+          <th>Work</th>
+          <th>Targets</th>
+          <th>Assignee</th>
+          <th>Priority</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tasks.map((task) => (
+          <tr key={task.key}>
+            <td>
+              {formatDateTime(task.due_start)}
+              <div className="small text-muted">to {formatDateTime(task.due_end)}</div>
+            </td>
+            <td>
+              <strong>{task.title}</strong>
+              <div>
+                <Badge bg={task.origin === 'generated' ? 'info' : 'secondary'}>{task.origin}</Badge> {task.task_type.replaceAll('_', ' ')}
+              </div>
+              {task.notes && <div>{task.notes}</div>}
+              {task.history.length > 0 && (
+                <details className="mt-1">
+                  <summary>History ({task.history.length})</summary>
+                  {task.history.map((entry) => (
+                    <div className="small" key={entry.pk}>
+                      {formatDateTime(entry.created)} · {entry.action} · {entry.actor_name ?? 'system'}
+                      {entry.reason ? ` — ${entry.reason}` : ''}
+                    </div>
+                  ))}
+                </details>
+              )}
+            </td>
+            <td>
+              {task.links
+                .filter((link) => link.role === 'target')
+                .map((link) => (
+                  <div key={`${link.target_type}:${link.object_id}`}>{link.url ? <NavLink to={link.url}>{link.label}</NavLink> : link.label}</div>
+                ))}
+            </td>
+            <td>{task.assignee_name ?? 'Unassigned'}</td>
+            <td>{task.priority}</td>
+            <td>
+              <TaskActions task={task} />
+            </td>
+          </tr>
+        ))}
+        {tasks.length === 0 && (
+          <tr>
+            <td colSpan={6} className="text-muted">
+              No work in this view.
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </Table>
+  )
+}
+
+function RuleEditor({ rules }: { rules: Array<WorkRule> }) {
+  const cache = useQueryClient()
+  const [name, setName] = React.useState('')
+  const [taskType, setTaskType] = React.useState('watering')
+  const [frequency, setFrequency] = React.useState<'daily' | 'weekly'>('daily')
+  const mutation = useMutation({
+    mutationFn: ({ pk, values }: { pk?: number; values: object }) => (pk ? updateWorkRule(pk, values) : addWorkRule(values)),
+    onSuccess: () => cache.invalidateQueries({ queryKey: queryKeys.work.rules })
+  })
+  const add = () =>
+    mutation.mutate({
+      values: {
+        code: `care-${Date.now()}`,
+        name,
+        task_type: taskType,
+        trigger: 'calendar',
+        frequency,
+        interval: 1,
+        weekdays: frequency === 'weekly' ? [0] : [],
+        priority: 20,
+        due_start_offset_days: 0,
+        due_end_offset_days: 0,
+        local_due_time: '09:00'
+      }
+    })
+  return (
+    <Card className="mt-4">
+      <Card.Header>Automation rules</Card.Header>
+      <Card.Body>
+        <Table size="sm">
+          <thead>
+            <tr>
+              <th>Rule</th>
+              <th>Trigger</th>
+              <th>Recurrence</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {rules.map((rule) => (
+              <tr key={rule.pk}>
+                <td>{rule.name}</td>
+                <td>{rule.trigger.replaceAll('_', ' ')}</td>
+                <td>{rule.frequency || 'From source date'}</td>
+                <td>
+                  <Button size="sm" variant="outline-secondary" onClick={() => mutation.mutate({ pk: rule.pk, values: { active: !rule.active } })}>
+                    {rule.active ? 'Disable' : 'Enable'}
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+        <Row className="g-2">
+          <Col>
+            <Form.Control placeholder="New care rule" value={name} onChange={(event) => setName(event.target.value)} />
+          </Col>
+          <Col>
+            <Form.Select value={taskType} onChange={(event) => setTaskType(event.target.value)}>
+              {TASK_TYPES.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </Form.Select>
+          </Col>
+          <Col>
+            <Form.Select value={frequency} onChange={(event) => setFrequency(event.target.value as 'daily' | 'weekly')}>
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly on Monday</option>
+            </Form.Select>
+          </Col>
+          <Col xs="auto">
+            <Button disabled={!name} onClick={add}>
+              Add rule
+            </Button>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function WorkQueueView() {
+  const [view, setView] = React.useState<WorkView>('today')
+  const [taskType, setTaskType] = React.useState('')
+  const [priority, setPriority] = React.useState('')
+  const [assignee, setAssignee] = React.useState('')
+  const [batch, setBatch] = React.useState('')
+  const [location, setLocation] = React.useState('')
+  const filters: WorkFilters = {
+    view,
+    task_type: taskType || undefined,
+    priority: priority ? Number(priority) : undefined,
+    assignee: assignee ? Number(assignee) : undefined,
+    batch: batch ? Number(batch) : undefined,
+    location: location ? Number(location) : undefined
+  }
+  const tasks = useQuery({ queryKey: queryKeys.work.tasks(filters), queryFn: ({ signal }) => getWorkTasks(filters, signal) })
+  const rules = useQuery({ queryKey: queryKeys.work.rules, queryFn: ({ signal }) => getWorkRules(signal) })
+  const assignees = useQuery({ queryKey: queryKeys.work.assignees, queryFn: ({ signal }) => getWorkAssignees(signal) })
+  return (
+    <main className="container-fluid py-3">
+      <h1>Nursery work</h1>
+      <p>Generated and manually scheduled work stays here until it is completed or deliberately skipped.</p>
+      <ManualTaskForm />
+      <Nav variant="tabs" activeKey={view} onSelect={(key) => key && setView(key as WorkView)}>
+        {VIEWS.map(([value, label]) => (
+          <Nav.Item key={value}>
+            <Nav.Link eventKey={value}>{label}</Nav.Link>
+          </Nav.Item>
+        ))}
+      </Nav>
+      <Row className="g-2 py-3">
+        <Col md={3}>
+          <Form.Select aria-label="Task type" value={taskType} onChange={(event) => setTaskType(event.target.value)}>
+            <option value="">All task types</option>
+            {TASK_TYPES.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={2}>
+          <Form.Control aria-label="Batch ID" type="number" min={1} placeholder="Batch ID" value={batch} onChange={(event) => setBatch(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Control aria-label="Location ID" type="number" min={1} placeholder="Location ID" value={location} onChange={(event) => setLocation(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Form.Control aria-label="Priority" type="number" placeholder="Priority" value={priority} onChange={(event) => setPriority(event.target.value)} />
+        </Col>
+        <Col md={3}>
+          <Form.Select aria-label="Assignee" value={assignee} onChange={(event) => setAssignee(event.target.value)}>
+            <option value="">All assignees</option>
+            {(assignees.data ?? []).map((user) => (
+              <option key={user.pk} value={user.pk}>
+                {user.username}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+      </Row>
+      <TaskTable tasks={tasks.data ?? []} />
+      <RuleEditor rules={rules.data ?? []} />
+    </main>
+  )
+}
+
+export { WorkQueueView }

--- a/work/apps.py
+++ b/work/apps.py
@@ -8,3 +8,7 @@ class WorkConfig(AppConfig):
 
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'work'
+
+    def ready(self):
+        """Register workspace-profile integration after models are loaded."""
+        from . import signals  # pylint: disable=import-outside-toplevel,unused-import

--- a/work/rest.py
+++ b/work/rest.py
@@ -101,6 +101,12 @@ class ManualTaskSerializer(serializers.Serializer):
         if recurrence and recurrence.get('frequency') not in {
                 WorkTaskRule.Frequency.DAILY, WorkTaskRule.Frequency.WEEKLY}:
             raise serializers.ValidationError({'recurrence': 'Choose daily or weekly recurrence.'})
+        if recurrence.get('frequency') == WorkTaskRule.Frequency.WEEKLY:
+            weekdays = recurrence.get('weekdays', [])
+            if not weekdays or any(day not in range(7) for day in weekdays):
+                raise serializers.ValidationError({
+                    'recurrence': 'Weekly recurrence requires weekdays from 0 through 6.',
+                })
         return attrs
 
 
@@ -159,6 +165,20 @@ def _in_view(task, view, workspace, now):
     return task.due_start < day_end and task.due_end >= day_start
 
 
+def _has_target(task, target_type, object_id):
+    """Match projected or persisted concrete links without trusting snapshots."""
+    if isinstance(task, ProjectedTask):
+        return any(
+            link.target._meta.model_name == target_type and link.target.pk == object_id
+            for link in task.targets
+        )
+    return task.links.filter(
+        role=WorkTaskLink.Role.TARGET,
+        content_type__model=target_type,
+        object_id=object_id,
+    ).exists()
+
+
 class NurseryWorkMixin(RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin):
     required_workspace_modes = (Workspace.Mode.NURSERY,)
 
@@ -190,6 +210,10 @@ class WorkTaskViewSet(NurseryWorkMixin, viewsets.GenericViewSet):
         assignee = request.query_params.get('assignee')
         if assignee:
             rows = [row for row in rows if row.assignee and str(row.assignee.pk) == assignee]
+        for parameter, target_type in (('batch', 'productionbatch'), ('location', 'location')):
+            value = request.query_params.get(parameter)
+            if value and value.isdigit():
+                rows = [row for row in rows if _has_target(row, target_type, int(value))]
         rows.sort(key=lambda row: (row.due_end, -row.priority, row.key))
         return Response([
             _projected_data(row) if isinstance(row, ProjectedTask) else WorkTaskSerializer(row).data

--- a/work/signals.py
+++ b/work/signals.py
@@ -1,0 +1,34 @@
+"""Create conservative automation defaults when Nursery mode is enabled."""
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from workspaces.models import Workspace
+
+from .models import WorkTaskRule, WorkTaskType
+
+
+DEFAULT_RULES = (
+    ('germination-check', 'Germination checks', WorkTaskType.GERMINATION, WorkTaskRule.Trigger.GERMINATION),
+    ('planned-milestone', 'Production milestones', WorkTaskType.STAGE, WorkTaskRule.Trigger.PLAN_MILESTONE),
+    ('stage-review', 'Stage reviews', WorkTaskType.STAGE, WorkTaskRule.Trigger.STAGE_AGE),
+    ('ready-review', 'Ready-date reviews', WorkTaskType.READY, WorkTaskRule.Trigger.EXPECTED_READY),
+    ('maturity-review', 'Maturity and harvest reviews', WorkTaskType.HARVEST, WorkTaskRule.Trigger.MATURITY),
+)
+
+
+def ensure_default_rules(workspace):
+    """Idempotently install only rules backed by authoritative source dates."""
+    if workspace.mode != Workspace.Mode.NURSERY:
+        return
+    for code, name, task_type, trigger in DEFAULT_RULES:
+        WorkTaskRule.objects.get_or_create(
+            workspace=workspace, code=code,
+            defaults={'name': name, 'task_type': task_type, 'trigger': trigger},
+        )
+
+
+@receiver(post_save, sender=Workspace)
+def workspace_saved(sender, instance, **_kwargs):  # pylint: disable=unused-argument
+    """Install defaults when an existing Garden workspace becomes a Nursery."""
+    ensure_default_rules(instance)

--- a/work/test_rest.py
+++ b/work/test_rest.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 
 from workspaces.models import get_current_workspace
 
-from .models import WorkTask
+from .models import WorkTask, WorkTaskRule
 
 
 class WorkRESTTests(APITestCase):
@@ -75,3 +75,14 @@ class WorkRESTTests(APITestCase):
         self.workspace.mode = self.workspace.Mode.GARDEN
         self.workspace.save()
         self.assertEqual(self.client.get('/work/tasks/').status_code, 403)
+
+    def test_switching_to_nursery_installs_safe_default_rules(self):
+        """A profile change after migration receives the conservative defaults."""
+        WorkTaskRule.objects.filter(workspace=self.workspace).delete()
+        self.workspace.mode = self.workspace.Mode.GARDEN
+        self.workspace.save()
+        self.workspace.mode = self.workspace.Mode.NURSERY
+        self.workspace.save()
+        response = self.client.get('/work/rules/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 5)


### PR DESCRIPTION
Operators need an everyday screen for generated and manual work, including queue views, filters, recurrence, assignment, task actions, history, and automation setup. Documentation records the authoritative-queue boundary and deferred dependency adapters.

## Summary by Sourcery

Introduce a nursery-mode work workspace with queue views, task management actions, and automation rule controls for operators.

New Features:
- Add a nursery-only frontend Work queue page with task views, filters, manual scheduling, and in-place task actions.
- Expose work tasks, rules, and assignees via new frontend API integrations and react-query cache keys.
- Provide automation rule management UI for enabling, disabling, and creating conservative care rules.

Enhancements:
- Extend backend task recurrence validation to enforce valid weekday selection for weekly schedules.
- Support filtering nursery work tasks by associated batch and location targets in the backend list API.
- Automatically install default authoritative work rules when a workspace switches into Nursery mode via signals.

Tests:
- Add a test ensuring that switching a workspace to Nursery mode provisions the default work rules set.