### PR TITLE
feat(plants): add maturity basis metadata

### DIFF
--- a/plants/migrations/0003_maturity_basis.py
+++ b/plants/migrations/0003_maturity_basis.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plants', '0002_workspace_ownership'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='plant',
+            name='maturity_basis',
+            field=models.CharField(
+                choices=[('seed', 'From seed'), ('transplanting', 'From transplanting')],
+                default='seed',
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name='plantvariety',
+            name='maturity_basis',
+            field=models.CharField(
+                blank=True,
+                choices=[('seed', 'From seed'), ('transplanting', 'From transplanting')],
+                default=None,
+                help_text='Leave blank to inherit the plant default.',
+                max_length=16,
+                null=True,
+            ),
+        ),
+    ]

--- a/plants/models.py
+++ b/plants/models.py
@@ -6,6 +6,13 @@ from django.db import models
 from workspaces.models import WorkspaceOwnedModel
 
 
+class MaturityBasis(models.TextChoices):
+    """The cultivation event from which maturity days are counted."""
+
+    SEED = 'seed', 'From seed'
+    TRANSPLANTING = 'transplanting', 'From transplanting'
+
+
 class PlantFamily(WorkspaceOwnedModel):
     """
     Plant Family
@@ -31,6 +38,11 @@ class Plant(WorkspaceOwnedModel):
     germination_days_max = models.IntegerField(null=True, blank=True)
     maturity_days_min = models.IntegerField(null=True, blank=True)
     maturity_days_max = models.IntegerField(null=True, blank=True)
+    maturity_basis = models.CharField(
+        max_length=16,
+        choices=MaturityBasis.choices,
+        default=MaturityBasis.SEED,
+    )
 
     def __str__(self):
         return self.name
@@ -50,6 +62,19 @@ class PlantVariety(WorkspaceOwnedModel):
     germination_days_max = models.IntegerField(null=True, blank=True)
     maturity_days_min = models.IntegerField(null=True, blank=True)
     maturity_days_max = models.IntegerField(null=True, blank=True)
+    maturity_basis = models.CharField(
+        max_length=16,
+        choices=MaturityBasis.choices,
+        null=True,
+        blank=True,
+        default=None,
+        help_text='Leave blank to inherit the plant default.',
+    )
+
+    @property
+    def effective_maturity_basis(self):
+        """Return this variety's override or its plant's default."""
+        return self.maturity_basis or self.plant.maturity_basis
 
     def __str__(self):
         return self.name

--- a/plants/rest.py
+++ b/plants/rest.py
@@ -23,7 +23,7 @@ class PlantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializ
     """
     class Meta:
         model = Plant
-        fields = ['pk', 'family', 'name', 'notes', 'spacing', 'inter_row_spacing', 'plants_per_square_foot', 'germination_days_min', 'germination_days_max', 'maturity_days_min', 'maturity_days_max']
+        fields = ['pk', 'family', 'name', 'notes', 'spacing', 'inter_row_spacing', 'plants_per_square_foot', 'germination_days_min', 'germination_days_max', 'maturity_days_min', 'maturity_days_max', 'maturity_basis']
 
     workspace_field_lookups = {'family': 'workspace'}
 
