### PR TITLE
feat(frontend): operate nursery stocktakes

### DIFF
--- a/frontend/js/api/inventory.ts
+++ b/frontend/js/api/inventory.ts
@@ -8,13 +8,46 @@ import {
   ItemUnitConversionCreate,
   StockReceipt,
   StockReceiptFilters,
-  StockReceiptWrite
+  StockReceiptWrite,
+  Stocktake,
+  StocktakeScope
 } from '../types/inventory'
 import { csrfDelete, csrfPatch, csrfPost, fetchAsJson } from '../utils'
 
 const ITEMS_URL = '/inventory/items/'
 const CONVERSIONS_URL = '/inventory/conversions/'
 const RECEIPTS_URL = '/inventory/receipts/'
+const STOCKTAKES_URL = '/inventory/stocktakes/'
+
+function getStocktakes(signal?: AbortSignal): Promise<Array<Stocktake>> {
+  return fetchAsJson<Array<Stocktake>>(STOCKTAKES_URL, signal)
+}
+
+function getStocktake(pk: number, signal?: AbortSignal): Promise<Stocktake> {
+  return fetchAsJson<Stocktake>(`${STOCKTAKES_URL}${pk}/`, signal)
+}
+
+async function createStocktake(scope: StocktakeScope, notes: string): Promise<Stocktake> {
+  const response = await csrfPost(STOCKTAKES_URL, { scope, notes, blind: true })
+  return response.json() as Promise<Stocktake>
+}
+
+async function stocktakeAction(pk: number, action: string, data: object = {}): Promise<Stocktake> {
+  const response = await csrfPost(`${STOCKTAKES_URL}${pk}/${action}/`, data)
+  return response.json() as Promise<Stocktake>
+}
+
+async function countStocktakeTarget(pk: number, target: number, countedQuantity: string, notes: string): Promise<void> {
+  await csrfPost(`${STOCKTAKES_URL}${pk}/count/`, { target, counted_quantity: countedQuantity, notes })
+}
+
+async function scanStocktakeTarget(pk: number, code: string): Promise<void> {
+  await csrfPost(`${STOCKTAKES_URL}${pk}/scan-count/`, { code })
+}
+
+async function resolveStocktakeVariance(pk: number, variance: number, action: string, reason: string, acceptConflict: boolean, payload: object = {}): Promise<void> {
+  await csrfPost(`${STOCKTAKES_URL}${pk}/resolve-variance/`, { variance, action, reason, accept_conflict: acceptConflict, payload })
+}
 
 function getInventoryBalances(item: number, signal?: AbortSignal): Promise<Array<InventoryBalance>> {
   return fetchAsJson<Array<InventoryBalance>>(`/inventory/balances/?item=${item}`, signal)
@@ -104,8 +137,15 @@ export {
   getInventoryUnits,
   getItemUnitConversions,
   getStockReceipts,
+  getStocktake,
+  getStocktakes,
   postStockReceipt,
   reverseStockReceipt,
+  createStocktake,
+  countStocktakeTarget,
+  resolveStocktakeVariance,
+  scanStocktakeTarget,
+  stocktakeAction,
   setInventoryItemActive,
   setItemUnitConversionActive,
   updateStockReceipt

--- a/frontend/js/inventory/stocktakes.tsx
+++ b/frontend/js/inventory/stocktakes.tsx
@@ -1,0 +1,242 @@
+import React from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { Alert, Badge, Button, Card, Col, Form, ListGroup, ProgressBar, Row, Table } from 'react-bootstrap'
+import { Link, useParams } from 'react-router'
+
+import { countStocktakeTarget, createStocktake, getStocktake, getStocktakes, resolveStocktakeVariance, scanStocktakeTarget, stocktakeAction } from '../api/inventory'
+import { getLocations } from '../api/locations'
+import { queryClient, queryKeys } from '../query'
+import { StocktakeTarget, StocktakeVariance } from '../types/inventory'
+
+function StocktakeListView() {
+  const [location, setLocation] = React.useState<number | ''>('')
+  const [notes, setNotes] = React.useState('')
+  const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+  const sessions = useQuery({ queryKey: queryKeys.inventory.stocktakes, queryFn: ({ signal }) => getStocktakes(signal) })
+  const create = useMutation({
+    mutationFn: () => createStocktake({ location: location as number, include_descendants: true }, notes),
+    onSuccess: async () => {
+      setNotes('')
+      await queryClient.invalidateQueries({ queryKey: queryKeys.inventory.stocktakes })
+    }
+  })
+  return (
+    <main className="container py-3">
+      <h1>Stocktakes</h1>
+      <p>Freeze a physical area, count without expected quantities, then review and post each variance.</p>
+      <Card body className="mb-3">
+        <Card.Title>Open a blind stocktake</Card.Title>
+        <Row className="g-2 align-items-end">
+          <Col md={5}>
+            <Form.Label>Location and descendants</Form.Label>
+            <Form.Select value={location} onChange={(event) => setLocation(Number(event.target.value) || '')}>
+              <option value="">Select location</option>
+              {(locations.data ?? []).map((row) => (
+                <option value={row.pk} key={row.pk}>
+                  {row.full_name}
+                </option>
+              ))}
+            </Form.Select>
+          </Col>
+          <Col md={5}>
+            <Form.Label>Notes</Form.Label>
+            <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </Col>
+          <Col md={2}>
+            <Button size="lg" disabled={!location || create.isPending} onClick={() => create.mutate()}>
+              Open
+            </Button>
+          </Col>
+        </Row>
+      </Card>
+      <Table responsive hover>
+        <thead>
+          <tr>
+            <th>Session</th>
+            <th>Status</th>
+            <th>Progress</th>
+            <th>Opened</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(sessions.data ?? []).map((row) => (
+            <tr key={row.pk}>
+              <td>
+                <Link to={`/inventory/stocktakes/${row.pk}`}>Stocktake {row.pk}</Link>
+              </td>
+              <td>
+                <Badge bg={row.status === 'posted' ? 'success' : 'secondary'}>{row.status}</Badge>
+              </td>
+              <td>
+                {row.progress.counted} / {row.progress.total}
+              </td>
+              <td>{new Date(row.counted_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </main>
+  )
+}
+
+function CountTarget({ stocktakePk, target, refresh }: { stocktakePk: number; target: StocktakeTarget; refresh: () => Promise<unknown> }) {
+  const [quantity, setQuantity] = React.useState('')
+  const [notes, setNotes] = React.useState('')
+  const count = useMutation({
+    mutationFn: () => countStocktakeTarget(stocktakePk, target.pk, quantity, notes),
+    onSuccess: () => refresh()
+  })
+  const quantityTarget = ['lot', 'seed_packet', 'cohort'].includes(target.target_type)
+  return (
+    <ListGroup.Item>
+      <div className="d-flex justify-content-between gap-2 align-items-center flex-wrap">
+        <div>
+          <strong>{target.display}</strong>
+          <br />
+          <small>{target.target_type.replaceAll('_', ' ')}</small>
+        </div>
+        {target.accepted_count ? (
+          <Badge bg="success">Counted {target.accepted_count.counted_quantity ?? 'present'}</Badge>
+        ) : quantityTarget ? (
+          <div className="d-flex gap-2">
+            <Form.Control inputMode="decimal" aria-label={`Count ${target.display}`} value={quantity} onChange={(event) => setQuantity(event.target.value)} placeholder="Count" />
+            <Form.Control aria-label={`Notes for ${target.display}`} value={notes} onChange={(event) => setNotes(event.target.value)} placeholder="Notes" />
+            <Button size="lg" disabled={!quantity || count.isPending} onClick={() => count.mutate()}>
+              Save
+            </Button>
+          </div>
+        ) : (
+          <Badge bg="warning" text="dark">
+            Scan identity
+          </Badge>
+        )}
+      </div>
+    </ListGroup.Item>
+  )
+}
+
+function ReviewVariance({ stocktakePk, variance, refresh }: { stocktakePk: number; variance: StocktakeVariance; refresh: () => Promise<unknown> }) {
+  const [action, setAction] = React.useState('')
+  const [reason, setReason] = React.useState('')
+  const resolve = useMutation({
+    mutationFn: () => resolveStocktakeVariance(stocktakePk, variance.pk, action, reason, variance.source_changed),
+    onSuccess: () => refresh()
+  })
+  if (variance.resolution_action)
+    return (
+      <Badge bg="success">
+        {variance.resolution_action}: {variance.resolution_reason}
+      </Badge>
+    )
+  return (
+    <div>
+      {variance.source_changed && <Alert variant="warning">Source changed after opening. Saving explicitly accepts this conflict.</Alert>}
+      <div className="d-flex gap-2 flex-wrap">
+        <Form.Select value={action} onChange={(event) => setAction(event.target.value)} aria-label="Correction action">
+          <option value="">Choose correction</option>
+          <option value="adjust">Adjust quantity</option>
+          <option value="move">Move</option>
+          <option value="lost">Record lost</option>
+          <option value="state_correct">Correct state</option>
+          <option value="no_change">No change</option>
+        </Form.Select>
+        <Form.Control value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Required reason" />
+        <Button disabled={!action || !reason.trim() || resolve.isPending} onClick={() => resolve.mutate()}>
+          Resolve
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function StocktakeDetailView() {
+  const { stocktakeId } = useParams()
+  const pk = Number(stocktakeId)
+  const [scan, setScan] = React.useState('')
+  const session = useQuery({ queryKey: queryKeys.inventory.stocktake(pk), queryFn: ({ signal }) => getStocktake(pk, signal), enabled: Number.isInteger(pk) })
+  const refresh = async () => session.refetch()
+  const transition = useMutation({ mutationFn: ({ action, data = {} }: { action: string; data?: object }) => stocktakeAction(pk, action, data), onSuccess: () => refresh() })
+  const scanMutation = useMutation({
+    mutationFn: () => scanStocktakeTarget(pk, scan),
+    onSuccess: async () => {
+      setScan('')
+      await refresh()
+    }
+  })
+  const row = session.data
+  if (!row) return <main className="container py-3">Loading stocktake…</main>
+  const percent = row.progress.total ? (row.progress.counted / row.progress.total) * 100 : 0
+  return (
+    <main className="container py-3">
+      <h1>Stocktake {row.pk}</h1>
+      <Badge bg="secondary" className="mb-2">
+        {row.status}
+      </Badge>
+      <ProgressBar now={percent} label={`${row.progress.counted}/${row.progress.total}`} className="mb-3" />
+      {row.status === 'open' && (
+        <div className="d-flex gap-2 mb-3">
+          <Button variant="outline-secondary" onClick={() => transition.mutate({ action: 'pause' })}>
+            Pause
+          </Button>
+          <Button onClick={() => transition.mutate({ action: 'begin-review' })}>Begin review</Button>
+        </div>
+      )}
+      {row.status === 'paused' && (
+        <Button className="mb-3" onClick={() => transition.mutate({ action: 'resume' })}>
+          Resume
+        </Button>
+      )}
+      {row.status === 'review' && (
+        <Button className="mb-3" onClick={() => transition.mutate({ action: 'approve' })}>
+          Approve resolved review
+        </Button>
+      )}
+      {row.status === 'approved' && (
+        <Button className="mb-3" variant="success" onClick={() => transition.mutate({ action: 'post' })}>
+          Post corrections
+        </Button>
+      )}
+      {row.status === 'posted' && (
+        <Button className="mb-3" variant="outline-danger" onClick={() => transition.mutate({ action: 'reverse', data: { reason: 'Stocktake reversed by reviewer' } })}>
+          Reverse stocktake
+        </Button>
+      )}
+      {['open', 'paused'].includes(row.status) && (
+        <Card body className="mb-3">
+          <Form.Label>Scan tray, cohort, or plant</Form.Label>
+          <div className="d-flex gap-2">
+            <Form.Control size="lg" value={scan} onChange={(event) => setScan(event.target.value)} />
+            <Button size="lg" disabled={!scan.trim()} onClick={() => scanMutation.mutate()}>
+              Count scan
+            </Button>
+          </div>
+        </Card>
+      )}
+      <ListGroup>
+        {row.targets.map((target) => (
+          <CountTarget stocktakePk={pk} target={target} refresh={refresh} key={target.pk} />
+        ))}
+      </ListGroup>
+      {['review', 'approved', 'posted', 'reversed'].includes(row.status) && (
+        <section className="mt-4">
+          <h2>Variances</h2>
+          {row.targets.flatMap((target) =>
+            target.variances.map((variance) => (
+              <Card body className="mb-2" key={variance.pk}>
+                <strong>
+                  {target.display}: {variance.kind}
+                </strong>
+                <p>
+                  Value: {variance.variance_value ?? 'Unknown'} {variance.currency ?? ''}
+                </p>
+                <ReviewVariance stocktakePk={pk} variance={variance} refresh={refresh} />
+              </Card>
+            ))
+          )}
+        </section>
+      )}
+    </main>
+  )
+}
+
+export { StocktakeDetailView, StocktakeListView }

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -225,6 +225,7 @@ function ScannerView() {
   const [cameraError, setCameraError] = React.useState('')
   const [scanned, setScanned] = React.useState<Array<{ id: number; code: string; display: string }>>([])
   const [healthScanned, setHealthScanned] = React.useState<Array<{ type: HealthScopeType; id: number; code: string; display: string }>>([])
+  const [stocktakeCode, setStocktakeCode] = React.useState('')
   const video = React.useRef<HTMLVideoElement>(null)
   const controls = React.useRef<IScannerControls | undefined>(undefined)
   const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
@@ -250,6 +251,7 @@ function ScannerView() {
           productionbatch: 'batch',
           location: 'location'
         }
+        if (resolved.status === 'active' && resolved.capabilities?.includes('stocktake_count')) setStocktakeCode(resolved.current_code ?? resolved.code ?? '')
         const type = scopes[target.target_type]
         if (type) {
           setHealthScanned((current) =>
@@ -294,6 +296,15 @@ function ScannerView() {
       <h1>Scan labels</h1>
       <Row className="g-3">
         <Col lg={6}>
+          {stocktakeCode && (
+            <Alert variant="info">
+              <strong>Stocktake-ready identity</strong>
+              <div className="font-monospace">{stocktakeCode}</div>
+              <Link to="/inventory/stocktakes">
+                <Button className="mt-2">Open stocktakes</Button>
+              </Link>
+            </Alert>
+          )}
           <Card body>
             <video ref={video} className="scanner-video" muted playsInline />
             <div className="d-flex gap-2 mt-2">

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -21,6 +21,7 @@ import { WorkspaceModeRoute, WorkspaceSettings } from './workspace.js'
 import { InventoryCatalog } from './inventory.js'
 import { LocationsCatalog } from './locations.js'
 import { InventoryReceiptsView } from './inventory/receipts.js'
+import { StocktakeDetailView, StocktakeListView } from './inventory/stocktakes.js'
 import { InputApplicationsView } from './applications/applications.js'
 import { ProductionBatchDetailView, ProductionBatchTable } from './plantings/batches.js'
 import { HarvestsView, YieldReportView } from './plantings/harvests.js'
@@ -155,6 +156,8 @@ function FrontEndPage() {
         <Route path="/locations" element={<LocationsCatalog />} />
         <Route path="/inventory" element={<InventoryCatalog />} />
         <Route path="/inventory/receipts" element={<InventoryReceiptsView />} />
+        <Route path="/inventory/stocktakes" element={<StocktakeListView />} />
+        <Route path="/inventory/stocktakes/:stocktakeId" element={<StocktakeDetailView />} />
         <Route path="/applications" element={<InputApplicationsView />} />
         <Route path="/labels" element={<LabelsView />} />
         <Route path="/scan" element={<ScannerView />} />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -97,6 +97,11 @@ function GPTopBar({ workspace }: GPTopBarProps) {
             <NavDropdown.Item as={NavLink} to="/inventory/receipts">
               Receiving
             </NavDropdown.Item>
+            {workspace.mode === 'nursery' && (
+              <NavDropdown.Item as={NavLink} to="/inventory/stocktakes">
+                Stocktakes
+              </NavDropdown.Item>
+            )}
             <NavDropdown.Item as={NavLink} to="/applications">
               Input applications
             </NavDropdown.Item>

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -39,7 +39,9 @@ const queryKeys = {
     conversions: (itemPk: number) => ['inventory', 'conversions', itemPk] as const,
     receiptsAll: ['inventory', 'receipts'] as const,
     receipts: (status: string, seedPacket: string) => ['inventory', 'receipts', status, seedPacket] as const,
-    balances: (itemPk: number | '') => ['inventory', 'balances', itemPk] as const
+    balances: (itemPk: number | '') => ['inventory', 'balances', itemPk] as const,
+    stocktakes: ['inventory', 'stocktakes'] as const,
+    stocktake: (pk: number) => ['inventory', 'stocktakes', pk] as const
   },
   garden: {
     all: ['garden'] as const,

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -210,6 +210,72 @@ interface StockReceiptFilters {
   seed_packet?: boolean
 }
 
+type StocktakeStatus = 'open' | 'paused' | 'review' | 'approved' | 'posted' | 'reversed'
+type StocktakeTargetType = 'lot' | 'seed_packet' | 'tray' | 'cohort' | 'plant'
+
+interface StocktakeVariance {
+  pk: number
+  kind: 'quantity' | 'missing' | 'excess' | 'misplaced' | 'state_mismatch'
+  expected: Record<string, unknown>
+  observed: Record<string, unknown>
+  source_changed: boolean
+  conflict_resolution: string
+  resolution_action: string
+  resolution_reason: string
+  variance_value: string | null
+  currency: string | null
+}
+
+interface StocktakeCount {
+  pk: number
+  counted_quantity: string | null
+  observed_location: number | null
+  observed_state: string
+  code_snapshot: string
+  notes: string
+  counter: number | null
+  created: string
+}
+
+interface StocktakeTarget {
+  pk: number
+  target_type: StocktakeTargetType
+  target_object_id: number | null
+  display: string
+  expected_location: number | null
+  expected_quantity: string | null
+  expected_state: string
+  unexpected: boolean
+  count_status: 'pending' | 'counted' | 'recount'
+  accepted_count: StocktakeCount | null
+  counts: Array<StocktakeCount>
+  variances: Array<StocktakeVariance>
+  reconciliations: Array<{ pk: number; phase: 'post' | 'reverse'; domain: string; result: { app: string; model: string; object_id: number } }>
+}
+
+interface Stocktake {
+  pk: number
+  status: StocktakeStatus
+  blind: boolean
+  scope: Record<string, unknown>
+  notes: string
+  counted_at: string
+  progress: { counted: number; total: number }
+  targets: Array<StocktakeTarget>
+  attachments: Array<{ pk: number; target: number | null; url: string; label: string }>
+}
+
+interface StocktakeScope {
+  location: number
+  include_descendants?: boolean
+  target_types?: Array<StocktakeTargetType>
+  item?: number
+  category?: InventoryCategory
+  variety?: number
+  stage?: number
+  tray_state?: string
+}
+
 export {
   InventoryBalance,
   InventoryCategory,
@@ -231,6 +297,13 @@ export {
   StockReceiptLineWrite,
   StockReceiptStatus,
   StockReceiptWrite,
+  Stocktake,
+  StocktakeCount,
+  StocktakeScope,
+  StocktakeStatus,
+  StocktakeTarget,
+  StocktakeTargetType,
+  StocktakeVariance,
   UnitCode,
   UnitDimension
 }

--- a/frontend/js/types/workspace.ts
+++ b/frontend/js/types/workspace.ts
@@ -10,13 +10,22 @@ interface Workspace {
   measurement_system: MeasurementSystem
   override_tolerance_percent: string
   override_tolerance_floor: string
+  stocktake_two_person_required: boolean
   created: string
   updated: string
 }
 
 type WorkspaceUpdate = Pick<
   Workspace,
-  'name' | 'mode' | 'currency_code' | 'default_tax_rate' | 'timezone' | 'measurement_system' | 'override_tolerance_percent' | 'override_tolerance_floor'
+  | 'name'
+  | 'mode'
+  | 'currency_code'
+  | 'default_tax_rate'
+  | 'timezone'
+  | 'measurement_system'
+  | 'override_tolerance_percent'
+  | 'override_tolerance_floor'
+  | 'stocktake_two_person_required'
 >
 
 export { MeasurementSystem, Workspace, WorkspaceMode, WorkspaceUpdate }

--- a/frontend/js/workspace.tsx
+++ b/frontend/js/workspace.tsx
@@ -34,7 +34,8 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
     timezone: workspace.timezone,
     measurement_system: workspace.measurement_system,
     override_tolerance_percent: workspace.override_tolerance_percent,
-    override_tolerance_floor: workspace.override_tolerance_floor
+    override_tolerance_floor: workspace.override_tolerance_floor,
+    stocktake_two_person_required: workspace.stocktake_two_person_required
   })
   const mutation = useMutation({
     mutationFn: updateWorkspace,
@@ -50,7 +51,8 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
       timezone: workspace.timezone,
       measurement_system: workspace.measurement_system,
       override_tolerance_percent: workspace.override_tolerance_percent,
-      override_tolerance_floor: workspace.override_tolerance_floor
+      override_tolerance_floor: workspace.override_tolerance_floor,
+      stocktake_two_person_required: workspace.stocktake_two_person_required
     })
   }, [workspace])
 
@@ -149,6 +151,16 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
             Smallest difference, in an item&apos;s own unit, that can require a reason. Zero disables it, so the percentage alone applies.
           </Form.Text>
         </Form.Group>
+        {form.mode === 'nursery' && (
+          <Form.Check
+            className="mb-3"
+            type="switch"
+            id="stocktake-two-person"
+            label="Require a different reviewer from every stocktake counter"
+            checked={form.stocktake_two_person_required}
+            onChange={(event) => updateField('stocktake_two_person_required', event.target.checked)}
+          />
+        )}
         <Button type="submit" disabled={mutation.isPending}>
           {mutation.isPending ? 'Saving…' : 'Save settings'}
         </Button>

--- a/inventory/stocktake_rest.py
+++ b/inventory/stocktake_rest.py
@@ -3,6 +3,7 @@
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -72,6 +73,7 @@ class StocktakeCreateSerializer(serializers.Serializer):  # pylint: disable=abst
     scope = ScopeSerializer()
     blind = serializers.BooleanField(required=False, default=True)
     notes = serializers.CharField(required=False, allow_blank=True, default='')
+    work_task = serializers.IntegerField(min_value=1, required=False)
 
 
 class CountSerializer(CurrentWorkspaceSerializerMixin, serializers.Serializer):  # pylint: disable=abstract-method
@@ -282,6 +284,7 @@ class NurseryStocktakeViewSet(
         """Return one blind count sheet or revealed review document."""
         return Response(stocktake_data(self._get(pk)))
 
+    @transaction.atomic
     def create(self, request):
         """Resolve and freeze scope immediately when a session opens."""
         if 'lines' in request.data:
@@ -294,10 +297,29 @@ class NurseryStocktakeViewSet(
             return Response(stocktake_data(stocktake), status=status.HTTP_201_CREATED)
         serializer = StocktakeCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        work_task_id = values.pop('work_task', None)
+        task = None
+        if work_task_id:
+            from work.models import WorkTask  # pylint: disable=import-outside-toplevel
+            try:
+                task = WorkTask.objects.get(pk=work_task_id, workspace=self.get_current_workspace())
+            except WorkTask.DoesNotExist as exc:
+                raise serializers.ValidationError({'work_task': 'Work task not found.'}) from exc
         stocktake = _run(
             open_stocktake, self.get_current_workspace(), request.user,
-            **serializer.validated_data,
+            **values,
         )
+        if task:
+            from django.contrib.contenttypes.models import ContentType  # pylint: disable=import-outside-toplevel
+            from work.models import WorkTaskLink  # pylint: disable=import-outside-toplevel
+            WorkTaskLink.objects.create(
+                task=task, role=WorkTaskLink.Role.RESULT,
+                content_type=ContentType.objects.get_for_model(stocktake),
+                object_id=stocktake.pk, label=f'Stocktake {stocktake.pk}',
+                url=f'/inventory/stocktakes/{stocktake.pk}',
+                snapshot={'status': stocktake.status, 'scope': stocktake.scope},
+            )
         return Response(stocktake_data(self._get(stocktake.pk)), status=status.HTTP_201_CREATED)
 
     @action(detail=False, methods=['post'], url_path='scope-preview')

--- a/workspaces/rest.py
+++ b/workspaces/rest.py
@@ -20,6 +20,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
             'measurement_system',
             'override_tolerance_percent',
             'override_tolerance_floor',
+            'stocktake_two_person_required',
             'created',
             'updated',
         ]


### PR DESCRIPTION
Nursery staff need a mobile count and review workspace, scanner handoff, visible progress, correction controls, and a configurable two-person rule over the new backend workflow.

## Summary by Sourcery

Introduce nursery stocktake sessions with mobile-friendly counting, variance review, and workflow controls integrated into inventory and workspace settings.

New Features:
- Add frontend types and REST API endpoints for inventory stocktake sessions, targets, counts, and variances.
- Provide stocktake list and detail views for opening sessions, tracking progress, scanning identities, counting items, and resolving variances.
- Expose a nursery-only stocktakes navigation entry and integrate scanner support for stocktake-ready identities.
- Add a configurable workspace setting to enforce a two-person rule between stocktake counters and reviewers.
- Allow stocktakes to be optionally linked to work tasks when created, recording the association in task results.

Enhancements:
- Extend workspace REST and update payloads to include stocktake configuration in settings.