### PR TITLE
feat(stocktake): persist reviewed count sessions

### DIFF
--- a/inventory/migrations/0009_stocktake_approved_at_stocktake_approved_by_and_more.py
+++ b/inventory/migrations/0009_stocktake_approved_at_stocktake_approved_by_and_more.py
@@ -1,0 +1,162 @@
+import django.core.validators
+import django.db.models.deletion
+from decimal import Decimal
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0008_inventoryitem_container_footprint_m2_and_more'),
+        ('locations', '0004_backfill_location_paths'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='stocktake',
+            name='approved_at',
+            field=models.DateTimeField(blank=True, editable=False, null=True),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='approved_by',
+            field=models.ForeignKey(blank=True, editable=False, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='blind',
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='posted_by',
+            field=models.ForeignKey(blank=True, editable=False, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='reversed_by',
+            field=models.ForeignKey(blank=True, editable=False, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='reviewed_at',
+            field=models.DateTimeField(blank=True, editable=False, null=True),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='reviewed_by',
+            field=models.ForeignKey(blank=True, editable=False, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='scope',
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name='stocktake',
+            name='scope_digest',
+            field=models.CharField(blank=True, default='', max_length=64),
+        ),
+        migrations.AlterField(
+            model_name='stocktake',
+            name='status',
+            field=models.CharField(choices=[('draft', 'Draft'), ('open', 'Open'), ('paused', 'Paused'), ('review', 'In review'), ('approved', 'Approved'), ('posted', 'Posted'), ('reversed', 'Reversed')], default='draft', editable=False, max_length=16),
+        ),
+        migrations.CreateModel(
+            name='StocktakeCount',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('counted_quantity', models.DecimalField(blank=True, decimal_places=9, max_digits=24, null=True, validators=[django.core.validators.MinValueValidator(Decimal('0'))])),
+                ('observed_state', models.CharField(blank=True, default='', max_length=32)),
+                ('code_snapshot', models.CharField(blank=True, default='', max_length=64)),
+                ('resolved_identity', models.JSONField(blank=True, default=dict)),
+                ('notes', models.TextField(blank=True, default='')),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('counter', models.ForeignKey(editable=False, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('observed_location', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='locations.location')),
+            ],
+            options={
+                'ordering': ['created', 'pk'],
+            },
+        ),
+        migrations.CreateModel(
+            name='StocktakeTarget',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('target_type', models.CharField(choices=[('lot', 'Consumable lot'), ('seed_packet', 'Seed packet'), ('tray', 'Serialized tray'), ('cohort', 'Plant cohort'), ('plant', 'Individual plant')], max_length=16)),
+                ('target_key', models.CharField(max_length=96)),
+                ('target_object_id', models.PositiveBigIntegerField(blank=True, null=True)),
+                ('display', models.CharField(max_length=255)),
+                ('expected_quantity', models.DecimalField(blank=True, decimal_places=9, max_digits=24, null=True)),
+                ('expected_state', models.CharField(blank=True, default='', max_length=32)),
+                ('expected_snapshot', models.JSONField(default=dict)),
+                ('source_revision', models.CharField(max_length=64)),
+                ('unexpected', models.BooleanField(default=False)),
+                ('count_status', models.CharField(choices=[('pending', 'Pending'), ('counted', 'Counted'), ('recount', 'Recount requested')], default='pending', max_length=16)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+                ('accepted_count', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='accepted_for', to='inventory.stocktakecount')),
+                ('expected_location', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='locations.location')),
+                ('stocktake', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='targets', to='inventory.stocktake')),
+            ],
+            options={
+                'ordering': ['target_type', 'display', 'pk'],
+            },
+        ),
+        migrations.AddField(
+            model_name='stocktakecount',
+            name='target',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='counts', to='inventory.stocktaketarget'),
+        ),
+        migrations.CreateModel(
+            name='StocktakeAttachment',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('url', models.URLField(max_length=2048)),
+                ('label', models.CharField(blank=True, default='', max_length=255)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('created_by', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('stocktake', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='attachments', to='inventory.stocktake')),
+                ('target', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='attachments', to='inventory.stocktaketarget')),
+            ],
+            options={
+                'ordering': ['created', 'pk'],
+            },
+        ),
+        migrations.CreateModel(
+            name='StocktakeVariance',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('kind', models.CharField(choices=[('quantity', 'Quantity'), ('missing', 'Missing'), ('excess', 'Excess'), ('misplaced', 'Misplaced'), ('state_mismatch', 'State mismatch')], max_length=20)),
+                ('expected', models.JSONField(default=dict)),
+                ('observed', models.JSONField(default=dict)),
+                ('source_changed', models.BooleanField(default=False)),
+                ('current_revision', models.CharField(blank=True, default='', max_length=64)),
+                ('conflict_resolution', models.CharField(blank=True, choices=[('', 'No conflict'), ('accepted', 'Accepted current conflict'), ('refreshed', 'Refreshed snapshot'), ('recount', 'Recount requested')], default='', max_length=12)),
+                ('conflict_reason', models.TextField(blank=True, default='')),
+                ('resolution_action', models.CharField(blank=True, default='', max_length=32)),
+                ('resolution_payload', models.JSONField(blank=True, default=dict)),
+                ('resolution_reason', models.TextField(blank=True, default='')),
+                ('resolved_at', models.DateTimeField(blank=True, null=True)),
+                ('resolved_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('target', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='variances', to='inventory.stocktaketarget')),
+            ],
+            options={
+                'ordering': ['target_id', 'kind', 'pk'],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name='stocktaketarget',
+            constraint=models.UniqueConstraint(fields=('stocktake', 'target_key'), name='inventory_stocktake_target_key_unique'),
+        ),
+        migrations.AddConstraint(
+            model_name='stocktakeattachment',
+            constraint=models.UniqueConstraint(fields=('stocktake', 'url'), name='inventory_stocktake_attachment_url_unique'),
+        ),
+        migrations.AddConstraint(
+            model_name='stocktakevariance',
+            constraint=models.UniqueConstraint(fields=('target', 'kind'), name='inventory_stocktake_variance_kind_unique'),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -907,6 +907,10 @@ class Stocktake(WorkspaceOwnedModel):
         """Stocktake lifecycle states."""
 
         DRAFT = 'draft', 'Draft'
+        OPEN = 'open', 'Open'
+        PAUSED = 'paused', 'Paused'
+        REVIEW = 'review', 'In review'
+        APPROVED = 'approved', 'Approved'
         POSTED = 'posted', 'Posted'
         REVERSED = 'reversed', 'Reversed'
 
@@ -918,6 +922,9 @@ class Stocktake(WorkspaceOwnedModel):
     )
     counted_at = models.DateTimeField()
     notes = models.TextField(blank=True, default='')
+    blind = models.BooleanField(default=True)
+    scope = models.JSONField(default=dict, blank=True)
+    scope_digest = models.CharField(max_length=64, blank=True, default='')
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -926,6 +933,40 @@ class Stocktake(WorkspaceOwnedModel):
         related_name='+',
     )
     posted_at = models.DateTimeField(null=True, blank=True, editable=False)
