### PR TITLE
feat(plantings): honor maturity date anchors

### DIFF
--- a/plantings/test_maturity.py
+++ b/plantings/test_maturity.py
@@ -1,0 +1,131 @@
+"""Tests for maturity metadata anchors in current garden summaries."""
+
+from datetime import datetime, timedelta, timezone as datetime_timezone
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from plantings.models import (
+    GardenSquareTransplant,
+    SpecificPlantLocation,
+)
+from tests.factories import (
+    make_garden_square,
+    make_garden_square_sowing,
+    make_plant_variety,
+    make_seed_packet,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_seeds,
+    make_specific_plant,
+)
+
+
+class GardenMaturityDateTests(TestCase):
+    """Current garden dates use the variety's effective maturity basis."""
+
+    def setUp(self):
+        self.client.force_login(
+            get_user_model().objects.create_user(username='maturity-tester')
+        )
+        self.variety = make_plant_variety(
+            maturity_days_min=10,
+            maturity_days_max=12,
+        )
+        self.packet = make_seed_packet(
+            seeds=make_seeds(plant_variety=self.variety),
+        )
+        self.square = make_garden_square()
+
+    @staticmethod
+    def _response_datetime(value):
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+    def _result(self):
+        response = self.client.get('/plantings/garden/squares/current/')
+        self.assertEqual(response.status_code, 200)
+        return response.json()['plantings'][0]
+
+    def _tray_planting(self, planted):
+        sowing = make_seed_tray_planting(
+            seeds_used=self.packet,
+            planted=planted,
+            quantity=1,
+        )
+        allocation = make_seed_tray_cell_planting(
+            seed_tray_planting=sowing,
+            quantity=1,
+        )
+        return sowing, allocation
+
+    def test_direct_sow_always_counts_maturity_from_sowing(self):
+        """A crop sown in its final bed has no separate transplant anchor."""
+        self.variety.maturity_basis = 'transplanting'
+        self.variety.save(update_fields=['maturity_basis'])
+        sowed_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        make_garden_square_sowing(
+            seeds_used=self.packet,
+            quantity=1,
+            location=self.square,
+            planted=sowed_at,
+        )
+
+        result = self._result()
+
+        self.assertEqual(
+            self._response_datetime(result['maturity_date_early']),
+            sowed_at + timedelta(days=10),
+        )
+        self.assertEqual(
+            self._response_datetime(result['maturity_date_late']),
+            sowed_at + timedelta(days=12),
+        )
+
+    def test_aggregate_transplant_uses_configured_maturity_anchor(self):
+        """Aggregate garden transplants use either sowing or transplanting."""
+        sowed_at = datetime(2026, 3, 1, 9, tzinfo=datetime_timezone.utc)
+        transplanted_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        sowing, _allocation = self._tray_planting(sowed_at)
+        GardenSquareTransplant.objects.create(
+            original_planting=sowing,
+            transplanted=transplanted_at,
+            quantity=1,
+            location=self.square,
+        )
+
+        for basis, anchor in (
+            ('seed', sowed_at),
+            ('transplanting', transplanted_at),
+        ):
+            with self.subTest(basis=basis):
+                self.variety.maturity_basis = basis
+                self.variety.save(update_fields=['maturity_basis'])
+                self.assertEqual(
+                    self._response_datetime(self._result()['maturity_date_early']),
+                    anchor + timedelta(days=10),
+                )
+
+    def test_specific_plant_uses_configured_maturity_anchor(self):
+        """Individual garden plants share the effective basis rules."""
+        sowed_at = datetime(2026, 3, 1, 9, tzinfo=datetime_timezone.utc)
+        transplanted_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        _sowing, allocation = self._tray_planting(sowed_at)
+        plant = make_specific_plant(cell_planting=allocation)
+        SpecificPlantLocation.objects.create(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=self.square,
+            started=transplanted_at,
+        )
+
+        for basis, anchor in (
+            ('seed', sowed_at),
+            ('transplanting', transplanted_at),
+        ):
+            with self.subTest(basis=basis):
+                self.variety.maturity_basis = basis
+                self.variety.save(update_fields=['maturity_basis'])
+                self.assertEqual(
+                    self._response_datetime(self._result()['maturity_date_early']),
+                    anchor + timedelta(days=10),
+                )

