### PR TITLE
feat(health): surface active alerts in operations

### DIFF
--- a/frontend/js/locations.tsx
+++ b/frontend/js/locations.tsx
@@ -251,6 +251,11 @@ function OccupancyPanel({ location }: OccupancyPanelProps) {
     <Card>
       <Card.Header>What is standing in {location.full_name}</Card.Header>
       <Card.Body>
+        {occupancy.active_health_alerts > 0 && (
+          <Alert variant="warning">
+            {occupancy.active_health_alerts} active health alert{occupancy.active_health_alerts === 1 ? '' : 's'} affects stock here or below.
+          </Alert>
+        )}
         <Table size="sm" className="mb-0">
           <thead>
             <tr>

--- a/frontend/js/types/locations.ts
+++ b/frontend/js/types/locations.ts
@@ -55,6 +55,7 @@ interface LocationOccupancy {
   here: OccupancyCounts
   subtree: OccupancyCounts
   remaining: string | null
+  active_health_alerts: number
 }
 
 export { CapacityBasis, Location, LocationCreate, LocationOccupancy, LocationType, LocationUpdate, OccupancyCounts }

--- a/frontend/js/types/work.ts
+++ b/frontend/js/types/work.ts
@@ -8,6 +8,7 @@ interface WorkLink {
   label: string
   url: string
   snapshot: Record<string, unknown>
+  active_health_alerts: number
 }
 
 interface WorkHistory {

--- a/frontend/js/work.tsx
+++ b/frontend/js/work.tsx
@@ -196,7 +196,14 @@ function TaskTable({ tasks }: { tasks: Array<WorkTask> }) {
               {task.links
                 .filter((link) => link.role === 'target')
                 .map((link) => (
-                  <div key={`${link.target_type}:${link.object_id}`}>{link.url ? <NavLink to={link.url}>{link.label}</NavLink> : link.label}</div>
+                  <div key={`${link.target_type}:${link.object_id}`}>
+                    {link.url ? <NavLink to={link.url}>{link.label}</NavLink> : link.label}
+                    {link.active_health_alerts > 0 && (
+                      <Badge bg="warning" text="dark" className="ms-1">
+                        Health alert
+                      </Badge>
+                    )}
+                  </div>
                 ))}
             </td>
             <td>{task.assignee_name ?? 'Unassigned'}</td>

--- a/health/availability.py
+++ b/health/availability.py
@@ -1,7 +1,7 @@
 """Authoritative current quarantine projections and locking checks."""
 
 from django.core.exceptions import ValidationError
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 
 from .models import QuarantineAction, QuarantineCase, QuarantineMember
 
@@ -68,3 +68,36 @@ def require_available(targets, *, lock=False):
             'targets': f'Quarantined stock is unavailable: {blocked}.',
         })
     return rows
+
+
+def active_alert_count(workspace, scopes):
+    """Count active quarantine cases intersecting one reviewed target scope."""
+    from .services import preview_observation  # pylint: disable=import-outside-toplevel
+
+    try:
+        preview = preview_observation(workspace, scopes)
+    except ValidationError:
+        return 0
+    affected = Q(members__plant_id__in=preview['plants'])
+    affected |= Q(
+        members__cohort_id__in=[row['cohort'] for row in preview['cohorts']],
+    )
+    return active_cases(workspace).filter(affected).count()
+
+
+def target_alert_count(target):
+    """Count active quarantine cases for a supported generic task target."""
+    scope_types = {
+        'specificplant': 'plant',
+        'plantcohort': 'cohort',
+        'seedtray': 'tray',
+        'seedtraygeneration': 'generation',
+        'productionbatch': 'batch',
+        'location': 'location',
+    }
+    scope_type = scope_types.get(target._meta.model_name)  # pylint: disable=protected-access
+    if scope_type is None:
+        return 0
+    return active_alert_count(
+        target.workspace, [{'type': scope_type, 'id': target.pk}],
+    )

--- a/health/test_observations.py
+++ b/health/test_observations.py
@@ -3,16 +3,20 @@
 # Test names describe behavior directly.
 # pylint: disable=missing-function-docstring
 
+from uuid import uuid4
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
 
-from plantings.models import PlantCohort
+from plantings.models import PlantCohort, SpecificPlantLocation
 from tests.api import RESTContractTestCase
 from tests.factories import (
     make_seed_tray_cell_planting,
     make_seed_tray,
     make_seed_tray_generation,
     make_seed_tray_planting,
+    make_location,
     make_specific_plant,
     make_specific_plant_location,
 )
@@ -216,3 +220,48 @@ class HealthObservationRestTests(RESTContractTestCase):
         self.workspace.save()
         response = self.client.get('/health/observation-types/')
         self.assertEqual(response.status_code, 403)
+
+    def test_active_alerts_surface_in_location_and_task_views(self):
+        location = make_location(workspace=self.workspace)
+        plant = make_specific_plant(workspace=self.workspace)
+        make_specific_plant_location(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.LOCATION,
+            seed_tray_cell=None,
+            location=location,
+        )
+        scopes = [{'type': 'plant', 'id': plant.pk}]
+        preview = self.client.post(
+            '/health/observations/preview/', {'scopes': scopes}, format='json',
+        )
+        observation_type = HealthObservationType.objects.get(
+            workspace=self.workspace, code='pest-signs',
+        )
+        observation = self.client.post('/health/observations/', {
+            'scopes': scopes,
+            'reviewed_digest': preview.data['digest'],
+            'observation_type': observation_type.pk,
+            'severity': 'high',
+            'follow_up_due_at': timezone.now().isoformat(),
+        }, format='json')
+        constrained = self.client.post(
+            f"/health/observations/{observation.data['pk']}/quarantine/",
+            {
+                'idempotency_key': str(uuid4()),
+                'reason': 'Keep away from healthy plants.',
+            },
+            format='json',
+        )
+        self.assertEqual(constrained.status_code, 201, constrained.data)
+        occupancy = self.client.get(f'/locations/{location.pk}/occupancy/')
+        self.assertEqual(occupancy.data['active_health_alerts'], 1)
+        queue = self.client.get('/work/tasks/')
+        health_task = next(
+            row for row in queue.data
+            if row['source_snapshot'].get('health_observation') == observation.data['pk']
+        )
+        plant_link = next(
+            row for row in health_task['links']
+            if row['target_type'] == 'specificplant'
+        )
+        self.assertEqual(plant_link['active_health_alerts'], 1)

--- a/locations/rest.py
+++ b/locations/rest.py
@@ -161,6 +161,7 @@ class LocationViewSet(
         remaining = None
         if location.capacity_basis in Location.ENFORCED_BASES:
             remaining = location.capacity_value - below.of(location.capacity_basis)
+        from health.availability import active_alert_count  # pylint: disable=import-outside-toplevel
         return Response({
             'location': location.pk,
             'capacity_basis': location.capacity_basis,
@@ -170,6 +171,9 @@ class LocationViewSet(
             'here': here._asdict(),
             'subtree': below._asdict(),
             'remaining': _decimal_string(remaining),
+            'active_health_alerts': active_alert_count(
+                location.workspace, [{'type': 'location', 'id': location.pk}],
+            ),
         })
 
     def perform_destroy(self, instance):

--- a/work/rest.py
+++ b/work/rest.py
@@ -56,10 +56,19 @@ class HistorySerializer(serializers.ModelSerializer):
 
 class LinkSerializer(serializers.ModelSerializer):
     target_type = serializers.CharField(source='content_type.model', read_only=True)
+    active_health_alerts = serializers.SerializerMethodField()
 
     class Meta:
         model = WorkTaskLink
-        fields = ['role', 'target_type', 'object_id', 'label', 'url', 'snapshot']
+        fields = [
+            'role', 'target_type', 'object_id', 'label', 'url', 'snapshot',
+            'active_health_alerts',
+        ]
+
+    def get_active_health_alerts(self, link):
+        from health.availability import target_alert_count  # pylint: disable=import-outside-toplevel
+
+        return target_alert_count(link.target)
 
 
 class WorkTaskSerializer(serializers.ModelSerializer):
@@ -134,9 +143,16 @@ def _projected_data(task):
             'target_type': row.target._meta.model_name,
             'object_id': row.target.pk, 'label': row.label, 'url': row.url,
             'snapshot': {},
+            'active_health_alerts': _target_health_alert_count(row.target),
         } for row in task.targets],
         'history': [], 'created': None, 'updated': None,
     }
+
+
+def _target_health_alert_count(target):
+    from health.availability import target_alert_count  # pylint: disable=import-outside-toplevel
+
+    return target_alert_count(target)
 
 
 def _effective_status(task, now):


### PR DESCRIPTION
Location occupancy and work targets need the same live quarantine signal as stock registers so operators do not overlook constrained plants while moving or scheduling work.

## Summary by Sourcery

Surface active health quarantine alerts in location occupancy and work task views so operators can see constrained stock and plants when planning operations.

New Features:
- Expose active health alert counts in location occupancy API and frontend panel.
- Include active health alert counts on work task links and task projection data, with a UI badge for affected targets.

Enhancements:
- Add utilities to compute active health alert counts for generic targets and location scopes based on quarantine cases and observation previews.

Tests:
- Extend health observations tests to cover surfacing of active alerts in location occupancy and work task queues.