### PR TITLE
feat(frontend): operate nursery sales orders

### DIFF
--- a/frontend/js/api/sales.ts
+++ b/frontend/js/api/sales.ts
@@ -1,0 +1,88 @@
+import { csrfPatch, csrfPost, fetchAsJson } from '../utils'
+import { AllocationPreview, Customer, SalesAllocation, SalesOrder, SalesOrderLine, SalesOrderLineWrite, SalesOrderStatus } from '../types/sales'
+
+const CUSTOMERS_URL = '/sales/customers/'
+const ORDERS_URL = '/sales/orders/'
+const LINES_URL = '/sales/order-lines/'
+
+function getCustomers(signal?: AbortSignal): Promise<Array<Customer>> {
+  return fetchAsJson<Array<Customer>>(CUSTOMERS_URL, signal)
+}
+
+async function createCustomer(data: Partial<Customer>): Promise<Customer> {
+  const response = await csrfPost(CUSTOMERS_URL, data)
+  return response.json() as Promise<Customer>
+}
+
+async function updateCustomer(pk: number, data: Partial<Customer>): Promise<Customer> {
+  const response = await csrfPatch(`${CUSTOMERS_URL}${pk}/`, data)
+  return response.json() as Promise<Customer>
+}
+
+function getSalesOrders(signal?: AbortSignal): Promise<Array<SalesOrder>> {
+  return fetchAsJson<Array<SalesOrder>>(ORDERS_URL, signal)
+}
+
+function getSalesOrder(pk: number, signal?: AbortSignal): Promise<SalesOrder> {
+  return fetchAsJson<SalesOrder>(`${ORDERS_URL}${pk}/`, signal)
+}
+
+async function createSalesOrder(data: { status: 'quote' | 'draft'; customer?: number | null; requested_date?: string | null; notes?: string }): Promise<SalesOrder> {
+  const response = await csrfPost(ORDERS_URL, data)
+  return response.json() as Promise<SalesOrder>
+}
+
+async function updateSalesOrder(pk: number, data: Partial<Pick<SalesOrder, 'customer' | 'requested_date' | 'notes' | 'prices_include_tax'>>): Promise<SalesOrder> {
+  const response = await csrfPatch(`${ORDERS_URL}${pk}/`, data)
+  return response.json() as Promise<SalesOrder>
+}
+
+async function createSalesOrderLine(data: SalesOrderLineWrite): Promise<SalesOrderLine> {
+  const response = await csrfPost(LINES_URL, data)
+  return response.json() as Promise<SalesOrderLine>
+}
+
+async function orderAction(pk: number, action: 'to-draft' | 'confirm' | 'cancel', data: object = {}): Promise<SalesOrder> {
+  const response = await csrfPost(`${ORDERS_URL}${pk}/${action}/`, data)
+  return response.json() as Promise<SalesOrder>
+}
+
+async function previewAllocation(pk: number, data: object): Promise<AllocationPreview> {
+  const response = await csrfPost(`${ORDERS_URL}${pk}/allocation-preview/`, data)
+  return response.json() as Promise<AllocationPreview>
+}
+
+async function allocateOrderLine(pk: number, line: number, plantIds: Array<number>, unitIds: Array<number>, expiresAt: string | null): Promise<Array<SalesAllocation>> {
+  const response = await csrfPost(`${ORDERS_URL}${pk}/allocate/`, { line, plant_ids: plantIds, unit_ids: unitIds, expires_at: expiresAt })
+  return response.json() as Promise<Array<SalesAllocation>>
+}
+
+async function closeAllocations(pk: number, action: 'release' | 'expire', allocations: Array<number>, reason: string): Promise<Array<SalesAllocation>> {
+  const response = await csrfPost(`${ORDERS_URL}${pk}/${action}/`, { allocations, reason })
+  return response.json() as Promise<Array<SalesAllocation>>
+}
+
+function getAvailableSerializedUnits(item: number, signal?: AbortSignal): Promise<Array<{ pk: number; item: number; asset_code: string }>> {
+  return fetchAsJson(`/inventory/serialized-units/?item=${item}&physical_state=available`, signal)
+}
+
+function editableOrder(status: SalesOrderStatus): boolean {
+  return status === 'quote' || status === 'draft'
+}
+
+export {
+  allocateOrderLine,
+  closeAllocations,
+  createCustomer,
+  createSalesOrder,
+  createSalesOrderLine,
+  editableOrder,
+  getAvailableSerializedUnits,
+  getCustomers,
+  getSalesOrder,
+  getSalesOrders,
+  orderAction,
+  previewAllocation,
+  updateCustomer,
+  updateSalesOrder
+}

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -11,6 +11,7 @@ import { queryKeys } from './query'
 import { LabelFormat, LabelPrintJob, LabelResolution } from './types/labels'
 import { BulkOperationPanel } from './plantings/bulk_operations'
 import { HealthScopeType } from './types/health'
+import { allocateOrderLine, getSalesOrders, previewAllocation } from './api/sales'
 
 import './labels.css'
 