--- a/plantings/views.py
+++ b/plantings/views.py
@@ -10,6 +10,8 @@ from django.http import HttpResponseNotAllowed, JsonResponse, HttpResponse
 from django.shortcuts import get_object_or_404
 
 from gp.utils import get_request_data
+from plants.metadata import variety_days
+from plants.models import MaturityBasis
 from workspaces.models import get_current_workspace
 from .models import SeedTrayPlanting, GardenSquareDirectSowPlanting, GardenSquareTransplant, SpecificPlant, SpecificPlantLocation
 
@@ -107,12 +109,14 @@ def seedtray_complete(request):
 
 
 def _get_variety_days(variety):
-    return (
-        variety.germination_days_min or variety.plant.germination_days_min,
-        variety.germination_days_max or variety.plant.germination_days_max,
-        variety.maturity_days_min or variety.plant.maturity_days_min,
-        variety.maturity_days_max or variety.plant.maturity_days_max,
-    )
+    return (*variety_days(variety, 'germination'), *variety_days(variety, 'maturity'))
+
+
+def _maturity_anchor(variety, sowed_at, transplanted_at=None):
+    """Choose the recorded event configured as the start of maturity."""
+    if variety.effective_maturity_basis == MaturityBasis.TRANSPLANTING:
+        return transplanted_at
+    return sowed_at
 
 
 def _add_nullable_days(value, days):
@@ -194,8 +198,14 @@ def gardensquare_current(request):
             'notes': planting.notes,
             'germination_date_early': _add_nullable_days(planting.planted, germination_min),
             'germination_date_late': _add_nullable_days(planting.planted, germination_max),
-            'maturity_date_early': _add_nullable_days(transplanting.transplanted, maturity_min),
-            'maturity_date_late': _add_nullable_days(transplanting.transplanted, maturity_max)
+            'maturity_date_early': _add_nullable_days(
+                _maturity_anchor(variety, planting.planted, transplanting.transplanted),
+                maturity_min,
+            ),
+            'maturity_date_late': _add_nullable_days(
+                _maturity_anchor(variety, planting.planted, transplanting.transplanted),
+                maturity_max,
+            )
         })
     specific_plant_locations = SpecificPlantLocation.objects.filter(
         specific_plant__workspace=workspace,
@@ -225,8 +235,12 @@ def gardensquare_current(request):
             'notes': location.notes or location.specific_plant.notes,
             'germination_date_early': _add_nullable_days(planting.planted, germination_min),
             'germination_date_late': _add_nullable_days(planting.planted, germination_max),
-            'maturity_date_early': _add_nullable_days(location.started, maturity_min),
-            'maturity_date_late': _add_nullable_days(location.started, maturity_max),
+            'maturity_date_early': _add_nullable_days(
+                _maturity_anchor(variety, planting.planted, location.started), maturity_min,
+            ),
+            'maturity_date_late': _add_nullable_days(
+                _maturity_anchor(variety, planting.planted, location.started), maturity_max,
+            ),
         })
     return JsonResponse({'plantings': planting_data})
 

--- a/plants/metadata.py
+++ b/plants/metadata.py
@@ -1,0 +1,17 @@
+"""Resolve variety overrides against their plant-level cultivation defaults."""
+
+
+def variety_metadata_value(variety, field_name):
+    """Return a variety value when set, otherwise the matching plant value."""
+    value = getattr(variety, field_name)
+    if value is not None:
+        return value
+    return getattr(variety.plant, field_name)
+
+
+def variety_days(variety, prefix):
+    """Return one effective minimum/maximum day range."""
+    return (
+        variety_metadata_value(variety, f'{prefix}_days_min'),
+        variety_metadata_value(variety, f'{prefix}_days_max'),
+    )