+    reviewed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        editable=False,
+        related_name='+',
+    )
+    reviewed_at = models.DateTimeField(null=True, blank=True, editable=False)
+    approved_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        editable=False,
+        related_name='+',
+    )
+    approved_at = models.DateTimeField(null=True, blank=True, editable=False)
+    posted_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        editable=False,
+        related_name='+',
+    )
+    reversed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        editable=False,
+        related_name='+',
+    )
     reversed_at = models.DateTimeField(null=True, blank=True, editable=False)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
@@ -937,8 +978,8 @@ class Stocktake(WorkspaceOwnedModel):
         return f'Stocktake {self.pk or "draft"}'
 
     def save(self, *args, **kwargs):
-        if not self.pk and self.status != self.Status.DRAFT:
-            raise ValidationError('Stocktakes must be created as drafts.')
+        if not self.pk and self.status not in {self.Status.DRAFT, self.Status.OPEN}:
+            raise ValidationError('Stocktakes must be created as drafts or open sessions.')
         if self.pk:
             previous = type(self).objects.filter(pk=self.pk).only('status').first()
             if previous and previous.status != self.Status.DRAFT:
@@ -947,9 +988,185 @@ class Stocktake(WorkspaceOwnedModel):
         super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        if self.status != self.Status.DRAFT:
