### PR TITLE
feat(health): add nursery health workspace

### DIFF
--- a/frontend/js/api/health.ts
+++ b/frontend/js/api/health.ts
@@ -1,0 +1,65 @@
+import { csrfPost, fetchAsJson } from '../utils'
+import { HealthCatalogValue, HealthObservation, HealthObservationCreate, HealthPreview, HealthReport, HealthScope, QuarantineCase } from '../types/health'
+
+function getHealthObservationTypes(signal?: AbortSignal): Promise<Array<HealthCatalogValue>> {
+  return fetchAsJson('/health/observation-types/', signal)
+}
+
+function getHealthDiagnoses(signal?: AbortSignal): Promise<Array<HealthCatalogValue>> {
+  return fetchAsJson('/health/diagnoses/', signal)
+}
+
+function getHealthObservations(signal?: AbortSignal): Promise<Array<HealthObservation>> {
+  return fetchAsJson('/health/observations/', signal)
+}
+
+function previewHealthObservation(scopes: Array<HealthScope>): Promise<HealthPreview> {
+  return csrfPost('/health/observations/preview/', { scopes }).then((response) => response.json() as Promise<HealthPreview>)
+}
+
+function createHealthObservation(data: HealthObservationCreate): Promise<HealthObservation> {
+  return csrfPost('/health/observations/', data).then((response) => response.json() as Promise<HealthObservation>)
+}
+
+function correctHealthObservation(observation: number, data: object): Promise<HealthObservation> {
+  return csrfPost(`/health/observations/${observation}/correct/`, data).then((response) => response.json() as Promise<HealthObservation>)
+}
+
+function quarantineHealthObservation(observation: number, data: object): Promise<QuarantineCase> {
+  return csrfPost(`/health/observations/${observation}/quarantine/`, data).then((response) => response.json() as Promise<QuarantineCase>)
+}
+
+function linkHealthTreatment(observation: number, data: object): Promise<object> {
+  return csrfPost(`/health/observations/${observation}/treatment/`, data).then((response) => response.json() as Promise<object>)
+}
+
+function recordHealthFollowUp(observation: number, data: object): Promise<object> {
+  return csrfPost(`/health/observations/${observation}/follow-up/`, data).then((response) => response.json() as Promise<object>)
+}
+
+function getQuarantineCases(signal?: AbortSignal): Promise<Array<QuarantineCase>> {
+  return fetchAsJson('/health/quarantines/', signal)
+}
+
+function actOnQuarantine(casePk: number, action: 'release' | 'escalate' | 'cull', data: object): Promise<QuarantineCase> {
+  return csrfPost(`/health/quarantines/${casePk}/${action}/`, data).then((response) => response.json() as Promise<QuarantineCase>)
+}
+
+function getHealthReport(signal?: AbortSignal): Promise<HealthReport> {
+  return fetchAsJson('/health/observations/reports/', signal)
+}
+
+export {
+  actOnQuarantine,
+  correctHealthObservation,
+  createHealthObservation,
+  getHealthDiagnoses,
+  getHealthObservationTypes,
+  getHealthObservations,
+  getHealthReport,
+  getQuarantineCases,
+  linkHealthTreatment,
+  previewHealthObservation,
+  quarantineHealthObservation,
+  recordHealthFollowUp
+}

