### PR TITLE
feat(stocktake): count and review frozen scopes

### DIFF
--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -987,9 +987,10 @@ class StocktakeViewSet(
 def register_ledger_routes(router):
     """Attach ledger viewsets to the inventory API router."""
     from .serialized_rest import InventoryUnitViewSet  # pylint: disable=import-outside-toplevel
+    from .stocktake_rest import NurseryStocktakeViewSet  # pylint: disable=import-outside-toplevel
 
     router.register(r'receipts', StockReceiptViewSet)
     router.register(r'lots', StockLotViewSet)
     router.register(r'serialized-units', InventoryUnitViewSet)
     router.register(r'movements', StockMovementViewSet)
-    router.register(r'stocktakes', StocktakeViewSet)
+    router.register(r'stocktakes', NurseryStocktakeViewSet, basename='stocktake')

--- a/inventory/stocktake_rest.py
+++ b/inventory/stocktake_rest.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
-from django.utils import timezone
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -28,6 +27,7 @@ from .stocktakes import (
     request_recount,
     resolve_variance,
     scope_rows,
+    transition_stocktake,
 )
 
 
@@ -345,9 +345,7 @@ class NurseryStocktakeViewSet(
 
     def _transition(self, pk, allowed, next_status):
         stocktake = self._get(pk)
-        if stocktake.status not in allowed:
-            raise serializers.ValidationError({'status': 'This transition is not available.'})
-        Stocktake.objects.filter(pk=stocktake.pk).update(status=next_status, updated=timezone.now())
+        _run(transition_stocktake, stocktake, allowed, next_status)
         return Response(stocktake_data(self._get(pk)))
 
     @action(detail=True, methods=['post'])

--- a/inventory/stocktake_rest.py
+++ b/inventory/stocktake_rest.py
@@ -3,7 +3,6 @@
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import transaction
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -25,6 +24,7 @@ from .stocktakes import (
     open_stocktake,
     record_count,
     request_recount,
+    resolve_identity_target,
     resolve_variance,
     scope_rows,
     transition_stocktake,
@@ -312,24 +312,7 @@ class NurseryStocktakeViewSet(
                 raise serializers.ValidationError({'code': 'This code belongs to another workspace.'})
             raise serializers.ValidationError({'code': 'No label uses this code.'})
         identity = code.identity
-        mapping = {
-            'seedtray': StocktakeTarget.TargetType.TRAY,
-            'plantcohort': StocktakeTarget.TargetType.COHORT,
-            'specificplant': StocktakeTarget.TargetType.PLANT,
-        }
-        target_type = mapping.get(identity.target_content_type.model)
-        if target_type is None:
-            raise serializers.ValidationError({'code': 'This identity cannot be counted in a stocktake.'})
-        key = f'{target_type}:{identity.target_object_id}'
-        target = stocktake.targets.filter(target_key=key).first()
-        if target is None:
-            with transaction.atomic():
-                target = StocktakeTarget.objects.create(
-                    stocktake=stocktake, target_type=target_type,
-                    target_key=key, target_object_id=identity.target_object_id,
-                    display=identity.target_snapshot.get('display', key),
-                    expected_snapshot={}, source_revision='', unexpected=True,
-                )
+        target = _run(resolve_identity_target, stocktake, identity)
         values = serializer.validated_data
         count = _run(
             record_count, stocktake, request.user, target.pk,

--- a/inventory/stocktake_rest.py
+++ b/inventory/stocktake_rest.py
@@ -1,0 +1,447 @@
+"""REST workflow for frozen, blind, reviewed nursery stocktakes."""
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from labels.models import LabelCode
+from locations.models import Location
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
+from .models import (
+    Stocktake,
+    StocktakeAttachment,
+    StocktakeTarget,
+    StocktakeVariance,
+)
+from .ledger import post_stocktake, reverse_stocktake
+from .stocktakes import (
+    approve_stocktake,
+    begin_review,
+    open_stocktake,
+    record_count,
+    request_recount,
+    resolve_variance,
+    scope_rows,
+)
+
+
+def _errors(exc):
+    return exc.message_dict if hasattr(exc, 'message_dict') else {'detail': exc.messages}
+
+
+def _run(service, *args, **kwargs):
+    try:
+        return service(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise serializers.ValidationError(_errors(exc)) from exc
+
+
+class ScopeSerializer(CurrentWorkspaceSerializerMixin, serializers.Serializer):  # pylint: disable=abstract-method
+    """Validate the filters whose resolved targets are frozen at creation."""
+
+    location = serializers.PrimaryKeyRelatedField(queryset=Location.objects.all())
+    include_descendants = serializers.BooleanField(required=False, default=False)
+    target_types = serializers.ListField(
+        child=serializers.ChoiceField(choices=StocktakeTarget.TargetType.choices),
+        required=False,
+    )
+    item = serializers.IntegerField(min_value=1, required=False)
+    category = serializers.CharField(required=False)
+    variety = serializers.IntegerField(min_value=1, required=False)
+    stage = serializers.IntegerField(min_value=1, required=False)
+    tray_state = serializers.CharField(required=False)
+    workspace_field_lookups = {'location': 'workspace'}
+
+    def to_internal_value(self, data):
+        values = super().to_internal_value(data)
+        values['location'] = values['location'].pk
+        return values
+
+
+class StocktakeCreateSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Open a session from reviewed scope input."""
+
+    scope = ScopeSerializer()
+    blind = serializers.BooleanField(required=False, default=True)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class CountSerializer(CurrentWorkspaceSerializerMixin, serializers.Serializer):  # pylint: disable=abstract-method
+    """Validate one quantity entry or resolved identity scan."""
+
+    target = serializers.IntegerField(min_value=1)
+    counted_quantity = serializers.DecimalField(
+        max_digits=24, decimal_places=9, min_value=Decimal('0'), required=False,
+    )
+    observed_location = serializers.PrimaryKeyRelatedField(
+        queryset=Location.objects.all(), required=False, allow_null=True,
+    )
+    observed_state = serializers.CharField(required=False, allow_blank=True, default='')
+    code_snapshot = serializers.CharField(required=False, allow_blank=True, default='')
+    resolved_identity = serializers.JSONField(required=False)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    workspace_field_lookups = {'observed_location': 'workspace'}
+
+
+class ScanCountSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Resolve a label inside the current workspace before recording it."""
+
+    code = serializers.CharField(trim_whitespace=True, allow_blank=False)
+    counted_quantity = serializers.DecimalField(
+        max_digits=24, decimal_places=9, min_value=Decimal('0'), required=False,
+    )
+    observed_state = serializers.CharField(required=False, allow_blank=True, default='')
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class ReasonSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Require an audit explanation for a review transition."""
+
+    reason = serializers.CharField(trim_whitespace=True, allow_blank=False)
+
+
+class RecountSerializer(ReasonSerializer):  # pylint: disable=abstract-method
+    """Identify the reviewed target that needs another count."""
+
+    target = serializers.IntegerField(min_value=1)
+
+
+class VarianceResolutionSerializer(ReasonSerializer):  # pylint: disable=abstract-method
+    """Capture an explicit correction rather than guessing from variance type."""
+
+    variance = serializers.IntegerField(min_value=1)
+    action = serializers.ChoiceField(choices=(
+        'no_change', 'adjust', 'move', 'lost', 'state_correct',
+    ))
+    payload = serializers.JSONField(required=False)
+    accept_conflict = serializers.BooleanField(required=False, default=False)
+
+
+class AttachmentSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Attach an externally hosted image or document to retained evidence."""
+
+    target = serializers.IntegerField(min_value=1, required=False)
+    url = serializers.URLField(max_length=2048)
+    label = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+def _count_data(count):
+    if count is None:
+        return None
+    return {
+        'pk': count.pk,
+        'counted_quantity': (
+            str(count.counted_quantity) if count.counted_quantity is not None else None
+        ),
+        'observed_location': count.observed_location_id,
+        'observed_state': count.observed_state,
+        'code_snapshot': count.code_snapshot,
+        'resolved_identity': count.resolved_identity,
+        'notes': count.notes,
+        'counter': count.counter_id,
+        'created': count.created,
+    }
+
+
+def _variance_data(variance):
+    return {
+        'pk': variance.pk, 'kind': variance.kind,
+        'expected': variance.expected, 'observed': variance.observed,
+        'source_changed': variance.source_changed,
+        'current_revision': variance.current_revision,
+        'conflict_resolution': variance.conflict_resolution,
+        'conflict_reason': variance.conflict_reason,
+        'resolution_action': variance.resolution_action,
+        'resolution_payload': variance.resolution_payload,
+        'resolution_reason': variance.resolution_reason,
+        'resolved_by': variance.resolved_by_id,
+        'resolved_at': variance.resolved_at,
+    }
+
+
+def _target_data(target, reveal_expected):
+    return {
+        'pk': target.pk,
+        'target_type': target.target_type,
+        'target_key': target.target_key,
+        'target_object_id': target.target_object_id,
+        'display': target.display,
+        'expected_location': target.expected_location_id,
+        'expected_quantity': (
+            str(target.expected_quantity)
+            if reveal_expected and target.expected_quantity is not None else None
+        ),
+        'expected_state': target.expected_state if reveal_expected else '',
+        'expected_snapshot': target.expected_snapshot if reveal_expected else {},
+        'unexpected': target.unexpected,
+        'count_status': target.count_status,
+        'accepted_count': _count_data(target.accepted_count),
+        'counts': [_count_data(count) for count in target.counts.all()],
+        'variances': [_variance_data(row) for row in target.variances.all()],
+    }
+
+
+def stocktake_data(stocktake):
+    """Serialize workflow state while preserving blind-count behavior."""
+    if not stocktake.targets.exists():
+        from .ledger_rest import StocktakeSerializer  # pylint: disable=import-outside-toplevel
+        return StocktakeSerializer(stocktake).data
+    reveal = not stocktake.blind or stocktake.status in {
+        Stocktake.Status.REVIEW, Stocktake.Status.APPROVED,
+        Stocktake.Status.POSTED, Stocktake.Status.REVERSED,
+    }
+    targets = list(stocktake.targets.all())
+    counted = sum(target.accepted_count_id is not None for target in targets)
+    return {
+        'pk': stocktake.pk, 'status': stocktake.status,
+        'blind': stocktake.blind, 'scope': stocktake.scope,
+        'notes': stocktake.notes, 'counted_at': stocktake.counted_at,
+        'created_by': stocktake.created_by_id,
+        'reviewed_by': stocktake.reviewed_by_id,
+        'reviewed_at': stocktake.reviewed_at,
+        'approved_by': stocktake.approved_by_id,
+        'approved_at': stocktake.approved_at,
+        'posted_by': stocktake.posted_by_id,
+        'posted_at': stocktake.posted_at,
+        'reversed_by': stocktake.reversed_by_id,
+        'reversed_at': stocktake.reversed_at,
+        'progress': {'counted': counted, 'total': len(targets)},
+        'targets': [_target_data(target, reveal) for target in targets],
+        'attachments': [
+            {'pk': row.pk, 'target': row.target_id, 'url': row.url,
+             'label': row.label, 'created_by': row.created_by_id,
+             'created': row.created}
+            for row in stocktake.attachments.all()
+        ],
+    }
+
+
+class NurseryStocktakeViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ViewSet,
+):
+    """Count, review, and approve stock without bypassing domain ledgers."""
+
+    def get_queryset(self):
+        return Stocktake.objects.filter(workspace=self.get_current_workspace()).select_related(
+            'created_by', 'reviewed_by', 'approved_by', 'posted_by', 'reversed_by',
+        ).prefetch_related(
+            'targets__accepted_count', 'targets__counts', 'targets__variances',
+            'attachments',
+        )
+
+    def _get(self, pk):
+        try:
+            return self.get_queryset().get(pk=pk)
+        except Stocktake.DoesNotExist as exc:
+            from rest_framework.exceptions import NotFound  # pylint: disable=import-outside-toplevel
+            raise NotFound('Stocktake not found.') from exc
+
+    def list(self, request):  # pylint: disable=unused-argument
+        """List session summaries without returning every count sheet."""
+        rows = []
+        for stocktake in self.get_queryset():
+            data = stocktake_data(stocktake)
+            data.pop('targets')
+            data.pop('attachments')
+            rows.append(data)
+        return Response(rows)
+
+    def retrieve(self, request, pk=None):  # pylint: disable=unused-argument
+        """Return one blind count sheet or revealed review document."""
+        return Response(stocktake_data(self._get(pk)))
+
+    def create(self, request):
+        """Resolve and freeze scope immediately when a session opens."""
+        if 'lines' in request.data:
+            from .ledger_rest import StocktakeSerializer  # pylint: disable=import-outside-toplevel
+            serializer = StocktakeSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            stocktake = serializer.save(
+                workspace=self.get_current_workspace(), created_by=request.user,
+            )
+            return Response(stocktake_data(stocktake), status=status.HTTP_201_CREATED)
+        serializer = StocktakeCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        stocktake = _run(
+            open_stocktake, self.get_current_workspace(), request.user,
+            **serializer.validated_data,
+        )
+        return Response(stocktake_data(self._get(stocktake.pk)), status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=['post'], url_path='scope-preview')
+    def scope_preview(self, request):
+        """Show target totals without creating audit records."""
+        serializer = ScopeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        rows = _run(scope_rows, self.get_current_workspace(), serializer.validated_data)
+        totals = {choice: 0 for choice in StocktakeTarget.TargetType.values}
+        for row in rows:
+            totals[row['target_type']] += 1
+        return Response({'total': len(rows), 'by_type': totals})
+
+    @action(detail=True, methods=['post'])
+    def count(self, request, pk=None):
+        """Append one manual quantity or identity count."""
+        stocktake = self._get(pk)
+        serializer = CountSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        target_id = values.pop('target')
+        count = _run(record_count, stocktake, request.user, target_id, **values)
+        return Response(_count_data(count), status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'], url_path='scan-count')
+    def scan_count(self, request, pk=None):
+        """Resolve and retain one scanned identity and exact code snapshot."""
+        stocktake = self._get(pk)
+        serializer = ScanCountSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        code_value = serializer.validated_data.pop('code').strip().upper()
+        code = LabelCode.objects.select_related(
+            'identity__target_content_type',
+        ).filter(workspace=self.get_current_workspace(), code=code_value).first()
+        if code is None:
+            if LabelCode.objects.filter(code=code_value).exists():
+                raise serializers.ValidationError({'code': 'This code belongs to another workspace.'})
+            raise serializers.ValidationError({'code': 'No label uses this code.'})
+        identity = code.identity
+        mapping = {
+            'seedtray': StocktakeTarget.TargetType.TRAY,
+            'plantcohort': StocktakeTarget.TargetType.COHORT,
+            'specificplant': StocktakeTarget.TargetType.PLANT,
+        }
+        target_type = mapping.get(identity.target_content_type.model)
+        if target_type is None:
+            raise serializers.ValidationError({'code': 'This identity cannot be counted in a stocktake.'})
+        key = f'{target_type}:{identity.target_object_id}'
+        target = stocktake.targets.filter(target_key=key).first()
+        if target is None:
+            with transaction.atomic():
+                target = StocktakeTarget.objects.create(
+                    stocktake=stocktake, target_type=target_type,
+                    target_key=key, target_object_id=identity.target_object_id,
+                    display=identity.target_snapshot.get('display', key),
+                    expected_snapshot={}, source_revision='', unexpected=True,
+                )
+        values = serializer.validated_data
+        count = _run(
+            record_count, stocktake, request.user, target.pk,
+            code_snapshot=code.code,
+            resolved_identity={
+                'identity': identity.pk, 'object_id': identity.target_object_id,
+                'target_type': identity.target_content_type.model,
+                'code_status': code.status,
+            },
+            **values,
+        )
+        return Response(_count_data(count), status=status.HTTP_201_CREATED)
+
+    def _transition(self, pk, allowed, next_status):
+        stocktake = self._get(pk)
+        if stocktake.status not in allowed:
+            raise serializers.ValidationError({'status': 'This transition is not available.'})
+        Stocktake.objects.filter(pk=stocktake.pk).update(status=next_status, updated=timezone.now())
+        return Response(stocktake_data(self._get(pk)))
+
+    @action(detail=True, methods=['post'])
+    def pause(self, request, pk=None):  # pylint: disable=unused-argument
+        """Pause an open mobile count without losing progress."""
+        return self._transition(pk, {Stocktake.Status.OPEN}, Stocktake.Status.PAUSED)
+
+    @action(detail=True, methods=['post'])
+    def resume(self, request, pk=None):  # pylint: disable=unused-argument
+        """Resume a paused count."""
+        return self._transition(pk, {Stocktake.Status.PAUSED}, Stocktake.Status.OPEN)
+
+    @action(detail=True, methods=['post'], url_path='begin-review')
+    def review(self, request, pk=None):
+        """Reveal frozen expectations and calculate review variances."""
+        stocktake = _run(begin_review, self._get(pk), request.user)
+        return Response(stocktake_data(self._get(stocktake.pk)))
+
+    @action(detail=True, methods=['post'], url_path='request-recount')
+    def recount(self, request, pk=None):
+        """Return one reviewed target to blind counting."""
+        serializer = RecountSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        stocktake = self._get(pk)
+        try:
+            target = stocktake.targets.get(pk=serializer.validated_data['target'])
+        except StocktakeTarget.DoesNotExist as exc:
+            raise serializers.ValidationError({'target': 'Target not found.'}) from exc
+        stocktake = _run(
+            request_recount, stocktake, target, request.user,
+            serializer.validated_data['reason'],
+        )
+        return Response(stocktake_data(self._get(stocktake.pk)))
+
+    @action(detail=True, methods=['post'], url_path='resolve-variance')
+    def resolve(self, request, pk=None):
+        """Record one explicit reviewer-selected correction."""
+        serializer = VarianceResolutionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        stocktake = self._get(pk)
+        try:
+            variance = StocktakeVariance.objects.get(
+                pk=serializer.validated_data.pop('variance'),
+                target__stocktake=stocktake,
+            )
+        except StocktakeVariance.DoesNotExist as exc:
+            raise serializers.ValidationError({'variance': 'Variance not found.'}) from exc
+        variance = _run(resolve_variance, variance, request.user, **serializer.validated_data)
+        return Response(_variance_data(variance))
+
+    @action(detail=True, methods=['post'])
+    def approve(self, request, pk=None):  # pylint: disable=unused-argument
+        """Approve a fully resolved review without changing source records."""
+        stocktake = _run(approve_stocktake, self._get(pk), request.user)
+        return Response(stocktake_data(self._get(stocktake.pk)))
+
+    @action(detail=True, methods=['post'])
+    def post(self, request, pk=None):  # pylint: disable=unused-argument
+        """Retain the legacy lot-only posting action during the transition."""
+        stocktake = self._get(pk)
+        if stocktake.targets.exists():
+            raise serializers.ValidationError({'status': 'Approve this session before posting.'})
+        stocktake, _movements = _run(post_stocktake, stocktake, request.user)
+        return Response(stocktake_data(stocktake))
+
+    @action(detail=True, methods=['post'])
+    def reverse(self, request, pk=None):
+        """Reverse a legacy lot-only stocktake through its existing service."""
+        serializer = ReasonSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        stocktake = self._get(pk)
+        if stocktake.targets.exists():
+            raise serializers.ValidationError({'status': 'Use reviewed-session reversal.'})
+        stocktake, _movements = _run(
+            reverse_stocktake, stocktake, request.user,
+            serializer.validated_data['reason'],
+        )
+        return Response(stocktake_data(stocktake))
+
+    @action(detail=True, methods=['post'], url_path='attachments')
+    def attach(self, request, pk=None):
+        """Retain a URL-based photo or document with the session."""
+        serializer = AttachmentSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        stocktake = self._get(pk)
+        target_id = serializer.validated_data.pop('target', None)
+        target = None
+        if target_id:
+            try:
+                target = stocktake.targets.get(pk=target_id)
+            except StocktakeTarget.DoesNotExist as exc:
+                raise serializers.ValidationError({'target': 'Target not found.'}) from exc
+        row = StocktakeAttachment.objects.create(
+            stocktake=stocktake, target=target, created_by=request.user,
+            **serializer.validated_data,
+        )
+        return Response({'pk': row.pk, 'url': row.url}, status=status.HTTP_201_CREATED)

--- a/inventory/stocktakes.py
+++ b/inventory/stocktakes.py
@@ -1,0 +1,450 @@
+"""Frozen-scope counting and review services for nursery stocktakes."""
+
+# Mixed stocktakes intentionally coordinate several authoritative domains.
+# pylint: disable=too-many-locals,too-many-branches,too-many-arguments,too-many-positional-arguments
+
+from decimal import Decimal
+from hashlib import sha256
+import json
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from locations.models import Location
+from plantings.growth import current_growth
+from plantings.lifecycle import plant_lifecycle_summary
+from plantings.models import PlantCohort, SpecificPlant, SpecificPlantLocation
+from seeds.models import SeedPacket
+from seeds.services import packet_inventory_snapshot
+from seedtrays.models import SeedTray
+
+from .ledger import physical_balance, quantize_quantity, unit_physical_state
+from .models import (
+    InventoryItem,
+    StockLot,
+    Stocktake,
+    StocktakeCount,
+    StocktakeTarget,
+    StocktakeVariance,
+)
+
+
+QUANTITY_TARGETS = {
+    StocktakeTarget.TargetType.LOT,
+    StocktakeTarget.TargetType.SEED_PACKET,
+    StocktakeTarget.TargetType.COHORT,
+}
+IDENTITY_TARGETS = {
+    StocktakeTarget.TargetType.TRAY,
+    StocktakeTarget.TargetType.PLANT,
+}
+
+
+def _digest(value):
+    encoded = json.dumps(value, sort_keys=True, separators=(',', ':')).encode()
+    return sha256(encoded).hexdigest()
+
+
+def _location_ids(workspace, scope):
+    location_id = scope.get('location')
+    if not location_id:
+        raise ValidationError({'location': 'Select a stocktake location.'})
+    try:
+        location = Location.objects.get(pk=location_id, workspace=workspace, active=True)
+    except Location.DoesNotExist as exc:
+        raise ValidationError({'location': 'Select an active location.'}) from exc
+    queryset = location.subtree() if scope.get('include_descendants') else Location.objects.filter(pk=location.pk)
+    return location, set(queryset.values_list('pk', flat=True))
+
+
+def _active_code(target):
+    """Return the current scannable code without requiring every target to have one."""
+    from labels.models import LabelCode, LabelIdentity  # pylint: disable=import-outside-toplevel
+
+    content_type = ContentType.objects.get_for_model(target, for_concrete_model=True)
+    identity = LabelIdentity.objects.filter(
+        workspace=target.workspace,
+        target_content_type=content_type,
+        target_object_id=target.pk,
+    ).first()
+    code = LabelCode.objects.filter(identity=identity, status=LabelCode.Status.ACTIVE).first() if identity else None
+    return code.code if code else ''
+
+
+def _target(target_type, key, instance, display, location, quantity, state, snapshot):
+    return {
+        'target_type': target_type,
+        'target_key': key,
+        'target_object_id': instance.pk,
+        'display': display,
+        'expected_location': location,
+        'expected_quantity': quantity,
+        'expected_state': state or '',
+        'expected_snapshot': snapshot,
+        'source_revision': _digest(snapshot),
+    }
+
+
+def _lot_targets(workspace, location_ids, scope):
+    packets = set(SeedPacket.objects.filter(workspace=workspace, stock_lot__isnull=False).values_list('stock_lot_id', flat=True))
+    lots = StockLot.objects.filter(
+        workspace=workspace,
+        item__active=True,
+        item__tracking_mode=InventoryItem.TrackingMode.LOT,
+    ).exclude(pk__in=packets).select_related('item')
+    if scope.get('item'):
+        lots = lots.filter(item_id=scope['item'])
+    if scope.get('category'):
+        lots = lots.filter(item__category=scope['category'])
+    locations = Location.objects.filter(pk__in=location_ids)
+    rows = []
+    for lot in lots:
+        for location in locations:
+            quantity = quantize_quantity(physical_balance(lot, location))
+            if quantity <= 0:
+                continue
+            snapshot = {
+                'quantity': str(quantity), 'location': location.pk,
+                'item': lot.item_id, 'unit': lot.item.base_unit,
+                'last_movement': lot.movements.order_by('-pk').values_list('pk', flat=True).first(),
+                'unit_cost': str(lot.base_unit_cost) if lot.base_unit_cost is not None else None,
+                'currency': lot.currency_code,
+            }
+            rows.append(_target(
+                StocktakeTarget.TargetType.LOT, f'lot:{lot.pk}:location:{location.pk}',
+                lot, f'{lot.item.name} · {lot.identifier}', location,
+                quantity, '', snapshot,
+            ))
+    return rows
+
+
+def _packet_targets(workspace, location_ids, scope):
+    packets = SeedPacket.objects.filter(
+        workspace=workspace, storage_location_id__in=location_ids,
+        stock_lot__isnull=False,
+    ).select_related('seeds', 'stock_lot__item', 'storage_location')
+    if scope.get('item'):
+        packets = packets.filter(stock_lot__item_id=scope['item'])
+    if scope.get('category') and scope['category'] != InventoryItem.Category.SEED:
+        return []
+    rows = []
+    for packet in packets:
+        inventory = packet_inventory_snapshot(packet)
+        quantity = inventory['remaining_quantity']
+        snapshot = {
+            'quantity': str(quantity) if quantity is not None else None,
+            'certainty': inventory['quantity_certainty'],
+            'location': packet.storage_location_id,
+            'lot': packet.stock_lot_id,
+            'last_reconciliation': packet.quantity_reconciliations.order_by('-pk').values_list('pk', flat=True).first(),
+            'last_movement': packet.stock_lot.movements.order_by('-pk').values_list('pk', flat=True).first(),
+            'unit': inventory['base_unit'],
+            'unit_cost': str(inventory['effective_base_unit_cost']) if inventory['effective_base_unit_cost'] is not None else None,
+            'currency': inventory['currency_code'],
+        }
+        rows.append(_target(
+            StocktakeTarget.TargetType.SEED_PACKET, f'seed_packet:{packet.pk}',
+            packet, str(packet.seeds), packet.storage_location,
+            quantity, inventory['quantity_certainty'], snapshot,
+        ))
+    return rows
+
+
+def _tray_targets(workspace, location_ids, scope):
+    trays = SeedTray.objects.filter(
+        workspace=workspace,
+        inventory_unit__current_location_id__in=location_ids,
+    ).select_related('inventory_unit__current_location', 'inventory_unit__item')
+    if scope.get('item'):
+        trays = trays.filter(inventory_unit__item_id=scope['item'])
+    if scope.get('category') and scope['category'] != InventoryItem.Category.TRAY:
+        return []
+    rows = []
+    for tray in trays:
+        unit = tray.inventory_unit
+        state = unit_physical_state(unit)
+        if scope.get('tray_state') and scope['tray_state'] != state:
+            continue
+        snapshot = {
+            'location': unit.current_location_id, 'state': state,
+            'unit': unit.pk, 'asset_code': unit.asset_code,
+            'label_code': _active_code(tray),
+            'last_movement': unit.movements.order_by('-pk').values_list('pk', flat=True).first(),
+            'acquisition_cost': str(unit.acquisition_cost) if unit.acquisition_cost is not None else None,
+            'currency': unit.currency_code,
+        }
+        rows.append(_target(
+            StocktakeTarget.TargetType.TRAY, f'tray:{tray.pk}', tray,
+            str(tray), unit.current_location, Decimal('1'), state, snapshot,
+        ))
+    return rows
+
+
+def _cohort_targets(workspace, location_ids, scope):
+    cohorts = PlantCohort.objects.filter(
+        workspace=workspace, location_id__in=location_ids, quantity__gt=0,
+    ).select_related('location', 'batch__variety__plant')
+    if scope.get('variety'):
+        cohorts = cohorts.filter(batch__variety_id=scope['variety'])
+    rows = []
+    for cohort in cohorts:
+        growth = current_growth(cohort)
+        stage = growth['stage']
+        if scope.get('stage') and (stage is None or stage.pk != int(scope['stage'])):
+            continue
+        snapshot = {
+            'quantity': cohort.quantity, 'location': cohort.location_id,
+            'state': cohort.lifecycle_state, 'revision': cohort.revision,
+            'variety': cohort.batch.variety_id,
+            'stage': stage.pk if stage else None, 'label_code': _active_code(cohort),
+        }
+        rows.append(_target(
+            StocktakeTarget.TargetType.COHORT, f'cohort:{cohort.pk}', cohort,
+            str(cohort), cohort.location, Decimal(cohort.quantity),
+            cohort.lifecycle_state, snapshot,
+        ))
+    return rows
+
+
+def _plant_location(plant):
+    placement = plant.locations.filter(ended__isnull=True).select_related(
+        'location', 'seed_tray_cell__seed_tray__inventory_unit__current_location',
+    ).first()
+    if placement is None:
+        return None
+    if placement.location_type == SpecificPlantLocation.LOCATION:
+        return placement.location
+    if placement.location_type == SpecificPlantLocation.SEED_TRAY_CELL:
+        return placement.seed_tray_cell.seed_tray.inventory_unit.current_location
+    return None
+
+
+def _plant_targets(workspace, location_ids, scope):
+    plants = SpecificPlant.objects.filter(workspace=workspace).select_related(
+        'batch__variety__plant',
+    ).prefetch_related('locations', 'lifecycle_events')
+    if scope.get('variety'):
+        plants = plants.filter(batch__variety_id=scope['variety'])
+    rows = []
+    for plant in plants:
+        location = _plant_location(plant)
+        if location is None or location.pk not in location_ids:
+            continue
+        state = plant_lifecycle_summary(plant).state
+        snapshot = {
+            'location': location.pk, 'state': state, 'batch': plant.batch_id,
+            'label_code': _active_code(plant),
+            'last_event': plant.lifecycle_events.order_by('-pk').values_list('pk', flat=True).first(),
+            'active_placement': plant.locations.filter(ended__isnull=True).values_list('pk', flat=True).first(),
+        }
+        rows.append(_target(
+            StocktakeTarget.TargetType.PLANT, f'plant:{plant.pk}', plant,
+            str(plant), location, Decimal('1'), state, snapshot,
+        ))
+    return rows
+
+
+SOURCE_BUILDERS = {
+    StocktakeTarget.TargetType.LOT: _lot_targets,
+    StocktakeTarget.TargetType.SEED_PACKET: _packet_targets,
+    StocktakeTarget.TargetType.TRAY: _tray_targets,
+    StocktakeTarget.TargetType.COHORT: _cohort_targets,
+    StocktakeTarget.TargetType.PLANT: _plant_targets,
+}
+
+
+def scope_rows(workspace, scope):
+    """Resolve current authoritative records selected by a scope contract."""
+    _location, location_ids = _location_ids(workspace, scope)
+    selected = scope.get('target_types') or list(SOURCE_BUILDERS)
+    invalid = set(selected) - set(SOURCE_BUILDERS)
+    if invalid:
+        raise ValidationError({'target_types': f'Unsupported target types: {sorted(invalid)}.'})
+    rows = []
+    for target_type in selected:
+        rows.extend(SOURCE_BUILDERS[target_type](workspace, location_ids, scope))
+    return rows
+
+
+@transaction.atomic
+def open_stocktake(workspace, user, scope, *, blind=True, notes=''):
+    """Freeze one scope and every expected physical fact at the same instant."""
+    rows = scope_rows(workspace, scope)
+    if not rows:
+        raise ValidationError({'scope': 'The selected scope contains no stock.'})
+    now = timezone.now()
+    stocktake = Stocktake.objects.create(
+        workspace=workspace, status=Stocktake.Status.OPEN,
+        counted_at=now, notes=notes, blind=blind, scope=scope,
+        scope_digest=_digest(sorted(row['target_key'] for row in rows)),
+        created_by=user,
+    )
+    StocktakeTarget.objects.bulk_create(
+        StocktakeTarget(stocktake=stocktake, **row) for row in rows
+    )
+    return stocktake
+
+
+@transaction.atomic
+def record_count(stocktake, user, target_id, *, counted_quantity=None,
+                 observed_location=None, observed_state='', code_snapshot='',
+                 resolved_identity=None, notes=''):
+    """Append one accepted count attempt without changing source records."""
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.OPEN:
+        raise ValidationError({'status': 'Resume this stocktake before counting.'})
+    target = StocktakeTarget.objects.select_for_update().get(
+        pk=target_id, stocktake=stocktake,
+    )
+    if target.count_status == StocktakeTarget.CountStatus.COUNTED:
+        raise ValidationError({'target': 'This target is already counted.'})
+    if target.target_type in QUANTITY_TARGETS and counted_quantity is None:
+        raise ValidationError({'counted_quantity': 'Enter the physical quantity.'})
+    count = StocktakeCount.objects.create(
+        target=target, counted_quantity=counted_quantity,
+        observed_location=observed_location, observed_state=observed_state,
+        code_snapshot=code_snapshot, resolved_identity=resolved_identity or {},
+        notes=notes, counter=user,
+    )
+    target.accepted_count = count
+    target.count_status = StocktakeTarget.CountStatus.COUNTED
+    target.save(update_fields=['accepted_count', 'count_status', 'updated'])
+    return count
+
+
+def _current_row(stocktake, target):
+    rows = SOURCE_BUILDERS[target.target_type](
+        stocktake.workspace,
+        {target.expected_location_id} if target.expected_location_id else set(),
+        {},
+    )
+    return next((row for row in rows if row['target_key'] == target.target_key), None)
+
+
+def _variance_rows(target, current):
+    count = target.accepted_count
+    expected = target.expected_snapshot
+    observed = {
+        'quantity': str(count.counted_quantity) if count and count.counted_quantity is not None else None,
+        'location': count.observed_location_id if count else None,
+        'state': count.observed_state if count else '',
+        'code': count.code_snapshot if count else '',
+    }
+    kinds = []
+    if target.target_type in QUANTITY_TARGETS:
+        if count and count.counted_quantity != target.expected_quantity:
+            kinds.append(StocktakeVariance.Kind.QUANTITY)
+    elif count is None:
+        kinds.append(StocktakeVariance.Kind.MISSING)
+    if target.unexpected:
+        kinds.append(StocktakeVariance.Kind.EXCESS)
+    if count and count.observed_location_id and count.observed_location_id != target.expected_location_id:
+        kinds.append(StocktakeVariance.Kind.MISPLACED)
+    if count and count.observed_state and count.observed_state != target.expected_state:
+        kinds.append(StocktakeVariance.Kind.STATE)
+    revision = current['source_revision'] if current else ''
+    changed = revision != target.source_revision
+    return kinds, expected, observed, changed, revision
+
+
+@transaction.atomic
+def begin_review(stocktake, user):
+    """Reveal expected facts and calculate variances without posting corrections."""
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    if stocktake.status not in {Stocktake.Status.OPEN, Stocktake.Status.PAUSED}:
+        raise ValidationError({'status': 'Only an open stocktake can enter review.'})
+    targets = list(stocktake.targets.select_for_update().select_related('accepted_count'))
+    pending_quantities = [
+        target.pk for target in targets
+        if target.target_type in QUANTITY_TARGETS and target.accepted_count_id is None
+    ]
+    if pending_quantities:
+        raise ValidationError({'targets': f'Count quantity targets before review: {pending_quantities}.'})
+    StocktakeVariance.objects.filter(target__stocktake=stocktake).delete()
+    for target in targets:
+        current = _current_row(stocktake, target)
+        kinds, expected, observed, changed, revision = _variance_rows(target, current)
+        for kind in kinds:
+            StocktakeVariance.objects.create(
+                target=target, kind=kind, expected=expected, observed=observed,
+                source_changed=changed, current_revision=revision,
+            )
+    now = timezone.now()
+    Stocktake.objects.filter(pk=stocktake.pk).update(
+        status=Stocktake.Status.REVIEW, reviewed_by=user,
+        reviewed_at=now, updated=now,
+    )
+    stocktake.refresh_from_db()
+    return stocktake
+
+
+@transaction.atomic
+def request_recount(stocktake, target, user, reason):
+    """Return one reviewed target to counting while retaining its attempts."""
+    if not reason.strip():
+        raise ValidationError({'reason': 'Explain why a recount is needed.'})
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.REVIEW:
+        raise ValidationError({'status': 'Recounts are requested during review.'})
+    target = StocktakeTarget.objects.select_for_update().get(pk=target.pk, stocktake=stocktake)
+    target.count_status = StocktakeTarget.CountStatus.RECOUNT
+    target.save(update_fields=['count_status', 'updated'])
+    target.variances.update(
+        conflict_resolution=StocktakeVariance.ConflictResolution.RECOUNT,
+        conflict_reason=reason, resolved_by=user, resolved_at=timezone.now(),
+    )
+    Stocktake.objects.filter(pk=stocktake.pk).update(status=Stocktake.Status.OPEN)
+    stocktake.refresh_from_db()
+    return stocktake
+
+
+@transaction.atomic
+def resolve_variance(variance, user, *, action, reason, payload=None,
+                     accept_conflict=False):
+    """Record the reviewer's explicit correction and stale-fact decision."""
+    variance = StocktakeVariance.objects.select_for_update().select_related(
+        'target__stocktake',
+    ).get(pk=variance.pk)
+    if variance.target.stocktake.status != Stocktake.Status.REVIEW:
+        raise ValidationError({'status': 'Resolve variances during review.'})
+    if not reason.strip():
+        raise ValidationError({'reason': 'Explain the variance resolution.'})
+    if variance.source_changed and not accept_conflict:
+        raise ValidationError({'conflict': 'Explicitly accept or recount this changed source.'})
+    variance.resolution_action = action
+    variance.resolution_payload = payload or {}
+    variance.resolution_reason = reason
+    variance.resolved_by = user
+    variance.resolved_at = timezone.now()
+    if variance.source_changed:
+        variance.conflict_resolution = StocktakeVariance.ConflictResolution.ACCEPTED
+        variance.conflict_reason = reason
+    variance.save()
+    return variance
+
+
+@transaction.atomic
+def approve_stocktake(stocktake, user):
+    """Freeze a fully resolved review, enforcing optional counter separation."""
+    stocktake = Stocktake.objects.select_for_update().select_related('workspace').get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.REVIEW:
+        raise ValidationError({'status': 'Only a reviewed stocktake can be approved.'})
+    unresolved = stocktake.targets.filter(
+        variances__isnull=False, variances__resolved_at__isnull=True,
+    ).values_list('variances__pk', flat=True)
+    unresolved = list(unresolved)
+    if unresolved:
+        raise ValidationError({'variances': f'Resolve variances before approval: {unresolved}.'})
+    if stocktake.workspace.stocktake_two_person_required:
+        counters = stocktake.targets.filter(counts__counter=user).exists()
+        if counters:
+            raise ValidationError({'reviewer': 'A counter cannot approve this stocktake.'})
+    now = timezone.now()
+    Stocktake.objects.filter(pk=stocktake.pk).update(
+        status=Stocktake.Status.APPROVED, approved_by=user,
+        approved_at=now, updated=now,
+    )
+    stocktake.refresh_from_db()
+    return stocktake

--- a/inventory/stocktakes.py
+++ b/inventory/stocktakes.py
@@ -40,6 +40,11 @@ IDENTITY_TARGETS = {
     StocktakeTarget.TargetType.TRAY,
     StocktakeTarget.TargetType.PLANT,
 }
+IDENTITY_TARGET_MAPPING = {
+    'seedtray': StocktakeTarget.TargetType.TRAY,
+    'plantcohort': StocktakeTarget.TargetType.COHORT,
+    'specificplant': StocktakeTarget.TargetType.PLANT,
+}
 
 
 def _digest(value):
@@ -297,6 +302,29 @@ def transition_stocktake(stocktake, allowed_statuses, next_status):
         raise ValidationError({'status': 'This transition is not available.'})
     stocktake.refresh_from_db()
     return stocktake
+
+
+@transaction.atomic
+def resolve_identity_target(stocktake, identity):
+    """Resolve a scanned identity to one frozen or unexpected count target."""
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    target_type = IDENTITY_TARGET_MAPPING.get(identity.target_content_type.model)
+    if target_type is None:
+        raise ValidationError({'code': 'This identity cannot be counted in a stocktake.'})
+    key = f'{target_type}:{identity.target_object_id}'
+    target, _created = StocktakeTarget.objects.get_or_create(
+        stocktake=stocktake,
+        target_key=key,
+        defaults={
+            'target_type': target_type,
+            'target_object_id': identity.target_object_id,
+            'display': identity.target_snapshot.get('display', key),
+            'expected_snapshot': {},
+            'source_revision': '',
+            'unexpected': True,
+        },
+    )
+    return target
 
 
 @transaction.atomic

--- a/inventory/stocktakes.py
+++ b/inventory/stocktakes.py
@@ -287,6 +287,18 @@ def open_stocktake(workspace, user, scope, *, blind=True, notes=''):
     return stocktake
 
 
+def transition_stocktake(stocktake, allowed_statuses, next_status):
+    """Atomically apply a lightweight status transition to a current row."""
+    updated = Stocktake.objects.filter(
+        pk=stocktake.pk,
+        status__in=allowed_statuses,
+    ).update(status=next_status, updated=timezone.now())
+    if updated != 1:
+        raise ValidationError({'status': 'This transition is not available.'})
+    stocktake.refresh_from_db()
+    return stocktake
+
+
 @transaction.atomic
 def record_count(stocktake, user, target_id, *, counted_quantity=None,
                  observed_location=None, observed_state='', code_snapshot='',
@@ -355,7 +367,9 @@ def begin_review(stocktake, user):
     stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
     if stocktake.status not in {Stocktake.Status.OPEN, Stocktake.Status.PAUSED}:
         raise ValidationError({'status': 'Only an open stocktake can enter review.'})
-    targets = list(stocktake.targets.select_for_update().select_related('accepted_count'))
+    targets = list(
+        stocktake.targets.select_for_update(of=('self',)).select_related('accepted_count')
+    )
     pending_quantities = [
         target.pk for target in targets
         if target.target_type in QUANTITY_TARGETS and target.accepted_count_id is None

--- a/inventory/test_stocktake_workflow.py
+++ b/inventory/test_stocktake_workflow.py
@@ -6,17 +6,22 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
+from rest_framework.test import APITestCase
 
 from locations.models import Location
 from workspaces.models import get_current_workspace
 
+from .ledger import MovementRequest, OpeningBalanceRequest, post_opening_balance, post_stock_movement
 from .models import (
+    InventoryItem,
+    StockMovement,
     Stocktake,
     StocktakeAttachment,
     StocktakeCount,
     StocktakeTarget,
     StocktakeVariance,
 )
+from .units import UnitCode
 
 
 class StocktakeWorkflowModelTests(TestCase):
@@ -94,3 +99,143 @@ class StocktakeWorkflowModelTests(TestCase):
     def test_two_person_requirement_defaults_off(self):
         """Existing shared workspaces do not acquire a surprise restriction."""
         self.assertFalse(self.workspace.stocktake_two_person_required)
+
+
+class StocktakeWorkflowRestTests(APITestCase):
+    """Blind count sheets reveal expectations only when review begins."""
+
+    url = '/inventory/stocktakes/'
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.user = get_user_model().objects.create_user(username='stocktake-api')
+        self.reviewer = get_user_model().objects.create_user(username='stocktake-reviewer')
+        self.client.force_authenticate(self.user)
+        self.location = Location.objects.create(
+            workspace=self.workspace, name='Stock room', code='STOCK-ROOM',
+            location_type=Location.LocationType.STORAGE,
+        )
+        self.item = InventoryItem.objects.create(
+            workspace=self.workspace, name='Potting mix',
+            category=InventoryItem.Category.GROWING_MEDIA,
+            base_unit=UnitCode.MILLILITRE,
+        )
+        self.lot, _movement = post_opening_balance(
+            self.workspace, self.user,
+            OpeningBalanceRequest(
+                item=self.item, quantity=Decimal('100'),
+                destination=self.location, acquisition_total=Decimal('20'),
+                received_on=timezone.localdate(),
+            ),
+        )
+
+    def _open(self):
+        response = self.client.post(self.url, {
+            'scope': {
+                'location': self.location.pk,
+                'target_types': ['lot'],
+            },
+            'blind': True,
+            'notes': 'Monthly count',
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response
+
+    def test_blind_count_review_and_approval_preserve_attempt(self):
+        """Review reveals the snapshot and requires an explicit variance action."""
+        opened = self._open()
+        target = opened.data['targets'][0]
+        self.assertIsNone(target['expected_quantity'])
+        counted = self.client.post(
+            f"{self.url}{opened.data['pk']}/count/",
+            {'target': target['pk'], 'counted_quantity': '95'},
+            format='json',
+        )
+        self.assertEqual(counted.status_code, 201, counted.data)
+
+        reviewed = self.client.post(
+            f"{self.url}{opened.data['pk']}/begin-review/", {}, format='json',
+        )
+        self.assertEqual(reviewed.status_code, 200, reviewed.data)
+        target = reviewed.data['targets'][0]
+        self.assertEqual(target['expected_quantity'], '100.000000000')
+        variance = target['variances'][0]
+        self.assertEqual(variance['kind'], StocktakeVariance.Kind.QUANTITY)
+
+        resolved = self.client.post(
+            f"{self.url}{opened.data['pk']}/resolve-variance/",
+            {
+                'variance': variance['pk'], 'action': 'adjust',
+                'reason': 'Measured spill',
+            },
+            format='json',
+        )
+        self.assertEqual(resolved.status_code, 200, resolved.data)
+        approved = self.client.post(
+            f"{self.url}{opened.data['pk']}/approve/", {}, format='json',
+        )
+        self.assertEqual(approved.status_code, 200, approved.data)
+        self.assertEqual(approved.data['status'], Stocktake.Status.APPROVED)
+        self.assertEqual(len(approved.data['targets'][0]['counts']), 1)
+
+    def test_changed_source_requires_explicit_conflict_acceptance(self):
+        """A movement after opening cannot be silently folded into approval."""
+        opened = self._open()
+        target = opened.data['targets'][0]
+        self.client.post(
+            f"{self.url}{opened.data['pk']}/count/",
+            {'target': target['pk'], 'counted_quantity': '90'}, format='json',
+        )
+        post_stock_movement(
+            self.workspace, self.user,
+            MovementRequest(
+                lot=self.lot,
+                movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=Decimal('1'), source=self.location,
+            ),
+        )
+        reviewed = self.client.post(
+            f"{self.url}{opened.data['pk']}/begin-review/", {}, format='json',
+        )
+        variance = reviewed.data['targets'][0]['variances'][0]
+        self.assertTrue(variance['source_changed'])
+        rejected = self.client.post(
+            f"{self.url}{opened.data['pk']}/resolve-variance/",
+            {
+                'variance': variance['pk'], 'action': 'adjust',
+                'reason': 'Reviewed movement',
+            }, format='json',
+        )
+        self.assertEqual(rejected.status_code, 400)
+        accepted = self.client.post(
+            f"{self.url}{opened.data['pk']}/resolve-variance/",
+            {
+                'variance': variance['pk'], 'action': 'adjust',
+                'reason': 'Reviewed movement', 'accept_conflict': True,
+            }, format='json',
+        )
+        self.assertEqual(accepted.status_code, 200, accepted.data)
+
+    def test_two_person_rule_rejects_a_counter_as_reviewer(self):
+        """Optional separation applies to identities even before task 58 roles."""
+        self.workspace.stocktake_two_person_required = True
+        self.workspace.save(update_fields=['stocktake_two_person_required', 'updated'])
+        opened = self._open()
+        target = opened.data['targets'][0]
+        self.client.post(
+            f"{self.url}{opened.data['pk']}/count/",
+            {'target': target['pk'], 'counted_quantity': '100'}, format='json',
+        )
+        self.client.post(
+            f"{self.url}{opened.data['pk']}/begin-review/", {}, format='json',
+        )
+        rejected = self.client.post(
+            f"{self.url}{opened.data['pk']}/approve/", {}, format='json',
+        )
+        self.assertEqual(rejected.status_code, 400)
+        self.client.force_authenticate(self.reviewer)
+        approved = self.client.post(
+            f"{self.url}{opened.data['pk']}/approve/", {}, format='json',
+        )
+        self.assertEqual(approved.status_code, 200, approved.data)

--- a/inventory/test_stocktake_workflow.py
+++ b/inventory/test_stocktake_workflow.py
@@ -21,6 +21,7 @@ from .models import (
     StocktakeTarget,
     StocktakeVariance,
 )
+from .stocktakes import transition_stocktake
 from .units import UnitCode
 
 
@@ -99,6 +100,23 @@ class StocktakeWorkflowModelTests(TestCase):
     def test_two_person_requirement_defaults_off(self):
         """Existing shared workspaces do not acquire a surprise restriction."""
         self.assertFalse(self.workspace.stocktake_two_person_required)
+
+    def test_status_transition_rejects_a_stale_instance(self):
+        """A concurrent status change cannot be overwritten by a stale request."""
+        stale_stocktake = Stocktake.objects.get(pk=self.stocktake.pk)
+        Stocktake.objects.filter(pk=self.stocktake.pk).update(
+            status=Stocktake.Status.PAUSED,
+        )
+
+        with self.assertRaisesMessage(ValidationError, 'transition is not available'):
+            transition_stocktake(
+                stale_stocktake,
+                {Stocktake.Status.OPEN},
+                Stocktake.Status.PAUSED,
+            )
+
+        self.stocktake.refresh_from_db()
+        self.assertEqual(self.stocktake.status, Stocktake.Status.PAUSED)
 
 
 class StocktakeWorkflowRestTests(APITestCase):

--- a/inventory/test_stocktake_workflow.py
+++ b/inventory/test_stocktake_workflow.py
@@ -1,6 +1,7 @@
 """Model contracts for reviewed nursery stocktake evidence."""
 
 from decimal import Decimal
+from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -21,7 +22,7 @@ from .models import (
     StocktakeTarget,
     StocktakeVariance,
 )
-from .stocktakes import transition_stocktake
+from .stocktakes import resolve_identity_target, transition_stocktake
 from .units import UnitCode
 
 
@@ -117,6 +118,22 @@ class StocktakeWorkflowModelTests(TestCase):
 
         self.stocktake.refresh_from_db()
         self.assertEqual(self.stocktake.status, Stocktake.Status.PAUSED)
+
+    def test_scanned_identity_resolution_reuses_an_unexpected_target(self):
+        """Scan orchestration creates one stable target outside the frozen scope."""
+        identity = SimpleNamespace(
+            target_content_type=SimpleNamespace(model='plantcohort'),
+            target_object_id=19,
+            target_snapshot={'display': 'Cohort 19'},
+        )
+
+        first = resolve_identity_target(self.stocktake, identity)
+        second = resolve_identity_target(self.stocktake, identity)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.target_type, StocktakeTarget.TargetType.COHORT)
+        self.assertEqual(first.display, 'Cohort 19')
+        self.assertTrue(first.unexpected)
 
 
 class StocktakeWorkflowRestTests(APITestCase):

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -169,6 +169,18 @@ def _resolution(code, workspace):  # pylint: disable=too-many-locals
     active_cohort = active_cohort and identity.target.quantity > 0
     if active_cohort:
         capabilities.append('cohort_operation')
+    stocktake_types = {
+        ('plantings', 'specificplant'),
+        ('plantings', 'plantcohort'),
+        ('seedtrays', 'seedtray'),
+    }
+    stocktake_enabled = all((
+        workspace.mode == Workspace.Mode.NURSERY,
+        resolution_status == LabelCode.Status.ACTIVE,
+        key in stocktake_types,
+    ))
+    if stocktake_enabled:
+        capabilities.append('stocktake_count')
     health_scopes = {
         ('plantings', 'specificplant'): 'plant',
         ('plantings', 'plantcohort'): 'cohort',


### PR DESCRIPTION
Operators need blind mixed-domain count sheets, retained recount evidence, explicit stale-source decisions, and scan support before any authoritative inventory corrections are allowed.

## Summary by Sourcery

Introduce a nursery-specific stocktake workflow that freezes mixed-domain scopes, supports blind counting, review with explicit variance resolution, and approval with optional two-person separation.

New Features:
- Expose a nursery stocktake REST API with endpoints for opening scoped sessions, counting (including scan-based counts), reviewing variances, approving, posting/reversing legacy sessions, and attaching evidence.
- Support scoped nursery stocktakes across lots, seed packets, trays, cohorts, and plants, including scope previews that report target totals before opening a session.
- Add label capabilities that mark certain nursery labels as eligible for stocktake counting.

Enhancements:
- Ensure stocktakes retain count attempts, review decisions, and attachment evidence, including reconciliation of source changes before approval.
- Enforce workspace-configurable two-person rules so counters cannot approve stocktakes when separation is required.

Tests:
- Add REST workflow tests covering blind count sheets, variance review and resolution, conflict acceptance when sources change, and enforcement of the two-person approval rule.