--- a/work/projections.py
+++ b/work/projections.py
@@ -13,13 +13,19 @@ from django.utils import timezone
 
 from plantings.growth import current_growth
 from plantings.models import (
+    GardenRowDirectSowPlanting,
+    GardenSquareDirectSowPlanting,
+    GardenSquareTransplant,
     NurseryPlanMilestone,
     NurseryProductionPlan,
     PlantCohort,
     ProductionBatch,
     SeedTrayPlanting,
     SpecificPlant,
+    SpecificPlantLocation,
 )
+from plants.metadata import variety_days
+from plants.models import MaturityBasis
 
 from .models import WorkTask, WorkTaskRule
 
@@ -85,10 +91,7 @@ def next_recurrence(workspace, after, frequency, interval=1, weekdays=()):
 
 
 def _metadata_days(variety, prefix):
-    minimum = getattr(variety, f'{prefix}_days_min')
-    maximum = getattr(variety, f'{prefix}_days_max')
-    plant = variety.plant
-    return minimum or getattr(plant, f'{prefix}_days_min'), maximum or getattr(plant, f'{prefix}_days_max')
+    return variety_days(variety, prefix)
 
 
 def _window(rule, start_day, end_day=None):
@@ -136,6 +139,8 @@ def _sowing_tasks(rule, maturity=False):
     tasks = []
     for sowing in rows:
         variety = sowing.batch.variety
+        if maturity and variety.effective_maturity_basis != MaturityBasis.SEED:
+            continue
         minimum, maximum = _metadata_days(variety, prefix)
         if minimum is None or maximum is None or not _allows(rule, variety=variety):
             continue
@@ -149,6 +154,136 @@ def _sowing_tasks(rule, maturity=False):
             targets, {'sowing': sowing.pk, 'planted': sowing.planted.isoformat()},
         ))
     return [task for task in tasks if task]