--- a/frontend/js/health.tsx
+++ b/frontend/js/health.tsx
@@ -1,0 +1,492 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+import { useSearchParams } from 'react-router'
+
+import {
+  actOnQuarantine,
+  correctHealthObservation,
+  createHealthObservation,
+  getHealthDiagnoses,
+  getHealthObservationTypes,
+  getHealthObservations,
+  getHealthReport,
+  getQuarantineCases,
+  linkHealthTreatment,
+  previewHealthObservation,
+  quarantineHealthObservation,
+  recordHealthFollowUp
+} from './api/health'
+import { getLocations } from './api/locations'
+import { queryKeys } from './query'
+import { HealthObservation, HealthPreview, HealthScope, HealthScopeType, HealthSeverity, QuarantineCase } from './types/health'
+import { formatDateTime } from './utils'
+
+const SCOPE_LABELS: Record<HealthScopeType, string> = {
+  plant: 'Plant',
+  cohort: 'Cohort',
+  tray: 'Tray (current fill)',
+  generation: 'Tray fill',
+  batch: 'Batch',
+  location: 'Location and descendants'
+}
+
+const SEVERITIES: Array<HealthSeverity> = ['low', 'moderate', 'high', 'critical']
+
+function invalidateHealth(cache: ReturnType<typeof useQueryClient>) {
+  return Promise.all([
+    cache.invalidateQueries({ queryKey: queryKeys.health.all }),
+    cache.invalidateQueries({ queryKey: queryKeys.plantings.registerAll }),
+    cache.invalidateQueries({ queryKey: queryKeys.plantings.cohortsAll }),
+    cache.invalidateQueries({ queryKey: queryKeys.work.all })
+  ])
+}
+
+function ObservationComposer({ initialScopes = [] }: { initialScopes?: Array<HealthScope> }) {
+  const cache = useQueryClient()
+  const { data: types = [] } = useQuery({ queryKey: queryKeys.health.types, queryFn: ({ signal }) => getHealthObservationTypes(signal) })
+  const { data: diagnoses = [] } = useQuery({ queryKey: queryKeys.health.diagnoses, queryFn: ({ signal }) => getHealthDiagnoses(signal) })
+  const [scopeType, setScopeType] = React.useState<HealthScopeType>('plant')
+  const [scopeId, setScopeId] = React.useState<number | ''>('')
+  const [scopes, setScopes] = React.useState<Array<HealthScope>>(initialScopes)
+  const [preview, setPreview] = React.useState<HealthPreview>()
+  const [observationType, setObservationType] = React.useState<number | ''>('')
+  const [severity, setSeverity] = React.useState<HealthSeverity>('moderate')
+  const [diagnosis, setDiagnosis] = React.useState<number | ''>('')
+  const [certainty, setCertainty] = React.useState<'suspected' | 'confirmed'>('suspected')
+  const [notes, setNotes] = React.useState('')
+  const [evidenceUrl, setEvidenceUrl] = React.useState('')
+  const [followUp, setFollowUp] = React.useState('')
+
+  React.useEffect(() => {
+    if (observationType === '' && types.length > 0) setObservationType(types[0].pk)
+  }, [types, observationType])
+
+  const previewMutation = useMutation({
+    mutationFn: () => previewHealthObservation(scopes),
+    onSuccess: setPreview
+  })
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createHealthObservation({
+        scopes,
+        reviewed_digest: preview?.digest ?? '',
+        observation_type: observationType as number,
+        severity,
+        diagnoses: diagnosis === '' ? [] : [{ diagnosis, certainty }],
+        evidence: evidenceUrl ? [{ url: evidenceUrl, label: 'Observation evidence' }] : [],
+        follow_up_due_at: followUp ? new Date(followUp).toISOString() : null,
+        notes
+      }),
+    onSuccess: () => {
+      setScopes([])
+      setPreview(undefined)
+      setNotes('')
+      setEvidenceUrl('')
+      setFollowUp('')
+      void invalidateHealth(cache)
+    }
+  })
+
+  function addScope() {
+    if (scopeId === '') return
+    const next = { type: scopeType, id: scopeId }
+    if (!scopes.some((scope) => scope.type === next.type && scope.id === next.id)) {
+      setScopes([...scopes, next])
+      setPreview(undefined)
+    }
+    setScopeId('')
+  }
+
+  return (
+    <Card body className="mb-3">
+      <h2 className="h5">Record an inspection</h2>
+      <p className="text-muted">Build a scope, review the exact living stock it resolves to, then record evidence without inferring a diagnosis.</p>
+      <Row className="g-2 align-items-end">
+        <Col md={4}>
+          <Form.Label>Scope type</Form.Label>
+          <Form.Select value={scopeType} onChange={(event) => setScopeType(event.target.value as HealthScopeType)}>
+            {Object.entries(SCOPE_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={4}>
+          <Form.Label>Record ID</Form.Label>
+          <Form.Control type="number" min={1} value={scopeId} onChange={(event) => setScopeId(event.target.value ? Number(event.target.value) : '')} />
+        </Col>
+        <Col md={4}>
+          <Button onClick={addScope} disabled={scopeId === ''}>
+            Add scope
+          </Button>
+        </Col>
+      </Row>
+      {scopes.length > 0 && (
+        <div className="my-2 d-flex gap-2 flex-wrap">
+          {scopes.map((scope) => (
+            <Button
+              key={`${scope.type}:${scope.id}`}
+              size="sm"
+              variant="outline-secondary"
+              onClick={() => {
+                setScopes(scopes.filter((row) => row !== scope))
+                setPreview(undefined)
+              }}
+            >
+              {SCOPE_LABELS[scope.type]} #{scope.id} ×
+            </Button>
+          ))}
+        </div>
+      )}
+      <Button variant="outline-primary" disabled={scopes.length === 0 || previewMutation.isPending} onClick={() => previewMutation.mutate()}>
+        Review affected stock
+      </Button>
+      {preview && (
+        <Alert variant="info" className="mt-3">
+          <strong>{preview.affected_count} plants represented:</strong> {preview.plants.length} identified plants and {preview.cohorts.length} whole cohorts.
+        </Alert>
+      )}
+      <Row className="g-2 mt-1">
+        <Col md={4}>
+          <Form.Label>Observation type</Form.Label>
+          <Form.Select value={observationType} onChange={(event) => setObservationType(Number(event.target.value))}>
+            {types
+              .filter((row) => row.active)
+              .map((row) => (
+                <option key={row.pk} value={row.pk}>
+                  {row.name}
+                </option>
+              ))}
+          </Form.Select>
+        </Col>
+        <Col md={3}>
+          <Form.Label>Severity</Form.Label>
+          <Form.Select value={severity} onChange={(event) => setSeverity(event.target.value as HealthSeverity)}>
+            {SEVERITIES.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={5}>
+          <Form.Label>Follow-up due</Form.Label>
+          <Form.Control type="datetime-local" value={followUp} onChange={(event) => setFollowUp(event.target.value)} />
+        </Col>
+        <Col md={6}>
+          <Form.Label>Diagnosis (optional)</Form.Label>
+          <Form.Select value={diagnosis} onChange={(event) => setDiagnosis(event.target.value ? Number(event.target.value) : '')}>
+            <option value="">Evidence only — no diagnosis</option>
+            {diagnoses
+              .filter((row) => row.active)
+              .map((row) => (
+                <option key={row.pk} value={row.pk}>
+                  {row.name}
+                </option>
+              ))}
+          </Form.Select>
+        </Col>
+        <Col md={3}>
+          <Form.Label>Certainty</Form.Label>
+          <Form.Select disabled={diagnosis === ''} value={certainty} onChange={(event) => setCertainty(event.target.value as 'suspected' | 'confirmed')}>
+            <option value="suspected">Suspected</option>
+            <option value="confirmed">Confirmed</option>
+          </Form.Select>
+        </Col>
+        <Col md={3}>
+          <Form.Label>Evidence URL</Form.Label>
+          <Form.Control type="url" value={evidenceUrl} onChange={(event) => setEvidenceUrl(event.target.value)} />
+        </Col>
+        <Col xs={12}>
+          <Form.Label>Notes</Form.Label>
+          <Form.Control as="textarea" value={notes} onChange={(event) => setNotes(event.target.value)} />
+        </Col>
+      </Row>
+      <Button className="mt-3" disabled={!preview || observationType === '' || createMutation.isPending} onClick={() => createMutation.mutate()}>
+        Record reviewed observation
+      </Button>
+    </Card>
+  )
+}
+
+function ObservationActions({ observation }: { observation: HealthObservation }) {
+  const cache = useQueryClient()
+  const { data: locations = [] } = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+  const [reason, setReason] = React.useState('')
+  const [destination, setDestination] = React.useState<number | ''>('')
+  const [application, setApplication] = React.useState<number | ''>('')
+  const [result, setResult] = React.useState('improving')
+  const [effectiveness, setEffectiveness] = React.useState('unknown')
+  const [correctionReason, setCorrectionReason] = React.useState('')
+  const [correctedSeverity, setCorrectedSeverity] = React.useState<HealthSeverity>(observation.severity)
+  const [correctedNotes, setCorrectedNotes] = React.useState(observation.notes)
+  const quarantineMutation = useMutation({
+    mutationFn: () =>
+      quarantineHealthObservation(observation.pk, {
+        idempotency_key: crypto.randomUUID(),
+        reason,
+        destination: destination === '' ? null : destination
+      }),
+    onSuccess: () => {
+      setReason('')
+      void invalidateHealth(cache)
+    }
+  })
+  const treatmentMutation = useMutation({
+    mutationFn: () => linkHealthTreatment(observation.pk, { application, notes: reason }),
+    onSuccess: () => {
+      setApplication('')
+      setReason('')
+      void invalidateHealth(cache)
+    }
+  })
+  const followUpMutation = useMutation({
+    mutationFn: () => recordHealthFollowUp(observation.pk, { result, effectiveness, notes: reason }),
+    onSuccess: () => {
+      setReason('')
+      void invalidateHealth(cache)
+    }
+  })
+  const correctionMutation = useMutation({
+    mutationFn: () =>
+      correctHealthObservation(observation.pk, {
+        observation_type: observation.observation_type,
+        severity: correctedSeverity,
+        diagnoses: observation.diagnoses.map((row) => ({ diagnosis: row.diagnosis, certainty: row.certainty })),
+        evidence: observation.evidence,
+        occurred_at: observation.occurred_at,
+        follow_up_due_at: observation.follow_up_due_at,
+        notes: correctedNotes,
+        correction_reason: correctionReason
+      }),
+    onSuccess: () => {
+      setCorrectionReason('')
+      void invalidateHealth(cache)
+    }
+  })
+  return (
+    <details className="mt-2">
+      <summary>Actions and corrections</summary>
+      <Row className="g-2 mt-1 align-items-end">
+        <Col md={5}>
+          <Form.Label>Reason / notes</Form.Label>
+          <Form.Control value={reason} onChange={(event) => setReason(event.target.value)} />
+        </Col>
+        <Col md={4}>
+          <Form.Label>Quarantine destination (optional)</Form.Label>
+          <Form.Select value={destination} onChange={(event) => setDestination(event.target.value ? Number(event.target.value) : '')}>
+            <option value="">Keep physical location</option>
+            {locations
+              .filter((row) => row.location_type === 'quarantine')
+              .map((row) => (
+                <option key={row.pk} value={row.pk}>
+                  {row.name}
+                </option>
+              ))}
+          </Form.Select>
+        </Col>
+        <Col md={3}>
+          <Button variant="warning" disabled={!reason || quarantineMutation.isPending} onClick={() => quarantineMutation.mutate()}>
+            Quarantine
+          </Button>
+        </Col>
+        <Col md={4}>
+          <Form.Label>Posted treatment application</Form.Label>
+          <Form.Control type="number" min={1} value={application} onChange={(event) => setApplication(event.target.value ? Number(event.target.value) : '')} />
+        </Col>
+        <Col md={3}>
+          <Button disabled={application === '' || treatmentMutation.isPending} onClick={() => treatmentMutation.mutate()}>
+            Link treatment
+          </Button>
+        </Col>
+        <Col md={2}>
+          <Form.Select value={result} onChange={(event) => setResult(event.target.value)}>
+            <option value="unresolved">Unresolved</option>
+            <option value="improving">Improving</option>
+            <option value="resolved">Resolved</option>
+            <option value="worsened">Worsened</option>
+          </Form.Select>
+        </Col>
+        <Col md={2}>
+          <Form.Select value={effectiveness} onChange={(event) => setEffectiveness(event.target.value)}>
+            <option value="unknown">Unknown</option>
+            <option value="ineffective">Ineffective</option>
+            <option value="partial">Partial</option>
+            <option value="effective">Effective</option>
+          </Form.Select>
+        </Col>
+        <Col md={1}>
+          <Button variant="outline-primary" disabled={followUpMutation.isPending} onClick={() => followUpMutation.mutate()}>
+            Follow up
+          </Button>
+        </Col>
+        <Col md={3}>
+          <Form.Label>Corrected severity</Form.Label>
+          <Form.Select value={correctedSeverity} onChange={(event) => setCorrectedSeverity(event.target.value as HealthSeverity)}>
+            {SEVERITIES.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={9}>
+          <Form.Label>Corrected notes</Form.Label>
+          <Form.Control value={correctedNotes} onChange={(event) => setCorrectedNotes(event.target.value)} />
+        </Col>
+        <Col md={8}>
+          <Form.Label>Correction reason</Form.Label>
+          <Form.Control value={correctionReason} onChange={(event) => setCorrectionReason(event.target.value)} />
+        </Col>
+        <Col md={4}>
+          <Button variant="outline-secondary" disabled={!correctionReason || correctionMutation.isPending} onClick={() => correctionMutation.mutate()}>
+            Append correction
+          </Button>
+        </Col>
+      </Row>
+    </details>
+  )
+}
+
+function QuarantineRow({ quarantine }: { quarantine: QuarantineCase }) {
+  const cache = useQueryClient()
+  const [reason, setReason] = React.useState('')
+  const mutation = useMutation({
+    mutationFn: (action: 'release' | 'escalate' | 'cull') => actOnQuarantine(quarantine.pk, action, { idempotency_key: crypto.randomUUID(), reason }),
+    onSuccess: () => {
+      setReason('')
+      void invalidateHealth(cache)
+    }
+  })
+  return (
+    <tr>
+      <td>#{quarantine.pk}</td>
+      <td>Observation #{quarantine.observation}</td>
+      <td>{quarantine.members.reduce((sum, row) => sum + row.quantity, 0)}</td>
+      <td>{quarantine.reason}</td>
+      <td>
+        <Form.Control size="sm" placeholder="Action reason" value={reason} onChange={(event) => setReason(event.target.value)} />
+      </td>
+      <td className="d-flex gap-1">
+        <Button size="sm" variant="success" disabled={!reason || mutation.isPending} onClick={() => mutation.mutate('release')}>
+          Release
+        </Button>
+        <Button size="sm" variant="warning" disabled={!reason || mutation.isPending} onClick={() => mutation.mutate('escalate')}>
+          Escalate
+        </Button>
+        <Button size="sm" variant="danger" disabled={!reason || mutation.isPending} onClick={() => mutation.mutate('cull')}>
+          Cull
+        </Button>
+      </td>
+    </tr>
+  )
+}
+
+function HealthView() {
+  const [searchParams] = useSearchParams()
+  const initialScopes = React.useMemo(
+    () =>
+      searchParams.getAll('scope').flatMap((value) => {
+        const [type, rawId] = value.split(':')
+        const id = Number(rawId)
+        if (!(type in SCOPE_LABELS) || !Number.isInteger(id) || id <= 0) return []
+        return [{ type: type as HealthScopeType, id }]
+      }),
+    [searchParams]
+  )
+  const { data: observations = [], isPending } = useQuery({ queryKey: queryKeys.health.observations, queryFn: ({ signal }) => getHealthObservations(signal) })
+  const { data: quarantines = [] } = useQuery({ queryKey: queryKeys.health.quarantines, queryFn: ({ signal }) => getQuarantineCases(signal) })
+  const { data: report } = useQuery({ queryKey: queryKeys.health.report, queryFn: ({ signal }) => getHealthReport(signal) })
+  const activeCases = quarantines.filter((row) => row.active)
+  return (
+    <main className="container py-3">
+      <h1>Plant health</h1>
+      <p>Inspect nursery stock, preserve evidence, constrain availability, connect treatment inputs, and review outcomes.</p>
+      {report && (
+        <Row className="g-2 mb-3">
+          <Col md={3}>
+            <Card body>
+              <div className="text-muted small">Observations</div>
+              <div className="fs-4">{report.summary.observations}</div>
+            </Card>
+          </Col>
+          <Col md={3}>
+            <Card body>
+              <div className="text-muted small">Active quarantines</div>
+              <div className="fs-4 text-warning">{activeCases.length}</div>
+            </Card>
+          </Col>
+          <Col md={6}>
+            <Card body>
+              <div className="text-muted small">Issues</div>
+              {Object.entries(report.summary.by_issue).map(([label, count]) => (
+                <Badge bg="secondary" className="me-1" key={label}>
+                  {label}: {count}
+                </Badge>
+              ))}
+            </Card>
+          </Col>
+        </Row>
+      )}
+      <ObservationComposer initialScopes={initialScopes} />
+      <h2 className="h4">Active quarantine</h2>
+      {activeCases.length === 0 ? (
+        <p className="text-muted">No stock is currently quarantined.</p>
+      ) : (
+        <Table responsive size="sm">
+          <thead>
+            <tr>
+              <th>Case</th>
+              <th>Source</th>
+              <th>Plants</th>
+              <th>Reason</th>
+              <th>Action reason</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {activeCases.map((row) => (
+              <QuarantineRow key={row.pk} quarantine={row} />
+            ))}
+          </tbody>
+        </Table>
+      )}
+      <h2 className="h4 mt-4">Observation history</h2>
+      {isPending ? (
+        <p>Loading health history…</p>
+      ) : (
+        observations.map((observation) => (
+          <Card body className="mb-2" key={observation.pk}>
+            <div className="d-flex justify-content-between">
+              <strong>
+                #{observation.pk} · {observation.observation_type_name}
+              </strong>
+              <Badge bg={observation.severity === 'critical' ? 'danger' : observation.severity === 'high' ? 'warning' : 'secondary'}>{observation.severity}</Badge>
+            </div>
+            <div className="text-muted small">
+              {formatDateTime(observation.occurred_at)} · {observation.affected_count} plants represented
+            </div>
+            <div>{observation.notes || 'No notes.'}</div>
+            {observation.diagnoses.map((row) => (
+              <Badge className="me-1" bg="info" key={row.diagnosis}>
+                {row.certainty}: {row.name}
+              </Badge>
+            ))}
+            {observation.evidence.map((row) => (
+              <div key={row.url}>
+                <a href={row.url} target="_blank" rel="noreferrer">
+                  {row.label || row.url}
+                </a>
+              </div>
+            ))}
+            <ObservationActions observation={observation} />
+          </Card>
+        ))
+      )}
+    </main>
+  )
+}
+
+export { HealthView }

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -10,6 +10,7 @@ import { getLocations } from './api/locations'
 import { queryKeys } from './query'
 import { LabelFormat, LabelPrintJob, LabelResolution } from './types/labels'
 import { BulkOperationPanel } from './plantings/bulk_operations'
+import { HealthScopeType } from './types/health'
 
 import './labels.css'
 
@@ -214,6 +215,7 @@ function ScannerView() {
   const [result, setResult] = React.useState<LabelResolution>()
   const [cameraError, setCameraError] = React.useState('')
   const [scanned, setScanned] = React.useState<Array<{ id: number; code: string; display: string }>>([])
+  const [healthScanned, setHealthScanned] = React.useState<Array<{ type: HealthScopeType; id: number; code: string; display: string }>>([])
   const video = React.useRef<HTMLVideoElement>(null)
   const controls = React.useRef<IScannerControls | undefined>(undefined)
   const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
@@ -229,6 +231,24 @@ function ScannerView() {
             ? current
             : [...current, { id: target.object_id, code: resolved.current_code ?? resolved.code ?? '', display: target.display }]
         )
+      }
+      if (resolved.status === 'active' && resolved.target && resolved.capabilities?.includes('health_inspection')) {
+        const target = resolved.target
+        const scopes: Record<string, HealthScopeType> = {
+          specificplant: 'plant',
+          plantcohort: 'cohort',
+          seedtray: 'tray',
+          productionbatch: 'batch',
+          location: 'location'
+        }
+        const type = scopes[target.target_type]
+        if (type) {
+          setHealthScanned((current) =>
+            current.some((entry) => entry.type === type && entry.id === target.object_id)
+              ? current
+              : [...current, { type, id: target.object_id, code: resolved.current_code ?? resolved.code ?? '', display: target.display }]
+          )
+        }
       }
     }
   })