-            raise ValidationError('Only draft stocktakes can be deleted.')
+        if self.status not in {self.Status.DRAFT, self.Status.OPEN, self.Status.PAUSED}:
+            raise ValidationError('Only unreviewed stocktakes can be deleted.')
         return super().delete(*args, **kwargs)
+
+
+class StocktakeTarget(models.Model):
+    """One frozen quantity or identity expected inside a stocktake scope."""
+
+    class TargetType(models.TextChoices):
+        """Physical domains that participate in a mixed stocktake."""
+
+        LOT = 'lot', 'Consumable lot'
+        SEED_PACKET = 'seed_packet', 'Seed packet'
+        TRAY = 'tray', 'Serialized tray'
+        COHORT = 'cohort', 'Plant cohort'
+        PLANT = 'plant', 'Individual plant'
+
+    class CountStatus(models.TextChoices):
+        """Whether this frozen target still needs physical evidence."""
+
+        PENDING = 'pending', 'Pending'
+        COUNTED = 'counted', 'Counted'
+        RECOUNT = 'recount', 'Recount requested'
+
+    stocktake = models.ForeignKey(
+        Stocktake, on_delete=models.CASCADE, related_name='targets',
+    )
+    target_type = models.CharField(max_length=16, choices=TargetType.choices)
+    target_key = models.CharField(max_length=96)
+    target_object_id = models.PositiveBigIntegerField(null=True, blank=True)
+    display = models.CharField(max_length=255)
+    expected_location = models.ForeignKey(
+        Location, on_delete=models.PROTECT, null=True, blank=True, related_name='+',
+    )
+    expected_quantity = models.DecimalField(
+        max_digits=QUANTITY_MAX_DIGITS,
+        decimal_places=QUANTITY_DECIMAL_PLACES,
+        null=True,
+        blank=True,
+    )
+    expected_state = models.CharField(max_length=32, blank=True, default='')
+    expected_snapshot = models.JSONField(default=dict)
+    source_revision = models.CharField(max_length=64)
+    unexpected = models.BooleanField(default=False)
+    count_status = models.CharField(
+        max_length=16, choices=CountStatus.choices, default=CountStatus.PENDING,
+    )
+    accepted_count = models.OneToOneField(
+        'StocktakeCount', on_delete=models.PROTECT, null=True, blank=True,
+        related_name='accepted_for',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ['target_type', 'display', 'pk']
+        constraints = [
+            models.UniqueConstraint(
+                fields=['stocktake', 'target_key'],
+                name='inventory_stocktake_target_key_unique',
+            ),
+        ]
+
+
+class StocktakeCount(models.Model):
+    """An immutable blind count attempt retained across recounts."""
+
+    target = models.ForeignKey(
+        StocktakeTarget, on_delete=models.PROTECT, related_name='counts',
+    )
+    counted_quantity = models.DecimalField(
+        max_digits=QUANTITY_MAX_DIGITS,
+        decimal_places=QUANTITY_DECIMAL_PLACES,
+        null=True,
+        blank=True,
+        validators=[MinValueValidator(Decimal('0'))],
+    )
+    observed_location = models.ForeignKey(
+        Location, on_delete=models.PROTECT, null=True, blank=True, related_name='+',
+    )
+    observed_state = models.CharField(max_length=32, blank=True, default='')
+    code_snapshot = models.CharField(max_length=64, blank=True, default='')
+    resolved_identity = models.JSONField(default=dict, blank=True)
+    notes = models.TextField(blank=True, default='')
+    counter = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True,
+        editable=False, related_name='+',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['created', 'pk']
+
+    def save(self, *args, **kwargs):
+        if self.pk:
+            raise ValidationError('Stocktake counts are immutable.')
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        raise ValidationError('Stocktake counts cannot be deleted.')
+
+
+class StocktakeVariance(models.Model):
+    """A reviewable difference between frozen scope and physical evidence."""
+
+    class Kind(models.TextChoices):
+        """Review classifications shared by quantity and identity counts."""
+
+        QUANTITY = 'quantity', 'Quantity'
+        MISSING = 'missing', 'Missing'
+        EXCESS = 'excess', 'Excess'
+        MISPLACED = 'misplaced', 'Misplaced'
+        STATE = 'state_mismatch', 'State mismatch'
+
+    class ConflictResolution(models.TextChoices):
+        """Explicit decisions for facts that changed after the snapshot."""
+
+        NONE = '', 'No conflict'
+        ACCEPTED = 'accepted', 'Accepted current conflict'
+        REFRESHED = 'refreshed', 'Refreshed snapshot'
+        RECOUNT = 'recount', 'Recount requested'
+
+    target = models.ForeignKey(
+        StocktakeTarget, on_delete=models.PROTECT, related_name='variances',
+    )
+    kind = models.CharField(max_length=20, choices=Kind.choices)
+    expected = models.JSONField(default=dict)
+    observed = models.JSONField(default=dict)
+    source_changed = models.BooleanField(default=False)
+    current_revision = models.CharField(max_length=64, blank=True, default='')
+    conflict_resolution = models.CharField(
+        max_length=12, choices=ConflictResolution.choices, blank=True, default='',
+    )
+    conflict_reason = models.TextField(blank=True, default='')
+    resolution_action = models.CharField(max_length=32, blank=True, default='')
+    resolution_payload = models.JSONField(default=dict, blank=True)
+    resolution_reason = models.TextField(blank=True, default='')
+    resolved_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True,
+        related_name='+',
+    )
+    resolved_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ['target_id', 'kind', 'pk']
+        constraints = [
+            models.UniqueConstraint(
+                fields=['target', 'kind'],
+                name='inventory_stocktake_variance_kind_unique',
+            ),
+        ]
+
+
+class StocktakeAttachment(models.Model):
+    """An externally hosted photo or document retained with count evidence."""
+
+    stocktake = models.ForeignKey(
+        Stocktake, on_delete=models.PROTECT, related_name='attachments',
+    )
+    target = models.ForeignKey(
+        StocktakeTarget, on_delete=models.PROTECT, null=True, blank=True,
+        related_name='attachments',
+    )
+    url = models.URLField(max_length=2048)
+    label = models.CharField(max_length=255, blank=True, default='')
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True,
+        related_name='+',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['created', 'pk']
+        constraints = [
+            models.UniqueConstraint(
+                fields=['stocktake', 'url'],
+                name='inventory_stocktake_attachment_url_unique',
+            ),
+        ]
 
 
 class StocktakeLine(models.Model):