@@ -226,9 +227,48 @@ function ScannerView() {
   const [scanned, setScanned] = React.useState<Array<{ id: number; code: string; display: string }>>([])
   const [healthScanned, setHealthScanned] = React.useState<Array<{ type: HealthScopeType; id: number; code: string; display: string }>>([])
   const [stocktakeCode, setStocktakeCode] = React.useState('')
+  const [salesOrder, setSalesOrder] = React.useState<number | ''>('')
+  const [salesLine, setSalesLine] = React.useState<number | ''>('')
+  const [orderScanned, setOrderScanned] = React.useState<Array<{ id: number; code: string; display: string }>>([])
+  const [orderConflict, setOrderConflict] = React.useState('')
   const video = React.useRef<HTMLVideoElement>(null)
   const controls = React.useRef<IScannerControls | undefined>(undefined)
   const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+  const orders = useQuery({ queryKey: queryKeys.sales.orders, queryFn: ({ signal }) => getSalesOrders(signal) })
+  const chosenOrder = orders.data?.find((entry) => entry.pk === salesOrder)
+  const chosenLine = chosenOrder?.lines.find((entry) => entry.pk === salesLine)
+  const orderAllocation = useMutation({
+    mutationFn: async (resolved: LabelResolution) => {
+      if (!chosenOrder || !chosenLine || !resolved.target) throw new Error('Choose an order line before scanning stock.')
+      const id = chosenLine.line_type === 'seedling' ? resolved.target.object_id : resolved.target.inventory_unit
+      if (id === undefined) throw new Error('That label is not compatible with the selected line.')
+      const preview = await previewAllocation(chosenOrder.pk, {
+        line: chosenLine.pk,
+        ...(chosenLine.line_type === 'seedling' ? { plant_ids: [id] } : { unit_ids: [id] })
+      })
+      if (preview.conflicts.length) throw new Error(preview.conflicts[0].reason.replaceAll('_', ' '))
+      return { id, code: resolved.current_code ?? resolved.code ?? '', display: resolved.target.display }
+    },
+    onSuccess: (entry) => {
+      setOrderConflict('')
+      setOrderScanned((current) => (current.some((item) => item.id === entry.id) ? current : [...current, entry]))
+    },
+    onError: (error) => setOrderConflict(error instanceof Error ? error.message : String(error))
+  })
+  const saveOrderAllocation = useMutation({
+    mutationFn: () =>
+      allocateOrderLine(
+        chosenOrder?.pk as number,
+        chosenLine?.pk as number,
+        chosenLine?.line_type === 'seedling' ? orderScanned.map((entry) => entry.id) : [],
+        chosenLine?.line_type === 'tray' ? orderScanned.map((entry) => entry.id) : [],
+        null
+      ),
+    onSuccess: () => {
+      setOrderScanned([])
+      void orders.refetch()
+    }
+  })
 
   const resolveMutation = useMutation({
     mutationFn: (input: string) => resolveLabel(input),
@@ -241,6 +281,9 @@ function ScannerView() {
             ? current
             : [...current, { id: target.object_id, code: resolved.current_code ?? resolved.code ?? '', display: target.display }]
         )
+      }
+      if (resolved.status === 'active' && resolved.target && resolved.capabilities?.includes('order_allocate') && chosenLine) {
+        orderAllocation.mutate(resolved)
       }
       if (resolved.status === 'active' && resolved.target && resolved.capabilities?.includes('health_inspection')) {
         const target = resolved.target
@@ -343,6 +386,78 @@ function ScannerView() {
           )}
         </Col>
         <Col lg={6}>
+          <h2>
+            Order allocation <Badge bg="primary">{orderScanned.length}</Badge>
+          </h2>
+          <Row className="g-2 mb-2">
+            <Col md={6}>
+              <Form.Select
+                value={salesOrder}
+                onChange={(event) => {
+                  setSalesOrder(event.target.value === '' ? '' : Number(event.target.value))
+                  setSalesLine('')
+                  setOrderScanned([])
+                }}
+              >
+                <option value="">Choose an order</option>
+                {(orders.data ?? [])
+                  .filter((entry) => ['quote', 'draft', 'confirmed', 'partially_fulfilled'].includes(entry.status))
+                  .map((entry) => (
+                    <option key={entry.pk} value={entry.pk}>
+                      {entry.order_number}
+                    </option>
+                  ))}
+              </Form.Select>
+            </Col>
+            <Col md={6}>
+              <Form.Select
+                value={salesLine}
+                disabled={!chosenOrder}
+                onChange={(event) => {
+                  setSalesLine(event.target.value === '' ? '' : Number(event.target.value))
+                  setOrderScanned([])
+                }}
+              >
+                <option value="">Choose a line before scanning</option>
+                {(chosenOrder?.lines ?? []).map((line) => (
+                  <option key={line.pk} value={line.pk}>
+                    {line.description} ({line.allocations.filter((allocation) => ['pending', 'reserved'].includes(allocation.status)).length}/{line.quantity})
+                  </option>
+                ))}
+              </Form.Select>
+            </Col>
+          </Row>
+          {orderConflict && <Alert variant="warning">Scan not added: {orderConflict}</Alert>}
+          {chosenLine && <p className="text-muted">Scan {chosenLine.line_type === 'seedling' ? 'plant' : 'tray'} labels to validate them against this line.</p>}
+          {orderScanned.length > 0 && (
+            <>
+              <ul className="list-group mb-2">
+                {orderScanned.map((entry) => (
+                  <li className="list-group-item d-flex justify-content-between" key={entry.id}>
+                    <span>
+                      {entry.display}
+                      <br />
+                      <small className="font-monospace">{entry.code}</small>
+                    </span>
+                    <Button variant="outline-danger" onClick={() => setOrderScanned(orderScanned.filter((item) => item.id !== entry.id))}>
+                      Remove
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                className="mb-4"
+                disabled={
+                  !chosenLine ||
+                  orderScanned.length + (chosenLine?.allocations.filter((allocation) => ['pending', 'reserved'].includes(allocation.status)).length ?? 0) >
+                    (chosenLine?.quantity ?? 0)
+                }
+                onClick={() => saveOrderAllocation.mutate()}
+              >
+                Add scans to order
+              </Button>
+            </>
+          )}
           <h2>
             Health inspection{' '}
             <Badge bg="warning" text="dark">

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -33,6 +33,7 @@ import { ProductionPlanningView } from './plantings/production_planning.js'
 import { LabelsView, ScannerView } from './labels.js'
 import { WorkQueueView } from './work.js'
 import { HealthView } from './health.js'
+import { CustomerListView, SalesOrderDetailView, SalesOrderListView } from './sales.js'
 
 function SeedTrayDetailsRoute() {
   const { trayId } = useParams()
@@ -72,6 +73,13 @@ function CohortDetailRoute() {
   const cohortPk = Number(cohortId)
   if (!cohortId || !Number.isInteger(cohortPk) || cohortPk <= 0) return <div>Cohort not found.</div>
   return <CohortDetailView cohortPk={cohortPk} />
+}
+
+function SalesOrderDetailRoute({ workspace }: { workspace: Workspace }) {
+  const { orderId } = useParams()
+  const orderPk = Number(orderId)
+  if (!orderId || !Number.isInteger(orderPk) || orderPk <= 0) return <div>Sales order not found.</div>
+  return <SalesOrderDetailView orderPk={orderPk} workspace={workspace} />
 }
 
 function FrontEndPage() {
@@ -159,6 +167,30 @@ function FrontEndPage() {
         <Route path="/inventory/stocktakes" element={<StocktakeListView />} />
         <Route path="/inventory/stocktakes/:stocktakeId" element={<StocktakeDetailView />} />
         <Route path="/applications" element={<InputApplicationsView />} />
+        <Route
+          path="/sales/orders"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <SalesOrderListView />
+            </WorkspaceModeRoute>
+          }
+        />
+        <Route
+          path="/sales/orders/:orderId"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <SalesOrderDetailRoute workspace={workspace} />
+            </WorkspaceModeRoute>
+          }
+        />
+        <Route
+          path="/sales/customers"
+          element={
+            <WorkspaceModeRoute workspace={workspace} enabledModes={['nursery']}>
+              <CustomerListView />
+            </WorkspaceModeRoute>
+          }
+        />
         <Route path="/labels" element={<LabelsView />} />
         <Route path="/scan" element={<ScannerView />} />
         <Route path="/scan/:code" element={<ScannerView />} />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -17,6 +17,7 @@ function GPTopBar({ workspace }: GPTopBarProps) {
   const seedTraysActive = pathname === '/seedtrays' || pathname.startsWith('/seedtrays/')
   const plantingActive = pathname === '/plantings' || pathname.startsWith('/plantings/') || pathname === '/health'
   const inventoryActive = pathname === '/inventory' || pathname.startsWith('/inventory/') || pathname.startsWith('/applications') || pathname.startsWith('/locations')
+  const salesActive = pathname === '/sales' || pathname.startsWith('/sales/')
 
   return (
     <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
@@ -43,6 +44,16 @@ function GPTopBar({ workspace }: GPTopBarProps) {
               Stock
             </NavDropdown.Item>
           </NavDropdown>
+          {workspace.mode === 'nursery' && (
+            <NavDropdown title="Sales" active={salesActive}>
+              <NavDropdown.Item as={NavLink} to="/sales/orders">
+                Orders
+              </NavDropdown.Item>
+              <NavDropdown.Item as={NavLink} to="/sales/customers">
+                Customers
+              </NavDropdown.Item>
+            </NavDropdown>
+          )}
           <NavDropdown title="Seed Trays" active={seedTraysActive}>
             <NavDropdown.Item as={NavLink} to="/seedtrays/models">
               Seed Tray Models

--- a/frontend/js/plantings/register.tsx
+++ b/frontend/js/plantings/register.tsx
@@ -51,6 +51,7 @@ function RegisterTotals({ totals }: TotalsProps) {
     { label: 'Growing', value: totals.growing },
     { label: 'Available', value: totals.available, variant: 'text-success' },
     { label: 'Quarantined', value: totals.quarantined, variant: 'text-warning' },
+    { label: 'Reserved', value: totals.reserved, variant: 'text-primary' },
     { label: 'Unresolved', value: totals.unresolved },
     { label: 'Retained', value: totals.retained },
     { label: 'Lost', value: totals.failed + totals.culled, variant: 'text-danger' }
@@ -116,6 +117,7 @@ function NurseryRegisterView() {
   const [readyTo, setReadyTo] = React.useState('')
   const [stageOverdue, setStageOverdue] = React.useState(false)
   const [quarantined, setQuarantined] = React.useState<boolean | undefined>(undefined)
+  const [reserved, setReserved] = React.useState<boolean | undefined>(undefined)
   const [page, setPage] = React.useState(1)
   const [selection, setSelection] = React.useState<RegisterSelection>(EMPTY_SELECTION)
 
@@ -137,6 +139,7 @@ function NurseryRegisterView() {
     expected_ready_to: readyTo || undefined,
     stage_overdue: stageOverdue || undefined,
     quarantined,
+    reserved,
     ordering,
     page,
     page_size: PAGE_SIZE
@@ -201,6 +204,17 @@ function NurseryRegisterView() {
             <Form.Label>Search</Form.Label>
             <Form.Control type="search" placeholder="Plant number, batch code, or crop" value={search} onChange={(event) => narrow(setSearch)(event.target.value)} />
           </Form.Group>
+        </Col>
+        <Col md={3}>
+          <Form.Label>Reservation</Form.Label>
+          <Form.Select
+            value={reserved === undefined ? '' : String(reserved)}
+            onChange={(event) => narrow(setReserved)(event.target.value === '' ? undefined : event.target.value === 'true')}
+          >
+            <option value="">Any status</option>
+            <option value="true">Reserved</option>
+            <option value="false">Not reserved</option>
+          </Form.Select>
         </Col>
         <Col md={3}>
           <Form.Group controlId="register-seed-tray">

--- a/frontend/js/plantings/register_list.tsx
+++ b/frontend/js/plantings/register_list.tsx
@@ -105,7 +105,7 @@ function RegisterTable({ rows, selection, setSelection }: RegisterTableProps) {
               <Form.Check
                 aria-label={`Select plant ${row.pk}`}
                 checked={isSelected(selection, row.pk)}
-                disabled={selection.mode === 'filter' || row.quarantined}
+                disabled={selection.mode === 'filter' || row.quarantined || row.reserved}
                 onChange={() => setSelection(toggleSelected(selection, row.pk))}
               />
             </td>
@@ -126,6 +126,11 @@ function RegisterTable({ rows, selection, setSelection }: RegisterTableProps) {
                   <Badge bg="warning" text="dark">
                     Quarantined · unavailable
                   </Badge>
+                </div>
+              )}
+              {row.reserved && (
+                <div>
+                  <Badge bg="primary">Reserved · unavailable</Badge>
                 </div>
               )}
             </td>

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -4,6 +4,13 @@ import { CohortFilters, NurseryRegisterFilters } from './types/plantings'
 import { WorkFilters } from './types/work'
 
 const queryKeys = {
+  sales: {
+    all: ['sales'] as const,
+    customers: ['sales', 'customers'] as const,
+    orders: ['sales', 'orders'] as const,
+    order: (pk: number) => ['sales', 'orders', pk] as const,
+    availableUnits: (item: number) => ['sales', 'available-units', item] as const
+  },
   health: {
     all: ['health'] as const,
     types: ['health', 'observation-types'] as const,

--- a/frontend/js/sales.tsx
+++ b/frontend/js/sales.tsx
@@ -1,0 +1,556 @@
+import React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
+import { Link } from 'react-router'
+
+import {
+  allocateOrderLine,
+  closeAllocations,
+  createCustomer,
+  createSalesOrder,
+  createSalesOrderLine,
+  editableOrder,
+  getAvailableSerializedUnits,
+  getCustomers,
+  getSalesOrder,
+  getSalesOrders,
+  orderAction,
+  previewAllocation,
+  updateCustomer,
+  updateSalesOrder
+} from './api/sales'
+import { getInventoryItems } from './api/inventory'
+import { getPlantVarieties } from './api/plants'
+import { queryClient, queryKeys } from './query'
+import { AllocationPreview, Customer, SalesDiscountType, SalesLineType, SalesOrder, SalesOrderLine } from './types/sales'
+import { Workspace } from './types/workspace'
+import { formatDate, formatMoney, localDatetimeInputValue } from './utils'
+
+function invalidateSales(orderPk?: number) {
+  void queryClient.invalidateQueries({ queryKey: queryKeys.sales.all })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.registerAll })
+  if (orderPk !== undefined) void queryClient.invalidateQueries({ queryKey: queryKeys.sales.order(orderPk) })
+}
+
+function CustomerForm({ customer }: { customer?: Customer }) {
+  const [name, setName] = React.useState(customer?.name ?? '')
+  const [email, setEmail] = React.useState(customer?.email ?? '')
+  const [phone, setPhone] = React.useState(customer?.phone ?? '')
+  const mutation = useMutation({
+    mutationFn: () => (customer ? updateCustomer(customer.pk, { name, email, phone }) : createCustomer({ name, email, phone })),
+    onSuccess: () => invalidateSales()
+  })
+  return (
+    <Form
+      className="mb-3"
+      onSubmit={(event) => {
+        event.preventDefault()
+        mutation.mutate()
+      }}
+    >
+      <Row className="g-2 align-items-end">
+        <Col md={4}>
+          <Form.Label>Name</Form.Label>
+          <Form.Control required value={name} onChange={(event) => setName(event.target.value)} />
+        </Col>
+        <Col md={3}>
+          <Form.Label>Email</Form.Label>
+          <Form.Control type="email" value={email} onChange={(event) => setEmail(event.target.value)} />
+        </Col>
+        <Col md={3}>
+          <Form.Label>Phone</Form.Label>
+          <Form.Control value={phone} onChange={(event) => setPhone(event.target.value)} />
+        </Col>
+        <Col md={2}>
+          <Button type="submit" disabled={!name.trim() || mutation.isPending}>
+            {customer ? 'Save' : 'Add customer'}
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  )
+}
+
+function CustomerListView() {
+  const customers = useQuery({ queryKey: queryKeys.sales.customers, queryFn: ({ signal }) => getCustomers(signal) })
+  const deactivate = useMutation({ mutationFn: (customer: Customer) => updateCustomer(customer.pk, { active: false }), onSuccess: () => invalidateSales() })
+  return (
+    <main className="container py-3">
+      <h1>Customers</h1>
+      <p>Keep historical customers and deactivate them when they should no longer be selected.</p>
+      <Card body className="mb-3">
+        <CustomerForm />
+      </Card>
+      {(customers.data ?? []).map((customer) => (
+        <Card body className="mb-2" key={customer.pk}>
+          <CustomerForm customer={customer} />
+          <div className="d-flex justify-content-between">
+            <span>{customer.active ? <Badge bg="success">Active</Badge> : <Badge bg="secondary">Inactive</Badge>}</span>
+            {customer.active && (
+              <Button size="sm" variant="outline-secondary" onClick={() => deactivate.mutate(customer)}>
+                Deactivate
+              </Button>
+            )}
+          </div>
+        </Card>
+      ))}
+    </main>
+  )
+}
+
+function SalesOrderListView() {
+  const orders = useQuery({ queryKey: queryKeys.sales.orders, queryFn: ({ signal }) => getSalesOrders(signal) })
+  const customers = useQuery({ queryKey: queryKeys.sales.customers, queryFn: ({ signal }) => getCustomers(signal) })
+  const [status, setStatus] = React.useState<'quote' | 'draft'>('draft')
+  const [customer, setCustomer] = React.useState<number | ''>('')
+  const create = useMutation({
+    mutationFn: () => createSalesOrder({ status, customer: customer === '' ? null : customer }),
+    onSuccess: (order) => {
+      invalidateSales(order.pk)
+      window.location.hash = `#/sales/orders/${order.pk}`
+    }
+  })
+  return (
+    <main className="container py-3">
+      <h1>Sales orders</h1>
+      <Card body className="mb-3">
+        <Row className="g-2 align-items-end">
+          <Col md={3}>
+            <Form.Label>Start as</Form.Label>
+            <Form.Select value={status} onChange={(event) => setStatus(event.target.value as 'quote' | 'draft')}>
+              <option value="draft">Draft order</option>
+              <option value="quote">Quote</option>
+            </Form.Select>
+          </Col>
+          <Col md={5}>
+            <Form.Label>Customer</Form.Label>
+            <Form.Select value={customer} onChange={(event) => setCustomer(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Walk-in / no customer</option>
+              {(customers.data ?? [])
+                .filter((entry) => entry.active)
+                .map((entry) => (
+                  <option key={entry.pk} value={entry.pk}>
+                    {entry.name}
+                  </option>
+                ))}
+            </Form.Select>
+          </Col>
+          <Col md={4}>
+            <Button onClick={() => create.mutate()}>Create</Button>
+          </Col>
+        </Row>
+      </Card>
+      <Table striped responsive>
+        <thead>
+          <tr>
+            <th>Order</th>
+            <th>Status</th>
+            <th>Customer</th>
+            <th>Requested</th>
+            <th>Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(orders.data ?? []).map((order) => (
+            <tr key={order.pk}>
+              <td>
+                <Link to={`/sales/orders/${order.pk}`}>{order.order_number}</Link>
+              </td>
+              <td>{order.status.replaceAll('_', ' ')}</td>
+              <td>{customers.data?.find((entry) => entry.pk === order.customer)?.name ?? 'Walk-in'}</td>
+              <td>{order.requested_date ? formatDate(order.requested_date) : 'Not set'}</td>
+              <td>{formatMoney(order.total_incl_tax, order.currency_code)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </main>
+  )
+}
+
+function LineForm({ order, workspace }: { order: SalesOrder; workspace: Workspace }) {
+  const varieties = useQuery({ queryKey: queryKeys.plants.varieties, queryFn: ({ signal }) => getPlantVarieties(signal) })
+  const trayItems = useQuery({
+    queryKey: ['inventory', 'sales-trays'],
+    queryFn: ({ signal }) => getInventoryItems({ category: 'tray', tracking_mode: 'serialized', active: true }, signal)
+  })
+  const [lineType, setLineType] = React.useState<SalesLineType>('seedling')
+  const [target, setTarget] = React.useState<number | ''>('')
+  const [description, setDescription] = React.useState('')
+  const [quantity, setQuantity] = React.useState(1)
+  const [unitPrice, setUnitPrice] = React.useState('')
+  const [taxRate, setTaxRate] = React.useState(workspace.default_tax_rate)
+  const [discountType, setDiscountType] = React.useState<SalesDiscountType>('none')
+  const [discountValue, setDiscountValue] = React.useState('0')
+  const mutation = useMutation({
+    mutationFn: () =>
+      createSalesOrderLine({
+        order: order.pk,
+        line_type: lineType,
+        variety: lineType === 'seedling' ? Number(target) : null,
+        tray_item: lineType === 'tray' ? Number(target) : null,
+        description,
+        quantity,
+        unit_price: unitPrice,
+        tax_rate: taxRate,
+        discount_type: discountType,
+        discount_value: discountType === 'none' ? '0' : discountValue
+      }),
+    onSuccess: () => invalidateSales(order.pk)
+  })
+  const targets = lineType === 'seedling' ? (varieties.data ?? []) : (trayItems.data ?? [])
+  return (
+    <Card body className="mb-3">
+      <Card.Title>Add line</Card.Title>
+      <Row className="g-2 align-items-end">
+        <Col md={2}>
+          <Form.Label>Type</Form.Label>
+          <Form.Select
+            value={lineType}
+            onChange={(event) => {
+              setLineType(event.target.value as SalesLineType)
+              setTarget('')
+            }}
+          >
+            <option value="seedling">Seedling</option>
+            <option value="tray">Serialized tray</option>
+          </Form.Select>
+        </Col>
+        <Col md={2}>
+          <Form.Label>{lineType === 'seedling' ? 'Variety' : 'Tray item'}</Form.Label>
+          <Form.Select value={target} onChange={(event) => setTarget(event.target.value === '' ? '' : Number(event.target.value))}>
+            <option value="">Select…</option>
+            {targets.map((entry) => (
+              <option key={entry.pk} value={entry.pk}>
+                {entry.name}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+        <Col md={2}>
+          <Form.Label>Description snapshot</Form.Label>
+          <Form.Control value={description} onChange={(event) => setDescription(event.target.value)} />
+        </Col>
+        <Col md={1}>
+          <Form.Label>Quantity</Form.Label>
+          <Form.Control type="number" min={1} value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+        </Col>
+        <Col md={1}>
+          <Form.Label>Unit price</Form.Label>
+          <Form.Control type="number" min={0} step="0.0001" value={unitPrice} onChange={(event) => setUnitPrice(event.target.value)} />
+        </Col>
+        <Col md={1}>
+          <Form.Label>Tax %</Form.Label>
+          <Form.Control type="number" min={0} max={100} step="0.0001" value={taxRate} onChange={(event) => setTaxRate(event.target.value)} />
+        </Col>
+        <Col md={1}>
+          <Form.Label>Discount</Form.Label>
+          <Form.Select value={discountType} onChange={(event) => setDiscountType(event.target.value as SalesDiscountType)}>
+            <option value="none">None</option>
+            <option value="fixed">Fixed</option>
+            <option value="percentage">Percent</option>
+          </Form.Select>
+        </Col>
+        <Col md={1}>
+          <Form.Label>Value</Form.Label>
+          <Form.Control disabled={discountType === 'none'} type="number" min={0} step="0.0001" value={discountValue} onChange={(event) => setDiscountValue(event.target.value)} />
+        </Col>
+        <Col md={1}>
+          <Button disabled={target === '' || !description.trim() || !unitPrice} onClick={() => mutation.mutate()}>
+            Add
+          </Button>
+        </Col>
+      </Row>
+      <Form.Text>Entered prices and fixed discounts {order.prices_include_tax ? 'include' : 'exclude'} tax / GST.</Form.Text>
+    </Card>
+  )
+}
+
+function AllocationPanel({ order, line }: { order: SalesOrder; line: SalesOrderLine }) {
+  const [plantIds, setPlantIds] = React.useState('')
+  const [batch, setBatch] = React.useState('')
+  const [tray, setTray] = React.useState('')
+  const [location, setLocation] = React.useState('')
+  const [readyTo, setReadyTo] = React.useState('')
+  const [selectedUnits, setSelectedUnits] = React.useState<Array<number>>([])
+  const [expiresAt, setExpiresAt] = React.useState('')
+  const [preview, setPreview] = React.useState<AllocationPreview>()
+  const units = useQuery({
+    queryKey: queryKeys.sales.availableUnits(line.tray_item ?? 0),
+    queryFn: ({ signal }) => getAvailableSerializedUnits(line.tray_item as number, signal),
+    enabled: line.line_type === 'tray'
+  })
+  const previewMutation = useMutation({
+    mutationFn: () => {
+      const ids = plantIds
+        .split(',')
+        .map((value) => Number(value.trim()))
+        .filter((value) => Number.isInteger(value) && value > 0)
+      if (line.line_type === 'tray') return previewAllocation(order.pk, { line: line.pk, unit_ids: selectedUnits })
+      if (ids.length) return previewAllocation(order.pk, { line: line.pk, plant_ids: ids })
+      return previewAllocation(order.pk, {
+        line: line.pk,
+        filters: {
+          state: ['available'],
+          reserved: false,
+          quarantined: false,
+          ...(batch ? { batch } : {}),
+          ...(tray ? { seed_tray: tray } : {}),
+          ...(location ? { location } : {}),
+          ...(readyTo ? { expected_ready_to: readyTo } : {})
+        }
+      })
+    },
+    onSuccess: setPreview
+  })
+  const allocate = useMutation({
+    mutationFn: () =>
+      allocateOrderLine(
+        order.pk,
+        line.pk,
+        line.line_type === 'seedling' ? (preview?.selected ?? []) : [],
+        line.line_type === 'tray' ? (preview?.selected ?? []) : [],
+        expiresAt ? new Date(expiresAt).toISOString() : null
+      ),
+    onSuccess: () => {
+      setPreview(undefined)
+      invalidateSales(order.pk)
+    }
+  })
+  const close = useMutation({
+    mutationFn: ({ allocation, action }: { allocation: number; action: 'release' | 'expire' }) =>
+      closeAllocations(order.pk, action, [allocation], `${action === 'release' ? 'Released' : 'Expired'} by operator.`),
+    onSuccess: () => invalidateSales(order.pk)
+  })
+  const active = line.allocations.filter((allocation) => allocation.status === 'pending' || allocation.status === 'reserved').length
+  return (
+    <Card body className="mt-2">
+      <div className="d-flex justify-content-between">
+        <strong>
+          Allocations {active}/{line.quantity}
+        </strong>
+        {active === line.quantity && <Badge bg="success">Complete</Badge>}
+      </div>
+      <ul className="mb-2">
+        {line.allocations.map((allocation) => (
+          <li key={allocation.pk}>
+            {allocation.plant ? `Plant #${allocation.plant}` : allocation.asset_code} · {allocation.status}
+            {allocation.expires_at && ` · expires ${formatDate(allocation.expires_at)}`}
+            {allocation.status === 'reserved' && (
+              <>
+                {' '}
+                <Button size="sm" variant="link" onClick={() => close.mutate({ allocation: allocation.pk, action: 'release' })}>
+                  Release
+                </Button>
+                {allocation.expires_at && new Date(allocation.expires_at) <= new Date() && (
+                  <Button size="sm" variant="link" onClick={() => close.mutate({ allocation: allocation.pk, action: 'expire' })}>
+                    Expire
+                  </Button>
+                )}
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+      {active < line.quantity && order.status !== 'cancelled' && order.status !== 'fulfilled' && (
+        <>
+          {line.line_type === 'seedling' ? (
+            <Row className="g-2">
+              <Col md={3}>
+                <Form.Control placeholder="Plant IDs, comma-separated" value={plantIds} onChange={(event) => setPlantIds(event.target.value)} />
+              </Col>
+              <Col md={2}>
+                <Form.Control placeholder="Batch ID filter" value={batch} onChange={(event) => setBatch(event.target.value)} />
+              </Col>
+              <Col md={2}>
+                <Form.Control placeholder="Tray ID filter" value={tray} onChange={(event) => setTray(event.target.value)} />
+              </Col>
+              <Col md={2}>
+                <Form.Control placeholder="Location ID filter" value={location} onChange={(event) => setLocation(event.target.value)} />
+              </Col>
+              <Col md={3}>
+                <Form.Control type="date" title="Expected ready by" value={readyTo} onChange={(event) => setReadyTo(event.target.value)} />
+              </Col>
+            </Row>
+          ) : (
+            <Form.Select
+              multiple
+              value={selectedUnits.map(String)}
+              onChange={(event) => setSelectedUnits(Array.from(event.target.selectedOptions).map((option) => Number(option.value)))}
+            >
+              {(units.data ?? []).map((unit) => (
+                <option key={unit.pk} value={unit.pk}>
+                  {unit.asset_code}
+                </option>
+              ))}
+            </Form.Select>
+          )}
+          <Row className="g-2 align-items-end mt-1">
+            <Col md={4}>
+              <Form.Label>Optional reservation expiry</Form.Label>
+              <Form.Control type="datetime-local" min={localDatetimeInputValue()} value={expiresAt} onChange={(event) => setExpiresAt(event.target.value)} />
+            </Col>
+            <Col md={8}>
+              <Button variant="outline-primary" onClick={() => previewMutation.mutate()}>
+                Preview exact stock
+              </Button>
+            </Col>
+          </Row>
+          {preview && (
+            <Alert variant={preview.conflicts.length ? 'warning' : 'success'} className="mt-2">
+              {preview.selected.length} eligible. {preview.conflicts.length} conflicts.
+              {preview.conflicts.map((conflict) => (
+                <div key={`${conflict.id}:${conflict.reason}`}>
+                  #{conflict.id}: {conflict.reason.replaceAll('_', ' ')}
+                </div>
+              ))}
+              <Button className="mt-2" disabled={preview.selected.length === 0 || active + preview.selected.length > line.quantity} onClick={() => allocate.mutate()}>
+                Allocate eligible stock
+              </Button>
+            </Alert>
+          )}
+        </>
+      )}
+    </Card>
+  )
+}
+
+function OrderTotals({ order }: { order: SalesOrder }) {
+  return (
+    <Card body className="mb-3">
+      <Row>
+        <Col>
+          Gross ex tax
+          <br />
+          <strong>{formatMoney(order.gross_ex_tax, order.currency_code)}</strong>
+        </Col>
+        <Col>
+          Discount ex tax
+          <br />
+          <strong>{formatMoney(order.discount_total_ex_tax, order.currency_code)}</strong>
+        </Col>
+        <Col>
+          Subtotal ex tax
+          <br />
+          <strong>{formatMoney(order.subtotal_ex_tax, order.currency_code)}</strong>
+        </Col>
+        <Col>
+          Tax / GST
+          <br />
+          <strong>{formatMoney(order.tax_total, order.currency_code)}</strong>
+        </Col>
+        <Col>
+          Total incl tax
+          <br />
+          <strong>{formatMoney(order.total_incl_tax, order.currency_code)}</strong>
+        </Col>
+        <Col>
+          Margin preview
+          <br />
+          <strong>{formatMoney(order.margin.estimated_margin, order.currency_code, order.margin.cost_complete ? 'Allocate every unit' : 'Unknown cost')}</strong>
+          {order.margin.provisional && <div className="text-warning small">Provisional production cost</div>}
+        </Col>
+      </Row>
+    </Card>
+  )
+}
+
+function SalesOrderDetailView({ orderPk, workspace }: { orderPk: number; workspace: Workspace }) {
+  const client = useQueryClient()
+  const orderQuery = useQuery({ queryKey: queryKeys.sales.order(orderPk), queryFn: ({ signal }) => getSalesOrder(orderPk, signal) })
+  const customers = useQuery({ queryKey: queryKeys.sales.customers, queryFn: ({ signal }) => getCustomers(signal) })
+  const order = orderQuery.data
+  const mutateOrder = useMutation({
+    mutationFn: (data: object) => updateSalesOrder(orderPk, data),
+    onSuccess: (updated) => client.setQueryData(queryKeys.sales.order(orderPk), updated)
+  })
+  const action = useMutation({
+    mutationFn: ({ name, data = {} }: { name: 'to-draft' | 'confirm' | 'cancel'; data?: object }) => orderAction(orderPk, name, data),
+    onSuccess: () => invalidateSales(orderPk)
+  })
+  if (!order) return <main className="container py-3">Loading order…</main>
+  const editable = editableOrder(order.status)
+  return (
+    <main className="container py-3">
+      <div className="d-flex justify-content-between align-items-center">
+        <h1>{order.order_number}</h1>
+        <Badge bg={order.status === 'confirmed' ? 'success' : order.status === 'cancelled' ? 'secondary' : 'primary'}>{order.status.replaceAll('_', ' ')}</Badge>
+      </div>
+      <Card body className="mb-3">
+        <Row className="g-2">
+          <Col md={4}>
+            <Form.Label>Customer</Form.Label>
+            <Form.Select
+              disabled={!editable}
+              value={order.customer ?? ''}
+              onChange={(event) => mutateOrder.mutate({ customer: event.target.value === '' ? null : Number(event.target.value) })}
+            >
+              <option value="">Walk-in / no customer</option>
+              {(customers.data ?? [])
+                .filter((entry) => entry.active || entry.pk === order.customer)
+                .map((entry) => (
+                  <option key={entry.pk} value={entry.pk}>
+                    {entry.name}
+                  </option>
+                ))}
+            </Form.Select>
+          </Col>
+          <Col md={3}>
+            <Form.Label>Requested date</Form.Label>
+            <Form.Control
+              disabled={!editable}
+              type="date"
+              value={order.requested_date ?? ''}
+              onChange={(event) => mutateOrder.mutate({ requested_date: event.target.value || null })}
+            />
+          </Col>
+          <Col md={5} className="d-flex align-items-end">
+            <Form.Check
+              disabled={!editable}
+              label="Entered prices and fixed discounts include tax / GST"
+              checked={order.prices_include_tax}
+              onChange={(event) => mutateOrder.mutate({ prices_include_tax: event.target.checked })}
+            />
+          </Col>
+        </Row>
+        {editable && order.lines.length > 0 && (
+          <Alert variant="warning" className="mt-2 mb-0">
+            Changing the tax-entry mode reinterprets existing entered numbers; it does not convert them.
+          </Alert>
+        )}
+      </Card>
+      <OrderTotals order={order} />
+      {editable && <LineForm order={order} workspace={workspace} />}
+      {order.lines.map((line) => (
+        <Card body className="mb-3" key={line.pk}>
+          <div className="d-flex justify-content-between">
+            <strong>{line.description}</strong>
+            <span>
+              {line.quantity} × {formatMoney(line.unit_price, order.currency_code)} ({line.prices_include_tax ? 'incl' : 'excl'} tax)
+            </span>
+          </div>
+          <div className="text-muted">
+            Discount {line.discount_type === 'percentage' ? `${line.discount_value}%` : formatMoney(line.discount_value, order.currency_code)} · Tax {line.tax_rate}% · Total{' '}
+            {formatMoney(line.total_incl_tax, order.currency_code)}
+          </div>
+          <AllocationPanel order={order} line={line} />
+        </Card>
+      ))}
+      <div className="d-flex gap-2">
+        {order.status === 'quote' && <Button onClick={() => action.mutate({ name: 'to-draft' })}>Accept as draft</Button>}
+        {order.status === 'draft' && (
+          <Button variant="success" disabled={order.lines.length === 0 || !order.margin.allocation_complete} onClick={() => action.mutate({ name: 'confirm' })}>
+            Confirm and reserve
+          </Button>
+        )}
+        {!['cancelled', 'fulfilled'].includes(order.status) && (
+          <Button variant="outline-danger" onClick={() => action.mutate({ name: 'cancel', data: { reason: 'Cancelled by operator.' } })}>
+            Cancel order
+          </Button>
+        )}
+      </div>
+    </main>
+  )
+}
+
+export { CustomerListView, SalesOrderDetailView, SalesOrderListView }

--- a/frontend/js/types/labels.ts
+++ b/frontend/js/types/labels.ts
@@ -13,6 +13,7 @@ interface LabelIdentity {
   batch?: string | null
   sowing_date?: string | null
   expected_ready?: string | null
+  inventory_unit?: number
 }
 
 interface LabelTemplate {

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -364,6 +364,7 @@ interface NurseryRegisterRow {
   lifecycle_state: PlantLifecycleState
   sellable: boolean
   quarantined: boolean
+  reserved: boolean
   final_outcome: PlantLifecycleEventType | null
   final_outcome_at: string | null
   location_type: PlantPlacementType | null
@@ -416,6 +417,7 @@ interface NurseryRegisterFilters {
   state?: Array<PlantLifecycleState>
   sellable?: boolean
   quarantined?: boolean
+  reserved?: boolean
   germinated_from?: string
   germinated_to?: string
   location_type?: PlantPlacementType | 'none'
@@ -442,6 +444,7 @@ type NurseryRegisterTotals = Record<PlantLifecycleState, number> & {
   total: number
   unresolved: number
   quarantined: number
+  reserved: number
   stage_counts: Record<string, number>
   grade_counts: Record<string, number>
   container_counts: Record<string, number>

--- a/frontend/js/types/sales.ts
+++ b/frontend/js/types/sales.ts
@@ -1,0 +1,126 @@
+type Customer = {
+  pk: number
+  name: string
+  email: string
+  phone: string
+  billing_address: string
+  delivery_address: string
+  notes: string
+  active: boolean
+  created: string
+  updated: string
+}
+
+type SalesOrderStatus = 'quote' | 'draft' | 'confirmed' | 'partially_fulfilled' | 'fulfilled' | 'cancelled'
+type SalesLineType = 'seedling' | 'tray'
+type SalesDiscountType = 'none' | 'fixed' | 'percentage'
+type SalesAllocationStatus = 'pending' | 'reserved' | 'released' | 'expired' | 'fulfilled'
+
+interface ReservationEvent {
+  pk: number
+  event_type: 'reserved' | 'released' | 'expired' | 'cancelled' | 'fulfilled'
+  occurred_at: string
+  reason: string
+  created_by: number | null
+  created: string
+}
+
+interface SalesAllocation {
+  pk: number
+  plant: number | null
+  inventory_unit: number | null
+  asset_code: string | null
+  status: SalesAllocationStatus
+  expires_at: string | null
+  created_by: number | null
+  created: string
+  updated: string
+  events: Array<ReservationEvent>
+}
+
+interface SalesOrderLine {
+  pk: number
+  order: number
+  line_type: SalesLineType
+  variety: number | null
+  tray_item: number | null
+  description: string
+  quantity: number
+  unit_price: string
+  tax_rate: string
+  discount_type: SalesDiscountType
+  discount_value: string
+  prices_include_tax: boolean
+  gross_ex_tax: string
+  discount_ex_tax: string
+  subtotal_ex_tax: string
+  tax_total: string
+  total_incl_tax: string
+  allocations: Array<SalesAllocation>
+  created: string
+  updated: string
+}
+
+interface SalesMargin {
+  allocation_complete: boolean
+  cost_complete: boolean
+  provisional: boolean
+  cost_total: string | null
+  estimated_margin: string | null
+  currency_code: string
+}
+
+interface SalesOrder {
+  pk: number
+  order_number: string
+  customer: number | null
+  status: SalesOrderStatus
+  quote_date: string | null
+  order_date: string | null
+  requested_date: string | null
+  currency_code: string
+  prices_include_tax: boolean
+  notes: string
+  gross_ex_tax: string
+  discount_total_ex_tax: string
+  subtotal_ex_tax: string
+  tax_total: string
+  total_incl_tax: string
+  created_by: number | null
+  created: string
+  updated: string
+  lines: Array<SalesOrderLine>
+  margin: SalesMargin
+}
+
+interface SalesOrderLineWrite {
+  order: number
+  line_type: SalesLineType
+  variety: number | null
+  tray_item: number | null
+  description: string
+  quantity: number
+  unit_price: string
+  tax_rate?: string
+  discount_type: SalesDiscountType
+  discount_value: string
+}
+
+interface AllocationPreview {
+  selected: Array<number>
+  conflicts: Array<{ id: number; reason: string }>
+}
+
+export {
+  AllocationPreview,
+  Customer,
+  SalesAllocation,
+  SalesAllocationStatus,
+  SalesDiscountType,
+  SalesLineType,
+  SalesMargin,
+  SalesOrder,
+  SalesOrderLine,
+  SalesOrderLineWrite,
+  SalesOrderStatus
+}

--- a/frontend/js/types/workspace.ts
+++ b/frontend/js/types/workspace.ts
@@ -6,6 +6,7 @@ interface Workspace {
   mode: WorkspaceMode
   currency_code: string
   default_tax_rate: string
+  sales_prices_include_tax: boolean
   timezone: string
   measurement_system: MeasurementSystem
   override_tolerance_percent: string
@@ -21,6 +22,7 @@ type WorkspaceUpdate = Pick<
   | 'mode'
   | 'currency_code'
   | 'default_tax_rate'
+  | 'sales_prices_include_tax'
   | 'timezone'
   | 'measurement_system'
   | 'override_tolerance_percent'

--- a/frontend/js/workspace.tsx
+++ b/frontend/js/workspace.tsx
@@ -31,6 +31,7 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
     mode: workspace.mode,
     currency_code: workspace.currency_code,
     default_tax_rate: workspace.default_tax_rate,
+    sales_prices_include_tax: workspace.sales_prices_include_tax,
     timezone: workspace.timezone,
     measurement_system: workspace.measurement_system,
     override_tolerance_percent: workspace.override_tolerance_percent,
@@ -48,6 +49,7 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
       mode: workspace.mode,
       currency_code: workspace.currency_code,
       default_tax_rate: workspace.default_tax_rate,
+      sales_prices_include_tax: workspace.sales_prices_include_tax,
       timezone: workspace.timezone,
       measurement_system: workspace.measurement_system,
       override_tolerance_percent: workspace.override_tolerance_percent,
@@ -105,6 +107,14 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
             value={form.default_tax_rate}
             onChange={(event) => updateField('default_tax_rate', event.target.value)}
           />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="workspace-sales-tax-mode">
+          <Form.Check
+            label="Prices entered on new sales orders include tax / GST"
+            checked={form.sales_prices_include_tax}
+            onChange={(event) => updateField('sales_prices_include_tax', event.target.checked)}
+          />
+          <Form.Text>Each order snapshots this default and may override it while still a quote or draft.</Form.Text>
         </Form.Group>
         <Form.Group className="mb-3" controlId="workspace-timezone">
           <Form.Label>Timezone</Form.Label>

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -107,6 +107,7 @@ def _target_values(identity, code=None):
     elif key == ('seedtrays', 'seedtray'):
         open_generation = target.generations.filter(status='open').first()
         values['display'] = f'Tray {target.pk} — {target.model.identifier}'
+        values['inventory_unit'] = target.inventory_unit_id
         if open_generation:
             sowings = list(open_generation.sowings.select_related('batch__variety'))
             batches = sorted({sowing.batch.code for sowing in sowings})


### PR DESCRIPTION
Add customer and order screens, configurable GST entry controls, exact stock allocation, reservation actions, scanner integration, and reservation-aware register display so nursery staff can run the sales workflow.

## Summary by Sourcery

Introduce nursery sales order management workflow including customer records, order creation, line pricing, and stock allocation with reservations.

New Features:
- Add nursery sales customers and orders screens with list and detail views gated by workspace mode.
- Enable creation and editing of sales orders and line items with configurable tax-inclusive price entry and discounts.
- Support allocating exact seedling plants and serialized tray units to sales order lines, including reservation expiry and status transitions.
- Integrate order-aware scanning to validate labels against selected order lines and add eligible stock to allocations.
- Expose sales navigation, routes, and query keys for customers, orders, and available units.

Enhancements:
- Extend nursery register to track and filter reserved plants, reflect reservations in totals, and prevent selecting reserved entries for bulk operations.
- Add workspace-level setting to control whether sales prices are entered tax-inclusive by default and snapshot this per order.
- Include inventory unit identifiers in label targets to support serialized tray allocation via scanning.