### PR TITLE
docs(stocktake): finish nursery workflow

### DIFF
--- a/frontend/js/inventory/stocktakes.tsx
+++ b/frontend/js/inventory/stocktakes.tsx
@@ -115,11 +115,36 @@ function CountTarget({ stocktakePk, target, refresh }: { stocktakePk: number; ta
   )
 }
 
-function ReviewVariance({ stocktakePk, variance, refresh }: { stocktakePk: number; variance: StocktakeVariance; refresh: () => Promise<unknown> }) {
+function ReviewVariance({
+  stocktakePk,
+  target,
+  variance,
+  refresh
+}: {
+  stocktakePk: number
+  target: StocktakeTarget
+  variance: StocktakeVariance
+  refresh: () => Promise<unknown>
+}) {
   const [action, setAction] = React.useState('')
   const [reason, setReason] = React.useState('')
+  const [location, setLocation] = React.useState<number | ''>('')
+  const [stateAction, setStateAction] = React.useState('')
+  const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+  const payload =
+    action === 'move'
+      ? { location }
+      : action === 'state_correct' && target.target_type === 'tray'
+        ? { state_action: stateAction, location: location || undefined }
+        : action === 'state_correct'
+          ? { event_type: stateAction }
+          : {}
   const resolve = useMutation({
-    mutationFn: () => resolveStocktakeVariance(stocktakePk, variance.pk, action, reason, variance.source_changed),
+    mutationFn: () => resolveStocktakeVariance(stocktakePk, variance.pk, action, reason, variance.source_changed, payload),
+    onSuccess: () => refresh()
+  })
+  const refreshSnapshot = useMutation({
+    mutationFn: () => stocktakeAction(stocktakePk, 'refresh-target', { target: target.pk, reason: reason || 'Refresh changed source before recount' }),
     onSuccess: () => refresh()
   })
   if (variance.resolution_action)
@@ -131,17 +156,51 @@ function ReviewVariance({ stocktakePk, variance, refresh }: { stocktakePk: numbe
   return (
     <div>
       {variance.source_changed && <Alert variant="warning">Source changed after opening. Saving explicitly accepts this conflict.</Alert>}
+      {variance.source_changed && (
+        <Button className="mb-2" variant="outline-warning" onClick={() => refreshSnapshot.mutate()}>
+          Refresh snapshot and recount
+        </Button>
+      )}
       <div className="d-flex gap-2 flex-wrap">
         <Form.Select value={action} onChange={(event) => setAction(event.target.value)} aria-label="Correction action">
           <option value="">Choose correction</option>
-          <option value="adjust">Adjust quantity</option>
-          <option value="move">Move</option>
-          <option value="lost">Record lost</option>
-          <option value="state_correct">Correct state</option>
+          {['lot', 'seed_packet', 'cohort'].includes(target.target_type) && <option value="adjust">Adjust quantity</option>}
+          {['tray', 'cohort', 'plant'].includes(target.target_type) && <option value="move">Move</option>}
+          {['tray', 'plant'].includes(target.target_type) && <option value="lost">Record lost</option>}
+          {['tray', 'plant'].includes(target.target_type) && <option value="state_correct">Correct state</option>}
           <option value="no_change">No change</option>
         </Form.Select>
         <Form.Control value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Required reason" />
-        <Button disabled={!action || !reason.trim() || resolve.isPending} onClick={() => resolve.mutate()}>
+        {(action === 'move' || (action === 'state_correct' && target.target_type === 'tray' && stateAction === 'return')) && (
+          <Form.Select value={location} onChange={(event) => setLocation(Number(event.target.value) || '')}>
+            <option value="">Select location</option>
+            {(locations.data ?? []).map((row) => (
+              <option value={row.pk} key={row.pk}>
+                {row.full_name}
+              </option>
+            ))}
+          </Form.Select>
+        )}
+        {action === 'state_correct' && target.target_type === 'tray' && (
+          <Form.Select value={stateAction} onChange={(event) => setStateAction(event.target.value)}>
+            <option value="">Select tray correction</option>
+            <option value="return">Return on hand</option>
+            <option value="retire">Retire</option>
+          </Form.Select>
+        )}
+        {action === 'state_correct' && target.target_type === 'plant' && (
+          <Form.Select value={stateAction} onChange={(event) => setStateAction(event.target.value)}>
+            <option value="">Select plant state</option>
+            <option value="ready">Ready</option>
+            <option value="retained">Retained</option>
+            <option value="failed">Failed</option>
+            <option value="culled">Culled</option>
+          </Form.Select>
+        )}
+        <Button
+          disabled={!action || !reason.trim() || (action === 'move' && !location) || (action === 'state_correct' && !stateAction) || resolve.isPending}
+          onClick={() => resolve.mutate()}
+        >
           Resolve
         </Button>
       </div>
@@ -229,7 +288,7 @@ function StocktakeDetailView() {
                 <p>
                   Value: {variance.variance_value ?? 'Unknown'} {variance.currency ?? ''}
                 </p>
-                <ReviewVariance stocktakePk={pk} variance={variance} refresh={refresh} />
+                <ReviewVariance stocktakePk={pk} target={target} variance={variance} refresh={refresh} />
               </Card>
             ))
           )}

--- a/inventory/stocktake_rest.py
+++ b/inventory/stocktake_rest.py
@@ -25,6 +25,7 @@ from .stocktakes import (
     open_stocktake,
     post_reviewed_stocktake,
     record_count,
+    refresh_target_snapshot,
     request_recount,
     resolve_identity_target,
     reverse_reviewed_stocktake,
@@ -59,6 +60,9 @@ class ScopeSerializer(CurrentWorkspaceSerializerMixin, serializers.Serializer): 
     variety = serializers.IntegerField(min_value=1, required=False)
     stage = serializers.IntegerField(min_value=1, required=False)
     tray_state = serializers.CharField(required=False)
+    selected_keys = serializers.ListField(
+        child=serializers.CharField(max_length=96), required=False,
+    )
     workspace_field_lookups = {'location': 'workspace'}
 
     def to_internal_value(self, data):
@@ -406,6 +410,22 @@ class NurseryStocktakeViewSet(
             raise serializers.ValidationError({'target': 'Target not found.'}) from exc
         stocktake = _run(
             request_recount, stocktake, target, request.user,
+            serializer.validated_data['reason'],
+        )
+        return Response(stocktake_data(self._get(stocktake.pk)))
+
+    @action(detail=True, methods=['post'], url_path='refresh-target')
+    def refresh_target(self, request, pk=None):
+        """Refresh one changed snapshot and require a retained recount."""
+        serializer = RecountSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        stocktake = self._get(pk)
+        try:
+            target = stocktake.targets.get(pk=serializer.validated_data['target'])
+        except StocktakeTarget.DoesNotExist as exc:
+            raise serializers.ValidationError({'target': 'Target not found.'}) from exc
+        stocktake = _run(
+            refresh_target_snapshot, stocktake, target, request.user,
             serializer.validated_data['reason'],
         )
         return Response(stocktake_data(self._get(stocktake.pk)))

--- a/inventory/stocktakes.py
+++ b/inventory/stocktakes.py
@@ -285,6 +285,12 @@ def scope_rows(workspace, scope):
     rows = []
     for target_type in selected:
         rows.extend(SOURCE_BUILDERS[target_type](workspace, location_ids, scope))
+    selected_keys = set(scope.get('selected_keys') or ())
+    if selected_keys:
+        rows = [row for row in rows if row['target_key'] in selected_keys]
+        missing = selected_keys - {row['target_key'] for row in rows}
+        if missing:
+            raise ValidationError({'selected_keys': f'Targets are outside this scope: {sorted(missing)}.'})
     return rows
 
 
@@ -410,6 +416,16 @@ def begin_review(stocktake, user):
     stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
     if stocktake.status not in {Stocktake.Status.OPEN, Stocktake.Status.PAUSED}:
         raise ValidationError({'status': 'Only an open stocktake can enter review.'})
+    frozen_keys = set(stocktake.targets.values_list('target_key', flat=True))
+    current_rows = scope_rows(stocktake.workspace, stocktake.scope)
+    entered = [row for row in current_rows if row['target_key'] not in frozen_keys]
+    if entered:
+        StocktakeTarget.objects.bulk_create(
+            StocktakeTarget(stocktake=stocktake, unexpected=True, **row)
+            for row in entered
+        )
+        stocktake.refresh_from_db()
+        return stocktake
     targets = list(
         stocktake.targets.select_for_update(of=('self',)).select_related('accepted_count')
     )
@@ -453,6 +469,36 @@ def request_recount(stocktake, target, user, reason):
     target.save(update_fields=['count_status', 'updated'])
     target.variances.update(
         conflict_resolution=StocktakeVariance.ConflictResolution.RECOUNT,
+        conflict_reason=reason, resolved_by=user, resolved_at=timezone.now(),
+    )
+    Stocktake.objects.filter(pk=stocktake.pk).update(status=Stocktake.Status.OPEN)
+    stocktake.refresh_from_db()
+    return stocktake
+
+
+@transaction.atomic
+def refresh_target_snapshot(stocktake, target, user, reason):
+    """Adopt current source facts and require a fresh physical count."""
+    if not reason.strip():
+        raise ValidationError({'reason': 'Explain why the snapshot is refreshed.'})
+    stocktake = Stocktake.objects.select_for_update().get(pk=stocktake.pk)
+    if stocktake.status != Stocktake.Status.REVIEW:
+        raise ValidationError({'status': 'Refresh changed targets during review.'})
+    target = StocktakeTarget.objects.select_for_update().get(pk=target.pk, stocktake=stocktake)
+    current = _current_row(stocktake, target)
+    if current is None:
+        raise ValidationError({'target': 'A missing source cannot be refreshed; recount or accept it.'})
+    target.expected_location = current['expected_location']
+    target.expected_quantity = current['expected_quantity']
+    target.expected_state = current['expected_state']
+    target.expected_snapshot = current['expected_snapshot']
+    target.source_revision = current['source_revision']
+    target.review_revision = ''
+    target.review_snapshot = {}
+    target.count_status = StocktakeTarget.CountStatus.RECOUNT
+    target.save()
+    target.variances.update(
+        conflict_resolution=StocktakeVariance.ConflictResolution.REFRESHED,
         conflict_reason=reason, resolved_by=user, resolved_at=timezone.now(),
     )
     Stocktake.objects.filter(pk=stocktake.pk).update(status=Stocktake.Status.OPEN)

--- a/inventory/test_stocktake_workflow.py
+++ b/inventory/test_stocktake_workflow.py
@@ -275,6 +275,58 @@ class StocktakeWorkflowRestTests(APITestCase):
         )
         self.assertEqual(accepted.status_code, 200, accepted.data)
 
+    def test_changed_source_can_refresh_and_require_a_recount(self):
+        """Refreshing preserves the old attempt but adopts a new expected revision."""
+        opened = self._open()
+        target = opened.data['targets'][0]
+        self.client.post(
+            f"{self.url}{opened.data['pk']}/count/",
+            {'target': target['pk'], 'counted_quantity': '90'}, format='json',
+        )
+        post_stock_movement(
+            self.workspace, self.user,
+            MovementRequest(
+                lot=self.lot, movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=Decimal('1'), source=self.location,
+            ),
+        )
+        self.client.post(
+            f"{self.url}{opened.data['pk']}/begin-review/", {}, format='json',
+        )
+        refreshed = self.client.post(
+            f"{self.url}{opened.data['pk']}/refresh-target/",
+            {'target': target['pk'], 'reason': 'Use the movement-corrected balance'},
+            format='json',
+        )
+        self.assertEqual(refreshed.status_code, 200, refreshed.data)
+        self.assertEqual(refreshed.data['status'], Stocktake.Status.OPEN)
+        row = refreshed.data['targets'][0]
+        self.assertEqual(row['count_status'], StocktakeTarget.CountStatus.RECOUNT)
+        self.assertEqual(len(row['counts']), 1)
+
+    def test_new_stock_entering_scope_is_added_before_review(self):
+        """A frozen scope reports a newly entered identity instead of ignoring it."""
+        opened = self._open()
+        target = opened.data['targets'][0]
+        self.client.post(
+            f"{self.url}{opened.data['pk']}/count/",
+            {'target': target['pk'], 'counted_quantity': '100'}, format='json',
+        )
+        post_opening_balance(
+            self.workspace, self.user,
+            OpeningBalanceRequest(
+                item=self.item, quantity=Decimal('5'), destination=self.location,
+                acquisition_total=Decimal('1'), received_on=timezone.localdate(),
+            ),
+        )
+        response = self.client.post(
+            f"{self.url}{opened.data['pk']}/begin-review/", {}, format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['status'], Stocktake.Status.OPEN)
+        self.assertEqual(response.data['progress']['total'], 2)
+        self.assertTrue(next(row for row in response.data['targets'] if row['unexpected'])['unexpected'])
+
     def test_two_person_rule_rejects_a_counter_as_reviewer(self):
         """Optional separation applies to identities even before task 58 roles."""
         self.workspace.stocktake_two_person_required = True


### PR DESCRIPTION
The shipped pathway now documents frozen blind scopes, stale-source refresh and recount decisions, domain correction posting, reversal, and the task 58 authorization deferral while the final regressions cover new stock entering scope.

## Summary by Sourcery

Document and enforce refreshed stocktake snapshots and newly entered stock within a frozen scope, and extend variance review options for different target types.

New Features:
- Allow reviewers to refresh a changed stocktake target snapshot, adopt current source facts, and trigger a required recount.
- Surface newly entered stock identities when beginning review on a frozen scope instead of ignoring them.
- Expose a REST endpoint for refreshing a single stocktake target during review.
- Extend the stocktake variance UI to support move and state-correction workflows with location and state selection for tray and plant targets.

Enhancements:
- Constrain stocktake scope rows to an optional list of selected target keys and validate any keys outside the scope.
- Update variance resolution handling to record refreshed conflict resolutions and reopen the stocktake for counting.

Tests:
- Add tests covering snapshot refresh behaviour and recount requirements when sources change during review.
- Add tests ensuring new stock entering scope is included as unexpected targets before review.