--- a/inventory/test_stocktake_workflow.py
+++ b/inventory/test_stocktake_workflow.py
@@ -1,0 +1,96 @@
+"""Model contracts for reviewed nursery stocktake evidence."""
+
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from locations.models import Location
+from workspaces.models import get_current_workspace
+
+from .models import (
+    Stocktake,
+    StocktakeAttachment,
+    StocktakeCount,
+    StocktakeTarget,
+    StocktakeVariance,
+)
+
+
+class StocktakeWorkflowModelTests(TestCase):
+    """Counts and review facts retain evidence instead of overwriting it."""
+
+    def setUp(self):
+        self.workspace = get_current_workspace()
+        self.user = get_user_model().objects.create_user(username='stock-counter')
+        self.location = Location.objects.create(
+            workspace=self.workspace,
+            name='North bench',
+            code='STOCK-NORTH',
+            location_type=Location.LocationType.BENCH,
+        )
+        self.stocktake = Stocktake.objects.create(
+            workspace=self.workspace,
+            status=Stocktake.Status.OPEN,
+            counted_at=timezone.now(),
+            created_by=self.user,
+            scope={'location': self.location.pk},
+        )
+        self.target = StocktakeTarget.objects.create(
+            stocktake=self.stocktake,
+            target_type=StocktakeTarget.TargetType.COHORT,
+            target_key='cohort:7',
+            target_object_id=7,
+            display='Cohort 7',
+            expected_location=self.location,
+            expected_quantity=Decimal('12'),
+            expected_state='growing',
+            expected_snapshot={'quantity': '12'},
+            source_revision='revision-3',
+        )
+
+    def test_count_attempts_are_immutable_and_one_can_be_accepted(self):
+        """A recount appends evidence while selection happens on the target."""
+        count = StocktakeCount.objects.create(
+            target=self.target,
+            counted_quantity=Decimal('11'),
+            observed_location=self.location,
+            counter=self.user,
+        )
+        self.target.accepted_count = count
+        self.target.count_status = StocktakeTarget.CountStatus.COUNTED
+        self.target.save(update_fields=['accepted_count', 'count_status', 'updated'])
+
+        count.notes = 'Changed later'
+        with self.assertRaisesMessage(ValidationError, 'immutable'):
+            count.save()
+        with self.assertRaisesMessage(ValidationError, 'cannot be deleted'):
+            count.delete()
+
+    def test_variance_and_attachment_retain_review_evidence(self):
+        """Variance details and externally hosted evidence remain connected."""
+        variance = StocktakeVariance.objects.create(
+            target=self.target,
+            kind=StocktakeVariance.Kind.QUANTITY,
+            expected={'quantity': '12'},
+            observed={'quantity': '11'},
+            source_changed=True,
+            current_revision='revision-4',
+        )
+        attachment = StocktakeAttachment.objects.create(
+            stocktake=self.stocktake,
+            target=self.target,
+            url='https://example.test/count.jpg',
+            label='Count sheet',
+            created_by=self.user,
+        )
+
+        self.assertEqual(variance.target, self.target)
+        self.assertEqual(attachment.stocktake, self.stocktake)
+        self.assertTrue(self.stocktake.blind)
+
+    def test_two_person_requirement_defaults_off(self):
+        """Existing shared workspaces do not acquire a surprise restriction."""
+        self.assertFalse(self.workspace.stocktake_two_person_required)

