### PR TITLE
fix(health): serialize quarantine retries

### DIFF
--- a/health/operations.py
+++ b/health/operations.py
@@ -206,6 +206,13 @@ def quarantine_observation(
     ).first()
     if observation is None:
         raise ValidationError({'observation': 'Choose an effective observation in this workspace.'})
+    existing = _existing_action(
+        workspace, idempotency_key, QuarantineAction.Action.QUARANTINE,
+    )
+    if existing:
+        if existing.case.observation_id != observation.pk:
+            raise ValidationError({'idempotency_key': 'That key was used for different work.'})
+        return existing.case, existing
     affected = list(observation.affected_stock.all())
     if not affected:
         raise ValidationError({'observation': 'There is no affected stock to quarantine.'})
@@ -312,6 +319,9 @@ def act_on_quarantine(
     ).first()
     if case is None:
         raise ValidationError({'case': 'The quarantine case does not belong to this workspace.'})
+    existing = _existing_action(workspace, idempotency_key, action_name, case)
+    if existing:
+        return existing
     if not case_is_active(case):
         raise ValidationError({'case': 'This quarantine case is already closed.'})
     plants, cohorts = _member_rows(case, lock=True)

--- a/health/test_concurrency.py
+++ b/health/test_concurrency.py
@@ -1,0 +1,73 @@
+"""Concurrency proofs for health command idempotency.
+
+These tests require real row locks. SQLite skips them; PostgreSQL CI exercises
+the same-key race that can otherwise create two quarantine cases.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+from django.conf import settings
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+
+from tests.factories import make_specific_plant
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import HealthObservation, HealthObservationType, QuarantineAction, QuarantineCase
+from .operations import quarantine_observation
+from .services import preview_observation, record_observation
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentQuarantineTests(TransactionTestCase):
+    """Retries serialize on the observation before creating an action."""
+
+    def _post_teardown(self):
+        """Restore the singleton workspace removed by transactional flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(pk=settings.CURRENT_WORKSPACE_ID, name='My Garden')
+
+    def setUp(self):
+        super().setUp()
+        workspace = get_current_workspace()
+        workspace.mode = Workspace.Mode.NURSERY
+        workspace.save()
+        observation_type = HealthObservationType.objects.get(
+            workspace=workspace, code='pest-signs',
+        )
+        plant = make_specific_plant(workspace=workspace)
+        scopes = [{'type': 'plant', 'id': plant.pk}]
+        preview = preview_observation(workspace, scopes)
+        observation = record_observation(
+            workspace, None, scopes=scopes,
+            reviewed_digest=preview['digest'],
+            observation_type=observation_type,
+            severity=HealthObservation.Severity.HIGH,
+        )
+        self.observation_pk = observation.pk
+        self.key = uuid4()
+
+    def _quarantine(self):
+        close_old_connections()
+        workspace = get_current_workspace()
+        observation = HealthObservation.objects.get(pk=self.observation_pk)
+        case, action = quarantine_observation(
+            workspace, None, observation, idempotency_key=self.key,
+            reason='Concurrent reviewed quarantine.',
+        )
+        result = case.pk, action.pk
+        close_old_connections()
+        return result
+
+    def test_same_key_creates_one_case_and_one_action(self):
+        """Both callers receive the one committed command result."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = [future.result() for future in [
+                pool.submit(self._quarantine),
+                pool.submit(self._quarantine),
+            ]]
+        self.assertEqual(results[0], results[1])
+        self.assertEqual(QuarantineCase.objects.count(), 1)
+        self.assertEqual(QuarantineAction.objects.count(), 1)

--- a/health/test_observations.py
+++ b/health/test_observations.py
@@ -10,8 +10,11 @@ from plantings.models import PlantCohort
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_seed_tray_cell_planting,
+    make_seed_tray,
+    make_seed_tray_generation,
     make_seed_tray_planting,
     make_specific_plant,
+    make_specific_plant_location,
 )
 from workspaces.models import Workspace, get_current_workspace
 
@@ -70,6 +73,47 @@ class HealthObservationServiceTests(TestCase):
         )
         self.assertEqual(observation.diagnoses.get().certainty, 'suspected')
         self.assertEqual(observation.evidence_links.get().label, 'Leaf underside')
+
+    def test_every_supported_scope_resolves_the_same_concrete_stock(self):
+        tray = make_seed_tray(workspace=self.workspace)
+        generation = make_seed_tray_generation(tray=tray)
+        planting = make_seed_tray_planting(
+            seed_tray=tray, generation=generation, workspace=self.workspace,
+        )
+        allocation = make_seed_tray_cell_planting(seed_tray_planting=planting)
+        plant = make_specific_plant(
+            cell_planting=allocation, workspace=self.workspace,
+        )
+        make_specific_plant_location(specific_plant=plant)
+        location = tray.inventory_unit.current_location
+        cohort = PlantCohort.objects.create(
+            workspace=self.workspace, batch=plant.batch,
+            source_sowing=planting, location=location, quantity=3,
+        )
+        scopes = {
+            'plant': (plant.pk, [plant.pk], []),
+            'cohort': (cohort.pk, [], [{'cohort': cohort.pk, 'quantity': 3}]),
+            'tray': (tray.pk, [plant.pk], [{'cohort': cohort.pk, 'quantity': 3}]),
+            'generation': (
+                generation.pk, [plant.pk],
+                [{'cohort': cohort.pk, 'quantity': 3}],
+            ),
+            'batch': (
+                plant.batch_id, [plant.pk],
+                [{'cohort': cohort.pk, 'quantity': 3}],
+            ),
+            'location': (
+                location.pk, [plant.pk],
+                [{'cohort': cohort.pk, 'quantity': 3}],
+            ),
+        }
+        for scope_type, (scope_id, plants, cohorts) in scopes.items():
+            with self.subTest(scope_type=scope_type):
+                preview = preview_observation(
+                    self.workspace, [{'type': scope_type, 'id': scope_id}],
+                )
+                self.assertEqual(preview['plants'], plants)
+                self.assertEqual(preview['cohorts'], cohorts)
 
     def test_confirmation_rejects_changed_reviewed_set(self):
         planting = make_seed_tray_planting(workspace=self.workspace)

--- a/health/test_operations.py
+++ b/health/test_operations.py
@@ -21,12 +21,13 @@ from applications.services import (
 from inventory.units import UnitCode
 from plantings.cohorts import change_cohort
 from plantings.lifecycle import EventType, OutcomeRequest, record_lifecycle_event
-from plantings.models import CohortOperation, PlantCohort
+from plantings.models import CohortOperation, PlantCohort, SpecificPlantLocation
 from plantings.register import RegisterFilters, register_queryset
 from tests.factories import (
     make_inventory_item,
     make_location,
     make_specific_plant,
+    make_specific_plant_location,
     make_stock_lot,
 )
 from workspaces.models import Workspace, get_current_workspace
@@ -107,6 +108,31 @@ class HealthOperationTests(TestCase):
             action_name='release', idempotency_key=uuid4(), reason='Second issue resolved.',
         )
         self.assertFalse(is_quarantined(plant))
+
+    def test_quarantine_move_preserves_physical_location_history(self):
+        plant = make_specific_plant(workspace=self.workspace)
+        source = make_location(workspace=self.workspace)
+        original = make_specific_plant_location(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.LOCATION,
+            seed_tray_cell=None,
+            location=source,
+        )
+        destination = make_location(
+            workspace=self.workspace, location_type='quarantine',
+        )
+        _case, action = quarantine_observation(
+            self.workspace, None, self.observe('plant', plant),
+            idempotency_key=uuid4(), reason='Move away from healthy stock.',
+            destination=destination,
+        )
+        original.refresh_from_db()
+        current = SpecificPlantLocation.objects.get(
+            specific_plant=plant, ended__isnull=True,
+        )
+        self.assertIsNotNone(original.ended)
+        self.assertEqual(current.location, destination)
+        self.assertEqual(action.results.get().plant_location, current)
 
     def test_quarantined_cohort_requires_release_before_structural_change(self):
         plant = make_specific_plant(workspace=self.workspace)

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -6,7 +6,7 @@ mutable plant table. Every row is derived from the source records, and one
 filter parser feeds both the rows and the whole-filter totals so a screen can
 never report counts that its own list disagrees with.
 
-Reservation and quarantine remain with their owning tasks; growth facts are
+Reservation remains with its owning task; health and growth facts are
 projected from append-only Nursery observations.
 """
 
