### PR TITLE
fix(seedtrays): align cell grid orientation

### DIFF
--- a/frontend/js/planting.tsx
+++ b/frontend/js/planting.tsx
@@ -35,6 +35,7 @@ import { SeedTrayCell } from './types/seedtrays'
 import { getSuppliers } from './api/supplies'
 import { BatchChooser, isChoiceComplete, type BatchChoice } from './plantings/batch_chooser'
 import { queryKeys } from './query'
+import { buildSeedTrayCellGrid } from './seedtray/grid'
 
 function packetVarietyPk(packetPk: number | undefined, packets: Array<SeedPacket>, seeds: Array<Seed>): number | undefined {
   if (packetPk === undefined) {
@@ -54,6 +55,7 @@ function packetBalanceLabel(packet: SeedPacket): string {
 
 interface SeedTrayCellGridProps {
   cells: Array<SeedTrayCell>
+  model: SeedTrayModel
   cellQuantities: { [cellPk: number]: number }
   quantity: number
   onUpdateCellQuantity: (cellPk: number, qty: number) => void
@@ -61,42 +63,41 @@ interface SeedTrayCellGridProps {
 
 class SeedTrayCellGrid extends React.PureComponent<SeedTrayCellGridProps> {
   render() {
-    const { cells, cellQuantities, quantity, onUpdateCellQuantity } = this.props
-    const cellsPerRow = 8
-    const cellGridRows = []
+    const { cells, model, cellQuantities, quantity, onUpdateCellQuantity } = this.props
+    const cellGrid = buildSeedTrayCellGrid(model, cells)
+    const cellGridRows = cellGrid.map((rowCells, rowIndex) => (
+      <tr key={rowIndex}>
+        {rowCells.map((cell, columnIndex) => (
+          <td key={cell?.pk ?? `empty-${rowIndex}-${columnIndex}`} style={{ padding: '8px', border: '1px solid #ccc', textAlign: 'center' }}>
+            {cell && (
+              <>
+                <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
+                  Cell {cell.x_position}, {cell.y_position}
+                </div>
+                <input
+                  type="number"
+                  min="0"
+                  placeholder="Qty"
+                  value={cellQuantities[cell.pk] || ''}
+                  onChange={(e) => {
+                    const rawValue = e.target.value
+                    const parsed = parseInt(rawValue, 10)
 
-    for (let i = 0; i < cells.length; i += cellsPerRow) {
-      const rowCells = cells.slice(i, i + cellsPerRow)
-      cellGridRows.push(
-        <tr key={i}>
-          {rowCells.map((cell) => (
-            <td key={cell.pk} style={{ padding: '8px', border: '1px solid #ccc', textAlign: 'center' }}>
-              <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
-                Cell {cell.x_position}, {cell.y_position}
-              </div>
-              <input
-                type="number"
-                min="0"
-                placeholder="Qty"
-                value={cellQuantities[cell.pk] || ''}
-                onChange={(e) => {
-                  const rawValue = e.target.value
-                  const parsed = parseInt(rawValue, 10)
+                    if (Number.isNaN(parsed)) {
+                      return
+                    }
 
-                  if (Number.isNaN(parsed)) {
-                    return
-                  }
-
-                  const clamped = Math.max(0, parsed)
-                  onUpdateCellQuantity(cell.pk, clamped)
-                }}
-                style={{ width: '50px' }}
-              />
-            </td>
-          ))}
-        </tr>
-      )
-    }
+                    const clamped = Math.max(0, parsed)
+                    onUpdateCellQuantity(cell.pk, clamped)
+                  }}
+                  style={{ width: '50px' }}
+                />
+              </>
+            )}
+          </td>
+        ))}
+      </tr>
+    ))
 
     const cellTotal = Object.values(cellQuantities).reduce((sum, qty) => sum + qty, 0)
 
@@ -229,6 +230,7 @@ function NewSeedTrayPlantingRow({ suppliers, varieties, seeds, seedPackets, seed
     )
   }
   const trayOptions = seedTrays.map((tray) => ({ value: tray.pk, label: `${tray.pk} (${seedTrayModels[tray.model]?.description})` }))
+  const selectedSeedTrayModel = seedTray === undefined ? undefined : seedTrayModels[seedTrays.find((tray) => tray.pk === seedTray)?.model ?? 0]
 
   return (
     <>
@@ -264,11 +266,11 @@ function NewSeedTrayPlantingRow({ suppliers, varieties, seeds, seedPackets, seed
           <Button onClick={done}>Cancel</Button>
         </td>
       </tr>
-      {seedTray !== undefined && seedTrayCells.length > 0 && (
+      {seedTray !== undefined && selectedSeedTrayModel && seedTrayCells.length > 0 && (
         <tr>
           <td colSpan={8} style={{ padding: '16px' }}>
             <div style={{ marginBottom: '8px', fontWeight: 'bold' }}>Select cells and quantities:</div>
-            <SeedTrayCellGrid cells={seedTrayCells} cellQuantities={cellQuantities} quantity={quantity} onUpdateCellQuantity={updateCellQuantity} />
+            <SeedTrayCellGrid cells={seedTrayCells} model={selectedSeedTrayModel} cellQuantities={cellQuantities} quantity={quantity} onUpdateCellQuantity={updateCellQuantity} />
           </td>
         </tr>
       )}

--- a/frontend/js/seedtray/grid.ts
+++ b/frontend/js/seedtray/grid.ts
@@ -1,0 +1,16 @@
+import { SeedTrayCell, SeedTrayModel } from '../types/seedtrays'
+
+function buildSeedTrayCellGrid(model: SeedTrayModel | undefined, cells: Array<SeedTrayCell>): (SeedTrayCell | undefined)[][] {
+  if (!model) return []
+  const grid: (SeedTrayCell | undefined)[][] = Array.from({ length: model.y_cells }, () => Array.from({ length: model.x_cells }, () => undefined))
+  cells.forEach((cell) => {
+    if (cell.x_position < 0 || cell.x_position >= model.x_cells) return
+    if (cell.y_position < 0 || cell.y_position >= model.y_cells) return
+    if (grid[cell.y_position][cell.x_position] === undefined) {
+      grid[cell.y_position][cell.x_position] = cell
+    }
+  })
+  return grid
+}
+
+export { buildSeedTrayCellGrid }

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { QueryClientProvider, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { CleanMediaDisposition, CleanPlantDisposition, CleanSeedDisposition, SeedTray, SeedTrayCell, SeedTrayGeneration, SeedTrayModel } from '../types/seedtrays'
+import { CleanMediaDisposition, CleanPlantDisposition, CleanSeedDisposition, SeedTray, SeedTrayCell, SeedTrayGeneration } from '../types/seedtrays'
 import { localDatetimeInputValue, parseLocalDatetimeInput, formatDate, formatDateTime } from '../utils'
 import {
   cleanSeedTrayGeneration,
@@ -24,6 +24,7 @@ import {
   reviewSeedTrayGeneration
 } from '../api/seedtrays'
 import { GenerationCleanForm, GenerationCostPanel } from './generation_clean'
+import { buildSeedTrayCellGrid } from './grid'
 import { Alert, Button, Card, Form, Table } from 'react-bootstrap'
 import { BulkPlantOperationRequest, PlantLifecycleEvent, PlantOutcomeAction, SeedTrayPlanting, SpecificPlant, SpecificPlantLocation, SpecificPlantMove } from '../types/plantings'
 import {
@@ -94,19 +95,6 @@ function computeCellData(specificPlants: Array<SpecificPlant> | undefined, plant
   return { cellCurrentPlantMap, cellPlantingMap, germinatedByCellPlanting, cellTotals }
 }
 
-function buildCellGrid(model: SeedTrayModel | undefined, cells: Array<SeedTrayCell>): (SeedTrayCell | undefined)[][] {
-  if (!model) return []
-  const grid: (SeedTrayCell | undefined)[][] = Array.from({ length: model.x_cells }, () => Array.from({ length: model.y_cells }, () => undefined))
-  cells.forEach((cell) => {
-    if (cell.x_position < 0 || cell.x_position >= model.x_cells) return
-    if (cell.y_position < 0 || cell.y_position >= model.y_cells) return
-    if (grid[cell.x_position][cell.y_position] === undefined) {
-      grid[cell.x_position][cell.y_position] = cell
-    }
-  })
-  return grid
-}
-
 function currentLocation(plant: SpecificPlant): SpecificPlantLocation | undefined {
   return plant.locations.find((l) => !l.ended)
 }
@@ -166,7 +154,7 @@ const SeedTrayCellView: React.FC<SeedTrayCellViewProps> = ({
 
   return (
     <td style={{ textAlign: 'center', minWidth: 70, verticalAlign: 'top' }}>
-      <div>{cell?.pk ?? ''}</div>
+      <div>{cell ? `Cell ${cell.x_position}, ${cell.y_position}` : ''}</div>
       {cell && <div style={{ fontWeight: 'bold' }}>{total || 0} sown</div>}
       {cell && <div style={{ color: 'green', fontSize: '0.85em' }}>{totalGerminated} germinated</div>}
       {plants.map((plant) => {
@@ -671,7 +659,7 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
   }, {})
   const seedTray = selectedSeedTray
   const seedTrayModel = seedTrayModels.find((model) => model.pk === seedTray?.model)
-  const seedTrayCells = buildCellGrid(seedTrayModel, allCells)
+  const seedTrayCells = buildSeedTrayCellGrid(seedTrayModel, allCells)
   const seeds = seedPacketDetails.reduce<Record<number, SeedPacketDetails>>((packets, packet) => {
     packets[packet.pk] = packet
     return packets


### PR DESCRIPTION
Render tray cells from their model coordinates in both sowing and detail views. This keeps x horizontal and y vertical, and labels cells by coordinates instead of database creation order.

## Summary by Sourcery

Align seed tray cell rendering with model coordinates in sowing and detail views, ensuring consistent x/y orientation and coordinate-based labeling.

New Features:
- Introduce a shared grid builder utility for arranging seed tray cells according to tray model dimensions.

Enhancements:
- Use tray model metadata when displaying seed tray cells in planting flows to reflect the actual physical layout.
- Update seed tray detail views to label cells by their x/y coordinates instead of database primary keys.