### PR TITLE
feat(stocktake): post domain corrections atomically

### DIFF
--- a/inventory/migrations/0010_stocktaketarget_review_revision_and_more.py
+++ b/inventory/migrations/0010_stocktaketarget_review_revision_and_more.py
@@ -1,0 +1,44 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0009_stocktake_approved_at_stocktake_approved_by_and_more'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='stocktaketarget',
+            name='review_revision',
+            field=models.CharField(blank=True, default='', max_length=64),
+        ),
+        migrations.AddField(
+            model_name='stocktaketarget',
+            name='review_snapshot',
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.CreateModel(
+            name='StocktakeReconciliation',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('phase', models.CharField(choices=[('post', 'Posted correction'), ('reverse', 'Reversal correction')], max_length=8)),
+                ('domain', models.CharField(max_length=32)),
+                ('result_app', models.CharField(max_length=64)),
+                ('result_model', models.CharField(max_length=64)),
+                ('result_object_id', models.PositiveBigIntegerField()),
+                ('before', models.JSONField(default=dict)),
+                ('after', models.JSONField(default=dict)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('created_by', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('reverses', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='reversed_by', to='inventory.stocktakereconciliation')),
+                ('target', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='reconciliations', to='inventory.stocktaketarget')),
+            ],
+            options={
+                'ordering': ['created', 'pk'],
+            },
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -1031,6 +1031,8 @@ class StocktakeTarget(models.Model):
     expected_state = models.CharField(max_length=32, blank=True, default='')
     expected_snapshot = models.JSONField(default=dict)
     source_revision = models.CharField(max_length=64)
+    review_revision = models.CharField(max_length=64, blank=True, default='')
+    review_snapshot = models.JSONField(default=dict, blank=True)
     unexpected = models.BooleanField(default=False)
     count_status = models.CharField(
         max_length=16, choices=CountStatus.choices, default=CountStatus.PENDING,
@@ -1167,6 +1169,39 @@ class StocktakeAttachment(models.Model):
                 name='inventory_stocktake_attachment_url_unique',
             ),
         ]
+
+
+class StocktakeReconciliation(models.Model):
+    """An immutable link to one authoritative correction or reversal."""
+
+    class Phase(models.TextChoices):
+        """Whether the result applies or compensates for a stocktake."""
+
+        POST = 'post', 'Posted correction'
+        REVERSE = 'reverse', 'Reversal correction'
+
+    target = models.ForeignKey(
+        StocktakeTarget, on_delete=models.PROTECT, related_name='reconciliations',
+    )
+    phase = models.CharField(max_length=8, choices=Phase.choices)
+    domain = models.CharField(max_length=32)
+    result_app = models.CharField(max_length=64)
+    result_model = models.CharField(max_length=64)
+    result_object_id = models.PositiveBigIntegerField()
+    before = models.JSONField(default=dict)
+    after = models.JSONField(default=dict)
+    reverses = models.ForeignKey(
+        'self', on_delete=models.PROTECT, null=True, blank=True,
+        related_name='reversed_by',
+    )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True,
+        related_name='+',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['created', 'pk']
 
 
 class StocktakeLine(models.Model):