@@ -34,7 +34,13 @@ class PlantVarietySerializer(CurrentWorkspaceSerializerMixin, serializers.ModelS
     """
     class Meta:
         model = PlantVariety
-        fields = ['pk', 'plant', 'name', 'notes', 'spacing', 'inter_row_spacing', 'plants_per_square_foot', 'germination_days_min', 'germination_days_max', 'maturity_days_min', 'maturity_days_max']
+        fields = [
+            'pk', 'plant', 'name', 'notes', 'spacing', 'inter_row_spacing',
+            'plants_per_square_foot', 'germination_days_min',
+            'germination_days_max', 'maturity_days_min', 'maturity_days_max',
+            'maturity_basis', 'effective_maturity_basis',
+        ]
+        read_only_fields = ['effective_maturity_basis']
 
     workspace_field_lookups = {'plant': 'workspace'}
 

--- a/plants/tests.py
+++ b/plants/tests.py
@@ -43,9 +43,10 @@ class PlantRESTContractTests(RESTContractTestCase):
                 'germination_days_max': 21,
                 'maturity_days_min': 60,
                 'maturity_days_max': 80,
+                'maturity_basis': 'transplanting',
             },
         )
-        self.assert_create_retrieve(
+        variety = self.assert_create_retrieve(
             '/plants/variety/',
             {
                 'plant': plant['pk'],
@@ -60,3 +61,97 @@ class PlantRESTContractTests(RESTContractTestCase):
                 'maturity_days_max': 70,
             },
         )
+        self.assertIsNone(variety['maturity_basis'])
+        self.assertEqual(variety['effective_maturity_basis'], 'transplanting')
+
+    def test_resources_can_be_edited_and_reassigned(self):
+        """Catalog corrections may update details and hierarchy relationships."""
+        first_family = self.client.post(
+            '/plants/family/', {'name': 'First'}, format='json',
+        ).data
+        second_family = self.client.post(
+            '/plants/family/', {'name': 'Second'}, format='json',
+        ).data
+        first_plant = self.client.post(
+            '/plants/plant/',
+            {'family': first_family['pk'], 'name': 'Tomato'},
+            format='json',
+        ).data
+        second_plant = self.client.post(
+            '/plants/plant/',
+            {'family': second_family['pk'], 'name': 'Pepper'},
+            format='json',
+        ).data
+        variety = self.client.post(
+            '/plants/variety/',
+            {'plant': first_plant['pk'], 'name': 'Roma'},
+            format='json',
+        ).data
+
+        family_response = self.client.patch(
+            f"/plants/family/{first_family['pk']}/",
+            {'name': 'Nightshades', 'notes': 'Corrected'},
+            format='json',
+        )
+        plant_response = self.client.patch(
+            f"/plants/plant/{first_plant['pk']}/",
+            {
+                'family': second_family['pk'],
+                'notes': 'Moved after correction',
+                'maturity_days_min': 60,
+                'maturity_basis': 'transplanting',
+            },
+            format='json',
+        )
+        variety_response = self.client.patch(
+            f"/plants/variety/{variety['pk']}/",
+            {
+                'plant': second_plant['pk'],
+                'spacing': 450,
+                'maturity_basis': 'seed',
+            },
+            format='json',
+        )
+
+        self.assertEqual(family_response.status_code, 200, family_response.data)
+        self.assertEqual(family_response.data['name'], 'Nightshades')
+        self.assertEqual(plant_response.status_code, 200, plant_response.data)
+        self.assertEqual(plant_response.data['family'], second_family['pk'])
+        self.assertEqual(plant_response.data['maturity_basis'], 'transplanting')
+        self.assertEqual(variety_response.status_code, 200, variety_response.data)
+        self.assertEqual(variety_response.data['plant'], second_plant['pk'])
+        self.assertEqual(variety_response.data['effective_maturity_basis'], 'seed')
+
+    def test_variety_maturity_basis_can_return_to_inherited_default(self):
+        """A null override follows later changes to the parent plant default."""
+        family = self.client.post(
+            '/plants/family/', {'name': 'Family'}, format='json',
+        ).data
+        plant = self.client.post(
+            '/plants/plant/',
+            {
+                'family': family['pk'],
+                'name': 'Plant',
+                'maturity_basis': 'transplanting',
+            },
+            format='json',
+        ).data
+        variety = self.client.post(
+            '/plants/variety/',
+            {
+                'plant': plant['pk'],
+                'name': 'Variety',
+                'maturity_basis': 'seed',
+            },
+            format='json',
+        ).data
+
+        response = self.client.patch(
+            f"/plants/variety/{variety['pk']}/",
+            {'maturity_basis': None},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIsNone(response.data['maturity_basis'])
+        self.assertEqual(response.data['effective_maturity_basis'], 'transplanting')


### PR DESCRIPTION
Plant and variety records need an explicit, inheritable anchor so maturity calculations can distinguish sowing from transplanting without guessing from the workflow.

## Summary by Sourcery

Introduce explicit maturity basis metadata for plants and varieties, with inheritance from plant to variety and API exposure.

New Features:
- Add a maturity basis field to plants to indicate whether maturity days are counted from seed or transplanting.
- Allow plant varieties to optionally override the plant maturity basis while providing an effective inherited value when unset.

Enhancements:
- Expose maturity basis and effective maturity basis in the plant and variety REST serializers for client use.

Build:
- Add Django migration to create maturity basis fields and choices for plant and plant variety models.

Tests:
- Extend plant resource round-trip tests to cover maturity basis inheritance and editing flows.
- Add tests ensuring variety maturity basis can be overridden, reassigned, and reset to follow plant defaults after catalog corrections.