### PR TITLE
fix(labels): keep printed codes on one line

### DIFF
--- a/frontend/js/labels.css
+++ b/frontend/js/labels.css
@@ -24,6 +24,7 @@
 }
 
 .label-values {
+  container-type: inline-size;
   min-width: 0;
   font-size: 10pt;
   line-height: 1.15;
@@ -31,7 +32,8 @@
 
 .label-code {
   font-family: monospace;
-  overflow-wrap: anywhere;
+  font-size: min(10pt, 9cqi);
+  white-space: nowrap;
 }
 
 .scanner-video {


### PR DESCRIPTION
Size human-readable label codes from the available text column so fixed-length tray codes remain fully visible on sheet and roll layouts instead of wrapping their final character.

## Summary by Sourcery

Bug Fixes:
- Ensure monospace label codes render on a single line to avoid truncating or wrapping the final character on printed labels.