--- a/inventory/stocktake_rest.py
+++ b/inventory/stocktake_rest.py
@@ -22,9 +22,11 @@ from .stocktakes import (
     approve_stocktake,
     begin_review,
     open_stocktake,
+    post_reviewed_stocktake,
     record_count,
     request_recount,
     resolve_identity_target,
+    reverse_reviewed_stocktake,
     resolve_variance,
     scope_rows,
     transition_stocktake,
@@ -150,7 +152,7 @@ def _count_data(count):
 
 
 def _variance_data(variance):
-    return {
+    data = {
         'pk': variance.pk, 'kind': variance.kind,
         'expected': variance.expected, 'observed': variance.observed,
         'source_changed': variance.source_changed,
@@ -163,6 +165,16 @@ def _variance_data(variance):
         'resolved_by': variance.resolved_by_id,
         'resolved_at': variance.resolved_at,
     }
+    unit_cost = variance.target.expected_snapshot.get('unit_cost')
+    if variance.kind == StocktakeVariance.Kind.QUANTITY and unit_cost is not None:
+        expected = Decimal(str(variance.expected.get('quantity') or '0'))
+        observed = Decimal(str(variance.observed.get('quantity') or '0'))
+        data['variance_value'] = str((abs(expected - observed) * Decimal(unit_cost)).quantize(Decimal('0.0001')))
+        data['currency'] = variance.target.expected_snapshot.get('currency')
+    else:
+        data['variance_value'] = None
+        data['currency'] = variance.target.expected_snapshot.get('currency')
+    return data
 
 
 def _target_data(target, reveal_expected):
@@ -184,6 +196,18 @@ def _target_data(target, reveal_expected):
         'accepted_count': _count_data(target.accepted_count),
         'counts': [_count_data(count) for count in target.counts.all()],
         'variances': [_variance_data(row) for row in target.variances.all()],
+        'reconciliations': [
+            {
+                'pk': row.pk, 'phase': row.phase, 'domain': row.domain,
+                'result': {
+                    'app': row.result_app, 'model': row.result_model,
+                    'object_id': row.result_object_id,
+                },
+                'before': row.before, 'after': row.after,
+                'reverses': row.reverses_id,
+            }
+            for row in target.reconciliations.all()
+        ],
     }
 
 
@@ -233,6 +257,7 @@ class NurseryStocktakeViewSet(
             'created_by', 'reviewed_by', 'approved_by', 'posted_by', 'reversed_by',
         ).prefetch_related(
             'targets__accepted_count', 'targets__counts', 'targets__variances',
+            'targets__reconciliations',
             'attachments',
         )
 
@@ -387,25 +412,30 @@ class NurseryStocktakeViewSet(
 
     @action(detail=True, methods=['post'])
     def post(self, request, pk=None):  # pylint: disable=unused-argument
-        """Retain the legacy lot-only posting action during the transition."""
+        """Atomically post a reviewed session or a legacy lot document."""
         stocktake = self._get(pk)
         if stocktake.targets.exists():
-            raise serializers.ValidationError({'status': 'Approve this session before posting.'})
-        stocktake, _movements = _run(post_stocktake, stocktake, request.user)
+            stocktake = _run(post_reviewed_stocktake, stocktake, request.user)
+        else:
+            stocktake, _movements = _run(post_stocktake, stocktake, request.user)
         return Response(stocktake_data(stocktake))
 
     @action(detail=True, methods=['post'])
     def reverse(self, request, pk=None):
-        """Reverse a legacy lot-only stocktake through its existing service."""
+        """Atomically compensate a reviewed session or legacy lot document."""
         serializer = ReasonSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         stocktake = self._get(pk)
         if stocktake.targets.exists():
-            raise serializers.ValidationError({'status': 'Use reviewed-session reversal.'})
-        stocktake, _movements = _run(
-            reverse_stocktake, stocktake, request.user,
-            serializer.validated_data['reason'],
-        )
+            stocktake = _run(
+                reverse_reviewed_stocktake, stocktake, request.user,
+                serializer.validated_data['reason'],
+            )
+        else:
+            stocktake, _movements = _run(
+                reverse_stocktake, stocktake, request.user,
+                serializer.validated_data['reason'],
+            )
         return Response(stocktake_data(stocktake))
 
     @action(detail=True, methods=['post'], url_path='attachments')

--- a/inventory/stocktakes.py
+++ b/inventory/stocktakes.py
@@ -706,7 +706,7 @@ def post_reviewed_stocktake(stocktake, user):
     if stocktake.status != Stocktake.Status.APPROVED:
         raise ValidationError({'status': 'Only an approved stocktake can be posted.'})
     targets = list(
-        stocktake.targets.select_for_update().select_related(
+        stocktake.targets.select_for_update(of=('self',)).select_related(
             'accepted_count', 'expected_location',
         ).prefetch_related('variances')
     )

--- a/inventory/stocktakes.py
+++ b/inventory/stocktakes.py
@@ -6,26 +6,41 @@
 from decimal import Decimal
 from hashlib import sha256
 import json
+from uuid import NAMESPACE_URL, uuid5
 
 from django.contrib.contenttypes.models import ContentType
+from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
 
 from locations.models import Location
 from plantings.growth import current_growth
-from plantings.lifecycle import plant_lifecycle_summary
+from plantings.lifecycle import EventType, OutcomeRequest, plant_lifecycle_summary, record_lifecycle_event
 from plantings.models import PlantCohort, SpecificPlant, SpecificPlantLocation
+from plantings.cohorts import change_cohort
+from plantings.rest import move_specific_plant
 from seeds.models import SeedPacket
 from seeds.services import packet_inventory_snapshot
 from seedtrays.models import SeedTray
 
-from .ledger import physical_balance, quantize_quantity, unit_physical_state
+from .ledger import (
+    MovementRequest,
+    UnitMovementRequest,
+    physical_balance,
+    post_stock_movement,
+    post_unit_movement,
+    quantize_quantity,
+    reverse_movement,
+    unit_physical_state,
+)
 from .models import (
     InventoryItem,
     StockLot,
+    StockMovement,
     Stocktake,
     StocktakeCount,
+    StocktakeReconciliation,
     StocktakeTarget,
     StocktakeVariance,
 )
@@ -407,6 +422,9 @@ def begin_review(stocktake, user):
     StocktakeVariance.objects.filter(target__stocktake=stocktake).delete()
     for target in targets:
         current = _current_row(stocktake, target)
+        target.review_revision = current['source_revision'] if current else ''
+        target.review_snapshot = current['expected_snapshot'] if current else {}
+        target.save(update_fields=['review_revision', 'review_snapshot', 'updated'])
         kinds, expected, observed, changed, revision = _variance_rows(target, current)
         for kind in kinds:
             StocktakeVariance.objects.create(
@@ -455,6 +473,15 @@ def resolve_variance(variance, user, *, action, reason, payload=None,
         raise ValidationError({'reason': 'Explain the variance resolution.'})
     if variance.source_changed and not accept_conflict:
         raise ValidationError({'conflict': 'Explicitly accept or recount this changed source.'})
+    allowed = {
+        StocktakeTarget.TargetType.LOT: {'adjust', 'no_change'},
+        StocktakeTarget.TargetType.SEED_PACKET: {'adjust', 'no_change'},
+        StocktakeTarget.TargetType.COHORT: {'adjust', 'move', 'no_change'},
+        StocktakeTarget.TargetType.TRAY: {'move', 'lost', 'state_correct', 'no_change'},
+        StocktakeTarget.TargetType.PLANT: {'move', 'lost', 'state_correct', 'no_change'},
+    }
+    if action not in allowed[variance.target.target_type]:
+        raise ValidationError({'action': 'This correction is not valid for the target type.'})
     variance.resolution_action = action
     variance.resolution_payload = payload or {}
     variance.resolution_reason = reason
@@ -487,6 +514,316 @@ def approve_stocktake(stocktake, user):
     Stocktake.objects.filter(pk=stocktake.pk).update(
         status=Stocktake.Status.APPROVED, approved_by=user,
         approved_at=now, updated=now,
+    )
+    stocktake.refresh_from_db()
+    return stocktake
+
+
+def _result_link(target, result, user, domain, before, after):
+    return StocktakeReconciliation.objects.create(
+        target=target, phase=StocktakeReconciliation.Phase.POST,
+        domain=domain, result_app=result._meta.app_label,
+        result_model=result._meta.model_name, result_object_id=result.pk,
+        before=before, after=after, created_by=user,
+    )
+
+
+def _posting_reason(target):
+    variance = target.variances.exclude(resolution_action='no_change').first()
+    return variance.resolution_reason if variance else ''
+
+
+def _posting_action(target):
+    variance = target.variances.exclude(resolution_action='no_change').first()
+    return (variance.resolution_action, variance.resolution_payload) if variance else ('no_change', {})
+
+
+def _post_lot(stocktake, target, user, reason):
+    lot = StockLot.objects.get(pk=target.target_object_id, workspace=stocktake.workspace)
+    location = target.expected_location
+    before_quantity = quantize_quantity(physical_balance(lot, location))
+    counted = target.accepted_count.counted_quantity
+    delta = quantize_quantity(counted - before_quantity)
+    if not delta:
+        return None
+    movement_type = StockMovement.MovementType.ADJUSTMENT_GAIN
+    source, destination = None, location
+    if delta < 0:
+        movement_type = StockMovement.MovementType.ADJUSTMENT_LOSS
+        source, destination = location, None
+    movement = post_stock_movement(
+        stocktake.workspace, user,
+        MovementRequest(
+            lot=lot, movement_type=movement_type, quantity=abs(delta),
+            source=source, destination=destination, reason=reason,
+            reference=f'Stocktake {stocktake.pk}',
+        ),
+    )
+    return _result_link(
+        target, movement, user, 'lot',
+        {'quantity': str(before_quantity), 'location': location.pk},
+        {'quantity': str(counted), 'location': location.pk},
+    )
+
+
+def _post_packet(stocktake, target, user, reason, _action, payload):
+    from seeds.models import QuantityCertainty  # pylint: disable=import-outside-toplevel
+    from seeds.services import reconcile_packet_quantity  # pylint: disable=import-outside-toplevel
+
+    packet = SeedPacket.objects.get(pk=target.target_object_id, workspace=stocktake.workspace)
+    before = packet_inventory_snapshot(packet)
+    certainty = payload.get('quantity_certainty', QuantityCertainty.EXACT)
+    reconciliation = reconcile_packet_quantity(
+        packet, user, target.accepted_count.counted_quantity, certainty, reason,
+    )
+    after = packet_inventory_snapshot(packet)
+    return _result_link(
+        target, reconciliation, user, 'seed_packet',
+        {
+            'quantity': str(before['remaining_quantity']) if before['remaining_quantity'] is not None else None,
+            'certainty': before['quantity_certainty'],
+        },
+        {
+            'quantity': str(after['remaining_quantity']) if after['remaining_quantity'] is not None else None,
+            'certainty': after['quantity_certainty'],
+        },
+    )
+
+
+def _post_cohort(stocktake, target, user, reason, action, payload):
+    cohort = PlantCohort.objects.get(pk=target.target_object_id, workspace=stocktake.workspace)
+    before = {'quantity': cohort.quantity, 'location': cohort.location_id, 'revision': cohort.revision}
+    kwargs = {
+        'cohort_id': cohort.pk, 'expected_revision': cohort.revision,
+        'action': 'adjust' if action == 'adjust' else 'move',
+        'idempotency_key': uuid5(NAMESPACE_URL, f'stocktake:{stocktake.pk}:target:{target.pk}'),
+        'reason': reason,
+    }
+    if action == 'adjust':
+        counted = target.accepted_count.counted_quantity
+        if counted != counted.to_integral_value():
+            raise ValidationError({'quantity': 'Cohort counts must be whole plants.'})
+        kwargs['quantity'] = int(counted)
+    else:
+        kwargs['location'] = Location.objects.get(
+            pk=payload.get('location'), workspace=stocktake.workspace,
+        )
+    cohort, operation = change_cohort(stocktake.workspace, user, **kwargs)
+    return _result_link(
+        target, operation, user, 'cohort', before,
+        {'quantity': cohort.quantity, 'location': cohort.location_id, 'revision': cohort.revision},
+    )
+
+
+def _post_tray(stocktake, target, user, reason, action, payload):
+    tray = SeedTray.objects.select_related('inventory_unit__current_location').get(
+        pk=target.target_object_id, workspace=stocktake.workspace,
+    )
+    unit = tray.inventory_unit
+    before = {'location': unit.current_location_id, 'state': unit_physical_state(unit)}
+    if action == 'move':
+        movement_type = StockMovement.MovementType.TRANSFER
+        destination = Location.objects.get(pk=payload.get('location'), workspace=stocktake.workspace)
+    elif action == 'lost':
+        movement_type = StockMovement.MovementType.ADJUSTMENT_LOSS
+        destination = None
+    else:
+        choices = {
+            'return': StockMovement.MovementType.ADJUSTMENT_GAIN,
+            'retire': StockMovement.MovementType.WASTE,
+        }
+        try:
+            movement_type = choices[payload.get('state_action')]
+        except KeyError as exc:
+            raise ValidationError({'action': 'Select a valid tray state correction.'}) from exc
+        destination = Location.objects.filter(
+            pk=payload.get('location'), workspace=stocktake.workspace,
+        ).first()
+    movement = post_unit_movement(
+        stocktake.workspace, user,
+        UnitMovementRequest(
+            unit=unit, movement_type=movement_type, destination=destination,
+            reason=reason, reference=f'Stocktake {stocktake.pk}',
+        ),
+    )
+    unit.refresh_from_db()
+    return _result_link(
+        target, movement, user, 'tray', before,
+        {'location': unit.current_location_id, 'state': unit_physical_state(unit)},
+    )
+
+
+def _post_plant(stocktake, target, user, reason, action, payload):
+    plant = SpecificPlant.objects.get(pk=target.target_object_id, workspace=stocktake.workspace)
+    before_location = _plant_location(plant)
+    before = {
+        'location': before_location.pk if before_location else None,
+        'state': plant_lifecycle_summary(plant).state,
+    }
+    if action == 'move':
+        destination = Location.objects.get(pk=payload.get('location'), workspace=stocktake.workspace)
+        result = move_specific_plant(
+            plant,
+            {
+                'location_type': SpecificPlantLocation.LOCATION,
+                'location': destination,
+                'notes': reason,
+            },
+            user,
+        )
+    else:
+        event_type = EventType.LOST if action == 'lost' else payload.get('event_type')
+        allowed = {EventType.LOST, EventType.FAILED, EventType.CULLED, EventType.READY, EventType.RETAINED}
+        if event_type not in allowed:
+            raise ValidationError({'action': 'Select a valid plant state correction.'})
+        result = record_lifecycle_event(
+            plant, user,
+            OutcomeRequest(event_type, reason=reason, reference=f'Stocktake {stocktake.pk}'),
+        )
+    after_location = _plant_location(plant)
+    return _result_link(
+        target, result, user, 'plant', before,
+        {
+            'location': after_location.pk if after_location else None,
+            'state': plant_lifecycle_summary(plant).state,
+        },
+    )
+
+
+POSTERS = {
+    StocktakeTarget.TargetType.LOT: _post_lot,
+    StocktakeTarget.TargetType.SEED_PACKET: _post_packet,
+    StocktakeTarget.TargetType.COHORT: _post_cohort,
+    StocktakeTarget.TargetType.TRAY: _post_tray,
+    StocktakeTarget.TargetType.PLANT: _post_plant,
+}
+
+
+@transaction.atomic
+def post_reviewed_stocktake(stocktake, user):
+    """Revalidate and apply every approved correction in one transaction."""
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.APPROVED:
+        raise ValidationError({'status': 'Only an approved stocktake can be posted.'})
+    targets = list(
+        stocktake.targets.select_for_update().select_related(
+            'accepted_count', 'expected_location',
+        ).prefetch_related('variances')
+    )
+    for target in targets:
+        current = _current_row(stocktake, target)
+        current_revision = current['source_revision'] if current else ''
+        if current_revision != target.review_revision:
+            raise ValidationError({
+                'conflict': f'Target {target.pk} changed after review; review it again.',
+            })
+    for target in targets:
+        action, payload = _posting_action(target)
+        if action == 'no_change':
+            continue
+        reason = _posting_reason(target)
+        poster = POSTERS[target.target_type]
+        if target.target_type == StocktakeTarget.TargetType.LOT:
+            poster(stocktake, target, user, reason)
+        else:
+            poster(stocktake, target, user, reason, action, payload)
+    now = timezone.now()
+    Stocktake.objects.filter(pk=stocktake.pk).update(
+        status=Stocktake.Status.POSTED, posted_by=user,
+        posted_at=now, updated=now,
+    )
+    stocktake.refresh_from_db()
+    return stocktake
+
+
+def _reverse_link(link, stocktake, user, reason):
+    model = apps.get_model(link.result_app, link.result_model)
+    result = model.objects.get(pk=link.result_object_id)
+    if link.domain in {'lot', 'tray'}:
+        inverse = reverse_movement(result, user, reason)
+    elif link.domain == 'seed_packet':
+        from seeds.services import reverse_packet_reconciliation  # pylint: disable=import-outside-toplevel
+        inverse = reverse_packet_reconciliation(result, user, reason)
+    elif link.domain == 'cohort':
+        cohort = result.events.order_by('pk').first().cohort
+        action = 'adjust'
+        values = {'quantity': int(link.before['quantity'])}
+        if link.before.get('location') != link.after.get('location'):
+            action = 'move'
+            values = {
+                'location': Location.objects.get(
+                    pk=link.before['location'], workspace=stocktake.workspace,
+                ),
+            }
+        cohort, inverse = change_cohort(
+            stocktake.workspace, user, cohort_id=cohort.pk,
+            expected_revision=cohort.revision, action=action,
+            idempotency_key=uuid5(NAMESPACE_URL, f'stocktake:{stocktake.pk}:reverse:{link.pk}'),
+            reason=reason, **values,
+        )
+    elif link.domain == 'plant':
+        if link.result_model == 'plantlifecycleevent':
+            from plantings.lifecycle import reverse_lifecycle_event  # pylint: disable=import-outside-toplevel
+            inverse = reverse_lifecycle_event(result, user, reason)
+            plant = result.plant
+            if link.before.get('location') and _plant_location(plant) is None:
+                move_specific_plant(
+                    plant,
+                    {
+                        'location_type': SpecificPlantLocation.LOCATION,
+                        'location': Location.objects.get(
+                            pk=link.before['location'], workspace=stocktake.workspace,
+                        ),
+                        'notes': reason,
+                    },
+                    user,
+                )
+        else:
+            plant = result.specific_plant
+            location = Location.objects.get(
+                pk=link.before['location'], workspace=stocktake.workspace,
+            )
+            inverse = move_specific_plant(
+                plant,
+                {
+                    'location_type': SpecificPlantLocation.LOCATION,
+                    'location': location,
+                    'notes': reason,
+                },
+                user,
+            )
+    else:
+        raise ValidationError({'reverse': f'Unsupported reconciliation domain {link.domain}.'})
+    return StocktakeReconciliation.objects.create(
+        target=link.target, phase=StocktakeReconciliation.Phase.REVERSE,
+        domain=link.domain, result_app=inverse._meta.app_label,
+        result_model=inverse._meta.model_name, result_object_id=inverse.pk,
+        before=link.after, after=link.before, reverses=link, created_by=user,
+    )
+
+
+@transaction.atomic
+def reverse_reviewed_stocktake(stocktake, user, reason):
+    """Compensate every linked correction together or retain all of them."""
+    if not reason.strip():
+        raise ValidationError({'reason': 'Explain why the stocktake is reversed.'})
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.POSTED or not stocktake.targets.exists():
+        raise ValidationError({'status': 'Only a posted reviewed stocktake can be reversed.'})
+    links = list(
+        StocktakeReconciliation.objects.select_for_update().filter(
+            target__stocktake=stocktake,
+            phase=StocktakeReconciliation.Phase.POST,
+        ).order_by('-pk')
+    )
+    if StocktakeReconciliation.objects.filter(reverses__in=links).exists():
+        raise ValidationError({'status': 'This stocktake already has reversal corrections.'})
+    for link in links:
+        _reverse_link(link, stocktake, user, reason)
+    now = timezone.now()
+    Stocktake.objects.filter(pk=stocktake.pk).update(
+        status=Stocktake.Status.REVERSED, reversed_by=user,
+        reversed_at=now, updated=now,
     )
     stocktake.refresh_from_db()
     return stocktake

--- a/inventory/test_ledger_concurrency.py
+++ b/inventory/test_ledger_concurrency.py
@@ -1,5 +1,8 @@
 """PostgreSQL row-locking tests for inventory availability."""
 
+# Transactional concurrency fixtures deliberately restore migration seed data.
+# pylint: disable=duplicate-code
+
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date
 from decimal import Decimal
@@ -23,6 +26,15 @@ from .ledger import (
     post_unit_movement,
 )
 from .models import InventoryItem, Location, InventoryUnit, StockLot, StockMovement
+from .models import Stocktake, StocktakeVariance
+from .stocktakes import (
+    approve_stocktake,
+    begin_review,
+    open_stocktake,
+    post_reviewed_stocktake,
+    record_count,
+    resolve_variance,
+)
 from .units import UnitCode
 
 
@@ -112,6 +124,78 @@ class ConcurrentLedgerTests(TransactionTestCase):
             StockMovement.objects.filter(
                 lot_id=self.lot_pk,
                 movement_type=StockMovement.MovementType.CONSUMPTION,
+            ).count(),
+            1,
+        )
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentReviewedStocktakeTests(TransactionTestCase):
+    """One approved posting cannot create duplicate variance corrections."""
+
+    def _post_teardown(self):
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(pk=settings.CURRENT_WORKSPACE_ID, name='My Garden')
+
+    def setUp(self):
+        super().setUp()
+        workspace = get_current_workspace()
+        user = get_user_model().objects.create_user(username='concurrent-stocktake')
+        item = InventoryItem.objects.create(
+            workspace=workspace, name='Counted media',
+            category=InventoryItem.Category.GROWING_MEDIA,
+            base_unit=UnitCode.MILLILITRE,
+        )
+        location = Location.objects.create(
+            workspace=workspace, name='Count store', code='COUNT-STORE',
+            location_type=Location.LocationType.STORAGE,
+        )
+        lot, _movement = post_opening_balance(
+            workspace, user,
+            OpeningBalanceRequest(
+                item=item, quantity=Decimal('10'), destination=location,
+                acquisition_total=Decimal('10'), received_on=date(2026, 8, 1),
+            ),
+        )
+        stocktake = open_stocktake(
+            workspace, user,
+            {'location': location.pk, 'target_types': ['lot']},
+        )
+        target = stocktake.targets.get()
+        record_count(stocktake, user, target.pk, counted_quantity=Decimal('8'))
+        begin_review(stocktake, user)
+        variance = StocktakeVariance.objects.get(target=target)
+        resolve_variance(variance, user, action='adjust', reason='Physical count')
+        approve_stocktake(stocktake, user)
+        self.stocktake_pk = stocktake.pk
+        self.user_pk = user.pk
+        self.lot_pk = lot.pk
+
+    def _post(self):
+        close_old_connections()
+        try:
+            post_reviewed_stocktake(
+                Stocktake.objects.get(pk=self.stocktake_pk),
+                get_user_model().objects.get(pk=self.user_pk),
+            )
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'posted'
+        close_old_connections()
+        return result
+
+    def test_only_one_concurrent_post_applies_the_count(self):
+        """The stocktake row lock serializes identical approved submissions."""
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _index: self._post(), range(2)))
+
+        self.assertCountEqual(results, ['posted', 'rejected'])
+        self.assertEqual(
+            StockMovement.objects.filter(
+                lot_id=self.lot_pk,
+                movement_type=StockMovement.MovementType.ADJUSTMENT_LOSS,
             ).count(),
             1,
         )

--- a/inventory/test_stocktake_workflow.py
+++ b/inventory/test_stocktake_workflow.py
@@ -213,6 +213,29 @@ class StocktakeWorkflowRestTests(APITestCase):
         self.assertEqual(approved.status_code, 200, approved.data)
         self.assertEqual(approved.data['status'], Stocktake.Status.APPROVED)
         self.assertEqual(len(approved.data['targets'][0]['counts']), 1)
+        posted = self.client.post(
+            f"{self.url}{opened.data['pk']}/post/", {}, format='json',
+        )
+        self.assertEqual(posted.status_code, 200, posted.data)
+        self.assertEqual(posted.data['status'], Stocktake.Status.POSTED)
+        reconciliation = posted.data['targets'][0]['reconciliations'][0]
+        self.assertEqual(reconciliation['domain'], 'lot')
+        self.assertEqual(
+            posted.data['targets'][0]['variances'][0]['variance_value'],
+            '1.0000',
+        )
+        self.assertEqual(
+            StockMovement.objects.filter(lot=self.lot).count(), 2,
+        )
+        reversed_response = self.client.post(
+            f"{self.url}{opened.data['pk']}/reverse/",
+            {'reason': 'Counted the wrong shelf'}, format='json',
+        )
+        self.assertEqual(reversed_response.status_code, 200, reversed_response.data)
+        self.assertEqual(reversed_response.data['status'], Stocktake.Status.REVERSED)
+        self.assertEqual(
+            len(reversed_response.data['targets'][0]['reconciliations']), 2,
+        )
 
     def test_changed_source_requires_explicit_conflict_acceptance(self):
         """A movement after opening cannot be silently folded into approval."""

--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -32,6 +32,7 @@ class LifecycleState(models.TextChoices):
     RETAINED = 'retained', 'Retained'
     DONATED = 'donated', 'Donated'
     FAILED = 'failed', 'Failed'
+    LOST = 'lost', 'Lost'
     CULLED = 'culled', 'Culled'
     HARVESTED = 'harvested', 'Harvested'
 
@@ -44,6 +45,7 @@ STATE_AFTER = {
     EventType.RETAINED: LifecycleState.RETAINED,
     EventType.DONATED: LifecycleState.DONATED,
     EventType.FAILED: LifecycleState.FAILED,
+    EventType.LOST: LifecycleState.LOST,
     EventType.CULLED: LifecycleState.CULLED,
     EventType.HARVEST_FINISHED: LifecycleState.HARVESTED,
 }
@@ -59,6 +61,11 @@ ALLOWED_FROM = {
     },
     EventType.RETAINED: {LifecycleState.GROWING, LifecycleState.AVAILABLE},
     EventType.FAILED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.RETAINED,
+    },
+    EventType.LOST: {
         LifecycleState.GROWING,
         LifecycleState.AVAILABLE,
         LifecycleState.RETAINED,
@@ -86,6 +93,7 @@ FINAL_STATES = {
     LifecycleState.RETAINED,
     LifecycleState.DONATED,
     LifecycleState.FAILED,
+    LifecycleState.LOST,
     LifecycleState.CULLED,
     LifecycleState.HARVESTED,
 }
@@ -98,6 +106,7 @@ SELLABLE_STATES = {LifecycleState.AVAILABLE}
 CLOSES_LOCATION = {
     EventType.DONATED,
     EventType.FAILED,
+    EventType.LOST,
     EventType.CULLED,
     EventType.HARVEST_FINISHED,
 }
@@ -107,6 +116,7 @@ OUTCOME_EVENTS = (
     EventType.READY,
     EventType.RETAINED,
     EventType.FAILED,
+    EventType.LOST,
     EventType.CULLED,
     EventType.DONATED,
     EventType.HARVEST_FINISHED,

--- a/plantings/migrations/0035_alter_plantlifecycleevent_event_type.py
+++ b/plantings/migrations/0035_alter_plantlifecycleevent_event_type.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plantings', '0034_alter_nurseryplaninputrequirement_requirement_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='plantlifecycleevent',
+            name='event_type',
+            field=models.CharField(choices=[('germinated', 'Germinated'), ('ready', 'Ready for sale or use'), ('transplanted', 'Transplanted or planted out'), ('retained', 'Retained'), ('failed', 'Failed'), ('lost', 'Lost during stocktake'), ('culled', 'Culled'), ('donated', 'Donated'), ('harvest_finished', 'Harvest finished'), ('corrected', 'Corrected')], max_length=20),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -1299,6 +1299,7 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
         TRANSPLANTED = 'transplanted', 'Transplanted or planted out'
         RETAINED = 'retained', 'Retained'
         FAILED = 'failed', 'Failed'
+        LOST = 'lost', 'Lost during stocktake'
         CULLED = 'culled', 'Culled'
         DONATED = 'donated', 'Donated'
         HARVEST_FINISHED = 'harvest_finished', 'Harvest finished'

--- a/plantings/planning.py
+++ b/plantings/planning.py
@@ -446,6 +446,7 @@ def _batch_actuals(batch):
         batch=batch,
         event_type__in=(
             PlantLifecycleEvent.EventType.FAILED,
+            PlantLifecycleEvent.EventType.LOST,
             PlantLifecycleEvent.EventType.CULLED,
         ),
         reversal__isnull=True,

--- a/plantings/test_batches.py
+++ b/plantings/test_batches.py
@@ -382,6 +382,7 @@ class BatchPlantResolutionTests(TestCase):
                 'retained': 1,
                 'donated': 0,
                 'failed': 1,
+                'lost': 0,
                 'culled': 0,
                 'harvested': 0,
             },

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -39,6 +39,7 @@ FINAL_OUTCOMES = (
     (EventType.RETAINED, LifecycleState.RETAINED),
     (EventType.DONATED, LifecycleState.DONATED),
     (EventType.FAILED, LifecycleState.FAILED),
+    (EventType.LOST, LifecycleState.LOST),
     (EventType.CULLED, LifecycleState.CULLED),
     (EventType.HARVEST_FINISHED, LifecycleState.HARVESTED),
 )
@@ -130,7 +131,7 @@ class LifecycleStateAnnotationTests(TestCase):
             OutcomeRequest(EventType.READY, occurred_at=start + timedelta(days=1)),
         )
         for name, (event_type, _) in zip(
-            ('retained', 'donated', 'failed', 'culled', 'harvested'),
+            ('retained', 'donated', 'failed', 'lost', 'culled', 'harvested'),
             FINAL_OUTCOMES,
         ):
             plant = self.germinated_plant(start)

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -90,6 +90,7 @@ class RegisterTestCase(RESTContractTestCase):
             LifecycleState.RETAINED: EventType.RETAINED,
             LifecycleState.DONATED: EventType.DONATED,
             LifecycleState.FAILED: EventType.FAILED,
+            LifecycleState.LOST: EventType.LOST,
             LifecycleState.CULLED: EventType.CULLED,
             LifecycleState.HARVESTED: EventType.HARVEST_FINISHED,
         }