+
+
+def _direct_sow_maturity_tasks(rule):
+    """Project direct garden sowings from their sowing dates in every case."""
+    tasks = []
+    sources = (
+        (GardenRowDirectSowPlanting, 'row'),
+        (GardenSquareDirectSowPlanting, 'square'),
+    )
+    for model, label in sources:
+        rows = model.objects.filter(
+            workspace=rule.workspace,
+            removed=False,
+        ).select_related('batch__variety__plant', 'location')
+        for sowing in rows:
+            variety = sowing.batch.variety
+            minimum, maximum = _metadata_days(variety, 'maturity')
+            if minimum is None or maximum is None or not _allows(rule, variety=variety):
+                continue
+            planted = sowing.planted.astimezone(
+                ZoneInfo(rule.workspace.timezone)
+            ).date()
+            tasks.append(_source_task(
+                rule,
+                f'maturity:direct-{label}:{sowing.pk}',
+                f'Harvest review: {variety}',
+                planted + timedelta(days=minimum),
+                planted + timedelta(days=maximum),
+                [TargetLink(sowing, f'Direct sowing {sowing.pk}')],
+                {
+                    'sowing': sowing.pk,
+                    'planted': sowing.planted.isoformat(),
+                    'maturity_basis': MaturityBasis.SEED,
+                },
+            ))
+    return [task for task in tasks if task]
+
+
+def _transplant_maturity_tasks(rule):
+    """Project transplant-based maturity only from active garden-square placements."""
+    tasks = []
+    represented_sowings = set(
+        SpecificPlantLocation.objects.filter(
+            specific_plant__workspace=rule.workspace,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+        ).values_list(
+            'specific_plant__cell_planting__seed_tray_planting_id', flat=True,
+        )
+    )
+    aggregate_rows = GardenSquareTransplant.objects.filter(
+        workspace=rule.workspace,
+        removed=False,
+    ).exclude(
+        original_planting_id__in=represented_sowings,
+    ).select_related(
+        'original_planting__batch__variety__plant', 'location',
+    )
+    for transplant in aggregate_rows:
+        variety = transplant.original_planting.batch.variety
+        minimum, maximum = _metadata_days(variety, 'maturity')
+        if not all((
+            variety.effective_maturity_basis == MaturityBasis.TRANSPLANTING,
+            minimum is not None,
+            maximum is not None,
+            _allows(rule, variety=variety),
+        )):
+            continue
+        planted_out = transplant.transplanted.astimezone(
+            ZoneInfo(rule.workspace.timezone)
+        ).date()
+        tasks.append(_source_task(
+            rule,
+            f'maturity:transplant:{transplant.pk}',
+            f'Harvest review: {variety}',
+            planted_out + timedelta(days=minimum),
+            planted_out + timedelta(days=maximum),
+            [TargetLink(transplant, f'Transplant {transplant.pk}')],
+            {
+                'transplant': transplant.pk,
+                'transplanted': transplant.transplanted.isoformat(),
+                'maturity_basis': MaturityBasis.TRANSPLANTING,
+            },
+        ))
+
+    individual_rows = SpecificPlantLocation.objects.filter(
+        specific_plant__workspace=rule.workspace,
+        location_type=SpecificPlantLocation.GARDEN_SQUARE,
+        ended__isnull=True,
+    ).select_related(
+        'specific_plant__batch__variety__plant', 'garden_square',
+    )
+    for location in individual_rows:
+        variety = location.specific_plant.batch.variety
+        minimum, maximum = _metadata_days(variety, 'maturity')
+        if not all((
+            variety.effective_maturity_basis == MaturityBasis.TRANSPLANTING,
+            minimum is not None,
+            maximum is not None,
+            _allows(rule, variety=variety),
+        )):
+            continue
+        planted_out = location.started.astimezone(
+            ZoneInfo(rule.workspace.timezone)
+        ).date()
+        plant = location.specific_plant
+        tasks.append(_source_task(
+            rule,
+            f'maturity:plant:{plant.pk}',
+            f'Harvest review: {variety}',
+            planted_out + timedelta(days=minimum),
+            planted_out + timedelta(days=maximum),
+            [TargetLink(
+                plant, f'Plant {plant.pk}', f'/plantings/plants/{plant.pk}',
+            )],
+            {
+                'plant': plant.pk,
+                'transplanted': location.started.isoformat(),
+                'maturity_basis': MaturityBasis.TRANSPLANTING,
+            },
+        ))
+    return [task for task in tasks if task]
+
+
+def _maturity_tasks(rule):
+    """Combine maturity projections for sowings and actual transplants."""
+    return [
+        *_sowing_tasks(rule, maturity=True),
+        *_direct_sow_maturity_tasks(rule),
+        *_transplant_maturity_tasks(rule),
+    ]
 
 
 def _milestone_tasks(rule):
@@ -277,7 +412,7 @@ def _calendar_tasks(rule, today):
 
 PROJECTORS = {
     WorkTaskRule.Trigger.GERMINATION: _sowing_tasks,
-    WorkTaskRule.Trigger.MATURITY: lambda rule: _sowing_tasks(rule, maturity=True),
+    WorkTaskRule.Trigger.MATURITY: _maturity_tasks,
     WorkTaskRule.Trigger.PLAN_MILESTONE: _milestone_tasks,
     WorkTaskRule.Trigger.STAGE_AGE: _growth_tasks,
     WorkTaskRule.Trigger.EXPECTED_READY: lambda rule: _growth_tasks(rule, expected_ready=True),

--- a/work/test_projections.py
+++ b/work/test_projections.py
@@ -5,8 +5,23 @@ from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 
-from plantings.models import ProductionBatch, SeedTrayPlanting
-from tests.factories import make_plant_variety, make_seed_packet, make_seeds
+from plantings.models import (
+    GardenSquareTransplant,
+    ProductionBatch,
+    SeedTrayPlanting,
+    SpecificPlantLocation,
+)
+from tests.factories import (
+    make_garden_row_sowing,
+    make_garden_square,
+    make_plant_variety,
+    make_seed_packet,
+    make_seed_tray_cell_planting,
+    make_seed_tray_planting,
+    make_seeds,
+    make_specific_plant,
+    make_specific_plant_location,
+)
 from workspaces.models import get_current_workspace
 
 from .models import WorkTaskRule, WorkTaskType
@@ -56,3 +71,185 @@ class WorkProjectionTests(TestCase):
         )
         self.assertEqual(after.timetz().replace(tzinfo=None), time(9))
         self.assertNotEqual(before.utcoffset(), after.utcoffset())
