### PR TITLE
feat(sales): reserve exact nursery stock

### DIFF
--- a/labels/rest.py
+++ b/labels/rest.py
@@ -148,7 +148,7 @@ def _target_active(identity):
     return True
 
 
-def _resolution(code, workspace):  # pylint: disable=too-many-locals
+def _resolution(code, workspace):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """Build the safe scan contract for a code visible to this workspace."""
     if code.workspace_id != workspace.pk:
         return {'status': 'wrong_workspace', 'message': 'This code belongs to another workspace.'}
@@ -164,6 +164,26 @@ def _resolution(code, workspace):  # pylint: disable=too-many-locals
         summary = derive_state(identity.target.lifecycle_events.all())
         if summary.state in ('growing', 'available', 'retained'):
             capabilities.append('bulk_select')
+        if workspace.mode == Workspace.Mode.NURSERY and summary.state == 'available':
+            from sales.models import SalesOrderAllocation  # pylint: disable=import-outside-toplevel
+
+            reserved = SalesOrderAllocation.objects.filter(
+                plant=identity.target,
+                status=SalesOrderAllocation.Status.RESERVED,
+            ).exists()
+            if not reserved and not is_quarantined(identity.target):
+                capabilities.append('order_allocate')
+    if resolution_status == LabelCode.Status.ACTIVE and key == ('seedtrays', 'seedtray'):
+        from inventory.ledger import unit_physical_state  # pylint: disable=import-outside-toplevel
+        from sales.models import SalesOrderAllocation  # pylint: disable=import-outside-toplevel,reimported
+
+        unit = identity.target.inventory_unit
+        reserved = SalesOrderAllocation.objects.filter(
+            inventory_unit=unit,
+            status=SalesOrderAllocation.Status.RESERVED,
+        ).exists()
+        if workspace.mode == Workspace.Mode.NURSERY and unit_physical_state(unit) == 'available' and not reserved:
+            capabilities.append('order_allocate')
     active_cohort = resolution_status == LabelCode.Status.ACTIVE
     active_cohort = active_cohort and key == ('plantings', 'plantcohort')
     active_cohort = active_cohort and identity.target.quantity > 0

--- a/labels/test_rest.py
+++ b/labels/test_rest.py
@@ -11,6 +11,7 @@ from workspaces.models import Workspace, get_current_workspace
 from health.models import HealthObservation, HealthObservationType
 from health.operations import quarantine_observation
 from health.services import preview_observation, record_observation
+from plantings.lifecycle import EventType, OutcomeRequest, record_germination_event, record_lifecycle_event
 
 from .models import LabelCode, LabelPrintJob, LabelTemplate
 from .services import ensure_identity, replace_code, void_code
@@ -67,6 +68,16 @@ class LabelResolutionTests(TestCase):
         )
         constrained = self.resolve(self.code.code)
         self.assertIn('health_release', constrained.data['capabilities'])
+
+    def test_ready_unreserved_nursery_plant_can_be_scanned_into_an_order(self):
+        """Order allocation is offered only while exact stock is available."""
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        plant = self.identity.target
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        resolved = self.resolve(self.code.code)
+        self.assertIn('order_allocate', resolved.data['capabilities'])
 
     def test_unknown_replaced_void_and_wrong_workspace_are_explicit(self):
         """Every unusable scan explains its condition without target leakage."""

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -13,7 +13,7 @@ projected from append-only Nursery observations.
 from datetime import timedelta
 from typing import NamedTuple
 
-from django.db.models import BooleanField, Case, Count, DateField, DateTimeField, DecimalField, DurationField, ExpressionWrapper, F, IntegerField, OuterRef, Q, Subquery, Sum, TextField, Value, When
+from django.db.models import BooleanField, Case, Count, DateField, DateTimeField, DecimalField, DurationField, Exists, ExpressionWrapper, F, IntegerField, OuterRef, Q, Subquery, Sum, TextField, Value, When
 from django.db.models.functions import Coalesce, Now
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.exceptions import ValidationError
@@ -23,6 +23,7 @@ from inventory.rest_query import parse_boolean, parse_date, parse_datetime, pars
 from locations.models import Location
 from labels.models import LabelCode
 from health.availability import quarantine_expression, with_quarantine
+from sales.models import SalesOrderAllocation
 
 from .lifecycle import FINAL_STATES, SELLABLE_STATES, LifecycleState, with_lifecycle_state
 from .models import NurseryObservation, SpecificPlant, SpecificPlantLocation
@@ -66,6 +67,7 @@ class RegisterFilters(NamedTuple):
     states: tuple = ()
     sellable: object = None
     quarantined: object = None
+    reserved: object = None
     germinated_from: object = None
     germinated_to: object = None
     location_type: object = None
@@ -107,6 +109,7 @@ def parse_register_filters(query_params):
         states=states,
         sellable=parse_boolean(query_params.get('sellable'), 'sellable'),
         quarantined=parse_boolean(query_params.get('quarantined'), 'quarantined'),
+        reserved=parse_boolean(query_params.get('reserved'), 'reserved'),
         germinated_from=parse_datetime(query_params.get('germinated_from'), 'germinated_from'),
         germinated_to=parse_datetime(query_params.get('germinated_to'), 'germinated_to'),
         location_type=location_type,
@@ -190,10 +193,19 @@ def register_projection(workspace):
         .select_related(f'{_BATCH}__variety__plant')
     )
     queryset = with_quarantine(queryset)