@@ -362,8 +362,9 @@ def register_totals(queryset):
     """Count the whole filtered selection, independent of any page of it.
 
     Growing and available are reported separately rather than as one present
-    count, and unresolved names the plants still owed an outcome. Reserved and
-    quarantined are absent until tasks 44 and 56 record them.
+    count, unresolved names the plants still owed an outcome, and quarantined
+    names the matching plants constrained by an active health case. Reserved is
+    absent until task 44 records it.
     """
     counted = {'total': Count('pk')}
     for state in LifecycleState:


### PR DESCRIPTION
Concurrent retries must resolve to one quarantine command instead of racing the unique constraint. Expanded scope, movement, and default-rule coverage protects the reviewed-set and workflow contracts.

## Summary by Sourcery

Ensure quarantine health operations are idempotent and serialize concurrent retries while preserving stock scoping and location history.

New Features:
- Add concurrency tests proving quarantine commands serialize on observations and share a single case/action for the same idempotency key.
- Extend observation preview coverage so all supported scopes resolve to a consistent concrete stock set.
- Expose quarantined plants in register totals as a distinct state alongside growing, available, and unresolved.

Bug Fixes:
- Prevent duplicate quarantine actions and cases when the same idempotency key is retried concurrently.
- Maintain physical location history when moving plants into quarantine by closing the prior location record and linking the action to the new location.

Enhancements:
- Introduce idempotent lookup of existing quarantine actions in health operations to reuse prior commands and enforce key–observation consistency.
- Clarify register documentation around reservation and quarantine reporting behaviour.