### PR TITLE
Restrict inputs applicable to seed trays

### DIFF
--- a/applications/rest.py
+++ b/applications/rest.py
@@ -43,6 +43,11 @@ from .services import (
 
 TargetType = InputApplicationTarget.TargetType
 
+SEED_TRAY_INPUT_CATEGORIES = {
+    InventoryItem.Category.GROWING_MEDIA,
+    InventoryItem.Category.FERTILIZER_TREATMENT,
+}
+
 #: How each target type is reached, and the lookup that keeps it in workspace.
 #: A tray cell is not workspace owned in its own right, so it is scoped through
 #: the tray that holds it.
@@ -252,6 +257,24 @@ class ApplicationLineInputSerializer(CurrentWorkspaceSerializerMixin, ActionSeri
                 'Seed stock must be consumed by recording a sowing.'
             )
         return item
+
+    def validate(self, attrs):
+        """Only accept categories that can physically be applied to tray cells."""
+        attrs = super().validate(attrs)
+        targets_tray = attrs.get('tray') is not None or any(
+            target['target_type'] == TargetType.SEED_TRAY_CELL
+            for target in attrs.get('targets', [])
+        )
+        item = attrs['item']
+        invalid_tray_item = targets_tray and item.category not in SEED_TRAY_INPUT_CATEGORIES
+        if invalid_tray_item:
+            raise serializers.ValidationError({
+                'item': (
+                    'Only growing media or fertilizer/treatment can be applied '
+                    'to seed trays.'
+                ),
+            })
+        return attrs
 
 
 class ApplicationDraftSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):

--- a/applications/test_rest.py
+++ b/applications/test_rest.py
@@ -125,6 +125,78 @@ class ApplicationContractTests(ApplicationRESTTestCase):
         self.assertEqual(response.status_code, 400, response.data)
         self.assertIn('Seed stock must be consumed', str(response.data))
 
+    def test_treatment_can_be_applied_to_a_whole_seed_tray(self):
+        """Treatments are valid tray inputs alongside growing media."""
+        treatment = make_inventory_item(
+            category=InventoryItem.Category.FERTILIZER_TREATMENT,
+        )
+        treatment_lot = make_stock_lot(
+            item=treatment,
+            location=self.location,
+            quantity='50',
+        )
+
+        response = self.client.post(
+            URL,
+            self.payload(line={
+                'item': treatment.pk,
+                'lot': treatment_lot.pk,
+                'targets': [],
+                'tray': self.tray.pk,
+            }),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_non_input_categories_cannot_be_applied_to_a_seed_tray(self):
+        """Containers and unrelated stock do not become tray-cell inputs."""
+        rejected_categories = (
+            InventoryItem.Category.LABEL,
+            InventoryItem.Category.PACKAGING,
+            InventoryItem.Category.POT_CONTAINER,
+            InventoryItem.Category.TRAY,
+            InventoryItem.Category.OTHER,
+        )
+        for category in rejected_categories:
+            with self.subTest(category=category):
+                item = make_inventory_item(category=category)
+                lot = make_stock_lot(
+                    item=item,
+                    location=self.location,
+                    quantity='50',
+                )
+                response = self.client.post(
+                    URL,
+                    self.payload(line={
+                        'item': item.pk,
+                        'lot': lot.pk,
+                        'targets': [],
+                        'tray': self.tray.pk,
+                    }),
+                    format='json',
+                )
+
+                self.assertEqual(response.status_code, 400, response.data)
+                self.assertIn('Only growing media', str(response.data))
+
+    def test_category_rule_also_applies_to_explicit_tray_cells(self):
+        """Callers cannot bypass the tray shortcut rule with cell targets."""
+        pot = make_inventory_item(category=InventoryItem.Category.POT_CONTAINER)
+        pot_lot = make_stock_lot(item=pot, location=self.location, quantity='50')
+
+        response = self.client.post(
+            URL,
+            self.payload(line={
+                'item': pot.pk,
+                'lot': pot_lot.pk,
+            }),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('Only growing media', str(response.data))
+
     def test_a_draft_can_be_retrieved(self):
         """A stored draft reads back the same way it was created."""
         created = self.create_draft()

--- a/frontend/js/applications/application_form.tsx
+++ b/frontend/js/applications/application_form.tsx
@@ -64,9 +64,13 @@ function InputApplicationForm({ targets, batch = null, defaultTargetKeys, tray, 
     enabled: item !== ''
   })
 
-  // Seed stock is consumed by a sowing, not by an input application. Keeping
-  // it out of this selector prevents the two inventory workflows overlapping.
-  const applicableItems = items.filter((entry) => entry.category !== 'seed')
+  const targetsSeedTray = tray !== undefined || targets.some((target) => target.target_type === 'seed_tray_cell')
+  // Seed stock is consumed by a sowing, not by an input application. A tray's
+  // cells additionally receive only media and treatments; containers, labels,
+  // packaging, and unrelated physical stock have their own workflows.
+  const applicableItems = items.filter(
+    (entry) => entry.category !== 'seed' && (!targetsSeedTray || entry.category === 'growing_media' || entry.category === 'fertilizer_treatment')
+  )
   const chosenItem = applicableItems.find((entry) => entry.pk === item)
   const chosenBalance = balances.find((entry) => entry.lot === lot)
   const previewLine = preview?.lines[0]


### PR DESCRIPTION
Tray cells should receive growing media or fertilizer treatments, not containers, labels, packaging, or unrelated inventory. Apply the contextual allow-list in the UI and at the API boundary so direct requests cannot bypass it.

## Summary by Sourcery

Restrict seed tray input applications to growing media and fertilizer treatments and enforce this both in the backend API and frontend selection UI.

Bug Fixes:
- Prevent non-input inventory categories such as containers, labels, packaging, and other stock from being applied to seed trays via the API.

Enhancements:
- Allow fertilizer/treatment inventory items to be applied to whole seed trays alongside growing media.
- Apply a shared category allow-list when targeting either entire trays or explicit tray cells to ensure consistent validation across pathways.

Tests:
- Add REST tests covering allowed fertilizer treatments on trays, rejection of non-input categories for tray applications, and enforcement of rules when targeting individual tray cells.