### PR TITLE
feat(commerce): add sale lifecycle primitives

### DIFF
--- a/costing/services.py
+++ b/costing/services.py
@@ -65,6 +65,9 @@ DISPOSITION_OF_STATE = {
     LifecycleState.FAILED: 'production_loss',
     LifecycleState.CULLED: 'production_loss',
     LifecycleState.HARVESTED: 'harvested_output',
+    LifecycleState.SOLD: 'cogs',
+    LifecycleState.QUARANTINED: 'plant_inventory',
+    LifecycleState.DISCARDED: 'production_loss',
 }
 
 #: Every bucket a batch's value can sit in. `cogs` stays empty until tasks 44

--- a/costing/test_services.py
+++ b/costing/test_services.py
@@ -430,6 +430,14 @@ class DispositionTests(CostingServiceTestCase):
         breakdown = batch_cost_breakdown(self.batch)
         self.assertEqual(breakdown['totals']['production_loss'], '1.0800')
 
+    def test_a_sold_plant_moves_value_to_cogs(self):
+        """Commerce disposition classifies the frozen plant value as COGS."""
+        record_lifecycle_event(self.lost, self.user, OutcomeRequest(EventType.READY))
+        record_lifecycle_event(self.lost, self.user, OutcomeRequest(EventType.SOLD))
+        breakdown = batch_cost_breakdown(self.batch)
+        self.assertEqual(breakdown['totals']['cogs'], '1.0800')
+        self.assertEqual(breakdown['totals']['plant_inventory'], '1.0800')
+
     def test_an_outcome_needs_no_reallocation(self):
         """The bucket is derived, so no layer has to move when it changes."""
         record_lifecycle_event(

--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -872,6 +872,8 @@ def post_unit_movement(workspace, user, request):  # pylint: disable=too-many-br
         StockMovement.MovementType.ADJUSTMENT_LOSS,
         StockMovement.MovementType.WASTE,
         StockMovement.MovementType.ADJUSTMENT_GAIN,
+        StockMovement.MovementType.SALE,
+        StockMovement.MovementType.CUSTOMER_RETURN,
     }
     if request.movement_type not in allowed:
         raise ValidationError({'movement_type': 'Use a supported unit action.'})
@@ -883,6 +885,7 @@ def post_unit_movement(workspace, user, request):  # pylint: disable=too-many-br
     elif request.movement_type in {
         StockMovement.MovementType.ADJUSTMENT_LOSS,
         StockMovement.MovementType.WASTE,
+        StockMovement.MovementType.SALE,
     }:
         if not source:
             raise ValidationError({'unit': 'The unit is not currently on hand.'})
@@ -891,11 +894,17 @@ def post_unit_movement(workspace, user, request):  # pylint: disable=too-many-br
                 'unit': 'Move or dispose of active plants before removing this tray.',
             })
         destination = None
-    else:
+    elif request.movement_type == StockMovement.MovementType.ADJUSTMENT_GAIN:
         if state not in {'lost', 'retired'}:
             raise ValidationError({'unit': 'Only a lost or retired unit can be returned.'})
         if not destination:
             raise ValidationError({'destination': 'A return destination is required.'})
+        source = None
+    else:
+        if state != 'dispatched':
+            raise ValidationError({'unit': 'Only a dispatched unit can be returned.'})
+        if not destination:
+            raise ValidationError({'destination': 'A customer return destination is required.'})
         source = None
     if destination is not None:
         _check_unit_destination_capacity(unit, destination, request.reason)

--- a/inventory/test_serialized.py
+++ b/inventory/test_serialized.py
@@ -13,7 +13,7 @@ from locations.models import Location
 from supplies.models import Supplier
 from workspaces.models import get_current_workspace
 