+
+    def _maturity_rule(self):
+        WorkTaskRule.objects.filter(workspace=self.workspace).delete()
+        return WorkTaskRule.objects.create(
+            workspace=self.workspace,
+            code='maturity',
+            name='Maturity',
+            task_type=WorkTaskType.HARVEST,
+            trigger=WorkTaskRule.Trigger.MATURITY,
+        )
+
+    def test_seed_based_maturity_projects_from_tray_sowing(self):
+        """Seed-based varieties retain their sowing-based maturity reminder."""
+        self._maturity_rule()
+        variety = make_plant_variety(
+            workspace=self.workspace,
+            maturity_days_min=10,
+            maturity_days_max=12,
+            maturity_basis='seed',
+        )
+        packet = make_seed_packet(
+            workspace=self.workspace,
+            seeds=make_seeds(workspace=self.workspace, plant_variety=variety),
+        )
+        sowed_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        make_seed_tray_planting(
+            workspace=self.workspace,
+            seeds_used=packet,
+            planted=sowed_at,
+        )
+
+        tasks = projected_tasks(self.workspace)
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].due_start.date(), (sowed_at + timedelta(days=10)).date())
+        self.assertEqual(tasks[0].due_end.date(), (sowed_at + timedelta(days=12)).date())
+
+    def test_direct_sown_row_projects_from_sowing_for_transplant_variety(self):
+        """A direct-sown garden row always uses its sowing date."""
+        self._maturity_rule()
+        variety = make_plant_variety(
+            workspace=self.workspace,
+            maturity_days_min=10,
+            maturity_days_max=12,
+            maturity_basis='transplanting',
+        )
+        packet = make_seed_packet(
+            workspace=self.workspace,
+            seeds=make_seeds(workspace=self.workspace, plant_variety=variety),
+        )
+        sowed_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        make_garden_row_sowing(
+            workspace=self.workspace,
+            seeds_used=packet,
+            planted=sowed_at,
+        )
+
+        tasks = projected_tasks(self.workspace)
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].due_start.date(), (sowed_at + timedelta(days=10)).date())
+
+    def test_transplant_maturity_waits_for_active_garden_placement(self):
+        """Tray and nursery locations do not masquerade as transplant anchors."""
+        self._maturity_rule()
+        variety = make_plant_variety(
+            workspace=self.workspace,
+            maturity_days_min=10,
+            maturity_days_max=12,
+            maturity_basis='transplanting',
+        )
+        packet = make_seed_packet(
+            workspace=self.workspace,
+            seeds=make_seeds(workspace=self.workspace, plant_variety=variety),
+        )
+        sowing = make_seed_tray_planting(
+            workspace=self.workspace,
+            seeds_used=packet,
+        )
+        cell_planting = make_seed_tray_cell_planting(
+            seed_tray_planting=sowing,
+            quantity=1,
+        )
+        plant = make_specific_plant(
+            workspace=self.workspace,
+            cell_planting=cell_planting,
+        )
+        nursery_location = make_specific_plant_location(
+            specific_plant=plant,
+            started=datetime(2026, 3, 1, 9, tzinfo=datetime_timezone.utc),
+        )
+
+        self.assertEqual(projected_tasks(self.workspace), [])
+
+        transplanted_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        nursery_location.ended = transplanted_at
+        nursery_location.save(update_fields=['ended'])
+        SpecificPlantLocation.objects.create(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=make_garden_square(workspace=self.workspace),
+            started=transplanted_at,
+        )
+
+        tasks = projected_tasks(self.workspace)
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].due_start.date(), (transplanted_at + timedelta(days=10)).date())
+        self.assertIn(f'maturity:plant:{plant.pk}', tasks[0].key)
+
+    def test_individual_transplant_suppresses_matching_legacy_projection(self):
+        """Mixed migrated representations produce only one maturity reminder."""
+        self._maturity_rule()
+        variety = make_plant_variety(
+            workspace=self.workspace,
+            maturity_days_min=10,
+            maturity_days_max=12,
+            maturity_basis='transplanting',
+        )
+        packet = make_seed_packet(
+            workspace=self.workspace,
+            seeds=make_seeds(workspace=self.workspace, plant_variety=variety),
+        )
+        sowing = make_seed_tray_planting(
+            workspace=self.workspace,
+            seeds_used=packet,
+        )
+        square = make_garden_square(workspace=self.workspace)
+        GardenSquareTransplant.objects.create(
+            workspace=self.workspace,
+            original_planting=sowing,
+            quantity=1,
+            location=square,
+        )
+        plant = make_specific_plant(
+            workspace=self.workspace,
+            cell_planting=make_seed_tray_cell_planting(
+                seed_tray_planting=sowing,
+                quantity=1,
+            ),
+        )
+        SpecificPlantLocation.objects.create(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.GARDEN_SQUARE,
+            garden_square=square,
+        )
+
+        tasks = projected_tasks(self.workspace)
+
+        self.assertEqual(len(tasks), 1)
+        self.assertIn(f'maturity:plant:{plant.pk}', tasks[0].key)
+
+    def test_legacy_aggregate_transplant_projects_from_its_recorded_date(self):
+        """Unconverted aggregate transplants retain a usable maturity reminder."""
+        self._maturity_rule()
+        variety = make_plant_variety(
+            workspace=self.workspace,
+            maturity_days_min=10,
+            maturity_days_max=12,
+            maturity_basis='transplanting',
+        )
+        packet = make_seed_packet(
+            workspace=self.workspace,
+            seeds=make_seeds(workspace=self.workspace, plant_variety=variety),
+        )
+        sowing = make_seed_tray_planting(
+            workspace=self.workspace,
+            seeds_used=packet,
+        )
+        transplanted_at = datetime(2026, 4, 1, 9, tzinfo=datetime_timezone.utc)
+        transplant = GardenSquareTransplant.objects.create(
+            workspace=self.workspace,
+            original_planting=sowing,
+            transplanted=transplanted_at,
+            quantity=1,
+            location=make_garden_square(workspace=self.workspace),
+        )
+
+        tasks = projected_tasks(self.workspace)
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].due_start.date(), (transplanted_at + timedelta(days=10)).date())
+        self.assertIn(f'maturity:transplant:{transplant.pk}', tasks[0].key)


### PR DESCRIPTION
Maturity dates and projected harvest reviews must use the configured sowing or real garden-transplant event so nursery moves do not create misleading schedules.

## Summary by Sourcery

Align maturity scheduling and garden summaries with the configured seed vs transplant maturity basis, ensuring harvest reviews anchor to the correct sowing or garden transplant events.

New Features:
- Support maturity projections for direct garden sowings and transplant-based plantings using the appropriate event dates.

Bug Fixes:
- Prevent nursery-only locations and legacy aggregate transplants from producing misleading or duplicate maturity reminders by enforcing active garden placement anchors.

Enhancements:
- Centralize germination and maturity day-range resolution via shared variety metadata helpers to respect variety overrides against plant defaults.

Tests:
- Add projection tests covering seed tray sowings, direct sowings, aggregate transplants, and individual plant locations, plus garden-square summary tests verifying correct maturity anchors.