### PR TITLE
Exclude seed stock from input applications

### DIFF
--- a/applications/rest.py
+++ b/applications/rest.py
@@ -245,6 +245,14 @@ class ApplicationLineInputSerializer(CurrentWorkspaceSerializerMixin, ActionSeri
         'unit_conversion': 'workspace',
     }
 
+    def validate_item(self, item):
+        """Keep seed consumption in the sowing workflow that owns it."""
+        if item.category == InventoryItem.Category.SEED:
+            raise serializers.ValidationError(
+                'Seed stock must be consumed by recording a sowing.'
+            )
+        return item
+
 
 class ApplicationDraftSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):
     """The payload that creates or replaces a draft."""

--- a/applications/test_rest.py
+++ b/applications/test_rest.py
@@ -103,6 +103,28 @@ class ApplicationContractTests(ApplicationRESTTestCase):
         self.assertEqual(len(data['lines'][0]['targets']), 24)
         self.assertEqual(data['lines'][0]['calculated_base_quantity'], '0.960000000')
 
+    def test_seed_stock_cannot_be_recorded_as_an_input_application(self):
+        """Sowings, rather than generic applications, own seed consumption."""
+        seed = make_inventory_item(
+            category=InventoryItem.Category.SEED,
+            base_unit=UnitCode.SEED,
+        )
+        seed_lot = make_stock_lot(item=seed, location=self.location, quantity='50')
+
+        response = self.client.post(
+            URL,
+            self.payload(line={
+                'item': seed.pk,
+                'lot': seed_lot.pk,
+                'applied_quantity': '1',
+                'unit_code': UnitCode.SEED,
+            }),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('Seed stock must be consumed', str(response.data))
+
     def test_a_draft_can_be_retrieved(self):
         """A stored draft reads back the same way it was created."""
         created = self.create_draft()

--- a/frontend/js/applications/application_form.tsx
+++ b/frontend/js/applications/application_form.tsx
@@ -64,7 +64,10 @@ function InputApplicationForm({ targets, batch = null, defaultTargetKeys, tray, 
     enabled: item !== ''
   })
 
-  const chosenItem = items.find((entry) => entry.pk === item)
+  // Seed stock is consumed by a sowing, not by an input application. Keeping
+  // it out of this selector prevents the two inventory workflows overlapping.
+  const applicableItems = items.filter((entry) => entry.category !== 'seed')
+  const chosenItem = applicableItems.find((entry) => entry.pk === item)
   const chosenBalance = balances.find((entry) => entry.lot === lot)
   const previewLine = preview?.lines[0]
   const overrideRequired = previewLine?.override_required ?? false
@@ -176,7 +179,7 @@ function InputApplicationForm({ targets, batch = null, defaultTargetKeys, tray, 
                 }}
               >
                 <option value="">Select an item</option>
-                {items.map((entry) => (
+                {applicableItems.map((entry) => (
                   <option key={entry.pk} value={entry.pk}>
                     {entry.name}
                   </option>


### PR DESCRIPTION
Seed inventory is consumed through sowing records, so allowing it in the generic application workflow creates conflicting stock histories. Hide seed items in the form and reject them at the API boundary.

## Summary by Sourcery

Prevent seed inventory from being recorded via generic input applications, keeping seed consumption within the sowing workflow.

Bug Fixes:
- Reject seed-category items in the input application API to avoid conflicting seed stock histories.

Enhancements:
- Hide seed-category items from the input application form item selector so seed cannot be chosen there.

Tests:
- Add an API test ensuring seed stock cannot be recorded as an input application and returns a validation error.