@@ -303,6 +323,37 @@ function ScannerView() {
           )}
         </Col>
         <Col lg={6}>
+          <h2>
+            Health inspection{' '}
+            <Badge bg="warning" text="dark">
+              {healthScanned.length}
+            </Badge>
+          </h2>
+          {healthScanned.length === 0 ? (
+            <p className="text-muted">Eligible nursery labels scanned here will build an exact health-inspection scope.</p>
+          ) : (
+            <>
+              <ul className="list-group mb-3">
+                {healthScanned.map((entry) => (
+                  <li className="list-group-item d-flex justify-content-between" key={`${entry.type}:${entry.id}`}>
+                    <span>
+                      {entry.display}
+                      <br />
+                      <small className="font-monospace">{entry.code}</small>
+                    </span>
+                    <Button variant="outline-danger" onClick={() => setHealthScanned(healthScanned.filter((item) => item !== entry))}>
+                      Remove
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+              <Link to={`/health?${healthScanned.map((entry) => `scope=${encodeURIComponent(`${entry.type}:${entry.id}`)}`).join('&')}`}>
+                <Button variant="warning" className="mb-4">
+                  Review health scope
+                </Button>
+              </Link>
+            </>
+          )}
           <h2>
             Plant selection <Badge bg="secondary">{scanned.length}</Badge>
           </h2>

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -31,6 +31,7 @@ import { GrowthCatalogsView } from './plantings/growth_catalogs.js'
 import { ProductionPlanningView } from './plantings/production_planning.js'
 import { LabelsView, ScannerView } from './labels.js'
 import { WorkQueueView } from './work.js'
+import { HealthView } from './health.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -158,6 +159,14 @@ function FrontEndPage() {
         <Route path="/labels" element={<LabelsView />} />
         <Route path="/scan" element={<ScannerView />} />
         <Route path="/scan/:code" element={<ScannerView />} />
+        <Route
+          path="/health"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <HealthView />
+            </WorkspaceModeRoute>
+          }
+        />
         <Route
           path="/work"
           element={

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -15,7 +15,7 @@ function GPTopBar({ workspace }: GPTopBarProps) {
   const { pathname } = useLocation()
   const seedsActive = pathname === '/seeds' || pathname.startsWith('/seeds/')
   const seedTraysActive = pathname === '/seedtrays' || pathname.startsWith('/seedtrays/')
-  const plantingActive = pathname === '/plantings' || pathname.startsWith('/plantings/')
+  const plantingActive = pathname === '/plantings' || pathname.startsWith('/plantings/') || pathname === '/health'
   const inventoryActive = pathname === '/inventory' || pathname.startsWith('/inventory/') || pathname.startsWith('/applications') || pathname.startsWith('/locations')
 
   return (
@@ -65,6 +65,9 @@ function GPTopBar({ workspace }: GPTopBarProps) {
                 </NavDropdown.Item>
                 <NavDropdown.Item as={NavLink} to="/plantings/production-planning">
                   Production planning
+                </NavDropdown.Item>
+                <NavDropdown.Item as={NavLink} to="/health">
+                  Plant health
                 </NavDropdown.Item>
               </>
             )}

--- a/frontend/js/plantings/cohorts.tsx
+++ b/frontend/js/plantings/cohorts.tsx
@@ -138,6 +138,7 @@ function CohortRegisterView() {
   const [readyFrom, setReadyFrom] = React.useState('')
   const [readyTo, setReadyTo] = React.useState('')
   const [stageOverdue, setStageOverdue] = React.useState(false)
+  const [quarantined, setQuarantined] = React.useState<boolean | undefined>(undefined)
   const [page, setPage] = React.useState(1)
   const [selected, setSelected] = React.useState<Array<number>>([])
   const [mergeReason, setMergeReason] = React.useState('')
@@ -150,6 +151,7 @@ function CohortRegisterView() {
     expected_ready_from: readyFrom || undefined,
     expected_ready_to: readyTo || undefined,
     stage_overdue: stageOverdue || undefined,
+    quarantined,
     page,
     page_size: 50
   }
@@ -230,6 +232,17 @@ function CohortRegisterView() {
         <Col md="auto">
           <Form.Check label="Overdue at stage" checked={stageOverdue} onChange={(event) => setStageOverdue(event.target.checked)} />
         </Col>
+        <Col md={3}>
+          <Form.Select
+            aria-label="Quarantine status"
+            value={quarantined === undefined ? '' : String(quarantined)}
+            onChange={(event) => setQuarantined(event.target.value === '' ? undefined : event.target.value === 'true')}
+          >
+            <option value="">Any quarantine status</option>
+            <option value="true">Quarantined</option>
+            <option value="false">Not quarantined</option>
+          </Form.Select>
+        </Col>
       </Row>
       {selected.length >= 2 && (
         <Alert variant="light" className="d-flex gap-2 align-items-end">
@@ -280,7 +293,7 @@ function CohortRegisterView() {
                   <td>
                     <Form.Check
                       aria-label={`Select cohort ${cohort.pk}`}
-                      disabled={cohort.quantity === 0}
+                      disabled={cohort.quantity === 0 || cohort.quarantined}
                       checked={selected.includes(cohort.pk)}
                       onChange={(event) => setSelected(event.target.checked ? [...selected, cohort.pk] : selected.filter((pk) => pk !== cohort.pk))}
                     />
@@ -294,6 +307,13 @@ function CohortRegisterView() {
                   <td>{cohort.batch_code}</td>
                   <td>
                     <Badge bg={cohort.lifecycle_state === 'available' ? 'success' : 'secondary'}>{STATE_LABELS[cohort.lifecycle_state]}</Badge>
+                    {cohort.quarantined && (
+                      <div>
+                        <Badge bg="warning" text="dark">
+                          Quarantined · unavailable
+                        </Badge>
+                      </div>
+                    )}
                   </td>
                   <td>{cohort.quantity}</td>
                   <td>

--- a/frontend/js/plantings/register.tsx
+++ b/frontend/js/plantings/register.tsx
@@ -50,6 +50,7 @@ function RegisterTotals({ totals }: TotalsProps) {
     { label: 'Matching', value: totals.total },
     { label: 'Growing', value: totals.growing },
     { label: 'Available', value: totals.available, variant: 'text-success' },
+    { label: 'Quarantined', value: totals.quarantined, variant: 'text-warning' },
     { label: 'Unresolved', value: totals.unresolved },
     { label: 'Retained', value: totals.retained },
     { label: 'Lost', value: totals.failed + totals.culled, variant: 'text-danger' }
@@ -114,6 +115,7 @@ function NurseryRegisterView() {
   const [readyFrom, setReadyFrom] = React.useState('')
   const [readyTo, setReadyTo] = React.useState('')
   const [stageOverdue, setStageOverdue] = React.useState(false)
+  const [quarantined, setQuarantined] = React.useState<boolean | undefined>(undefined)
   const [page, setPage] = React.useState(1)
   const [selection, setSelection] = React.useState<RegisterSelection>(EMPTY_SELECTION)
 
@@ -134,6 +136,7 @@ function NurseryRegisterView() {
     expected_ready_from: readyFrom || undefined,
     expected_ready_to: readyTo || undefined,
     stage_overdue: stageOverdue || undefined,
+    quarantined,
     ordering,
     page,
     page_size: PAGE_SIZE
@@ -346,6 +349,17 @@ function NurseryRegisterView() {
         </Col>
         <Col md={3} className="d-flex align-items-end">
           <Form.Check label="Overdue at stage" checked={stageOverdue} onChange={(event) => narrow(setStageOverdue)(event.target.checked)} />
+        </Col>
+        <Col md={3}>
+          <Form.Label>Quarantine</Form.Label>
+          <Form.Select
+            value={quarantined === undefined ? '' : String(quarantined)}
+            onChange={(event) => narrow(setQuarantined)(event.target.value === '' ? undefined : event.target.value === 'true')}
+          >
+            <option value="">Any status</option>
+            <option value="true">Quarantined</option>
+            <option value="false">Not quarantined</option>
+          </Form.Select>
         </Col>
         <Col md={3}>
           <Form.Group controlId="register-germinated-to">

--- a/frontend/js/plantings/register_list.tsx
+++ b/frontend/js/plantings/register_list.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form, Table } from 'react-bootstrap'
+import { Badge, Form, Table } from 'react-bootstrap'
 import { NavLink } from 'react-router'
 
 import { formatDate, formatDateTime, formatMoney } from '../utils'
@@ -105,7 +105,7 @@ function RegisterTable({ rows, selection, setSelection }: RegisterTableProps) {
               <Form.Check
                 aria-label={`Select plant ${row.pk}`}
                 checked={isSelected(selection, row.pk)}
-                disabled={selection.mode === 'filter'}
+                disabled={selection.mode === 'filter' || row.quarantined}
                 onChange={() => setSelection(toggleSelected(selection, row.pk))}
               />
             </td>
@@ -121,6 +121,13 @@ function RegisterTable({ rows, selection, setSelection }: RegisterTableProps) {
             </td>
             <td>
               <LifecycleStateBadge state={row.lifecycle_state} />
+              {row.quarantined && (
+                <div>
+                  <Badge bg="warning" text="dark">
+                    Quarantined · unavailable
+                  </Badge>
+                </div>
+              )}
             </td>
             <td>
               {row.stage_name ?? '—'}

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -4,6 +4,14 @@ import { CohortFilters, NurseryRegisterFilters } from './types/plantings'
 import { WorkFilters } from './types/work'
 
 const queryKeys = {
+  health: {
+    all: ['health'] as const,
+    types: ['health', 'observation-types'] as const,
+    diagnoses: ['health', 'diagnoses'] as const,
+    observations: ['health', 'observations'] as const,
+    quarantines: ['health', 'quarantines'] as const,
+    report: ['health', 'report'] as const
+  },
   work: {
     all: ['work'] as const,
     tasks: (filters: WorkFilters) => ['work', 'tasks', filters] as const,

--- a/frontend/js/types/health.ts
+++ b/frontend/js/types/health.ts
@@ -1,0 +1,121 @@
+type HealthSeverity = 'low' | 'moderate' | 'high' | 'critical'
+type HealthScopeType = 'plant' | 'cohort' | 'tray' | 'generation' | 'batch' | 'location'
+
+interface HealthCatalogValue {
+  pk: number
+  code: string
+  name: string
+  display_order: number
+  active: boolean
+  category?: 'pest' | 'disease' | 'damage' | 'vigor' | 'other'
+}
+
+interface HealthScope {
+  type: HealthScopeType
+  id: number
+  label?: string
+}
+
+interface HealthPreview {
+  scopes: Array<Required<HealthScope>>
+  plants: Array<number>
+  cohorts: Array<{ cohort: number; quantity: number }>
+  affected_count: number
+  digest: string
+}
+
+interface HealthDiagnosisAssessment {
+  diagnosis: number
+  name?: string
+  category?: string
+  certainty: 'suspected' | 'confirmed'
+}
+
+interface HealthObservation {
+  pk: number
+  observation_type: number
+  observation_type_name: string
+  severity: HealthSeverity
+  occurred_at: string
+  follow_up_due_at: string | null
+  notes: string
+  scopes: Array<Required<HealthScope>>
+  affected: Array<{ type: 'plant' | 'cohort'; id: number; quantity: number }>
+  affected_count: number
+  diagnoses: Array<HealthDiagnosisAssessment>
+  evidence: Array<{ url: string; label: string }>
+  corrects: number | null
+  correction_reason: string
+  quarantine_cases: Array<{ pk: number; active: boolean; reason: string }>
+  treatments: Array<{ pk: number; application: number; application_status: string; follow_up_due_at: string | null; notes: string }>
+  follow_ups: Array<{
+    pk: number
+    treatment: number | null
+    occurred_at: string
+    result: string
+    effectiveness: string
+    notes: string
+    corrects: number | null
+    correction_reason: string
+  }>
+  created_by: number | null
+  created: string
+}
+
+interface HealthObservationCreate {
+  scopes: Array<HealthScope>
+  reviewed_digest: string
+  observation_type: number
+  severity: HealthSeverity
+  diagnoses?: Array<{ diagnosis: number; certainty: 'suspected' | 'confirmed' }>
+  evidence?: Array<{ url: string; label: string }>
+  occurred_at?: string
+  follow_up_due_at?: string | null
+  notes?: string
+}
+
+interface QuarantineCase {
+  pk: number
+  observation: number
+  observation_summary: string
+  reason: string
+  active: boolean
+  members: Array<{ type: 'plant' | 'cohort'; id: number; quantity: number }>
+  actions: Array<{ pk: number; action: string; occurred_at: string; reason: string; destination: number | null; created_by: number | null }>
+  created_by: number | null
+  created: string
+}
+
+interface HealthReport {
+  summary: {
+    observations: number
+    by_issue: Record<string, number>
+    by_severity: Record<string, number>
+    by_diagnosis: Record<string, number>
+    by_outcome: Record<string, number>
+  }
+  results: Array<{
+    observation: number
+    occurred_at: string
+    observation_type: string
+    severity: HealthSeverity
+    affected: Array<{ type: string; id: number; quantity: number }>
+    batches: Array<{ batch: number; code: string; variety: number; variety_name: string }>
+    seed_sources: Array<{ seed_packet: number; seed_product: number; supplier: number; supplier_name: string }>
+    treatments: Array<{ treatment: number; application: number; status: string; items: Array<string> }>
+    outcomes: Array<{ follow_up: number; result: string; effectiveness: string }>
+  }>
+}
+
+export {
+  HealthCatalogValue,
+  HealthDiagnosisAssessment,
+  HealthObservation,
+  HealthObservationCreate,
+  HealthPreview,
+  HealthReport,
+  HealthScope,
+  HealthScopeType,
+  HealthSeverity,
+  QuarantineCase
+}

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -290,6 +290,7 @@ interface SpecificPlant {
   locations: Array<SpecificPlantLocation>
   lifecycle_state: PlantLifecycleState
   sellable: boolean
+  quarantined: boolean
   final_outcome: PlantLifecycleEventType | null
   final_outcome_at: string | null
 }
@@ -362,6 +363,7 @@ interface NurseryRegisterRow {
   age_days: number
   lifecycle_state: PlantLifecycleState
   sellable: boolean
+  quarantined: boolean
   final_outcome: PlantLifecycleEventType | null
   final_outcome_at: string | null
   location_type: PlantPlacementType | null
@@ -413,6 +415,7 @@ interface NurseryRegisterFilters {
   batch?: number
   state?: Array<PlantLifecycleState>
   sellable?: boolean
+  quarantined?: boolean
   germinated_from?: string
   germinated_to?: string
   location_type?: PlantPlacementType | 'none'
@@ -438,6 +441,7 @@ interface NurseryRegisterFilters {
 type NurseryRegisterTotals = Record<PlantLifecycleState, number> & {
   total: number
   unresolved: number
+  quarantined: number
   stage_counts: Record<string, number>
   grade_counts: Record<string, number>
   container_counts: Record<string, number>
@@ -660,6 +664,7 @@ interface PlantCohort {
   source_sowing: number | null
   quantity: number
   lifecycle_state: CohortLifecycleState
+  quarantined: boolean
   location: number | null
   location_name: string | null
   observed_at: string
@@ -707,6 +712,7 @@ interface CohortFilters {
   location?: number
   state?: CohortLifecycleState
   active?: boolean
+  quarantined?: boolean
   stage?: number
   grade?: number
   container?: number


### PR DESCRIPTION
Operators need a reviewed UI for recording evidence, acting on quarantine, linking treatments, and seeing constrained stock. Scanner-built scopes and register warnings keep those actions tied to the exact affected stock.

## Summary by Sourcery

Introduce a nursery plant health workspace with scoped inspections, quarantine management, and observation history, integrated across registers and navigation.

New Features:
- Add a plant health workspace page for recording scoped inspections, managing quarantines, linking treatments, and viewing observation history.
- Enable scanner-driven construction of health scopes from eligible nursery labels and navigation into the health workspace.
- Expose health-related APIs and types for observations, diagnoses, quarantines, and summary reporting.

Enhancements:
- Extend nursery and cohort registers with quarantine status filters, totals, and badges, and prevent selection of quarantined stock.
- Integrate the plant health workspace into the main routing and plantings menu, grouped with nursery workflows.