--- a/seeds/migrations/0008_seedpacketquantityreconciliation_reversal_of.py
+++ b/seeds/migrations/0008_seedpacketquantityreconciliation_reversal_of.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("seeds", "0007_point_packets_at_the_locations_app"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="seedpacketquantityreconciliation",
+            name="reversal_of",
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="reversal",
+                to="seeds.seedpacketquantityreconciliation",
+            ),
+        ),
+    ]

--- a/seeds/models.py
+++ b/seeds/models.py
@@ -135,6 +135,13 @@ class SeedPacketQuantityReconciliation(WorkspaceOwnedModel):
         blank=True,
         related_name='seed_packet_reconciliation',
     )
+    reversal_of = models.OneToOneField(
+        'self',
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name='reversal',
+    )
     reason = models.TextField()
     recorded_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -152,8 +159,10 @@ class SeedPacketQuantityReconciliation(WorkspaceOwnedModel):
         """Keep counts numeric and inside the packet's workspace."""
         super().clean()
         errors = {}
-        if self.quantity_certainty == QuantityCertainty.UNKNOWN:
+        if self.quantity_certainty == QuantityCertainty.UNKNOWN and not self.reversal_of_id:
             errors['quantity_certainty'] = 'A physical count cannot be unknown.'
+        if self.reversal_of_id and self.reversal_of.packet_id != self.packet_id:
+            errors['reversal_of'] = 'A reversal must restore the same packet.'
         if self.packet_id and self.packet.workspace_id != self.workspace_id:
             errors['packet'] = 'The packet belongs to a different workspace.'
         if self.movement_id and self.movement.workspace_id != self.workspace_id:

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -388,3 +388,41 @@ def reconcile_packet_quantity(packet, user, count, certainty, reason):
     )
     packet.stock_lot.item.mark_stock_history_started(timezone.now())
     return reconciliation
