### PR TITLE
fix(labels): separate code heading from value

### DIFF
--- a/frontend/js/labels.css
+++ b/frontend/js/labels.css
@@ -32,7 +32,7 @@
 
 .label-code {
   font-family: monospace;
-  font-size: min(10pt, 9cqi);
+  font-size: min(10pt, 8cqi);
   white-space: nowrap;
 }
 

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -34,8 +34,17 @@ function PrintArea({ job }: { job: LabelPrintJob }) {
               const value = item.target[field]
               if (value === undefined || value === null || value === '') return null
               return (
-                <div key={field} className={field === 'code' ? 'label-code' : undefined}>
-                  {field === 'display' ? <strong>{String(value)}</strong> : `${field.replaceAll('_', ' ')}: ${String(value)}`}
+                <div key={field}>
+                  {field === 'display' ? (
+                    <strong>{String(value)}</strong>
+                  ) : field === 'code' ? (
+                    <>
+                      <div>code:</div>
+                      <div className="label-code">{String(value)}</div>
+                    </>
+                  ) : (
+                    `${field.replaceAll('_', ' ')}: ${String(value)}`
+                  )}
                 </div>
               )
             })}


### PR DESCRIPTION
Place the code field heading above the fixed-length identifier and retain print-width headroom so sheet and roll labels show the complete value without wrapping or clipping.

## Summary by Sourcery

Adjust label rendering so code headings are separated from code values and ensure code values fit within print width without wrapping or clipping.

Bug Fixes:
- Prevent sheet and roll label code values from wrapping or being clipped by reducing the responsive font size.

Enhancements:
- Separate the code field label from its fixed-length identifier to improve readability of printed labels.