-from .ledger import unit_physical_state
+from .ledger import UnitMovementRequest, post_unit_movement, unit_physical_state
 from .models import (
     InventoryItem,
     InventoryUnit,
@@ -163,6 +163,42 @@ class SerializedInventoryTests(TestCase):
         first.refresh_from_db()
         self.assertIsNone(first.current_location_id)
         self.assertEqual(unit_physical_state(first), 'lost')
+
+    def test_commerce_dispatch_and_customer_return_are_exact_unit_actions(self):
+        """Sales can dispatch and restore only the named serialized unit."""
+        self.post_receipt(quantity='1', cost='12')
+        unit = InventoryUnit.objects.get()
+        sold = post_unit_movement(
+            self.workspace,
+            self.user,
+            UnitMovementRequest(
+                unit=unit,
+                movement_type=StockMovement.MovementType.SALE,
+                occurred_at=timezone.now(),
+                reason='Order fulfillment',
+                reference='fulfillment:1',
+            ),
+        )
+        unit.refresh_from_db()
+        self.assertEqual(unit_physical_state(unit), 'dispatched')
+        self.assertFalse(unit.active)
+        returned = post_unit_movement(
+            self.workspace,
+            self.user,
+            UnitMovementRequest(
+                unit=unit,
+                movement_type=StockMovement.MovementType.CUSTOMER_RETURN,
+                destination=self.store,
+                occurred_at=timezone.now(),
+                reason='Customer return',
+                reference='return:1',
+            ),
+        )
+        unit.refresh_from_db()
+        self.assertEqual(sold.source_id, self.store.pk)
+        self.assertEqual(returned.destination_id, self.store.pk)
+        self.assertEqual(unit_physical_state(unit), 'returned')
+        self.assertTrue(unit.active)
 
     def test_serialized_collection_filters_and_generic_actions_reject_units(self):
         """The public collection reports derived unit facts without lot writes."""

--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -35,6 +35,9 @@ class LifecycleState(models.TextChoices):
     LOST = 'lost', 'Lost'
     CULLED = 'culled', 'Culled'
     HARVESTED = 'harvested', 'Harvested'
+    SOLD = 'sold', 'Sold'
+    QUARANTINED = 'quarantined', 'Returned quarantined'
+    DISCARDED = 'discarded', 'Returned discarded'
 
 
 #: The state each fact leaves behind. `transplanted` and `corrected` are absent
@@ -48,6 +51,10 @@ STATE_AFTER = {
     EventType.LOST: LifecycleState.LOST,
     EventType.CULLED: LifecycleState.CULLED,
     EventType.HARVEST_FINISHED: LifecycleState.HARVESTED,
+    EventType.SOLD: LifecycleState.SOLD,
+    EventType.RETURNED_AVAILABLE: LifecycleState.AVAILABLE,
+    EventType.RETURNED_QUARANTINED: LifecycleState.QUARANTINED,
+    EventType.RETURNED_DISCARDED: LifecycleState.DISCARDED,
 }
 
 #: The states each fact may be recorded from. `germinated` is absent because it
@@ -85,6 +92,10 @@ ALLOWED_FROM = {
         LifecycleState.AVAILABLE,
         LifecycleState.RETAINED,
     },
+    EventType.SOLD: {LifecycleState.AVAILABLE},
+    EventType.RETURNED_AVAILABLE: {LifecycleState.SOLD},
+    EventType.RETURNED_QUARANTINED: {LifecycleState.SOLD},
+    EventType.RETURNED_DISCARDED: {LifecycleState.SOLD},
 }
 
 #: States that resolve a plant. Retained is final for availability without
@@ -96,6 +107,8 @@ FINAL_STATES = {
     LifecycleState.LOST,
     LifecycleState.CULLED,
     LifecycleState.HARVESTED,
+    LifecycleState.SOLD,
+    LifecycleState.DISCARDED,
 }
 
 #: States in which a plant is offerable to somebody else.
@@ -109,6 +122,8 @@ CLOSES_LOCATION = {
     EventType.LOST,
     EventType.CULLED,
     EventType.HARVEST_FINISHED,
+    EventType.SOLD,
+    EventType.RETURNED_DISCARDED,
 }
 
 #: Facts an operator may record directly against a plant.