+
+
+@transaction.atomic
+def reverse_packet_reconciliation(reconciliation, user, reason):
+    """Restore the packet certainty and ledger state before one physical count."""
+    if not reason.strip():
+        raise ValidationError({'reason': 'A reason is required.'})
+    reconciliation = SeedPacketQuantityReconciliation.objects.select_for_update().select_related(
+        'packet__stock_lot', 'movement',
+    ).get(pk=reconciliation.pk)
+    if hasattr(reconciliation, 'reversal'):
+        raise ValidationError({'reconciliation': 'This packet count is already reversed.'})
+    previous = SeedPacketQuantityReconciliation.objects.filter(
+        packet=reconciliation.packet, pk__lt=reconciliation.pk,
+    ).order_by('-pk').first()
+    movement = None
+    if reconciliation.movement_id:
+        from inventory.ledger import reverse_movement  # pylint: disable=import-outside-toplevel
+        movement = reverse_movement(reconciliation.movement, user, reason)
+    if previous:
+        counted = previous.counted_quantity
+        certainty = previous.quantity_certainty
+        reconstructed = previous.reconstructed_initial_quantity
+    else:
+        counted = Decimal('0')
+        certainty = reconciliation.packet.stock_lot.quantity_certainty
+        reconstructed = reconciliation.packet.stock_lot.initial_base_quantity or Decimal('0')
+    return SeedPacketQuantityReconciliation.objects.create(
+        workspace=reconciliation.workspace,
+        packet=reconciliation.packet,
+        counted_quantity=counted,
+        quantity_certainty=certainty,
+        reconstructed_initial_quantity=reconstructed,
+        movement=movement,
+        reversal_of=reconciliation,
+        reason=reason,
+        recorded_by=user,
+    )

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -395,9 +395,11 @@ def reverse_packet_reconciliation(reconciliation, user, reason):
     """Restore the packet certainty and ledger state before one physical count."""
     if not reason.strip():
         raise ValidationError({'reason': 'A reason is required.'})
