### PR TITLE
feat(sales): post nursery commerce atomically

### DIFF
--- a/sales/commerce.py
+++ b/sales/commerce.py
@@ -1,0 +1,699 @@
+"""Atomic fulfillment, payment, return, refund, and reversal commands."""
+
+# The services coordinate several ledgers deliberately in one transaction.
+# pylint: disable=too-many-locals,too-many-branches,too-many-statements
+# pylint: disable=too-many-arguments
+
+import hashlib
+import json
+from decimal import Decimal
+from uuid import uuid5
+
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import transaction
+from django.db.models import Sum
+from django.utils import timezone
+
+from costing.services import plant_cost_breakdown
+from health.operations import act_on_quarantine, quarantine_observation
+from health.services import preview_observation, record_observation
+from inventory.ledger import (
+    MovementRequest,
+    UnitMovementRequest,
+    lock_lots,
+    lock_units,
+    post_stock_movement,
+    post_unit_movement,
+    reverse_movement,
+)
+from inventory.models import InventoryItem, StockMovement
+from plantings.lifecycle import (
+    EventType,
+    OutcomeRequest,
+    record_lifecycle_event,
+    reverse_lifecycle_event,
+)
+from plantings.models import SpecificPlant, SpecificPlantLocation
+
+from .calculations import line_position_amounts, money, proportional_refund
+from .models import (
+    Fulfillment,
+    FulfillmentLine,
+    FulfillmentNumberSequence,
+    FulfillmentPackagingLine,
+    Payment,
+    Refund,
+    RefundLine,
+    ReservationEvent,
+    SalesOrder,
+    SalesOrderAllocation,
+    SalesReturn,
+    SalesReturnLine,
+)
+
+
+def request_fingerprint(values):
+    """Return a stable digest so one operation key cannot mean two requests."""
+    encoded = json.dumps(values, sort_keys=True, separators=(',', ':'), default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _actor(user):
+    return user if user is not None and user.is_authenticated else None
+
+
+def _existing(model, workspace, operation_key, fingerprint):
+    row = model.objects.filter(
+        workspace=workspace, operation_key=operation_key,
+    ).first()
+    if row and row.request_fingerprint != fingerprint:
+        raise ValidationError({
+            'operation_key': 'That operation key was already used for different work.',
+        })
+    return row
+
+
+def _number(workspace):
+    sequence, _created = FulfillmentNumberSequence.objects.select_for_update(
+        of=('self',),
+    ).get_or_create(
+        workspace=workspace,
+    )
+    number = sequence.next_number
+    sequence.next_number += 1
+    sequence.save(update_fields=['next_number'])
+    return f'FUL-{number:06d}'
+
+
+def _effective(queryset):
+    return queryset.filter(reversal_of__isnull=True, reversal__isnull=True)
+
+
+def _effective_fulfillment_lines(order):
+    return FulfillmentLine.objects.filter(
+        fulfillment__order=order,
+        fulfillment__reversal_of__isnull=True,
+        fulfillment__reversal__isnull=True,
+    ).select_related('allocation__line', 'fulfillment')
+
+
+def _effective_return_line_ids(order):
+    return set(SalesReturnLine.objects.filter(
+        sales_return__order=order,
+        sales_return__reversal_of__isnull=True,
+        sales_return__reversal__isnull=True,
+    ).values_list('fulfillment_line_id', flat=True))
+
+
+def recompute_order_status(order):
+    """Derive fulfillment status from effective dispatch and return facts."""
+    order = SalesOrder.objects.select_for_update(of=('self',)).get(pk=order.pk)
+    if order.status == SalesOrder.Status.CANCELLED:
+        return order
+    returned = _effective_return_line_ids(order)
+    fulfilled = _effective_fulfillment_lines(order).exclude(pk__in=returned).count()
+    requested = sum(order.lines.values_list('quantity', flat=True))
+    if fulfilled == 0:
+        next_status = SalesOrder.Status.CONFIRMED
+    elif fulfilled < requested:
+        next_status = SalesOrder.Status.PARTIALLY_FULFILLED
+    else:
+        next_status = SalesOrder.Status.FULFILLED
+    SalesOrder.objects.filter(pk=order.pk).update(
+        status=next_status, updated=timezone.now(),
+    )
+    order.status = next_status
+    return order
+
+
+def _available_positions(order):
+    returned = _effective_return_line_ids(order)
+    occupied = {}
+    for row in _effective_fulfillment_lines(order).exclude(pk__in=returned):
+        occupied.setdefault(row.allocation.line_id, set()).add(row.commercial_position)
+    return {
+        line.pk: [
+            position for position in range(1, line.quantity + 1)
+            if position not in occupied.get(line.pk, set())
+        ]
+        for line in order.lines.all()
+    }
+
+
+def _plant_cost(plant):
+    breakdown = plant_cost_breakdown(plant)
+    value = breakdown['provisional_value'] or breakdown['final_value']
+    return (
+        Decimal(value) if value is not None else None,
+        bool(breakdown['provisional']),
+    )
+
+
+def _validate_tray_riders(units, selected_plant_ids):
+    for unit in units.values():
+        try:
+            tray = unit.seed_tray
+        except ObjectDoesNotExist:
+            continue
+        riders = set(SpecificPlantLocation.objects.filter(
+            seed_tray_cell__tray=tray, ended__isnull=True,
+        ).values_list('specific_plant_id', flat=True))
+        if not riders.issubset(selected_plant_ids):
+            raise ValidationError({
+                'allocations': f'Tray {tray.pk} still carries plants not in this fulfillment.',
+            })
+
+
+@transaction.atomic
+def post_fulfillment(order, user, *, operation_key, allocation_ids,
+                     packaging=(), fulfilled_at=None, notes=''):
+    """Dispatch exact reserved stock and recognize its revenue and direct cost."""
+    requested_at = fulfilled_at
+    fulfilled_at = fulfilled_at or timezone.now()
+    payload = {
+        'order': order.pk, 'allocations': sorted(set(allocation_ids)),
+        'packaging': sorted(packaging, key=lambda row: (row['lot'].pk, row['source'].pk)),
+        'fulfilled_at': requested_at, 'notes': notes,
+    }
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(Fulfillment, order.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    order = SalesOrder.objects.select_for_update(
+        of=('self',),
+    ).prefetch_related('lines').get(pk=order.pk)
+    if order.status not in {
+            SalesOrder.Status.CONFIRMED, SalesOrder.Status.PARTIALLY_FULFILLED}:
+        raise ValidationError({'status': 'Only a confirmed incomplete order can be fulfilled.'})
+    existing = _existing(Fulfillment, order.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    wanted = sorted(set(allocation_ids))
+    if not wanted:
+        raise ValidationError({'allocations': 'Select at least one reserved allocation.'})
+    allocations = list(SalesOrderAllocation.objects.select_for_update(of=('self',)).select_related(
+        'line', 'plant__batch', 'inventory_unit__item',
+    ).filter(line__order=order, pk__in=wanted).order_by('pk'))
+    if len(allocations) != len(wanted) or any(
+            row.status != SalesOrderAllocation.Status.RESERVED for row in allocations):
+        raise ValidationError({'allocations': 'One or more active reservations are unavailable.'})
+    plant_ids = [row.plant_id for row in allocations if row.plant_id]
+    unit_ids = [row.inventory_unit_id for row in allocations if row.inventory_unit_id]
+    plants = {
+        row.pk: row for row in SpecificPlant.objects.select_for_update(of=('self',))
+        .select_related('batch').filter(workspace=order.workspace, pk__in=plant_ids)
+        .order_by('pk')
+    }
+    units = lock_units(order.workspace, unit_ids)
+    lot_ids = [row['lot'].pk for row in packaging]
+    lots = lock_lots(order.workspace, lot_ids)
+    _validate_tray_riders(units, set(plant_ids))
+    positions = _available_positions(order)
+    fulfillment = Fulfillment.objects.create(
+        workspace=order.workspace, order=order,
+        fulfillment_number=_number(order.workspace), fulfilled_at=fulfilled_at,
+        notes=notes.strip(), operation_key=operation_key,
+        request_fingerprint=fingerprint, created_by=_actor(user),
+    )
+    for allocation in allocations:
+        available = positions[allocation.line_id]
+        if not available:
+            raise ValidationError({'allocations': 'A line has no remaining quantity to fulfill.'})
+        position = available.pop(0)
+        amounts = line_position_amounts(allocation.line)[position]
+        lifecycle_event = None
+        stock_movement = None
+        if allocation.plant_id:
+            plant = plants[allocation.plant_id]
+            lifecycle_event = record_lifecycle_event(
+                plant, user,
+                OutcomeRequest(
+                    EventType.SOLD, occurred_at=fulfilled_at,
+                    reference=f'fulfillment:{fulfillment.pk}:allocation:{allocation.pk}',
+                ),
+            )
+            cogs_amount, provisional = _plant_cost(plant)
+        else:
+            unit = units[allocation.inventory_unit_id]
+            stock_movement = post_unit_movement(
+                order.workspace, user,
+                UnitMovementRequest(
+                    unit=unit, movement_type=StockMovement.MovementType.SALE,
+                    occurred_at=fulfilled_at, reason='Order fulfillment',
+                    reference=f'fulfillment:{fulfillment.pk}:allocation:{allocation.pk}',
+                ),
+            )
+            cogs_amount, provisional = unit.acquisition_cost, False
+        FulfillmentLine.objects.create(
+            fulfillment=fulfillment, allocation=allocation,
+            commercial_position=position, cogs_amount=cogs_amount,
+            cogs_provisional=provisional, currency_code=order.currency_code,
+            lifecycle_event=lifecycle_event, stock_movement=stock_movement,
+            **amounts,
+        )
+        SalesOrderAllocation.objects.filter(pk=allocation.pk).update(
+            status=SalesOrderAllocation.Status.FULFILLED, updated=timezone.now(),
+        )
+        ReservationEvent.objects.create(
+            allocation=allocation, event_type=ReservationEvent.EventType.FULFILLED,
+            occurred_at=fulfilled_at, created_by=_actor(user),
+        )
+    for item in packaging:
+        lot = lots[item['lot'].pk]
+        if lot.item.category != InventoryItem.Category.PACKAGING:
+            raise ValidationError({'packaging': 'Choose packaging inventory lots only.'})
+        movement = post_stock_movement(
+            order.workspace, user,
+            MovementRequest(
+                lot=lot, movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=item['quantity'], source=item['source'],
+                occurred_at=fulfilled_at, reason='Fulfillment packaging',
+                reference=f'fulfillment:{fulfillment.pk}',
+            ),
+        )
+        cost = None
+        if lot.base_unit_cost is not None:
+            cost = money(Decimal(item['quantity']) * lot.base_unit_cost)
+        FulfillmentPackagingLine.objects.create(
+            fulfillment=fulfillment, lot=lot, source=item['source'],
+            quantity=item['quantity'], base_unit=lot.item.base_unit,
+            unit_cost=lot.base_unit_cost, cogs_amount=cost,
+            currency_code=lot.currency_code, stock_movement=movement,
+        )
+    recompute_order_status(order)
+    return fulfillment
+
+
+@transaction.atomic
+def record_payment(order, user, *, operation_key, paid_on, amount, method,
+                   external_reference='', notes=''):
+    """Record operational cash independently from fulfillment timing."""
+    amount = money(amount)
+    payload = {
+        'order': order.pk, 'paid_on': paid_on, 'amount': amount,
+        'method': method, 'external_reference': external_reference, 'notes': notes,
+    }
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(Payment, order.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    order = SalesOrder.objects.select_for_update(of=('self',)).get(pk=order.pk)
+    if order.status in {SalesOrder.Status.QUOTE, SalesOrder.Status.DRAFT, SalesOrder.Status.CANCELLED}:
+        raise ValidationError({'status': 'Payments require an active confirmed order.'})
+    return Payment.objects.create(
+        workspace=order.workspace, order=order, paid_on=paid_on, amount=amount,
+        currency_code=order.currency_code, method=method,
+        external_reference=external_reference.strip(), notes=notes.strip(),
+        operation_key=operation_key, request_fingerprint=fingerprint,
+        created_by=_actor(user),
+    )
+
+
+def _return_event(outcome):
+    return {
+        SalesReturnLine.Outcome.AVAILABLE: EventType.RETURNED_AVAILABLE,
+        SalesReturnLine.Outcome.QUARANTINED: EventType.RETURNED_QUARANTINED,
+        SalesReturnLine.Outcome.DISCARDED: EventType.RETURNED_DISCARDED,
+    }[outcome]
+
+
+@transaction.atomic
+def post_return(order, user, *, operation_key, items, reason, returned_at=None,
+                notes='', observation_type=None, severity=None,
+                follow_up_due_at=None):
+    """Return exact fulfilled stock with an explicit physical outcome."""
+    requested_at = returned_at
+    returned_at = returned_at or timezone.now()
+    payload = {
+        'order': order.pk, 'items': sorted(items, key=lambda row: row['fulfillment_line'].pk),
+        'reason': reason, 'returned_at': requested_at, 'notes': notes,
+        'observation_type': getattr(observation_type, 'pk', None),
+        'severity': severity, 'follow_up_due_at': follow_up_due_at,
+    }
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(SalesReturn, order.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    if not reason.strip() or not items:
+        raise ValidationError({'reason': 'A reason and at least one returned item are required.'})
+    order = SalesOrder.objects.select_for_update(of=('self',)).get(pk=order.pk)
+    line_ids = [row['fulfillment_line'].pk for row in items]
+    lines = {
+        row.pk: row for row in FulfillmentLine.objects.select_for_update(of=('self',))
+        .select_related('allocation__plant', 'allocation__inventory_unit')
+        .filter(fulfillment__order=order, fulfillment__reversal__isnull=True,
+                pk__in=line_ids).order_by('pk')
+    }
+    if len(lines) != len(set(line_ids)):
+        raise ValidationError({'items': 'One or more fulfillment lines are unavailable.'})
+    already = _effective(SalesReturn.objects.filter(order=order)).filter(
+        lines__fulfillment_line_id__in=line_ids,
+    ).exists()
+    if already:
+        raise ValidationError({'items': 'One or more items were already returned.'})
+    quarantined_plants = []
+    sales_return = SalesReturn.objects.create(
+        workspace=order.workspace, order=order, returned_at=returned_at,
+        reason=reason.strip(), notes=notes.strip(), operation_key=operation_key,
+        request_fingerprint=fingerprint, created_by=_actor(user),
+    )
+    for item in items:
+        line = lines[item['fulfillment_line'].pk]
+        allocation = line.allocation
+        outcome = item['outcome']
+        destination = item.get('destination')
+        if outcome != SalesReturnLine.Outcome.DISCARDED and destination is None:
+            raise ValidationError({'destination': 'Available and quarantined returns need a destination.'})
+        lifecycle_event = None
+        return_movement = None
+        discard_movement = None
+        if allocation.plant_id:
+            lifecycle_event = record_lifecycle_event(
+                allocation.plant, user,
+                OutcomeRequest(
+                    _return_event(outcome), occurred_at=returned_at, reason=reason,
+                    reference=f'return:{sales_return.pk}:line:{line.pk}',
+                ),
+            )
+            if destination:
+                from plantings.rest import move_specific_plant  # pylint: disable=import-outside-toplevel
+                move_specific_plant(allocation.plant, {
+                    'location_type': SpecificPlantLocation.LOCATION,
+                    'location': destination,
+                    'started': returned_at,
+                    'notes': reason,
+                }, user=user)
+            if outcome == SalesReturnLine.Outcome.QUARANTINED:
+                quarantined_plants.append(allocation.plant)
+        else:
+            unit = allocation.inventory_unit
+            return_destination = destination
+            if return_destination is None:
+                return_destination = line.stock_movement.source
+            return_movement = post_unit_movement(
+                order.workspace, user,
+                UnitMovementRequest(
+                    unit=unit,
+                    movement_type=StockMovement.MovementType.CUSTOMER_RETURN,
+                    destination=return_destination, occurred_at=returned_at,
+                    reason=reason, reference=f'return:{sales_return.pk}:line:{line.pk}',
+                ),
+            )
+            if outcome == SalesReturnLine.Outcome.DISCARDED:
+                discard_movement = post_unit_movement(
+                    order.workspace, user,
+                    UnitMovementRequest(
+                        unit=unit, movement_type=StockMovement.MovementType.WASTE,
+                        occurred_at=returned_at, reason=reason,
+                        reference=f'return:{sales_return.pk}:discard:{line.pk}',
+                    ),
+                )
+        SalesReturnLine.objects.create(
+            sales_return=sales_return, fulfillment_line=line, outcome=outcome,
+            destination=destination, lifecycle_event=lifecycle_event,
+            return_movement=return_movement, discard_movement=discard_movement,
+        )
+        SalesOrderAllocation.objects.filter(pk=allocation.pk).update(
+            status=SalesOrderAllocation.Status.RETURNED, updated=timezone.now(),
+        )
+    if quarantined_plants:
+        if observation_type is None or severity is None:
+            raise ValidationError({'health': 'Quarantined plants need an observation type and severity.'})
+        scopes = [{'type': 'plant', 'id': plant.pk} for plant in quarantined_plants]
+        preview = preview_observation(order.workspace, scopes)
+        observation = record_observation(
+            order.workspace, user, scopes=scopes, reviewed_digest=preview['digest'],
+            observation_type=observation_type, severity=severity,
+            occurred_at=returned_at, follow_up_due_at=follow_up_due_at,
+            notes=reason,
+        )
+        case, _action = quarantine_observation(
+            order.workspace, user, observation, idempotency_key=operation_key,
+            reason=reason, occurred_at=returned_at,
+        )
+        SalesReturn.objects.filter(pk=sales_return.pk).update(
+            health_observation=observation, quarantine_case=case,
+        )
+        sales_return.health_observation = observation
+        sales_return.quarantine_case = case
+    recompute_order_status(order)
+    return sales_return
+
+
+@transaction.atomic
+def post_refund(order, user, *, operation_key, payment, fulfillment_lines,
+                amount, reason, refunded_at=None, sales_return=None, notes=''):
+    """Refund paid value and classify it against original recognized lines."""
+    requested_at = refunded_at
+    refunded_at = refunded_at or timezone.now()
+    amount = money(amount)
+    line_ids = sorted(set(line.pk for line in fulfillment_lines))
+    payload = {
+        'order': order.pk, 'payment': payment.pk, 'lines': line_ids,
+        'amount': amount, 'reason': reason, 'refunded_at': requested_at,
+        'sales_return': getattr(sales_return, 'pk', None), 'notes': notes,
+    }
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(Refund, order.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    order = SalesOrder.objects.select_for_update(of=('self',)).get(pk=order.pk)
+    payment = Payment.objects.select_for_update(of=('self',)).filter(
+        pk=payment.pk, order=order, reversal__isnull=True, reversal_of__isnull=True,
+    ).first()
+    if payment is None:
+        raise ValidationError({'payment': 'Choose an effective payment from this order.'})
+    if sales_return and sales_return.order_id != order.pk:
+        raise ValidationError({'sales_return': 'Choose a return from this order.'})
+    lines = list(FulfillmentLine.objects.select_for_update(of=('self',)).filter(
+        fulfillment__order=order, fulfillment__reversal__isnull=True,
+        fulfillment__reversal_of__isnull=True, pk__in=line_ids,
+    ).order_by('pk'))
+    if len(lines) != len(line_ids) or not lines:
+        raise ValidationError({'fulfillment_lines': 'Choose effective fulfilled items.'})
+    paid_refunded = _effective(payment.refunds.all()).aggregate(
+        total=Sum('amount'),
+    )['total'] or Decimal('0')
+    if amount > payment.amount - paid_refunded:
+        raise ValidationError({'amount': 'The refund exceeds this payment balance.'})
+    available = []
+    for line in lines:
+        prior = RefundLine.objects.filter(
+            fulfillment_line=line,
+            refund__reversal_of__isnull=True,
+            refund__reversal__isnull=True,
+        ).aggregate(total=Sum('total_incl_tax'))['total'] or Decimal('0')
+        available.append({
+            'line': line,
+            'remaining_total': money(line.total_incl_tax - prior),
+        })
+    try:
+        shares = proportional_refund(amount, available)
+    except ValueError as exc:
+        raise ValidationError({'amount': str(exc)}) from exc
+    refund = Refund.objects.create(
+        workspace=order.workspace, order=order, payment=payment,
+        sales_return=sales_return, refunded_at=refunded_at, amount=amount,
+        currency_code=order.currency_code, reason=reason.strip(), notes=notes.strip(),
+        operation_key=operation_key, request_fingerprint=fingerprint,
+        created_by=_actor(user),
+    )
+    RefundLine.objects.bulk_create([
+        RefundLine(refund=refund, fulfillment_line=share.pop('line'), **share)
+        for share in shares
+    ])
+    return refund
+
+
+def order_commerce_summary(order):
+    """Return separate physical, revenue, refund, and cash totals."""
+    fulfilled = _effective_fulfillment_lines(order)
+    returned_ids = _effective_return_line_ids(order)
+    refunds = _effective(order.refunds.all())
+    payments = _effective(order.payments.all())
+    fulfilled_total = fulfilled.aggregate(total=Sum('total_incl_tax'))['total'] or 0
+    refunded_total = refunds.aggregate(total=Sum('amount'))['total'] or 0
+    paid_total = payments.aggregate(total=Sum('amount'))['total'] or 0
+    net_order = money(order.total_incl_tax - refunded_total)
+    net_paid = money(paid_total - refunded_total)
+    outstanding = money(max(net_order - net_paid, Decimal('0')))
+    overpaid = money(max(net_paid - net_order, Decimal('0')))
+    if net_paid == 0:
+        payment_status = 'unpaid'
+    elif net_paid < net_order:
+        payment_status = 'partially_paid'
+    elif net_paid == net_order:
+        payment_status = 'paid'
+    else:
+        payment_status = 'overpaid'
+    return {
+        'requested_quantity': sum(order.lines.values_list('quantity', flat=True)),
+        'reserved_quantity': order.lines.filter(
+            allocations__status=SalesOrderAllocation.Status.RESERVED,
+        ).count(),
+        'fulfilled_quantity': fulfilled.count(),
+        'returned_quantity': len(returned_ids),
+        'fulfilled_total_incl_tax': f'{money(fulfilled_total):f}',
+        'refunded_total_incl_tax': f'{money(refunded_total):f}',
+        'paid_total': f'{money(paid_total):f}',
+        'net_paid_total': f'{net_paid:f}',
+        'outstanding_total': f'{outstanding:f}',
+        'overpaid_total': f'{overpaid:f}',
+        'payment_status': payment_status,
+        'currency_code': order.currency_code,
+    }
+
+
+@transaction.atomic
+def reverse_fulfillment(original, user, *, operation_key, reason, occurred_at=None):
+    """Append a fulfillment reversal and restore its exact reservations."""
+    requested_at = occurred_at
+    occurred_at = occurred_at or timezone.now()
+    payload = {'original': original.pk, 'reason': reason, 'occurred_at': requested_at}
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(Fulfillment, original.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    original = Fulfillment.objects.select_for_update(of=('self',)).prefetch_related(
+        'lines__allocation', 'packaging_lines',
+    ).get(pk=original.pk, reversal_of__isnull=True)
+    if hasattr(original, 'reversal'):
+        raise ValidationError({'fulfillment': 'This fulfillment is already reversed.'})
+    if _effective(SalesReturn.objects.filter(
+            lines__fulfillment_line__fulfillment=original)).exists():
+        raise ValidationError({'fulfillment': 'Reverse linked returns first.'})
+    if _effective(Refund.objects.filter(
+            lines__fulfillment_line__fulfillment=original)).exists():
+        raise ValidationError({'fulfillment': 'Reverse linked refunds first.'})
+    reversal = Fulfillment.objects.create(
+        workspace=original.workspace, order=original.order,
+        fulfillment_number=_number(original.workspace), fulfilled_at=occurred_at,
+        notes=reason.strip(), reversal_of=original, operation_key=operation_key,
+        request_fingerprint=fingerprint, created_by=_actor(user),
+    )
+    for line in original.lines.all():
+        if line.lifecycle_event_id:
+            reverse_lifecycle_event(line.lifecycle_event, user, reason, occurred_at)
+        if line.stock_movement_id:
+            reverse_movement(line.stock_movement, user, reason, occurred_at)
+        SalesOrderAllocation.objects.filter(pk=line.allocation_id).update(
+            status=SalesOrderAllocation.Status.RESERVED, updated=timezone.now(),
+        )
+    for packaging in original.packaging_lines.all():
+        reverse_movement(packaging.stock_movement, user, reason, occurred_at)
+    recompute_order_status(original.order)
+    return reversal
+
+
+@transaction.atomic
+def reverse_payment(original, user, *, operation_key, reason, occurred_at=None):
+    """Append a payment reversal after all dependent refunds are reversed."""
+    requested_at = occurred_at
+    occurred_at = occurred_at or timezone.now()
+    payload = {'original': original.pk, 'reason': reason, 'occurred_at': requested_at}
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(Payment, original.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    original = Payment.objects.select_for_update(of=('self',)).get(
+        pk=original.pk, reversal_of__isnull=True,
+    )
+    if hasattr(original, 'reversal'):
+        raise ValidationError({'payment': 'This payment is already reversed.'})
+    if _effective(original.refunds.all()).exists():
+        raise ValidationError({'payment': 'Reverse linked refunds first.'})
+    return Payment.objects.create(
+        workspace=original.workspace, order=original.order,
+        paid_on=occurred_at.date(), amount=original.amount,
+        currency_code=original.currency_code, method=original.method,
+        external_reference=original.external_reference, notes=reason.strip(),
+        reversal_of=original, operation_key=operation_key,
+        request_fingerprint=fingerprint, created_by=_actor(user),
+    )
+
+
+@transaction.atomic
+def reverse_refund(original, user, *, operation_key, reason, occurred_at=None):
+    """Append a monetary reversal without rewriting recognized refund rows."""
+    requested_at = occurred_at
+    occurred_at = occurred_at or timezone.now()
+    payload = {'original': original.pk, 'reason': reason, 'occurred_at': requested_at}
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(Refund, original.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    original = Refund.objects.select_for_update(of=('self',)).get(
+        pk=original.pk, reversal_of__isnull=True,
+    )
+    if hasattr(original, 'reversal'):
+        raise ValidationError({'refund': 'This refund is already reversed.'})
+    return Refund.objects.create(
+        workspace=original.workspace, order=original.order,
+        payment=original.payment, sales_return=original.sales_return,
+        refunded_at=occurred_at, amount=original.amount,
+        currency_code=original.currency_code, reason=reason.strip(),
+        reversal_of=original, operation_key=operation_key,
+        request_fingerprint=fingerprint, created_by=_actor(user),
+    )
+
+
+@transaction.atomic
+def reverse_return(original, user, *, operation_key, reason, occurred_at=None):
+    """Append a physical-return reversal if the stock has not moved on."""
+    requested_at = occurred_at
+    occurred_at = occurred_at or timezone.now()
+    payload = {'original': original.pk, 'reason': reason, 'occurred_at': requested_at}
+    fingerprint = request_fingerprint(payload)
+    existing = _existing(SalesReturn, original.workspace, operation_key, fingerprint)
+    if existing:
+        return existing
+    original = SalesReturn.objects.select_for_update(of=('self',)).prefetch_related(
+        'lines__fulfillment_line__allocation',
+    ).get(pk=original.pk, reversal_of__isnull=True)
+    if hasattr(original, 'reversal'):
+        raise ValidationError({'sales_return': 'This return is already reversed.'})
+    if _effective(original.refunds.all()).exists():
+        raise ValidationError({'sales_return': 'Reverse linked refunds first.'})
+    targets = []
+    for line in original.lines.all():
+        allocation = line.fulfillment_line.allocation
+        target_filter = {'plant_id': allocation.plant_id} if allocation.plant_id else {
+            'inventory_unit_id': allocation.inventory_unit_id,
+        }
+        moved_on = SalesOrderAllocation.objects.filter(
+            **target_filter,
+            status__in=[SalesOrderAllocation.Status.RESERVED,
+                        SalesOrderAllocation.Status.FULFILLED],
+        ).exclude(pk=allocation.pk).exists()
+        if moved_on:
+            targets.append(allocation.pk)
+    if targets:
+        raise ValidationError({'sales_return': 'Returned stock has already been reallocated.'})
+    reversal = SalesReturn.objects.create(
+        workspace=original.workspace, order=original.order,
+        returned_at=occurred_at, reason=reason.strip(), reversal_of=original,
+        operation_key=operation_key, request_fingerprint=fingerprint,
+        created_by=_actor(user),
+    )
+    if original.quarantine_case_id:
+        act_on_quarantine(
+            original.workspace, user, original.quarantine_case,
+            action_name='release', idempotency_key=uuid5(operation_key, 'release'),
+            reason=reason, occurred_at=occurred_at,
+        )
+    for line in original.lines.all():
+        if line.discard_movement_id:
+            reverse_movement(line.discard_movement, user, reason, occurred_at)
+        if line.return_movement_id:
+            reverse_movement(line.return_movement, user, reason, occurred_at)
+        if line.lifecycle_event_id:
+            SpecificPlantLocation.objects.filter(
+                specific_plant=line.fulfillment_line.allocation.plant,
+                ended__isnull=True,
+            ).update(ended=occurred_at)
+            reverse_lifecycle_event(line.lifecycle_event, user, reason, occurred_at)
+        SalesOrderAllocation.objects.filter(
+            pk=line.fulfillment_line.allocation_id,
+        ).update(status=SalesOrderAllocation.Status.FULFILLED, updated=timezone.now())
+    recompute_order_status(original.order)
+    return reversal

--- a/sales/rest.py
+++ b/sales/rest.py
@@ -1,6 +1,7 @@
 """Workspace-scoped customer, order, and reservation REST workflows."""
 
-# pylint: disable=too-many-ancestors
+# pylint: disable=too-many-ancestors,missing-class-docstring
+# pylint: disable=missing-function-docstring,abstract-method
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import QueryDict
@@ -9,6 +10,9 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from health.models import HealthObservation, HealthObservationType
+from inventory.models import StockLot
+from locations.models import Location
 from plantings.register import parse_register_filters, register_queryset
 from workspaces.models import Workspace
 from workspaces.scoping import (
@@ -17,7 +21,32 @@ from workspaces.scoping import (
     RequireWorkspaceModeMixin,
 )
 
-from .models import Customer, ReservationEvent, SalesOrder, SalesOrderAllocation, SalesOrderLine
+from .commerce import (
+    order_commerce_summary,
+    post_fulfillment,
+    post_refund,
+    post_return,
+    record_payment,
+    reverse_fulfillment,
+    reverse_payment,
+    reverse_refund,
+    reverse_return,
+)
+from .models import (
+    Customer,
+    Fulfillment,
+    FulfillmentLine,
+    FulfillmentPackagingLine,
+    Payment,
+    Refund,
+    RefundLine,
+    ReservationEvent,
+    SalesOrder,
+    SalesOrderAllocation,
+    SalesOrderLine,
+    SalesReturn,
+    SalesReturnLine,
+)
 from .services import (
     allocate_targets,
     cancel_order,
@@ -117,6 +146,7 @@ class SalesOrderSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSer
     status = serializers.ChoiceField(choices=SalesOrder.Status.choices, required=False)
     lines = SalesOrderLineSerializer(many=True, read_only=True)
     margin = serializers.SerializerMethodField()
+    commerce = serializers.SerializerMethodField()
 
     class Meta:
         model = SalesOrder
@@ -125,7 +155,7 @@ class SalesOrderSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSer
             'requested_date', 'currency_code', 'prices_include_tax', 'notes',
             'gross_ex_tax', 'discount_total_ex_tax', 'subtotal_ex_tax',
             'tax_total', 'total_incl_tax', 'created_by', 'created', 'updated',
-            'lines', 'margin',
+            'lines', 'margin', 'commerce',
         ]
         read_only_fields = [
             'order_number', 'gross_ex_tax', 'discount_total_ex_tax',
@@ -139,6 +169,10 @@ class SalesOrderSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSer
     def get_margin(self, order):
         """Expose a clearly qualified ex-tax margin preview."""
         return order_margin(order)
+
+    def get_commerce(self, order):
+        """Expose physical, recognized, refunded, and cash totals separately."""
+        return order_commerce_summary(order)
 
     def validate(self, attrs):
         """Reserve status changes for explicit transition actions."""
@@ -215,6 +249,176 @@ class ReasonSerializer(ActionSerializer):  # pylint: disable=abstract-method
     """Optional audit reason for a document transition."""
 
     reason = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class CommerceRecordSerializer(serializers.ModelSerializer):
+    """Shared immutable action state derived from reversal links."""
+
+    status = serializers.SerializerMethodField()
+
+    def get_status(self, record):
+        if record.reversal_of_id:
+            return 'reversal'
+        if hasattr(record, 'reversal'):
+            return 'reversed'
+        return 'posted'
+
+
+class FulfillmentLineSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FulfillmentLine
+        fields = [
+            'pk', 'allocation', 'commercial_position', 'gross_ex_tax',
+            'discount_ex_tax', 'subtotal_ex_tax', 'tax_total',
+            'total_incl_tax', 'cogs_amount', 'cogs_provisional',
+            'currency_code', 'lifecycle_event', 'stock_movement',
+        ]
+
+
+class FulfillmentPackagingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FulfillmentPackagingLine
+        fields = [
+            'pk', 'lot', 'source', 'quantity', 'base_unit', 'unit_cost',
+            'cogs_amount', 'currency_code', 'stock_movement',
+        ]
+
+
+class FulfillmentSerializer(CommerceRecordSerializer):
+    lines = FulfillmentLineSerializer(many=True, read_only=True)
+    packaging_lines = FulfillmentPackagingSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Fulfillment
+        fields = [
+            'pk', 'fulfillment_number', 'fulfilled_at', 'status', 'notes',
+            'operation_key', 'created_by', 'created', 'reversal_of', 'lines',
+            'packaging_lines',
+        ]
+
+
+class PaymentSerializer(CommerceRecordSerializer):
+    class Meta:
+        model = Payment
+        fields = [
+            'pk', 'paid_on', 'amount', 'currency_code', 'method',
+            'external_reference', 'notes', 'status', 'operation_key',
+            'created_by', 'created', 'reversal_of',
+        ]
+
+
+class SalesReturnLineSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SalesReturnLine
+        fields = [
+            'pk', 'fulfillment_line', 'outcome', 'destination',
+            'lifecycle_event', 'return_movement', 'discard_movement',
+        ]
+
+
+class SalesReturnSerializer(CommerceRecordSerializer):
+    lines = SalesReturnLineSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SalesReturn
+        fields = [
+            'pk', 'returned_at', 'reason', 'notes', 'status',
+            'health_observation', 'quarantine_case', 'operation_key',
+            'created_by', 'created', 'reversal_of', 'lines',
+        ]
+
+
+class RefundLineSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RefundLine
+        fields = [
+            'pk', 'fulfillment_line', 'gross_ex_tax', 'discount_ex_tax',
+            'subtotal_ex_tax', 'tax_total', 'total_incl_tax',
+        ]
+
+
+class RefundSerializer(CommerceRecordSerializer):
+    lines = RefundLineSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Refund
+        fields = [
+            'pk', 'payment', 'sales_return', 'refunded_at', 'amount',
+            'currency_code', 'reason', 'notes', 'status', 'operation_key',
+            'created_by', 'created', 'reversal_of', 'lines',
+        ]
+
+
+class PackagingWriteSerializer(serializers.Serializer):
+    lot = serializers.PrimaryKeyRelatedField(queryset=StockLot.objects.all())
+    source = serializers.PrimaryKeyRelatedField(queryset=Location.objects.all())
+    quantity = serializers.DecimalField(max_digits=18, decimal_places=9, min_value=0)
+
+
+class FulfillmentWriteSerializer(ActionSerializer):
+    operation_key = serializers.UUIDField()
+    allocation_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1), allow_empty=False,
+    )
+    packaging = PackagingWriteSerializer(many=True, required=False, default=list)
+    fulfilled_at = serializers.DateTimeField(required=False)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class PaymentWriteSerializer(ActionSerializer):
+    operation_key = serializers.UUIDField()
+    paid_on = serializers.DateField()
+    amount = serializers.DecimalField(max_digits=14, decimal_places=4, min_value=0)
+    method = serializers.ChoiceField(choices=Payment.Method.choices)
+    external_reference = serializers.CharField(required=False, allow_blank=True, default='')
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class ReturnItemWriteSerializer(serializers.Serializer):
+    fulfillment_line = serializers.PrimaryKeyRelatedField(
+        queryset=FulfillmentLine.objects.all(),
+    )
+    outcome = serializers.ChoiceField(choices=SalesReturnLine.Outcome.choices)
+    destination = serializers.PrimaryKeyRelatedField(
+        queryset=Location.objects.all(), required=False, allow_null=True,
+    )
+
+
+class ReturnWriteSerializer(ActionSerializer):
+    operation_key = serializers.UUIDField()
+    items = ReturnItemWriteSerializer(many=True, allow_empty=False)
+    returned_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=False)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+    observation_type = serializers.PrimaryKeyRelatedField(
+        queryset=HealthObservationType.objects.all(), required=False,
+        allow_null=True,
+    )
+    severity = serializers.ChoiceField(
+        choices=HealthObservation.Severity.choices, required=False, allow_null=True,
+    )
+    follow_up_due_at = serializers.DateTimeField(required=False, allow_null=True)
+
+
+class RefundWriteSerializer(ActionSerializer):
+    operation_key = serializers.UUIDField()
+    payment = serializers.PrimaryKeyRelatedField(queryset=Payment.objects.all())
+    sales_return = serializers.PrimaryKeyRelatedField(
+        queryset=SalesReturn.objects.all(), required=False, allow_null=True,
+    )
+    fulfillment_lines = serializers.PrimaryKeyRelatedField(
+        queryset=FulfillmentLine.objects.all(), many=True, allow_empty=False,
+    )
+    amount = serializers.DecimalField(max_digits=14, decimal_places=4, min_value=0)
+    refunded_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=False)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class ReverseWriteSerializer(ActionSerializer):
+    operation_key = serializers.UUIDField()
+    occurred_at = serializers.DateTimeField(required=False)
+    reason = serializers.CharField(allow_blank=False)
 
 
 class CustomerViewSet(
@@ -377,6 +581,115 @@ class SalesOrderViewSet(RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin,
         values.is_valid(raise_exception=True)
         order = _run(cancel_order, self.get_object(), request.user, values.validated_data['reason'])
         return Response(self.get_serializer(order).data)
+
+    @action(detail=True, methods=['get', 'post'], url_path='fulfillments')
+    def fulfillments(self, request, pk=None):  # pylint: disable=unused-argument
+        """List fulfillment history or atomically post one dispatch."""
+        order = self.get_object()
+        if request.method == 'GET':
+            rows = order.fulfillments.prefetch_related('lines', 'packaging_lines')
+            return Response(FulfillmentSerializer(rows, many=True).data)
+        values = FulfillmentWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(post_fulfillment, order, request.user, **values.validated_data)
+        return Response(FulfillmentSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True, methods=['post'],
+        url_path=r'fulfillments/(?P<document_id>[^/.]+)/reverse',
+    )
+    def reverse_fulfillment_record(self, request, document_id=None, pk=None):  # pylint: disable=unused-argument
+        """Append a reversal for one fulfillment in this order."""
+        order = self.get_object()
+        original = order.fulfillments.filter(pk=document_id).first()
+        if original is None:
+            raise ValidationError({'fulfillment': 'Choose a fulfillment from this order.'})
+        values = ReverseWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(reverse_fulfillment, original, request.user, **values.validated_data)
+        return Response(FulfillmentSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get', 'post'], url_path='payments')
+    def payments(self, request, pk=None):  # pylint: disable=unused-argument
+        """List payment history or record operational cash."""
+        order = self.get_object()
+        if request.method == 'GET':
+            return Response(PaymentSerializer(order.payments.all(), many=True).data)
+        values = PaymentWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(record_payment, order, request.user, **values.validated_data)
+        return Response(PaymentSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True, methods=['post'],
+        url_path=r'payments/(?P<document_id>[^/.]+)/reverse',
+    )
+    def reverse_payment_record(self, request, document_id=None, pk=None):  # pylint: disable=unused-argument
+        """Append a reversal for one payment in this order."""
+        order = self.get_object()
+        original = order.payments.filter(pk=document_id).first()
+        if original is None:
+            raise ValidationError({'payment': 'Choose a payment from this order.'})
+        values = ReverseWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(reverse_payment, original, request.user, **values.validated_data)
+        return Response(PaymentSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get', 'post'], url_path='returns')
+    def returns(self, request, pk=None):  # pylint: disable=unused-argument
+        """List physical returns or post explicit item outcomes."""
+        order = self.get_object()
+        if request.method == 'GET':
+            return Response(SalesReturnSerializer(
+                order.returns.prefetch_related('lines'), many=True,
+            ).data)
+        values = ReturnWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(post_return, order, request.user, **values.validated_data)
+        return Response(SalesReturnSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True, methods=['post'],
+        url_path=r'returns/(?P<document_id>[^/.]+)/reverse',
+    )
+    def reverse_return_record(self, request, document_id=None, pk=None):  # pylint: disable=unused-argument
+        """Append a reversal for one physical return in this order."""
+        order = self.get_object()
+        original = order.returns.filter(pk=document_id).first()
+        if original is None:
+            raise ValidationError({'sales_return': 'Choose a return from this order.'})
+        values = ReverseWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(reverse_return, original, request.user, **values.validated_data)
+        return Response(SalesReturnSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get', 'post'], url_path='refunds')
+    def refunds(self, request, pk=None):  # pylint: disable=unused-argument
+        """List classified refunds or post a paid-value correction."""
+        order = self.get_object()
+        if request.method == 'GET':
+            return Response(RefundSerializer(
+                order.refunds.prefetch_related('lines'), many=True,
+            ).data)
+        values = RefundWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(post_refund, order, request.user, **values.validated_data)
+        return Response(RefundSerializer(row).data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True, methods=['post'],
+        url_path=r'refunds/(?P<document_id>[^/.]+)/reverse',
+    )
+    def reverse_refund_record(self, request, document_id=None, pk=None):  # pylint: disable=unused-argument
+        """Append a reversal for one refund in this order."""
+        order = self.get_object()
+        original = order.refunds.filter(pk=document_id).first()
+        if original is None:
+            raise ValidationError({'refund': 'Choose a refund from this order.'})
+        values = ReverseWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        row = _run(reverse_refund, original, request.user, **values.validated_data)
+        return Response(RefundSerializer(row).data, status=status.HTTP_201_CREATED)
 
 
 router = routers.SimpleRouter()

--- a/sales/test_commerce.py
+++ b/sales/test_commerce.py
@@ -1,0 +1,260 @@
+"""End-to-end contracts for fulfillment, cash, returns, and refunds."""
+
+# pylint: disable=duplicate-code,missing-function-docstring
+
+from decimal import Decimal
+from uuid import uuid4
+
+from health.models import HealthObservationType, QuarantineCase
+from inventory.models import InventoryItem, StockMovement
+from locations.models import Location
+from plantings.lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_germination_event,
+    record_lifecycle_event,
+)
+from tests.api import RESTContractTestCase
+from tests.factories import make_inventory_item, make_specific_plant, make_stock_lot
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import Fulfillment, Payment, Refund, SalesOrder, SalesOrderAllocation
+
+
+class CommerceRESTTests(RESTContractTestCase):
+    """Posted commerce stays exact, linked, idempotent, and reversible."""
+
+    orders_url = '/sales/orders/'
+    lines_url = '/sales/order-lines/'
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.currency_code = 'NZD'
+        self.workspace.default_tax_rate = Decimal('15')
+        self.workspace.sales_prices_include_tax = False
+        self.workspace.save()
+        self.store = Location.objects.create(
+            workspace=self.workspace, name='Dispatch store', code='DISPATCH',
+            location_type=Location.LocationType.STORAGE,
+        )
+
+    def available_plant(self, batch=None, cell_planting=None):
+        values = {'workspace': self.workspace}
+        if batch is not None:
+            values['batch'] = batch
+        if cell_planting is not None:
+            values['cell_planting'] = cell_planting
+        plant = make_specific_plant(**values)
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        return plant
+
+    def confirmed_order(self, plants):
+        response = self.client.post(self.orders_url, {'status': 'draft'}, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        order = response.data
+        response = self.client.post(self.lines_url, {
+            'order': order['pk'], 'line_type': 'seedling',
+            'variety': plants[0].batch.variety_id,
+            'description': 'Sale seedlings', 'quantity': len(plants),
+            'unit_price': '10.0000', 'tax_rate': '15.0000',
+            'discount_type': 'fixed', 'discount_value': '1.0000',
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        allocated = self.client.post(
+            f"{self.orders_url}{order['pk']}/allocate/",
+            {'line': response.data['pk'], 'plant_ids': [plant.pk for plant in plants]},
+            format='json',
+        )
+        self.assertEqual(allocated.status_code, 201, allocated.data)
+        confirmed = self.client.post(
+            f"{self.orders_url}{order['pk']}/confirm/", {}, format='json',
+        )
+        self.assertEqual(confirmed.status_code, 200, confirmed.data)
+        return confirmed.data, allocated.data
+
+    def fulfill(self, order, allocations):
+        response = self.client.post(
+            f"{self.orders_url}{order['pk']}/fulfillments/",
+            {'operation_key': str(uuid4()), 'allocation_ids': allocations},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def test_partial_then_complete_fulfillment_reconciles_exact_positions(self):
+        first_plant = self.available_plant()
+        plants = [first_plant, self.available_plant(
+            batch=first_plant.batch, cell_planting=first_plant.cell_planting,
+        )]
+        order, allocations = self.confirmed_order(plants)
+        first = self.fulfill(order, [allocations[0]['pk']])
+        detail = self.client.get(f"{self.orders_url}{order['pk']}/")
+        self.assertEqual(detail.data['status'], SalesOrder.Status.PARTIALLY_FULFILLED)
+        self.assertEqual(detail.data['commerce']['fulfilled_quantity'], 1)
+        second = self.fulfill(order, [allocations[1]['pk']])
+        detail = self.client.get(f"{self.orders_url}{order['pk']}/")
+        self.assertEqual(detail.data['status'], SalesOrder.Status.FULFILLED)
+        fulfilled_total = Decimal(first['lines'][0]['total_incl_tax'])
+        fulfilled_total += Decimal(second['lines'][0]['total_incl_tax'])
+        self.assertEqual(fulfilled_total, Decimal('21.8500'))
+        self.assertTrue(all(
+            plant_lifecycle_summary(plant).state == LifecycleState.SOLD
+            for plant in plants
+        ))
+
+    def test_retry_returns_the_original_fulfillment_without_double_sale(self):
+        order, allocations = self.confirmed_order([self.available_plant()])
+        key = str(uuid4())
+        payload = {'operation_key': key, 'allocation_ids': [allocations[0]['pk']]}
+        first = self.client.post(
+            f"{self.orders_url}{order['pk']}/fulfillments/", payload, format='json',
+        )
+        second = self.client.post(
+            f"{self.orders_url}{order['pk']}/fulfillments/", payload, format='json',
+        )
+        self.assertEqual(first.status_code, 201, first.data)
+        self.assertEqual(second.status_code, 201, second.data)
+        self.assertEqual(second.data['pk'], first.data['pk'])
+        self.assertEqual(Fulfillment.objects.filter(reversal_of__isnull=True).count(), 1)
+
+    def test_packaging_consumption_is_costed_and_linked(self):
+        order, allocations = self.confirmed_order([self.available_plant()])
+        item = make_inventory_item(
+            workspace=self.workspace, category=InventoryItem.Category.PACKAGING,
+        )
+        lot = make_stock_lot(
+            workspace=self.workspace, item=item, location=self.store,
+            quantity=Decimal('10'), base_unit_cost=Decimal('2'),
+            acquisition_total=Decimal('20'),
+        )
+        response = self.client.post(
+            f"{self.orders_url}{order['pk']}/fulfillments/", {
+                'operation_key': str(uuid4()),
+                'allocation_ids': [allocations[0]['pk']],
+                'packaging': [{
+                    'lot': lot.pk, 'source': self.store.pk, 'quantity': '2',
+                }],
+            }, format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['packaging_lines'][0]['cogs_amount'], '4.0000')
+        self.assertEqual(StockMovement.objects.filter(
+            movement_type=StockMovement.MovementType.CONSUMPTION,
+            reference=f"fulfillment:{response.data['pk']}",
+        ).count(), 1)
+
+    def test_payment_refund_and_reversals_preserve_balances(self):
+        order, allocations = self.confirmed_order([self.available_plant()])
+        fulfillment = self.fulfill(order, [allocations[0]['pk']])
+        payment = self.client.post(f"{self.orders_url}{order['pk']}/payments/", {
+            'operation_key': str(uuid4()), 'paid_on': '2026-08-14',
+            'amount': '10.3500', 'method': 'card',
+        }, format='json')
+        self.assertEqual(payment.status_code, 201, payment.data)
+        refund = self.client.post(f"{self.orders_url}{order['pk']}/refunds/", {
+            'operation_key': str(uuid4()), 'payment': payment.data['pk'],
+            'fulfillment_lines': [fulfillment['lines'][0]['pk']],
+            'amount': '5.1750', 'reason': 'Goodwill adjustment',
+        }, format='json')
+        self.assertEqual(refund.status_code, 201, refund.data)
+        self.assertEqual(refund.data['lines'][0]['tax_total'], '0.6750')
+        detail = self.client.get(f"{self.orders_url}{order['pk']}/")
+        self.assertEqual(detail.data['commerce']['payment_status'], 'paid')
+        reversed_refund = self.client.post(
+            f"{self.orders_url}{order['pk']}/refunds/{refund.data['pk']}/reverse/",
+            {'operation_key': str(uuid4()), 'reason': 'Refund entered twice.'},
+            format='json',
+        )
+        self.assertEqual(reversed_refund.status_code, 201, reversed_refund.data)
+        reversed_payment = self.client.post(
+            f"{self.orders_url}{order['pk']}/payments/{payment.data['pk']}/reverse/",
+            {'operation_key': str(uuid4()), 'reason': 'Card payment voided.'},
+            format='json',
+        )
+        self.assertEqual(reversed_payment.status_code, 201, reversed_payment.data)
+        self.assertEqual(Payment.objects.count(), 2)
+        self.assertEqual(Refund.objects.count(), 2)
+
+    def test_available_return_reopens_quantity_for_a_new_allocation(self):
+        plant = self.available_plant()
+        order, allocations = self.confirmed_order([plant])
+        fulfillment = self.fulfill(order, [allocations[0]['pk']])
+        returned = self.client.post(f"{self.orders_url}{order['pk']}/returns/", {
+            'operation_key': str(uuid4()), 'reason': 'Customer changed plans.',
+            'items': [{
+                'fulfillment_line': fulfillment['lines'][0]['pk'],
+                'outcome': 'available', 'destination': self.store.pk,
+            }],
+        }, format='json')
+        self.assertEqual(returned.status_code, 201, returned.data)
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.AVAILABLE)
+        detail = self.client.get(f"{self.orders_url}{order['pk']}/")
+        self.assertEqual(detail.data['status'], SalesOrder.Status.CONFIRMED)
+        replacement = self.client.post(
+            f"{self.orders_url}{order['pk']}/allocate/",
+            {'line': fulfillment['lines'][0]['allocation'] and order['lines'][0]['pk'],
+             'plant_ids': [plant.pk]},
+            format='json',
+        )
+        self.assertEqual(replacement.status_code, 201, replacement.data)
+        self.assertNotEqual(replacement.data[0]['pk'], allocations[0]['pk'])
+        self.assertEqual(replacement.data[0]['status'], SalesOrderAllocation.Status.RESERVED)
+
+    def test_fulfillment_and_return_reversals_restore_prior_states(self):
+        plant = self.available_plant()
+        order, allocations = self.confirmed_order([plant])
+        fulfillment = self.fulfill(order, [allocations[0]['pk']])
+        returned = self.client.post(f"{self.orders_url}{order['pk']}/returns/", {
+            'operation_key': str(uuid4()), 'reason': 'Temporary return.',
+            'items': [{
+                'fulfillment_line': fulfillment['lines'][0]['pk'],
+                'outcome': 'available', 'destination': self.store.pk,
+            }],
+        }, format='json')
+        reversed_return = self.client.post(
+            f"{self.orders_url}{order['pk']}/returns/{returned.data['pk']}/reverse/",
+            {'operation_key': str(uuid4()), 'reason': 'Return was entered in error.'},
+            format='json',
+        )
+        self.assertEqual(reversed_return.status_code, 201, reversed_return.data)
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.SOLD)
+        reversed_fulfillment = self.client.post(
+            f"{self.orders_url}{order['pk']}/fulfillments/{fulfillment['pk']}/reverse/",
+            {'operation_key': str(uuid4()), 'reason': 'Dispatch was entered in error.'},
+            format='json',
+        )
+        self.assertEqual(
+            reversed_fulfillment.status_code, 201, reversed_fulfillment.data,
+        )
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.AVAILABLE)
+        allocation = SalesOrderAllocation.objects.get(pk=allocations[0]['pk'])
+        self.assertEqual(allocation.status, SalesOrderAllocation.Status.RESERVED)
+
+    def test_quarantined_return_opens_a_formal_health_case(self):
+        plant = self.available_plant()
+        order, allocations = self.confirmed_order([plant])
+        fulfillment = self.fulfill(order, [allocations[0]['pk']])
+        quarantine = Location.objects.create(
+            workspace=self.workspace, name='Return quarantine', code='RETURN-Q',
+            location_type=Location.LocationType.QUARANTINE,
+        )
+        observation_type = HealthObservationType.objects.get(
+            workspace=self.workspace, code='physical-damage',
+        )
+        response = self.client.post(f"{self.orders_url}{order['pk']}/returns/", {
+            'operation_key': str(uuid4()), 'reason': 'Damage found on return.',
+            'observation_type': observation_type.pk, 'severity': 'moderate',
+            'items': [{
+                'fulfillment_line': fulfillment['lines'][0]['pk'],
+                'outcome': 'quarantined', 'destination': quarantine.pk,
+            }],
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIsNotNone(response.data['health_observation'])
+        self.assertTrue(QuarantineCase.objects.filter(pk=response.data['quarantine_case']).exists())
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.QUARANTINED)

--- a/sales/test_concurrency.py
+++ b/sales/test_concurrency.py
@@ -1,9 +1,10 @@
 """PostgreSQL proofs for exact-stock reservation locking."""
 
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code,missing-function-docstring
 
 from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
+from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -15,6 +16,7 @@ from plantings.lifecycle import EventType, OutcomeRequest, record_germination_ev
 from tests.factories import make_seed_tray, make_specific_plant
 from workspaces.models import Workspace
 
+from .commerce import post_fulfillment
 from .models import SalesOrder, SalesOrderAllocation, SalesOrderLine
 from .services import allocate_targets, confirm_order, create_order
 
@@ -111,3 +113,47 @@ class ConcurrentTrayReservationTests(ReservationConcurrencyTestCase):
             results = sorted(pool.map(self._confirm, self.order_pks))
         self.assertEqual(results, ['confirmed', 'rejected'])
         self.assertEqual(SalesOrderAllocation.objects.filter(status='reserved').count(), 1)
+
+
+@skipUnlessDBFeature('has_select_for_update')
+class ConcurrentFulfillmentTests(ReservationConcurrencyTestCase):
+    """One reserved allocation cannot be sold by two posting requests."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = Workspace.objects.get(pk=settings.CURRENT_WORKSPACE_ID)
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        self.user = get_user_model().objects.create_user(username='fulfillment-racer')
+        plant = make_specific_plant(workspace=self.workspace)
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        order, line = self._order_with_line(
+            SalesOrderLine.LineType.SEEDLING, variety=plant.batch.variety,
+        )
+        allocation = allocate_targets(line, self.user, plant_ids=[plant.pk])[0]
+        confirm_order(order, self.user)
+        self.order_pk = order.pk
+        self.allocation_pk = allocation.pk
+
+    def _fulfill(self, _index):
+        close_old_connections()
+        order = SalesOrder.objects.get(pk=self.order_pk)
+        user = get_user_model().objects.get(pk=self.user.pk)
+        try:
+            post_fulfillment(
+                order, user, operation_key=uuid4(),
+                allocation_ids=[self.allocation_pk],
+            )
+        except ValidationError:
+            result = 'rejected'
+        else:
+            result = 'fulfilled'
+        close_old_connections()
+        return result
+
+    def test_exactly_one_fulfillment_posts(self):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = sorted(pool.map(self._fulfill, range(2)))
+        self.assertEqual(results, ['fulfilled', 'rejected'])
+        self.assertEqual(SalesOrderAllocation.objects.filter(status='fulfilled').count(), 1)


### PR DESCRIPTION
Confirmed reservations now need a single auditable path through dispatch, packaging usage, payment, return, quarantine, refund, and reversal. The services lock exact stock, preserve recognized terms and costs, reject dependent corrections, and make retries safe with request fingerprints.

## Summary by Sourcery

Add atomic, auditable commerce workflows for nursery sales orders, covering fulfillment, payments, returns, refunds, and reversals with idempotent request handling and derived order status updates.

New Features:
- Expose a commerce summary block on sales orders that reports quantities, monetary totals, and payment status separately from pricing.
- Add REST endpoints on sales orders to post and list fulfillments, payments, returns, refunds, and to reverse each of these records atomically using operation keys.
- Introduce commerce domain services to post fulfillments, payments, returns, refunds, and reversals while coordinating stock, plant lifecycle, quarantine, and financial ledgers in a single transaction.

Enhancements:
- Include serialized views of fulfillment, payment, return, and refund records and their lines, including immutable status derived from reversal relationships.

Tests:
- Add end-to-end REST contract tests covering fulfillment, packaging cost recognition, payments, refunds, returns, quarantine flows, and all reversal paths for nursery commerce.
- Add concurrency tests to ensure only one fulfillment can consume a reserved allocation under concurrent posting.