--- a/plantings/migrations/0036_commerce_lifecycle_events.py
+++ b/plantings/migrations/0036_commerce_lifecycle_events.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [('plantings', '0035_alter_plantlifecycleevent_event_type')]
+
+    operations = [
+        migrations.AlterField(
+            model_name='plantlifecycleevent',
+            name='event_type',
+            field=models.CharField(
+                choices=[
+                    ('germinated', 'Germinated'),
+                    ('ready', 'Ready for sale or use'),
+                    ('transplanted', 'Transplanted or planted out'),
+                    ('retained', 'Retained'),
+                    ('failed', 'Failed'),
+                    ('lost', 'Lost during stocktake'),
+                    ('culled', 'Culled'),
+                    ('donated', 'Donated'),
+                    ('harvest_finished', 'Harvest finished'),
+                    ('sold', 'Sold'),
+                    ('returned_available', 'Returned available'),
+                    ('returned_quarantined', 'Returned quarantined'),
+                    ('returned_discarded', 'Returned discarded'),
+                    ('corrected', 'Corrected'),
+                ],
+                max_length=24,
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -1303,6 +1303,10 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
         CULLED = 'culled', 'Culled'
         DONATED = 'donated', 'Donated'
         HARVEST_FINISHED = 'harvest_finished', 'Harvest finished'
+        SOLD = 'sold', 'Sold'
+        RETURNED_AVAILABLE = 'returned_available', 'Returned available'
+        RETURNED_QUARANTINED = 'returned_quarantined', 'Returned quarantined'
+        RETURNED_DISCARDED = 'returned_discarded', 'Returned discarded'
         CORRECTED = 'corrected', 'Corrected'
 
     plant = models.ForeignKey(
@@ -1316,7 +1320,7 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
         editable=False,
         related_name='plant_lifecycle_events',
     )
-    event_type = models.CharField(max_length=20, choices=EventType.choices)
+    event_type = models.CharField(max_length=24, choices=EventType.choices)
     occurred_at = models.DateTimeField()
     reason = models.TextField(blank=True, default='')
     reference = models.CharField(max_length=255, blank=True, default='')

--- a/plantings/test_batches.py
+++ b/plantings/test_batches.py
@@ -385,6 +385,9 @@ class BatchPlantResolutionTests(TestCase):
                 'lost': 0,
                 'culled': 0,
                 'harvested': 0,
+                'sold': 0,
+                'quarantined': 0,
+                'discarded': 0,
             },
         )
 

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -82,6 +82,33 @@ class LifecycleStateDerivationTests(TestCase):
         summary = plant_lifecycle_summary(self.plant)
         self.assertEqual(summary.state, LifecycleState.AVAILABLE)
 
+    def test_commerce_events_sell_and_reopen_a_plant_explicitly(self):
+        """A returned plant is sellable only for the available outcome."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.SOLD))
+        self.assertEqual(plant_lifecycle_summary(self.plant).state, LifecycleState.SOLD)
+        record_lifecycle_event(
+            self.plant,
+            self.user,
+            OutcomeRequest(EventType.RETURNED_AVAILABLE),
+        )
+        self.assertTrue(plant_lifecycle_summary(self.plant).sellable)
+
+    def test_quarantined_and_discarded_returns_are_not_sellable(self):
+        """Every return outcome has a distinct auditable lifecycle state."""
+        for event_type, expected in (
+                (EventType.RETURNED_QUARANTINED, LifecycleState.QUARANTINED),
+                (EventType.RETURNED_DISCARDED, LifecycleState.DISCARDED)):
+            with self.subTest(event_type=event_type):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+                record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.SOLD))
+                record_lifecycle_event(plant, self.user, OutcomeRequest(event_type))
+                summary = plant_lifecycle_summary(plant)
+                self.assertEqual(summary.state, expected)
+                self.assertFalse(summary.sellable)
+
     def test_each_final_outcome_derives_its_state_and_metadata(self):
         """Every resolving fact reports itself as the final outcome."""
         for event_type, expected_state in FINAL_OUTCOMES:
@@ -141,6 +168,26 @@ class LifecycleStateAnnotationTests(TestCase):
                 self.user,
                 OutcomeRequest(event_type, occurred_at=start + timedelta(days=2)),
             )
+            plants[name] = plant
+
+        for name, returned_event in (
+                ('sold', None),
+                ('quarantined', EventType.RETURNED_QUARANTINED),
+                ('discarded', EventType.RETURNED_DISCARDED)):
+            plant = self.germinated_plant(start)
+            record_lifecycle_event(
+                plant, self.user,
+                OutcomeRequest(EventType.READY, occurred_at=start + timedelta(days=1)),
+            )
+            record_lifecycle_event(
+                plant, self.user,
+                OutcomeRequest(EventType.SOLD, occurred_at=start + timedelta(days=2)),
+            )
+            if returned_event:
+                record_lifecycle_event(
+                    plant, self.user,
+                    OutcomeRequest(returned_event, occurred_at=start + timedelta(days=3)),
+                )
             plants[name] = plant
 
         plants['transplanted'] = self.germinated_plant(start)


### PR DESCRIPTION
Fulfillment needs auditable plant dispositions and exact serialized-unit sale and return movements before sales documents can coordinate them atomically. The costing projection now classifies sold value as COGS while preserving explicit returned-stock outcomes.

## Summary by Sourcery

Introduce commerce lifecycle support for plants and serialized inventory units, including explicit sale and customer return flows with corresponding costing classifications and auditable states.

New Features:
- Add sale and return lifecycle event types for plants with explicit states for sold, returned-available, quarantined, and discarded outcomes.
- Enable serialized inventory units to participate in sale and customer return movements as exact unit-level actions.

Enhancements:
- Classify sold plant value as cost of goods sold while preserving returned stock in plant inventory costing buckets.
- Extend lifecycle and offerability rules to treat sold and discarded plants as final outcomes and define sellable behavior for returned plants.
- Tighten unit movement validation to constrain sales to on-hand units and customer returns to previously dispatched units.

Tests:
- Add lifecycle tests covering plant sale, various return outcomes, and their sellable states.
- Add serialized inventory tests verifying unit-level sale dispatch, customer return restoration, and location tracking.
- Add costing tests ensuring sold plants move value into COGS while keeping inventory totals consistent.