-    reconciliation = SeedPacketQuantityReconciliation.objects.select_for_update().select_related(
-        'packet__stock_lot', 'movement',
-    ).get(pk=reconciliation.pk)
+    reconciliation = (
+        SeedPacketQuantityReconciliation.objects.select_for_update(of=('self',))
+        .select_related('packet__stock_lot', 'movement')
+        .get(pk=reconciliation.pk)
+    )
     if hasattr(reconciliation, 'reversal'):
         raise ValidationError({'reconciliation': 'This packet count is already reversed.'})
     previous = SeedPacketQuantityReconciliation.objects.filter(

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -7,6 +7,8 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
 from inventory.models import QuantityCertainty, StockMovement, StockReceipt
+from seeds.models import SeedPacketQuantityReconciliation
+from seeds.services import packet_inventory_snapshot, reverse_packet_reconciliation
 from plantings.models import (
     GardenSquareDirectSowPlanting,
     GardenSquareTransplant,
@@ -313,6 +315,33 @@ class SeedPacketInventoryWorkflowTests(APITestCase):
             '0.250000000000',
         )
         self.assertFalse(response.data['empty'])
+
+    def test_reversing_first_count_restores_unknown_packet_certainty(self):
+        """A stocktake reversal does not leave invented packet certainty behind."""
+        packet = self.post_draft(
+            self.create_draft(QuantityCertainty.UNKNOWN)['pk'],
+        )
+        self.client.post(
+            f"/seeds/packets/{packet['pk']}/reconcile/",
+            {
+                'counted_quantity': '24',
+                'quantity_certainty': QuantityCertainty.EXACT,
+                'reason': 'Counted packet contents',
+            },
+            format='json',
+        )
+        reconciliation = SeedPacketQuantityReconciliation.objects.get(
+            packet_id=packet['pk'], reversal_of__isnull=True,
+        )
+
+        reversal = reverse_packet_reconciliation(
+            reconciliation, self.user, 'Counted the wrong packet.',
+        )
+        snapshot = packet_inventory_snapshot(reversal.packet)
+
+        self.assertEqual(snapshot['quantity_certainty'], QuantityCertainty.UNKNOWN)
+        self.assertIsNone(snapshot['remaining_quantity'])
+        self.assertEqual(reversal.reversal_of, reconciliation)
 
     def test_estimated_packet_count_posts_audited_loss(self):
         """A low physical count corrects the balance instead of editing receipt history."""


### PR DESCRIPTION
Approved stocktakes must revalidate source revisions, use each stock type's authoritative service, retain reconciliation links and variance value, and reverse every correction without losing the original count.

## Summary by Sourcery

Introduce atomic posting and reversal of reviewed stocktakes with authoritative domain corrections and immutable reconciliation links across inventory, seeds, and plant lifecycle domains.

New Features:
- Add transactional post and reverse workflows for reviewed stocktakes that revalidate source revisions and apply corrections via per-target authoritative services (lots, packets, cohorts, trays, plants).
- Expose stocktake reconciliation records and monetary variance values through the stocktake REST API for client visibility into applied and reversed corrections.
- Support explicit LOST lifecycle events for plants and integrate them into planning, state transitions, and test coverage.

Bug Fixes:
- Ensure concurrent posting of the same approved stocktake is serialized so only one correction is applied and duplicates are rejected.
- Prevent leaving incorrect certainty on seed packets by allowing packet quantity reconciliations to be reversed back to their prior certainty and reconstructed quantity.

Enhancements:
- Constrain variance resolution actions by target type to prevent invalid corrections for lots, packets, cohorts, trays, and plants.
- Capture review-time source revision and snapshot on stocktake targets so posting can detect changes after review and require re-review.
- Introduce a generic StocktakeReconciliation model to retain before/after state and linkage to authoritative correction and reversal operations across domains.
- Extend seed packet reconciliation validation to enforce consistent reversal relationships and workspace alignment.

Tests:
- Add concurrency tests to verify only one of multiple simultaneous reviewed stocktake postings succeeds and creates a single adjustment movement.
- Extend stocktake workflow tests to cover posting and reversal of reviewed sessions, including reconciliation records and variance value reporting.
- Add tests covering reversal of seed packet reconciliations to restore unknown certainty and quantities.
- Update plant lifecycle and registration tests to cover the new LOST lifecycle event type and its final outcome behavior.

Chores:
- Add database migrations introducing stocktake target review fields, the StocktakeReconciliation model, seed packet reconciliation reversal links, and the LOST plant lifecycle event type.