+    queryset = queryset.annotate(
+        reserved=Exists(
+            SalesOrderAllocation.objects.filter(
+                plant_id=OuterRef('pk'),
+                status=SalesOrderAllocation.Status.RESERVED,
+            ),
+        ),
+    )
     return queryset.annotate(
         sellable=Case(
             When(
                 ~quarantine_expression(),
+                reserved=False,
                 lifecycle_state__in=sorted(SELLABLE_STATES),
                 then=Value(True),
             ),
@@ -293,6 +305,8 @@ def register_queryset(workspace, filters):  # pylint: disable=too-many-branches
         queryset = queryset.filter(sellable=filters.sellable)
     if filters.quarantined is not None:
         queryset = queryset.filter(quarantined=filters.quarantined)
+    if filters.reserved is not None:
+        queryset = queryset.filter(reserved=filters.reserved)
     if filters.germinated_from is not None:
         queryset = queryset.filter(germinated__gte=filters.germinated_from)
     if filters.germinated_to is not None:
@@ -366,17 +380,30 @@ def register_totals(queryset):
     names the matching plants constrained by an active health case. Reserved is
     absent until task 44 records it.
     """
-    counted = {'total': Count('pk')}
-    for state in LifecycleState:
-        counted[state.value] = Count('pk', filter=Q(lifecycle_state=state.value))
-    counted['unresolved'] = Count(
-        'pk',
-        filter=~Q(lifecycle_state__in=sorted(FINAL_STATES)),
-    )
-    counted['quarantined'] = Count(
-        'pk', filter=quarantine_expression(),
-    )
-    totals = queryset.order_by().aggregate(**counted)
+    totals = {
+        'total': 0,
+        'unresolved': 0,
+        'quarantined': 0,
+        'reserved': 0,
+        **{state.value: 0 for state in LifecycleState},
+    }
+    core_rows = queryset.order_by().values(
+        'lifecycle_state', 'quarantined', 'reserved',
+    ).annotate(count=Count('pk'))
+    for row in core_rows:
+        count = row['count']
+        state = row['lifecycle_state']
+        totals['total'] += count
+        if state not in FINAL_STATES:
+            totals['unresolved'] += count
+        if row['quarantined']:
+            totals['quarantined'] += count
+        if row['reserved']:
+            totals['reserved'] += count
+        if state != LifecycleState.AVAILABLE or (
+            not row['quarantined'] and not row['reserved']
+        ):
+            totals[state] += count
     totals['stage_counts'] = {
         str(row['current_stage']): row['count']
         for row in queryset.order_by().values('current_stage').annotate(count=Count('pk'))

--- a/plantings/register_rest.py
+++ b/plantings/register_rest.py
@@ -84,6 +84,7 @@ class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abst
     lifecycle_state = serializers.CharField(read_only=True)
     sellable = serializers.BooleanField(read_only=True)
     quarantined = serializers.BooleanField(read_only=True)
+    reserved = serializers.BooleanField(read_only=True)
     final_outcome = serializers.CharField(read_only=True, allow_null=True)
     final_outcome_at = serializers.DateTimeField(read_only=True, allow_null=True)
     location_type = serializers.CharField(

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -174,6 +174,7 @@ class RegisterContractTests(RegisterTestCase):
             'pk',
             'plant_name',
             'quarantined',
+            'reserved',
             'seed_tray',
             'seed_tray_cell',
             'sellable',

--- a/sales/rest.py
+++ b/sales/rest.py
@@ -1,0 +1,385 @@
+"""Workspace-scoped customer, order, and reservation REST workflows."""
+
+# pylint: disable=too-many-ancestors
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.http import QueryDict
+from rest_framework import mixins, routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from plantings.register import parse_register_filters, register_queryset
+from workspaces.models import Workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+    RequireWorkspaceModeMixin,
+)
+
+from .models import Customer, ReservationEvent, SalesOrder, SalesOrderAllocation, SalesOrderLine
+from .services import (
+    allocate_targets,
+    cancel_order,
+    close_reservations,
+    confirm_order,
+    create_order,
+    deallocate_pending,
+    order_margin,
+    preview_targets,
+    quote_to_draft,
+    update_pricing_mode,
+)
+
+
+def _model_errors(error):
+    """Translate domain validation into field-oriented API errors."""
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _run(function, *args, **kwargs):
+    """Run one domain command with REST-native validation errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+class CustomerSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Editable customer details without exposing workspace ownership."""
+
+    class Meta:
+        model = Customer
+        fields = ['pk', 'name', 'email', 'phone', 'billing_address', 'delivery_address', 'notes', 'active', 'created', 'updated']
+        read_only_fields = ['created', 'updated']
+
+
+class ReservationEventSerializer(serializers.ModelSerializer):
+    """Read-only reservation history."""
+
+    class Meta:
+        model = ReservationEvent
+        fields = ['pk', 'event_type', 'occurred_at', 'reason', 'created_by', 'created']
+        read_only_fields = fields
+
+
+class AllocationSerializer(serializers.ModelSerializer):
+    """One exact pending or historical allocation."""
+
+    events = ReservationEventSerializer(many=True, read_only=True)
+    asset_code = serializers.CharField(source='inventory_unit.asset_code', read_only=True, allow_null=True)
+
+    class Meta:
+        model = SalesOrderAllocation
+        fields = ['pk', 'plant', 'inventory_unit', 'asset_code', 'status', 'expires_at', 'created_by', 'created', 'updated', 'events']
+        read_only_fields = fields
+
+
+class SalesOrderLineSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Editable commercial terms and read-only concrete allocations."""
+
+    allocations = AllocationSerializer(many=True, read_only=True)
+    prices_include_tax = serializers.BooleanField(source='order.prices_include_tax', read_only=True)
+
+    class Meta:
+        model = SalesOrderLine
+        fields = [
+            'pk', 'order', 'line_type', 'variety', 'tray_item', 'description',
+            'quantity', 'unit_price', 'tax_rate', 'discount_type', 'discount_value',
+            'prices_include_tax', 'gross_ex_tax', 'discount_ex_tax',
+            'subtotal_ex_tax', 'tax_total', 'total_incl_tax', 'allocations',
+            'created', 'updated',
+        ]
+        read_only_fields = [
+            'gross_ex_tax', 'discount_ex_tax', 'subtotal_ex_tax', 'tax_total',
+            'total_incl_tax', 'created', 'updated',
+        ]
+
+    workspace_field_lookups = {
+        'order': 'workspace',
+        'variety': 'workspace',
+        'tray_item': 'workspace',
+    }
+
+    def validate(self, attrs):
+        """Fill a new line's tax rate from its immutable order context."""
+        order = self.instance.order if self.instance else attrs['order']
+        if order.status not in {SalesOrder.Status.QUOTE, SalesOrder.Status.DRAFT}:
+            raise ValidationError({'order': 'Confirmed commercial terms are immutable.'})
+        if self.instance is None and 'tax_rate' not in attrs:
+            attrs['tax_rate'] = attrs['order'].workspace.default_tax_rate
+        return attrs
+
+
+class SalesOrderSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Order header, snapshotted totals, exact allocations, and margin."""
+
+    status = serializers.ChoiceField(choices=SalesOrder.Status.choices, required=False)
+    lines = SalesOrderLineSerializer(many=True, read_only=True)
+    margin = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SalesOrder
+        fields = [
+            'pk', 'order_number', 'customer', 'status', 'quote_date', 'order_date',
+            'requested_date', 'currency_code', 'prices_include_tax', 'notes',
+            'gross_ex_tax', 'discount_total_ex_tax', 'subtotal_ex_tax',
+            'tax_total', 'total_incl_tax', 'created_by', 'created', 'updated',
+            'lines', 'margin',
+        ]
+        read_only_fields = [
+            'order_number', 'gross_ex_tax', 'discount_total_ex_tax',
+            'subtotal_ex_tax', 'tax_total', 'total_incl_tax', 'created_by',
+            'created', 'updated',
+        ]
+        extra_kwargs = {'currency_code': {'required': False}, 'prices_include_tax': {'required': False}}
+
+    workspace_field_lookups = {'customer': 'workspace'}
+
+    def get_margin(self, order):
+        """Expose a clearly qualified ex-tax margin preview."""
+        return order_margin(order)
+
+    def validate(self, attrs):
+        """Reserve status changes for explicit transition actions."""
+        if self.instance and 'status' in attrs:
+            raise ValidationError({'status': 'Use an explicit order action.'})
+        customer = attrs.get('customer')
+        if customer is not None and not customer.active:
+            raise ValidationError({'customer': 'Select an active customer.'})
+        return attrs
+
+    def create(self, validated_data):
+        """Use the numbering service and snapshot workspace defaults."""
+        request = self.context['request']
+        return _run(create_order, self.context['workspace'], request.user, **validated_data)
+
+    def update(self, instance, validated_data):
+        """Recalculate all line snapshots when draft pricing mode changes."""
+        validated_data.pop('status', None)
+        pricing_mode = validated_data.pop('prices_include_tax', instance.prices_include_tax)
+        if pricing_mode != instance.prices_include_tax:
+            instance = _run(update_pricing_mode, instance, pricing_mode)
+        return super().update(instance, validated_data)
+
+
+class ActionSerializer(serializers.Serializer):
+    """Validation-only serializer base for explicit commands."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class TargetSelectionSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Exact IDs or register filters for a selection preview."""
+
+    line = serializers.IntegerField(min_value=1)
+    plant_ids = serializers.ListField(child=serializers.IntegerField(min_value=1), required=False, default=list)
+    unit_ids = serializers.ListField(child=serializers.IntegerField(min_value=1), required=False, default=list)
+    filters = serializers.DictField(required=False, default=dict)
+
+    def validate(self, attrs):
+        """Require one unambiguous selection source."""
+        sources = sum(bool(attrs[name]) for name in ('plant_ids', 'unit_ids', 'filters'))
+        if sources != 1:
+            raise ValidationError('Select exactly one of plant_ids, unit_ids, or filters.')
+        return attrs
+
+
+class AllocationRequestSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Concrete targets to attach to one order line."""
+
+    line = serializers.IntegerField(min_value=1)
+    plant_ids = serializers.ListField(child=serializers.IntegerField(min_value=1), required=False, default=list)
+    unit_ids = serializers.ListField(child=serializers.IntegerField(min_value=1), required=False, default=list)
+    expires_at = serializers.DateTimeField(required=False, allow_null=True)
+
+    def validate(self, attrs):
+        """Require plants or units, never a mixture."""
+        if bool(attrs['plant_ids']) == bool(attrs['unit_ids']):
+            raise ValidationError('Select plants or serialized units.')
+        return attrs
+
+
+class AllocationIdsSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """A non-empty set of allocation identities."""
+
+    allocations = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False)
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class ReasonSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Optional audit reason for a document transition."""
+
+    reason = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class CustomerViewSet(
+    RequireWorkspaceModeMixin,
+    CurrentWorkspaceViewSetMixin,
+    mixins.CreateModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Manage active and historical customers without deletion."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    queryset = Customer.objects.order_by('name', 'pk')
+    serializer_class = CustomerSerializer
+
+    def get_queryset(self):
+        """Optionally narrow the register by active state or name."""
+        queryset = super().get_queryset()
+        active = self.request.query_params.get('active')
+        if active in {'true', 'false'}:
+            queryset = queryset.filter(active=active == 'true')
+        search = self.request.query_params.get('search', '').strip()
+        return queryset.filter(name__icontains=search) if search else queryset
+
+
+class SalesOrderLineViewSet(RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Edit line terms only while their parent order remains editable."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    workspace_lookup = 'order__workspace'
+    bind_workspace_on_create = False
+    queryset = SalesOrderLine.objects.select_related('order', 'variety', 'tray_item').prefetch_related('allocations__events')
+    serializer_class = SalesOrderLineSerializer
+
+    def destroy(self, request, *args, **kwargs):
+        """Translate the model's confirmed-term deletion guard."""
+        _run(self.get_object().delete)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class SalesOrderViewSet(RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Read orders and perform explicit commercial/reservation transitions."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    bind_workspace_on_create = False
+    queryset = SalesOrder.objects.select_related('customer', 'workspace').prefetch_related('lines__allocations__events')
+    serializer_class = SalesOrderSerializer
+
+    def get_serializer_context(self):
+        """Supply the workspace used for server-owned creation defaults."""
+        context = super().get_serializer_context()
+        context['workspace'] = self.get_current_workspace()
+        return context
+
+    def get_queryset(self):
+        """Filter the order register by status and customer."""
+        queryset = super().get_queryset()
+        order_status = self.request.query_params.get('status')
+        customer = self.request.query_params.get('customer')
+        if order_status:
+            queryset = queryset.filter(status=order_status)
+        if customer:
+            queryset = queryset.filter(customer_id=customer)
+        return queryset
+
+    def destroy(self, request, *args, **kwargs):
+        """Translate the model's historical-order deletion guard."""
+        _run(self.get_object().delete)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def _line(self, order, line_id):
+        """Resolve a line only within the action's already-scoped order."""
+        try:
+            return order.lines.select_related('order', 'variety', 'tray_item').get(pk=line_id)
+        except SalesOrderLine.DoesNotExist as exc:
+            raise ValidationError({'line': 'Select a line from this order.'}) from exc
+
+    @action(detail=True, methods=['post'], url_path='to-draft')
+    def to_draft(self, request, pk=None):  # pylint: disable=unused-argument
+        """Accept a quote into the draft order workflow."""
+        order = _run(quote_to_draft, self.get_object())
+        return Response(self.get_serializer(order).data)
+
+    @action(detail=True, methods=['post'], url_path='allocation-preview')
+    def allocation_preview(self, request, pk=None):  # pylint: disable=unused-argument
+        """Resolve explicit IDs or plant-register filters without writing."""
+        values = TargetSelectionSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        order = self.get_object()
+        line = self._line(order, data['line'])
+        if data['filters']:
+            if line.line_type != SalesOrderLine.LineType.SEEDLING:
+                raise ValidationError({'filters': 'Register filters select seedlings only.'})
+            query = QueryDict('', mutable=True)
+            for name, value in data['filters'].items():
+                query.setlist(name, value if isinstance(value, list) else [str(value)])
+            query['variety'] = str(line.variety_id)
+            plant_ids = list(register_queryset(order.workspace, parse_register_filters(query)).values_list('pk', flat=True)[:5001])
+            if len(plant_ids) > 5000:
+                raise ValidationError({'filters': 'Narrow the selection to 5000 plants or fewer.'})
+            data['plant_ids'] = plant_ids
+        result = _run(preview_targets, line, data['plant_ids'], data['unit_ids'])
+        return Response(result)
+
+    @action(detail=True, methods=['post'])
+    def allocate(self, request, pk=None):  # pylint: disable=unused-argument
+        """Attach exact targets, reserving replacements when already confirmed."""
+        values = AllocationRequestSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        line = self._line(self.get_object(), data['line'])
+        allocations = _run(
+            allocate_targets,
+            line,
+            request.user,
+            data['plant_ids'],
+            data['unit_ids'],
+            data.get('expires_at'),
+        )
+        return Response(AllocationSerializer(allocations, many=True).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'])
+    def deallocate(self, request, pk=None):  # pylint: disable=unused-argument
+        """Remove tentative selections before confirmation."""
+        values = AllocationIdsSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        _run(deallocate_pending, self.get_object(), values.validated_data['allocations'])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=True, methods=['post'])
+    def confirm(self, request, pk=None):  # pylint: disable=unused-argument
+        """Reserve every line's exact stock in one transaction."""
+        order = _run(confirm_order, self.get_object(), request.user)
+        return Response(self.get_serializer(order).data)
+
+    def _close(self, request, action_name):
+        values = AllocationIdsSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        allocations = _run(close_reservations, self.get_object(), request.user, data['allocations'], action_name, data['reason'])
+        return Response(AllocationSerializer(allocations, many=True).data)
+
+    @action(detail=True, methods=['post'])
+    def release(self, request, pk=None):  # pylint: disable=unused-argument
+        """Release selected unfulfilled reservations."""
+        return self._close(request, 'release')
+
+    @action(detail=True, methods=['post'])
+    def expire(self, request, pk=None):  # pylint: disable=unused-argument
+        """Explicitly expire selected overdue or unwanted reservations."""
+        return self._close(request, 'expire')
+
+    @action(detail=True, methods=['post'])
+    def cancel(self, request, pk=None):  # pylint: disable=unused-argument
+        """Cancel an incomplete order and release unfulfilled stock."""
+        values = ReasonSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        order = _run(cancel_order, self.get_object(), request.user, values.validated_data['reason'])
+        return Response(self.get_serializer(order).data)
+
+
+router = routers.SimpleRouter()
+router.register(r'customers', CustomerViewSet)
+router.register(r'order-lines', SalesOrderLineViewSet)
+router.register(r'orders', SalesOrderViewSet)

--- a/sales/services.py
+++ b/sales/services.py
@@ -1,10 +1,28 @@
 """Transactional commands for sales orders and exact reservations."""
 
+# pylint: disable=too-many-locals
+
+from decimal import Decimal
+
 from django.core.exceptions import ValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from .models import SalesOrder, SalesOrderNumberSequence
+from costing.services import plant_cost_breakdown
+from health.availability import is_quarantined
+from inventory.ledger import lock_units, unit_physical_state
+from inventory.models import InventoryUnit
+from plantings.lifecycle import SELLABLE_STATES, plant_lifecycle_summary
+from plantings.models import SpecificPlant
+
+from .calculations import money
+from .models import (
+    ReservationEvent,
+    SalesOrder,
+    SalesOrderAllocation,
+    SalesOrderLine,
+    SalesOrderNumberSequence,
+)
 
 
 @transaction.atomic
@@ -49,3 +67,294 @@ def update_pricing_mode(order, prices_include_tax):
         line.save()
     order.refresh_from_db()
     return order
+
+
+@transaction.atomic
+def quote_to_draft(order):
+    """Accept a quote into an editable order without changing its terms."""
+    order = SalesOrder.objects.select_for_update().get(pk=order.pk)
+    if order.status != SalesOrder.Status.QUOTE:
+        raise ValidationError({'status': 'Only a quote can become a draft.'})
+    SalesOrder.objects.filter(pk=order.pk).update(
+        status=SalesOrder.Status.DRAFT,
+        order_date=timezone.localdate(),
+        updated=timezone.now(),
+    )
+    order.refresh_from_db()
+    return order
+
+
+def _locked_plants(workspace, plant_ids):
+    """Lock concrete plants in deterministic identifier order."""
+    requested = sorted(set(plant_ids))
+    plants = list(
+        SpecificPlant.objects.select_for_update(of=('self',))
+        .select_related('batch__variety')
+        .filter(workspace=workspace, pk__in=requested)
+        .order_by('pk')
+    )
+    if len(plants) != len(requested):
+        raise ValidationError({'plants': 'One or more plants are unavailable.'})
+    return {plant.pk: plant for plant in plants}
+
+
+def _target_error(line, target):
+    """Return why a locked target cannot currently satisfy this line."""
+    if line.line_type == SalesOrderLine.LineType.SEEDLING:
+        if target.batch.variety_id != line.variety_id:
+            return 'wrong_variety'
+        if plant_lifecycle_summary(target).state not in SELLABLE_STATES:
+            return 'not_sellable'
+        if is_quarantined(target):
+            return 'quarantined'
+        reserved = SalesOrderAllocation.objects.filter(
+            plant=target,
+            status=SalesOrderAllocation.Status.RESERVED,
+        ).exclude(line=line).exists()
+    else:
+        if target.item_id != line.tray_item_id:
+            return 'wrong_item'
+        if unit_physical_state(target) != 'available':
+            return 'not_available'
+        reserved = SalesOrderAllocation.objects.filter(
+            inventory_unit=target,
+            status=SalesOrderAllocation.Status.RESERVED,
+        ).exclude(line=line).exists()
+    return 'already_reserved' if reserved else None
+
+
+def preview_targets(line, plant_ids=(), unit_ids=()):
+    """Resolve explicit target IDs to compatible selections and conflicts."""
+    workspace = line.order.workspace
+    if line.line_type == SalesOrderLine.LineType.SEEDLING and unit_ids:
+        raise ValidationError({'units': 'A seedling line accepts plants only.'})
+    if line.line_type == SalesOrderLine.LineType.TRAY and plant_ids:
+        raise ValidationError({'plants': 'A tray line accepts serialized units only.'})
+    model = SpecificPlant if plant_ids else InventoryUnit
+    ids = sorted(set(plant_ids or unit_ids))
+    targets = {
+        row.pk: row
+        for row in model.objects.filter(pk__in=ids).select_related(
+            'batch__variety' if model is SpecificPlant else 'item',
+        )
+    }
+    selected = []
+    conflicts = []
+    for target_id in ids:
+        target = targets.get(target_id)
+        if target is None:
+            conflicts.append({'id': target_id, 'reason': 'unknown'})
+            continue
+        if target.workspace_id != workspace.pk:
+            conflicts.append({'id': target_id, 'reason': 'wrong_workspace'})
+            continue
+        reason = _target_error(line, target)
+        if reason:
+            conflicts.append({'id': target_id, 'reason': reason})
+        else:
+            selected.append(target_id)
+    return {'selected': selected, 'conflicts': conflicts}
+
+
+@transaction.atomic
+def allocate_targets(line, user, plant_ids=(), unit_ids=(), expires_at=None):
+    """Add tentative targets, or immediately reserve confirmed replacements."""
+    order = SalesOrder.objects.select_for_update().get(pk=line.order_id)
+    line = SalesOrderLine.objects.select_related('order').get(pk=line.pk, order=order)
+    allowed = {
+        SalesOrder.Status.QUOTE,
+        SalesOrder.Status.DRAFT,
+        SalesOrder.Status.CONFIRMED,
+        SalesOrder.Status.PARTIALLY_FULFILLED,
+    }
+    if order.status not in allowed:
+        raise ValidationError({'status': 'This order cannot accept allocations.'})
+    ids = sorted(set(plant_ids or unit_ids))
+    targets = (
+        _locked_plants(order.workspace, ids)
+        if line.line_type == SalesOrderLine.LineType.SEEDLING
+        else lock_units(order.workspace, ids)
+    )
+    active_count = line.allocations.filter(
+        status__in=[SalesOrderAllocation.Status.PENDING, SalesOrderAllocation.Status.RESERVED],
+    ).count()
+    if active_count + len(ids) > line.quantity:
+        raise ValidationError({'allocations': 'Allocations cannot exceed the requested quantity.'})
+    immediate = order.status in {SalesOrder.Status.CONFIRMED, SalesOrder.Status.PARTIALLY_FULFILLED}
+    created = []
+    try:
+        for target_id in ids:
+            target = targets[target_id]
+            reason = _target_error(line, target)
+            if reason:
+                raise ValidationError({'allocations': f'Target {target_id}: {reason}.'})
+            allocation = SalesOrderAllocation.objects.create(
+                line=line,
+                plant=target if line.line_type == SalesOrderLine.LineType.SEEDLING else None,
+                inventory_unit=target if line.line_type == SalesOrderLine.LineType.TRAY else None,
+                status=SalesOrderAllocation.Status.RESERVED if immediate else SalesOrderAllocation.Status.PENDING,
+                expires_at=expires_at,
+                created_by=user,
+            )
+            if immediate:
+                _event(allocation, ReservationEvent.EventType.RESERVED, user)
+            created.append(allocation)
+    except IntegrityError as exc:
+        raise ValidationError({'allocations': 'One or more targets were reserved concurrently.'}) from exc
+    return created
+
+
+@transaction.atomic
+def deallocate_pending(order, allocation_ids):
+    """Remove tentative selections before they ever become reservations."""
+    order = SalesOrder.objects.select_for_update().get(pk=order.pk)
+    if order.status not in {SalesOrder.Status.QUOTE, SalesOrder.Status.DRAFT}:
+        raise ValidationError({'status': 'Only tentative allocations can be removed.'})
+    allocations = list(
+        SalesOrderAllocation.objects.filter(
+            pk__in=allocation_ids,
+            line__order=order,
+            status=SalesOrderAllocation.Status.PENDING,
+        ).order_by('pk')
+    )
+    if len(allocations) != len(set(allocation_ids)):
+        raise ValidationError({'allocations': 'One or more tentative allocations are unavailable.'})
+    for allocation in allocations:
+        allocation.delete()
+
+
+def _event(allocation, event_type, user, reason=''):
+    """Append one reservation fact at the service action's current time."""
+    return ReservationEvent.objects.create(
+        allocation=allocation,
+        event_type=event_type,
+        occurred_at=timezone.now(),
+        reason=reason.strip(),
+        created_by=user,
+    )
+
+
+@transaction.atomic
+def confirm_order(order, user):
+    """Atomically validate and reserve every exact unit promised by a draft."""
+    order = SalesOrder.objects.select_for_update().get(pk=order.pk)
+    if order.status != SalesOrder.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft order can be confirmed.'})
+    lines = list(order.lines.prefetch_related('allocations').order_by('pk'))
+    if not lines:
+        raise ValidationError({'lines': 'Add at least one order line.'})
+    pending = [allocation for line in lines for allocation in line.allocations.all() if allocation.status == SalesOrderAllocation.Status.PENDING]
+    for line in lines:
+        line_pending = [allocation for allocation in line.allocations.all() if allocation.status == SalesOrderAllocation.Status.PENDING]
+        if len(line_pending) != line.quantity:
+            raise ValidationError({'lines': f'Line {line.pk} requires exactly {line.quantity} allocations.'})
+    plant_ids = [allocation.plant_id for allocation in pending if allocation.plant_id]
+    unit_ids = [allocation.inventory_unit_id for allocation in pending if allocation.inventory_unit_id]
+    plants = _locked_plants(order.workspace, plant_ids)
+    units = lock_units(order.workspace, unit_ids)
+    try:
+        for allocation in sorted(pending, key=lambda row: row.pk):
+            target = plants[allocation.plant_id] if allocation.plant_id else units[allocation.inventory_unit_id]
+            reason = _target_error(allocation.line, target)
+            if reason:
+                raise ValidationError({'allocations': f'Target {target.pk}: {reason}.'})
+            SalesOrderAllocation.objects.filter(pk=allocation.pk).update(
+                status=SalesOrderAllocation.Status.RESERVED,
+                updated=timezone.now(),
+            )
+            allocation.status = SalesOrderAllocation.Status.RESERVED
+            _event(allocation, ReservationEvent.EventType.RESERVED, user)
+    except IntegrityError as exc:
+        raise ValidationError({'allocations': 'One or more targets were reserved concurrently.'}) from exc
+    SalesOrder.objects.filter(pk=order.pk).update(status=SalesOrder.Status.CONFIRMED, updated=timezone.now())
+    order.refresh_from_db()
+    return order
+
+
+@transaction.atomic
+def close_reservations(order, user, allocation_ids, action, reason=''):
+    """Release or explicitly expire selected unfulfilled reservations."""
+    statuses = {
+        'release': (SalesOrderAllocation.Status.RELEASED, ReservationEvent.EventType.RELEASED),
+        'expire': (SalesOrderAllocation.Status.EXPIRED, ReservationEvent.EventType.EXPIRED),
+        'cancel': (SalesOrderAllocation.Status.RELEASED, ReservationEvent.EventType.CANCELLED),
+    }
+    if action not in statuses:
+        raise ValueError('Unknown reservation closing action.')
+    order = SalesOrder.objects.select_for_update().get(pk=order.pk)
+    allocations = list(
+        SalesOrderAllocation.objects.select_for_update()
+        .filter(line__order=order, status=SalesOrderAllocation.Status.RESERVED, pk__in=allocation_ids)
+        .order_by('pk')
+    )
+    if len(allocations) != len(set(allocation_ids)):
+        raise ValidationError({'allocations': 'One or more active reservations are unavailable.'})
+    if action == 'expire':
+        not_due = [
+            allocation.pk for allocation in allocations
+            if allocation.expires_at is None or allocation.expires_at > timezone.now()
+        ]
+        if not_due:
+            raise ValidationError({'allocations': f'Reservations are not expired: {not_due}.'})
+    next_status, event_type = statuses[action]
+    for allocation in allocations:
+        SalesOrderAllocation.objects.filter(pk=allocation.pk).update(status=next_status, updated=timezone.now())
+        allocation.status = next_status
+        _event(allocation, event_type, user, reason)
+    return allocations
+
+
+@transaction.atomic
+def cancel_order(order, user, reason=''):
+    """Cancel an incomplete order and release every unfulfilled reservation."""
+    order = SalesOrder.objects.select_for_update().get(pk=order.pk)
+    if order.status == SalesOrder.Status.FULFILLED:
+        raise ValidationError({'status': 'A fulfilled order must use the return/refund workflow.'})
+    if order.status == SalesOrder.Status.CANCELLED:
+        raise ValidationError({'status': 'This order is already cancelled.'})
+    reserved_ids = list(
+        order.lines.filter(
+            allocations__status=SalesOrderAllocation.Status.RESERVED,
+        ).values_list('allocations__pk', flat=True)
+    )
+    if reserved_ids:
+        close_reservations(order, user, reserved_ids, 'cancel', reason)
+    SalesOrder.objects.filter(pk=order.pk).update(status=SalesOrder.Status.CANCELLED, updated=timezone.now())
+    order.refresh_from_db()
+    return order
+
+
+def order_margin(order):
+    """Return an ex-tax margin only when every allocated cost is known."""
+    allocations = list(
+        SalesOrderAllocation.objects.filter(
+            line__order=order,
+            status__in=[SalesOrderAllocation.Status.PENDING, SalesOrderAllocation.Status.RESERVED, SalesOrderAllocation.Status.FULFILLED],
+        ).select_related('plant__batch', 'inventory_unit')
+    )
+    allocated_count = len(allocations)
+    requested_count = sum(order.lines.values_list('quantity', flat=True))
+    cost = Decimal('0')
+    unknown = False
+    provisional = False
+    for allocation in allocations:
+        if allocation.plant_id:
+            breakdown = plant_cost_breakdown(allocation.plant)
+            unknown = unknown or breakdown['unknown_cost']
+            provisional = provisional or breakdown['provisional']
+            value = breakdown['provisional_value'] or breakdown['final_value']
+        else:
+            value = allocation.inventory_unit.acquisition_cost
+            unknown = unknown or value is None
+        if value is not None:
+            cost += Decimal(value)
+    complete = allocated_count == requested_count and not unknown
+    cost = money(cost)
+    return {
+        'allocation_complete': allocated_count == requested_count,
+        'cost_complete': not unknown,
+        'provisional': provisional,
+        'cost_total': f'{cost:f}' if not unknown else None,
+        'estimated_margin': f'{money(order.subtotal_ex_tax - cost):f}' if complete else None,
+        'currency_code': order.currency_code,
+    }

--- a/sales/test_concurrency.py
+++ b/sales/test_concurrency.py
@@ -1,0 +1,113 @@
+"""PostgreSQL proofs for exact-stock reservation locking."""
+
+# pylint: disable=duplicate-code
+
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+
+from plantings.lifecycle import EventType, OutcomeRequest, record_germination_event, record_lifecycle_event
+from tests.factories import make_seed_tray, make_specific_plant
+from workspaces.models import Workspace
+
+from .models import SalesOrder, SalesOrderAllocation, SalesOrderLine
+from .services import allocate_targets, confirm_order, create_order
+
+
+class ReservationConcurrencyTestCase(TransactionTestCase):
+    """Shared transaction fixtures and post-flush workspace restoration."""
+
+    workspace = None
+    user = None
+
+    def _post_teardown(self):
+        """Restore migration seed data removed by transactional flushing."""
+        super()._post_teardown()
+        if not Workspace.objects.filter(pk=settings.CURRENT_WORKSPACE_ID).exists():
+            Workspace.objects.create(pk=settings.CURRENT_WORKSPACE_ID, name='My Garden')
+
+    def _order_with_line(self, line_type, variety=None, tray_item=None):
+        """Create one draft with a single exact-quantity line."""
+        order = create_order(self.workspace, self.user)
+        line = SalesOrderLine.objects.create(
+            order=order,
+            line_type=line_type,
+            variety=variety,
+            tray_item=tray_item,
+            description='Concurrent target',
+            quantity=1,
+            unit_price=Decimal('10'),
+            tax_rate=Decimal('15'),
+        )
+        return order, line
+
+    def _confirm(self, order_pk):
+        """Attempt confirmation from an independent database connection."""
+        close_old_connections()
+        order = SalesOrder.objects.get(pk=order_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            confirm_order(order, user)
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'confirmed'
+        close_old_connections()
+        return result
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentPlantReservationTests(ReservationConcurrencyTestCase):
+    """Two drafts cannot reserve the same individual seedling."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = Workspace.objects.get(pk=settings.CURRENT_WORKSPACE_ID)
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        self.user = get_user_model().objects.create_user(username='plant-reservation-racer')
+        plant = make_specific_plant(workspace=self.workspace)
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        self.order_pks = []
+        for _index in range(2):
+            order, line = self._order_with_line(SalesOrderLine.LineType.SEEDLING, variety=plant.batch.variety)
+            allocate_targets(line, self.user, plant_ids=[plant.pk])
+            self.order_pks.append(order.pk)
+
+    def test_exactly_one_order_wins_the_plant(self):
+        """The plant lock makes one confirmation observe the other's reservation."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(pool.map(self._confirm, self.order_pks))
+        self.assertEqual(results, ['confirmed', 'rejected'])
+        self.assertEqual(SalesOrderAllocation.objects.filter(status='reserved').count(), 1)
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentTrayReservationTests(ReservationConcurrencyTestCase):
+    """Two drafts cannot reserve the same serialized tray unit."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = Workspace.objects.get(pk=settings.CURRENT_WORKSPACE_ID)
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        self.user = get_user_model().objects.create_user(username='tray-reservation-racer')
+        tray = make_seed_tray(workspace=self.workspace)
+        self.order_pks = []
+        for _index in range(2):
+            order, line = self._order_with_line(SalesOrderLine.LineType.TRAY, tray_item=tray.inventory_unit.item)
+            allocate_targets(line, self.user, unit_ids=[tray.inventory_unit_id])
+            self.order_pks.append(order.pk)
+
+    def test_exactly_one_order_wins_the_tray(self):
+        """The unit lock makes one confirmation observe the other's reservation."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(pool.map(self._confirm, self.order_pks))
+        self.assertEqual(results, ['confirmed', 'rejected'])
+        self.assertEqual(SalesOrderAllocation.objects.filter(status='reserved').count(), 1)

--- a/sales/test_rest.py
+++ b/sales/test_rest.py
@@ -1,0 +1,217 @@
+"""REST and reservation workflow contracts for nursery sales."""
+
+# pylint: disable=duplicate-code
+
+from decimal import Decimal
+
+from django.utils import timezone
+
+from plantings.lifecycle import EventType, OutcomeRequest, record_germination_event, record_lifecycle_event
+from tests.api import RESTContractTestCase
+from tests.factories import make_seed_tray, make_specific_plant
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import ReservationEvent, SalesOrder, SalesOrderAllocation
+
+
+class SalesRESTTests(RESTContractTestCase):
+    """Orders expose immutable terms and explicit exact-stock actions."""
+
+    orders_url = '/sales/orders/'
+    lines_url = '/sales/order-lines/'
+    customers_url = '/sales/customers/'
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.currency_code = 'NZD'
+        self.workspace.default_tax_rate = Decimal('15')
+        self.workspace.sales_prices_include_tax = True
+        self.workspace.save()
+
+    def create_order(self, **overrides):
+        """Create one order through its public endpoint."""
+        payload = {'status': SalesOrder.Status.DRAFT, 'notes': 'Counter order', **overrides}
+        response = self.client.post(self.orders_url, payload, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def make_available_plant(self):
+        """Create a germinated plant and record that it is ready for sale."""
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        return plant
+
+    def add_seedling_line(self, order, plant, quantity=1):
+        """Add commercial terms matching a plant's variety."""
+        response = self.client.post(self.lines_url, {
+            'order': order['pk'],
+            'line_type': 'seedling',
+            'variety': plant.batch.variety_id,
+            'description': plant.batch.variety.name,
+            'quantity': quantity,
+            'unit_price': '11.5000',
+            'tax_rate': '15.0000',
+            'discount_type': 'fixed',
+            'discount_value': '3.0000',
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def allocate(self, order, line, plants=None, units=None):
+        """Attach exact stock through the allocation action."""
+        response = self.client.post(
+            f"{self.orders_url}{order['pk']}/allocate/",
+            {'line': line['pk'], 'plant_ids': plants or [], 'unit_ids': units or []},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def test_customer_and_order_resources_snapshot_workspace_defaults(self):
+        """Walk-in and named orders share workspace-owned financial defaults."""
+        customer = self.client.post(self.customers_url, {'name': 'Kauri Landscapes'}, format='json')
+        self.assertEqual(customer.status_code, 201, customer.data)
+        order = self.create_order(customer=customer.data['pk'])
+        self.assertEqual(order['order_number'], 'SO-000001')
+        self.assertEqual(order['currency_code'], 'NZD')
+        self.assertTrue(order['prices_include_tax'])
+
+    def test_inclusive_line_returns_entered_and_canonical_totals(self):
+        """Inclusive entered terms extract tax and preserve reconciliation."""
+        plant = self.make_available_plant()
+        line = self.add_seedling_line(self.create_order(), plant, quantity=2)
+        self.assertEqual(line['unit_price'], '11.5000')
+        self.assertEqual(line['subtotal_ex_tax'], '17.3913')
+        self.assertEqual(line['tax_total'], '2.6087')
+        self.assertEqual(line['total_incl_tax'], '20.0000')
+
+    def test_confirmation_requires_exact_allocations_and_reserves_stock(self):
+        """A draft becomes confirmed only with one target per requested unit."""
+        plant = self.make_available_plant()
+        order = self.create_order()
+        line = self.add_seedling_line(order, plant)
+        incomplete = self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {}, format='json')
+        self.assertEqual(incomplete.status_code, 400)
+        allocations = self.allocate(order, line, plants=[plant.pk])
+        confirmed = self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {}, format='json')
+        self.assertEqual(confirmed.status_code, 200, confirmed.data)
+        self.assertEqual(confirmed.data['status'], SalesOrder.Status.CONFIRMED)
+        allocation = SalesOrderAllocation.objects.get(pk=allocations[0]['pk'])
+        self.assertEqual(allocation.status, SalesOrderAllocation.Status.RESERVED)
+        self.assertEqual(allocation.events.get().event_type, ReservationEvent.EventType.RESERVED)
+
+    def test_second_order_cannot_reserve_the_same_plant(self):
+        """Availability is checked again while holding the plant lock."""
+        plant = self.make_available_plant()
+        first = self.create_order()
+        first_line = self.add_seedling_line(first, plant)
+        self.allocate(first, first_line, plants=[plant.pk])
+        self.assertEqual(self.client.post(f"{self.orders_url}{first['pk']}/confirm/", {}).status_code, 200)
+
+        second = self.create_order()
+        second_line = self.add_seedling_line(second, plant)
+        preview = self.client.post(
+            f"{self.orders_url}{second['pk']}/allocation-preview/",
+            {'line': second_line['pk'], 'plant_ids': [plant.pk]},
+            format='json',
+        )
+        self.assertEqual(preview.status_code, 200)
+        self.assertEqual(preview.data['conflicts'][0]['reason'], 'already_reserved')
+        failed = self.client.post(
+            f"{self.orders_url}{second['pk']}/allocate/",
+            {'line': second_line['pk'], 'plant_ids': [plant.pk]},
+            format='json',
+        )
+        self.assertEqual(failed.status_code, 400)
+
+    def test_release_retains_history_and_restores_register_availability(self):
+        """Explicit release changes availability without deleting its audit."""
+        plant = self.make_available_plant()
+        order = self.create_order()
+        line = self.add_seedling_line(order, plant)
+        allocation = self.allocate(order, line, plants=[plant.pk])[0]
+        self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {})
+        reserved = self.client.get('/plantings/register/', {'reserved': 'true'})
+        self.assertEqual(reserved.data['count'], 1)
+        self.assertEqual(reserved.data['totals']['reserved'], 1)
+        released = self.client.post(
+            f"{self.orders_url}{order['pk']}/release/",
+            {'allocations': [allocation['pk']], 'reason': 'Customer changed quantity.'},
+            format='json',
+        )
+        self.assertEqual(released.status_code, 200, released.data)
+        available = self.client.get('/plantings/register/', {'sellable': 'true'})
+        self.assertEqual(available.data['count'], 1)
+        self.assertEqual(ReservationEvent.objects.filter(allocation_id=allocation['pk']).count(), 2)
+
+    def test_tray_allocation_validates_item_and_physical_state(self):
+        """Serialized tray lines reserve the exact compatible inventory unit."""
+        tray = make_seed_tray(workspace=self.workspace)
+        order = self.create_order(prices_include_tax=False)
+        response = self.client.post(self.lines_url, {
+            'order': order['pk'], 'line_type': 'tray',
+            'tray_item': tray.inventory_unit.item_id,
+            'description': 'Propagation tray', 'quantity': 1,
+            'unit_price': '10.0000', 'tax_rate': '15.0000',
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        self.allocate(order, response.data, units=[tray.inventory_unit_id])
+        confirmed = self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {})
+        self.assertEqual(confirmed.status_code, 200, confirmed.data)
+
+    def test_cancel_releases_reserved_stock(self):
+        """Cancellation preserves reservation facts and returns stock to promise."""
+        plant = self.make_available_plant()
+        order = self.create_order()
+        line = self.add_seedling_line(order, plant)
+        allocation = self.allocate(order, line, plants=[plant.pk])[0]
+        self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {})
+        cancelled = self.client.post(
+            f"{self.orders_url}{order['pk']}/cancel/",
+            {'reason': 'Order withdrawn.'},
+            format='json',
+        )
+        self.assertEqual(cancelled.status_code, 200, cancelled.data)
+        self.assertEqual(cancelled.data['status'], SalesOrder.Status.CANCELLED)
+        self.assertEqual(
+            SalesOrderAllocation.objects.get(pk=allocation['pk']).status,
+            SalesOrderAllocation.Status.RELEASED,
+        )
+
+    def test_confirmed_terms_ignore_later_workspace_default_changes(self):
+        """Changing GST defaults cannot rewrite an accepted order."""
+        plant = self.make_available_plant()
+        order = self.create_order()
+        line = self.add_seedling_line(order, plant)
+        self.allocate(order, line, plants=[plant.pk])
+        confirmed = self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {})
+        before = (confirmed.data['prices_include_tax'], confirmed.data['tax_total'])
+        self.workspace.default_tax_rate = Decimal('12.5')
+        self.workspace.sales_prices_include_tax = False
+        self.workspace.save()
+        after = self.client.get(f"{self.orders_url}{order['pk']}/")
+        self.assertEqual((after.data['prices_include_tax'], after.data['tax_total']), before)
+
+    def test_expiry_is_explicit_not_time_driven(self):
+        """An overdue reservation stays active until the expire action runs."""
+        plant = self.make_available_plant()
+        order = self.create_order()
+        line = self.add_seedling_line(order, plant)
+        response = self.client.post(
+            f"{self.orders_url}{order['pk']}/allocate/",
+            {'line': line['pk'], 'plant_ids': [plant.pk], 'expires_at': '2020-01-01T00:00:00Z'},
+            format='json',
+        )
+        allocation = response.data[0]
+        self.client.post(f"{self.orders_url}{order['pk']}/confirm/", {})
+        self.assertEqual(SalesOrderAllocation.objects.get(pk=allocation['pk']).status, 'reserved')
+        expired = self.client.post(
+            f"{self.orders_url}{order['pk']}/expire/",
+            {'allocations': [allocation['pk']], 'reason': f'Expired at {timezone.now().isoformat()}.'},
+            format='json',
+        )
+        self.assertEqual(expired.status_code, 200, expired.data)
+        self.assertEqual(expired.data[0]['status'], 'expired')

--- a/sales/urls.py
+++ b/sales/urls.py
@@ -1,9 +1,6 @@
 """URL routing for customer sales."""
 
 from django.urls import include, path
-from rest_framework import routers
-
-
-router = routers.SimpleRouter()
+from .rest import router
 
 urlpatterns = [path('', include(router.urls))]


### PR DESCRIPTION
Expose customer and order workflows, lock concrete plants and trays during confirmation, retain reservation history, qualify margin previews, and make register and scan availability reservation-aware.

## Summary by Sourcery

Introduce REST workflows and concurrency-safe exact stock reservation for nursery sales orders, and make availability-aware integrations across register and label scanning.

New Features:
- Add customer, order, line, and reservation REST APIs including allocation preview, allocation, confirmation, release, expiry, and cancellation actions.
- Support reserving exact nursery plants and serialized tray units against sales orders with explicit pending, reserved, released, expired, and cancelled states.
- Expose reservation history on allocations and provide an ex-tax margin preview based on allocated costs.
- Make nursery register rows and totals reservation-aware, including a reserved flag and updated sellable logic, and allow filtering by reservation state.
- Enable nursery label scans for available, unreserved plants and trays to offer order allocation capability.

Enhancements:
- Guard order and allocation workflows with domain validation, workspace scoping, and explicit status transitions, including quote-to-draft acceptance and immutable confirmed terms.
- Ensure concurrent reservation attempts for exact plants and trays are serialized using database locking and covered by dedicated concurrency tests.
- Refine sales URL routing to use the new REST router and update tests to cover REST contracts and reservation behaviour.

Tests:
- Add REST contract tests covering sales workflows, reservation lifecycle, tray allocation, cancellation, expiry, and interaction with workspace financial defaults.
- Add PostgreSQL-backed concurrency tests to prove exclusive reservations for individual plants and serialized tray units.