--- a/workspaces/migrations/0003_workspace_stocktake_two_person_required.py
+++ b/workspaces/migrations/0003_workspace_stocktake_two_person_required.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workspaces', '0002_workspace_override_tolerance_floor_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='workspace',
+            name='stocktake_two_person_required',
+            field=models.BooleanField(default=False, help_text='Require a stocktake reviewer to be different from every counter.'),
+        ),
+    ]

--- a/workspaces/models.py
+++ b/workspaces/models.py
@@ -99,6 +99,12 @@ class Workspace(models.Model):
             'reason, so a rounding-sized drift never does. Zero disables it.'
         ),
     )
+    stocktake_two_person_required = models.BooleanField(
+        default=False,
+        help_text=(
+            'Require a stocktake reviewer to be different from every counter.'
+        ),
+    )
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
Nursery stocktakes need immutable count attempts, frozen target evidence, review variances, and optional separation of duties before workflow APIs can safely post corrections.

## Summary by Sourcery

Introduce reviewed stocktake workflow with immutable count evidence, frozen scope targets, and support for multi-stage approval.

New Features:
- Add stocktake workflow statuses for open, paused, review, and approved sessions.
- Persist frozen stocktake targets, count attempts, variances, and external attachments as separate models linked to a stocktake.
- Track blind-count configuration, scope metadata, and reviewer/approver/poster identities and timestamps on stocktakes.
- Add workspace-level flag to require two-person stocktake workflows by enforcing a separate reviewer.

Enhancements:
- Relax stocktake creation and deletion rules to allow open and paused sessions prior to review.

Tests:
- Add model tests covering immutable stocktake counts, retained variance and attachment evidence, blind default behaviour, and two-person requirement defaults.