### PR TITLE
feat(frontend): operate fulfillment and returns

### DIFF
--- a/frontend/js/api/sales.ts
+++ b/frontend/js/api/sales.ts
@@ -1,5 +1,17 @@
 import { csrfPatch, csrfPost, fetchAsJson } from '../utils'
-import { AllocationPreview, Customer, SalesAllocation, SalesOrder, SalesOrderLine, SalesOrderLineWrite, SalesOrderStatus } from '../types/sales'
+import {
+  AllocationPreview,
+  Customer,
+  Fulfillment,
+  SalesAllocation,
+  SalesOrder,
+  SalesOrderLine,
+  SalesOrderLineWrite,
+  SalesOrderStatus,
+  SalesPayment,
+  SalesRefund,
+  SalesReturn
+} from '../types/sales'
 
 const CUSTOMERS_URL = '/sales/customers/'
 const ORDERS_URL = '/sales/orders/'
@@ -70,6 +82,50 @@ function editableOrder(status: SalesOrderStatus): boolean {
   return status === 'quote' || status === 'draft'
 }
 
+function getFulfillments(order: number, signal?: AbortSignal): Promise<Array<Fulfillment>> {
+  return fetchAsJson(`${ORDERS_URL}${order}/fulfillments/`, signal)
+}
+
+async function postFulfillment(order: number, data: object): Promise<Fulfillment> {
+  const response = await csrfPost(`${ORDERS_URL}${order}/fulfillments/`, data)
+  return response.json() as Promise<Fulfillment>
+}
+
+function getPayments(order: number, signal?: AbortSignal): Promise<Array<SalesPayment>> {
+  return fetchAsJson(`${ORDERS_URL}${order}/payments/`, signal)
+}
+
+async function postPayment(order: number, data: object): Promise<SalesPayment> {
+  const response = await csrfPost(`${ORDERS_URL}${order}/payments/`, data)
+  return response.json() as Promise<SalesPayment>
+}
+
+function getReturns(order: number, signal?: AbortSignal): Promise<Array<SalesReturn>> {
+  return fetchAsJson(`${ORDERS_URL}${order}/returns/`, signal)
+}
+
+async function postReturn(order: number, data: object): Promise<SalesReturn> {
+  const response = await csrfPost(`${ORDERS_URL}${order}/returns/`, data)
+  return response.json() as Promise<SalesReturn>
+}
+
+function getRefunds(order: number, signal?: AbortSignal): Promise<Array<SalesRefund>> {
+  return fetchAsJson(`${ORDERS_URL}${order}/refunds/`, signal)
+}
+
+async function postRefund(order: number, data: object): Promise<SalesRefund> {
+  const response = await csrfPost(`${ORDERS_URL}${order}/refunds/`, data)
+  return response.json() as Promise<SalesRefund>
+}
+
+async function reverseCommerce(order: number, kind: 'fulfillments' | 'payments' | 'returns' | 'refunds', record: number, reason: string): Promise<object> {
+  const response = await csrfPost(`${ORDERS_URL}${order}/${kind}/${record}/reverse/`, {
+    operation_key: crypto.randomUUID(),
+    reason
+  })
+  return response.json() as Promise<object>
+}
+
 export {
   allocateOrderLine,
   closeAllocations,
@@ -77,12 +133,21 @@ export {
   createSalesOrder,
   createSalesOrderLine,
   editableOrder,
+  getFulfillments,
   getAvailableSerializedUnits,
   getCustomers,
   getSalesOrder,
   getSalesOrders,
+  getPayments,
+  getRefunds,
+  getReturns,
   orderAction,
   previewAllocation,
+  postFulfillment,
+  postPayment,
+  postRefund,
+  postReturn,
+  reverseCommerce,
   updateCustomer,
   updateSalesOrder
 }

--- a/frontend/js/labels.tsx
+++ b/frontend/js/labels.tsx
@@ -11,7 +11,7 @@ import { queryKeys } from './query'
 import { LabelFormat, LabelPrintJob, LabelResolution } from './types/labels'
 import { BulkOperationPanel } from './plantings/bulk_operations'
 import { HealthScopeType } from './types/health'
-import { allocateOrderLine, getSalesOrders, previewAllocation } from './api/sales'
+import { allocateOrderLine, getFulfillments, getSalesOrders, postFulfillment, postReturn, previewAllocation } from './api/sales'
 
 import './labels.css'
 
@@ -229,7 +229,9 @@ function ScannerView() {
   const [stocktakeCode, setStocktakeCode] = React.useState('')
   const [salesOrder, setSalesOrder] = React.useState<number | ''>('')
   const [salesLine, setSalesLine] = React.useState<number | ''>('')
+  const [orderMode, setOrderMode] = React.useState<'allocate' | 'fulfill' | 'return'>('allocate')
   const [orderScanned, setOrderScanned] = React.useState<Array<{ id: number; code: string; display: string }>>([])
+  const [returnDestination, setReturnDestination] = React.useState<number | ''>('')
   const [orderConflict, setOrderConflict] = React.useState('')
   const video = React.useRef<HTMLVideoElement>(null)
   const controls = React.useRef<IScannerControls | undefined>(undefined)
@@ -237,6 +239,11 @@ function ScannerView() {
   const orders = useQuery({ queryKey: queryKeys.sales.orders, queryFn: ({ signal }) => getSalesOrders(signal) })
   const chosenOrder = orders.data?.find((entry) => entry.pk === salesOrder)
   const chosenLine = chosenOrder?.lines.find((entry) => entry.pk === salesLine)
+  const scannedFulfillments = useQuery({
+    queryKey: ['sales', salesOrder, 'scan-fulfillments'],
+    queryFn: ({ signal }) => getFulfillments(salesOrder as number, signal),
+    enabled: salesOrder !== '' && orderMode === 'return'
+  })
   const orderAllocation = useMutation({
     mutationFn: async (resolved: LabelResolution) => {
       if (!chosenOrder || !chosenLine || !resolved.target) throw new Error('Choose an order line before scanning stock.')
@@ -269,6 +276,24 @@ function ScannerView() {
       void orders.refetch()
     }
   })
+  const saveCommerceScans = useMutation<object>({
+    mutationFn: async () => {
+      if (!chosenOrder) throw new Error('Choose an order first.')
+      if (orderMode === 'fulfill') {
+        return await postFulfillment(chosenOrder.pk, { operation_key: crypto.randomUUID(), allocation_ids: orderScanned.map((entry) => entry.id) })
+      }
+      return await postReturn(chosenOrder.pk, {
+        operation_key: crypto.randomUUID(),
+        reason: 'Returned through label scan.',
+        items: orderScanned.map((entry) => ({ fulfillment_line: entry.id, outcome: 'available', destination: returnDestination }))
+      })
+    },
+    onSuccess: () => {
+      setOrderScanned([])
+      void orders.refetch()
+      void scannedFulfillments.refetch()
+    }
+  })
 
   const resolveMutation = useMutation({
     mutationFn: (input: string) => resolveLabel(input),
@@ -283,7 +308,33 @@ function ScannerView() {
         )
       }
       if (resolved.status === 'active' && resolved.target && resolved.capabilities?.includes('order_allocate') && chosenLine) {
-        orderAllocation.mutate(resolved)
+        if (orderMode === 'allocate') orderAllocation.mutate(resolved)
+      }
+      if (resolved.status === 'active' && resolved.target && chosenOrder && orderMode !== 'allocate') {
+        const target = resolved.target
+        const allocation = chosenOrder.lines
+          .flatMap((line) => line.allocations)
+          .find((entry) => entry.plant === (target.target_type === 'specificplant' ? target.object_id : null) || entry.inventory_unit === target.inventory_unit)
+        if (orderMode === 'fulfill' && resolved.capabilities?.includes('order_fulfill') && allocation?.status === 'reserved') {
+          setOrderScanned((current) =>
+            current.some((entry) => entry.id === allocation.pk)
+              ? current
+              : [...current, { id: allocation.pk, code: resolved.current_code ?? resolved.code ?? '', display: target.display }]
+          )
+        } else if (orderMode === 'return' && resolved.capabilities?.includes('order_return') && allocation) {
+          const fulfillmentLine = (scannedFulfillments.data ?? [])
+            .filter((entry) => entry.status === 'posted')
+            .flatMap((entry) => entry.lines)
+            .find((line) => line.allocation === allocation.pk)
+          if (fulfillmentLine)
+            setOrderScanned((current) =>
+              current.some((entry) => entry.id === fulfillmentLine.pk)
+                ? current
+                : [...current, { id: fulfillmentLine.pk, code: resolved.current_code ?? resolved.code ?? '', display: target.display }]
+            )
+        } else {
+          setOrderConflict(`That label is not eligible for ${orderMode} on the chosen order.`)
+        }
       }
       if (resolved.status === 'active' && resolved.target && resolved.capabilities?.includes('health_inspection')) {
         const target = resolved.target
@@ -387,10 +438,24 @@ function ScannerView() {
         </Col>
         <Col lg={6}>
           <h2>
-            Order allocation <Badge bg="primary">{orderScanned.length}</Badge>
+            Order commerce <Badge bg="primary">{orderScanned.length}</Badge>
           </h2>
           <Row className="g-2 mb-2">
-            <Col md={6}>
+            <Col md={4}>
+              <Form.Select
+                value={orderMode}
+                onChange={(event) => {
+                  setOrderMode(event.target.value as typeof orderMode)
+                  setOrderScanned([])
+                  setOrderConflict('')
+                }}
+              >
+                <option value="allocate">Allocate</option>
+                <option value="fulfill">Fulfill</option>
+                <option value="return">Return available</option>
+              </Form.Select>
+            </Col>
+            <Col md={4}>
               <Form.Select
                 value={salesOrder}
                 onChange={(event) => {
@@ -409,10 +474,10 @@ function ScannerView() {
                   ))}
               </Form.Select>
             </Col>
-            <Col md={6}>
+            <Col md={4}>
               <Form.Select
                 value={salesLine}
-                disabled={!chosenOrder}
+                disabled={!chosenOrder || orderMode !== 'allocate'}
                 onChange={(event) => {
                   setSalesLine(event.target.value === '' ? '' : Number(event.target.value))
                   setOrderScanned([])
@@ -428,7 +493,24 @@ function ScannerView() {
             </Col>
           </Row>
           {orderConflict && <Alert variant="warning">Scan not added: {orderConflict}</Alert>}
-          {chosenLine && <p className="text-muted">Scan {chosenLine.line_type === 'seedling' ? 'plant' : 'tray'} labels to validate them against this line.</p>}
+          {orderMode === 'allocate' && chosenLine && (
+            <p className="text-muted">Scan {chosenLine.line_type === 'seedling' ? 'plant' : 'tray'} labels to validate them against this line.</p>
+          )}
+          {orderMode === 'fulfill' && chosenOrder && (
+            <p className="text-muted">Scans stage reserved plants or trays from this order. Posting happens only when you confirm below.</p>
+          )}
+          {orderMode === 'return' && chosenOrder && (
+            <Form.Select className="mb-2" value={returnDestination} onChange={(event) => setReturnDestination(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Return destination</option>
+              {(locations.data ?? [])
+                .filter((location) => location.location_type !== 'quarantine')
+                .map((location) => (
+                  <option key={location.pk} value={location.pk}>
+                    {location.full_name}
+                  </option>
+                ))}
+            </Form.Select>
+          )}
           {orderScanned.length > 0 && (
             <>
               <ul className="list-group mb-2">
@@ -448,13 +530,15 @@ function ScannerView() {
               <Button
                 className="mb-4"
                 disabled={
-                  !chosenLine ||
-                  orderScanned.length + (chosenLine?.allocations.filter((allocation) => ['pending', 'reserved'].includes(allocation.status)).length ?? 0) >
-                    (chosenLine?.quantity ?? 0)
+                  orderMode === 'allocate'
+                    ? !chosenLine ||
+                      orderScanned.length + (chosenLine?.allocations.filter((allocation) => ['pending', 'reserved'].includes(allocation.status)).length ?? 0) >
+                        (chosenLine?.quantity ?? 0)
+                    : orderMode === 'return' && returnDestination === ''
                 }
-                onClick={() => saveOrderAllocation.mutate()}
+                onClick={() => (orderMode === 'allocate' ? saveOrderAllocation.mutate() : saveCommerceScans.mutate())}
               >
-                Add scans to order
+                {orderMode === 'allocate' ? 'Add scans to order' : orderMode === 'fulfill' ? 'Post scanned fulfillment' : 'Post scanned return'}
               </Button>
             </>
           )}

--- a/frontend/js/sales.tsx
+++ b/frontend/js/sales.tsx
@@ -12,14 +12,25 @@ import {
   editableOrder,
   getAvailableSerializedUnits,
   getCustomers,
+  getFulfillments,
+  getPayments,
+  getRefunds,
+  getReturns,
   getSalesOrder,
   getSalesOrders,
   orderAction,
+  postFulfillment,
+  postPayment,
+  postRefund,
+  postReturn,
   previewAllocation,
+  reverseCommerce,
   updateCustomer,
   updateSalesOrder
 } from './api/sales'
-import { getInventoryItems } from './api/inventory'
+import { getInventoryBalances, getInventoryItems } from './api/inventory'
+import { getLocations } from './api/locations'
+import { getHealthObservationTypes } from './api/health'
 import { getPlantVarieties } from './api/plants'
 import { queryClient, queryKeys } from './query'
 import { AllocationPreview, Customer, SalesDiscountType, SalesLineType, SalesOrder, SalesOrderLine } from './types/sales'
@@ -455,6 +466,373 @@ function OrderTotals({ order }: { order: SalesOrder }) {
   )
 }
 
+function CommercePanel({ order }: { order: SalesOrder }) {
+  const fulfillments = useQuery({ queryKey: ['sales', order.pk, 'fulfillments'], queryFn: ({ signal }) => getFulfillments(order.pk, signal) })
+  const payments = useQuery({ queryKey: ['sales', order.pk, 'payments'], queryFn: ({ signal }) => getPayments(order.pk, signal) })
+  const returns = useQuery({ queryKey: ['sales', order.pk, 'returns'], queryFn: ({ signal }) => getReturns(order.pk, signal) })
+  const refunds = useQuery({ queryKey: ['sales', order.pk, 'refunds'], queryFn: ({ signal }) => getRefunds(order.pk, signal) })
+  const locations = useQuery({ queryKey: queryKeys.locations.list('active'), queryFn: ({ signal }) => getLocations(signal, true) })
+  const healthTypes = useQuery({ queryKey: queryKeys.health.types, queryFn: ({ signal }) => getHealthObservationTypes(signal) })
+  const packagingItems = useQuery({
+    queryKey: ['inventory', 'sales-packaging'],
+    queryFn: ({ signal }) => getInventoryItems({ category: 'packaging', tracking_mode: 'lot', active: true }, signal)
+  })
+  const [selectedAllocations, setSelectedAllocations] = React.useState<Array<number>>([])
+  const [packagingItem, setPackagingItem] = React.useState<number | ''>('')
+  const packagingBalances = useQuery({
+    queryKey: ['inventory', 'sales-packaging-balances', packagingItem],
+    queryFn: ({ signal }) => getInventoryBalances(packagingItem as number, signal),
+    enabled: packagingItem !== ''
+  })
+  const [packagingBalance, setPackagingBalance] = React.useState('')
+  const [packagingQuantity, setPackagingQuantity] = React.useState('')
+  const [paymentAmount, setPaymentAmount] = React.useState('')
+  const [paymentMethod, setPaymentMethod] = React.useState<'cash' | 'card' | 'bank_transfer' | 'other'>('cash')
+  const [returnLine, setReturnLine] = React.useState<number | ''>('')
+  const [returnOutcome, setReturnOutcome] = React.useState<'available' | 'quarantined' | 'discarded'>('available')
+  const [returnDestination, setReturnDestination] = React.useState<number | ''>('')
+  const [returnReason, setReturnReason] = React.useState('')
+  const [healthType, setHealthType] = React.useState<number | ''>('')
+  const [healthSeverity, setHealthSeverity] = React.useState<'low' | 'moderate' | 'high' | 'critical'>('moderate')
+  const [refundPayment, setRefundPayment] = React.useState<number | ''>('')
+  const [refundLine, setRefundLine] = React.useState<number | ''>('')
+  const [refundAmount, setRefundAmount] = React.useState('')
+  const [refundReason, setRefundReason] = React.useState('')
+  const reserved = order.lines.flatMap((line) => line.allocations.filter((allocation) => allocation.status === 'reserved'))
+  const activeFulfillmentLines = (fulfillments.data ?? []).filter((entry) => entry.status === 'posted').flatMap((entry) => entry.lines)
+  const activePayments = (payments.data ?? []).filter((entry) => entry.status === 'posted')
+
+  function refreshCommerce() {
+    invalidateSales(order.pk)
+    void fulfillments.refetch()
+    void payments.refetch()
+    void returns.refetch()
+    void refunds.refetch()
+  }
+
+  const fulfill = useMutation({
+    mutationFn: () => {
+      const balance = packagingBalances.data?.find((entry) => `${entry.lot}:${entry.location}` === packagingBalance)
+      return postFulfillment(order.pk, {
+        operation_key: crypto.randomUUID(),
+        allocation_ids: selectedAllocations,
+        packaging: balance && Number(packagingQuantity) > 0 ? [{ lot: balance.lot, source: balance.location, quantity: packagingQuantity }] : []
+      })
+    },
+    onSuccess: () => {
+      setSelectedAllocations([])
+      setPackagingQuantity('')
+      refreshCommerce()
+    }
+  })
+  const pay = useMutation({
+    mutationFn: () =>
+      postPayment(order.pk, {
+        operation_key: crypto.randomUUID(),
+        paid_on: new Date().toISOString().slice(0, 10),
+        amount: paymentAmount,
+        method: paymentMethod
+      }),
+    onSuccess: () => {
+      setPaymentAmount('')
+      refreshCommerce()
+    }
+  })
+  const returnMutation = useMutation({
+    mutationFn: () =>
+      postReturn(order.pk, {
+        operation_key: crypto.randomUUID(),
+        reason: returnReason,
+        items: [
+          {
+            fulfillment_line: returnLine,
+            outcome: returnOutcome,
+            destination: returnOutcome === 'discarded' ? null : returnDestination
+          }
+        ],
+        ...(returnOutcome === 'quarantined' ? { observation_type: healthType, severity: healthSeverity } : {})
+      }),
+    onSuccess: () => {
+      setReturnLine('')
+      setReturnReason('')
+      refreshCommerce()
+    }
+  })
+  const refund = useMutation({
+    mutationFn: () =>
+      postRefund(order.pk, {
+        operation_key: crypto.randomUUID(),
+        payment: refundPayment,
+        fulfillment_lines: [refundLine],
+        amount: refundAmount,
+        reason: refundReason
+      }),
+    onSuccess: () => {
+      setRefundAmount('')
+      setRefundReason('')
+      refreshCommerce()
+    }
+  })
+  const reverse = useMutation({
+    mutationFn: ({ kind, pk }: { kind: 'fulfillments' | 'payments' | 'returns' | 'refunds'; pk: number }) => reverseCommerce(order.pk, kind, pk, 'Reversed by operator.'),
+    onSuccess: refreshCommerce
+  })
+
+  const audit = [
+    ...(fulfillments.data ?? []).map((entry) => ({
+      kind: 'fulfillments' as const,
+      pk: entry.pk,
+      at: entry.fulfilled_at,
+      label: `${entry.fulfillment_number} · ${entry.lines.length} dispatched`,
+      status: entry.status
+    })),
+    ...(payments.data ?? []).map((entry) => ({
+      kind: 'payments' as const,
+      pk: entry.pk,
+      at: entry.paid_on,
+      label: `Payment ${formatMoney(entry.amount, entry.currency_code)} · ${entry.method.replaceAll('_', ' ')}`,
+      status: entry.status
+    })),
+    ...(returns.data ?? []).map((entry) => ({
+      kind: 'returns' as const,
+      pk: entry.pk,
+      at: entry.returned_at,
+      label: `Return · ${entry.lines.map((line) => line.outcome).join(', ')}`,
+      status: entry.status
+    })),
+    ...(refunds.data ?? []).map((entry) => ({
+      kind: 'refunds' as const,
+      pk: entry.pk,
+      at: entry.refunded_at,
+      label: `Refund ${formatMoney(entry.amount, entry.currency_code)}`,
+      status: entry.status
+    }))
+  ].sort((left, right) => left.at.localeCompare(right.at))
+
+  return (
+    <>
+      <Card body className="mb-3">
+        <Card.Title>Commerce status</Card.Title>
+        <Row>
+          <Col>
+            Dispatched
+            <br />
+            <strong>{order.commerce.fulfilled_quantity}</strong>
+          </Col>
+          <Col>
+            Returned
+            <br />
+            <strong>{order.commerce.returned_quantity}</strong>
+          </Col>
+          <Col>
+            Paid
+            <br />
+            <strong>{formatMoney(order.commerce.net_paid_total, order.currency_code)}</strong>
+          </Col>
+          <Col>
+            Outstanding
+            <br />
+            <strong>{formatMoney(order.commerce.outstanding_total, order.currency_code)}</strong>
+          </Col>
+          <Col>
+            Status
+            <br />
+            <Badge bg={order.commerce.payment_status === 'paid' ? 'success' : 'secondary'}>{order.commerce.payment_status.replaceAll('_', ' ')}</Badge>
+          </Col>
+        </Row>
+      </Card>
+      {reserved.length > 0 && (
+        <Card body className="mb-3">
+          <Card.Title>Post fulfillment</Card.Title>
+          {reserved.map((allocation) => (
+            <Form.Check
+              key={allocation.pk}
+              label={allocation.plant ? `Plant #${allocation.plant}` : (allocation.asset_code ?? `Unit #${allocation.inventory_unit}`)}
+              checked={selectedAllocations.includes(allocation.pk)}
+              onChange={() => setSelectedAllocations((current) => (current.includes(allocation.pk) ? current.filter((pk) => pk !== allocation.pk) : [...current, allocation.pk]))}
+            />
+          ))}
+          <Row className="g-2 align-items-end mt-1">
+            <Col md={3}>
+              <Form.Label>Optional packaging item</Form.Label>
+              <Form.Select
+                value={packagingItem}
+                onChange={(event) => {
+                  setPackagingItem(event.target.value === '' ? '' : Number(event.target.value))
+                  setPackagingBalance('')
+                }}
+              >
+                <option value="">None</option>
+                {(packagingItems.data ?? []).map((item) => (
+                  <option key={item.pk} value={item.pk}>
+                    {item.name}
+                  </option>
+                ))}
+              </Form.Select>
+            </Col>
+            <Col md={4}>
+              <Form.Label>Exact lot and location</Form.Label>
+              <Form.Select disabled={packagingItem === ''} value={packagingBalance} onChange={(event) => setPackagingBalance(event.target.value)}>
+                <option value="">Select balance</option>
+                {(packagingBalances.data ?? [])
+                  .filter((balance) => Number(balance.available_quantity) > 0)
+                  .map((balance) => (
+                    <option key={`${balance.lot}:${balance.location}`} value={`${balance.lot}:${balance.location}`}>
+                      {balance.lot_identifier} · {balance.location_name} · {balance.available_quantity} {balance.base_unit}
+                    </option>
+                  ))}
+              </Form.Select>
+            </Col>
+            <Col md={2}>
+              <Form.Label>Quantity</Form.Label>
+              <Form.Control type="number" min="0" step="0.000000001" value={packagingQuantity} onChange={(event) => setPackagingQuantity(event.target.value)} />
+            </Col>
+            <Col md={3}>
+              <Button disabled={!selectedAllocations.length || fulfill.isPending} onClick={() => fulfill.mutate()}>
+                Post dispatch
+              </Button>
+            </Col>
+          </Row>
+        </Card>
+      )}
+      <Row className="g-3 mb-3">
+        <Col lg={4}>
+          <Card body className="h-100">
+            <Card.Title>Record payment</Card.Title>
+            <Form.Control
+              className="mb-2"
+              type="number"
+              min="0.0001"
+              step="0.0001"
+              placeholder="Amount"
+              value={paymentAmount}
+              onChange={(event) => setPaymentAmount(event.target.value)}
+            />
+            <Form.Select className="mb-2" value={paymentMethod} onChange={(event) => setPaymentMethod(event.target.value as typeof paymentMethod)}>
+              <option value="cash">Cash</option>
+              <option value="card">Card</option>
+              <option value="bank_transfer">Bank transfer</option>
+              <option value="other">Other</option>
+            </Form.Select>
+            <Button disabled={!paymentAmount || pay.isPending} onClick={() => pay.mutate()}>
+              Record payment
+            </Button>
+          </Card>
+        </Col>
+        <Col lg={4}>
+          <Card body className="h-100">
+            <Card.Title>Return exact item</Card.Title>
+            <Form.Select className="mb-2" value={returnLine} onChange={(event) => setReturnLine(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Fulfillment item</option>
+              {activeFulfillmentLines.map((line) => (
+                <option key={line.pk} value={line.pk}>
+                  Allocation #{line.allocation} · {formatMoney(line.total_incl_tax, line.currency_code)}
+                </option>
+              ))}
+            </Form.Select>
+            <Form.Select className="mb-2" value={returnOutcome} onChange={(event) => setReturnOutcome(event.target.value as typeof returnOutcome)}>
+              <option value="available">Available</option>
+              <option value="quarantined">Quarantined</option>
+              <option value="discarded">Discarded</option>
+            </Form.Select>
+            {returnOutcome !== 'discarded' && (
+              <Form.Select className="mb-2" value={returnDestination} onChange={(event) => setReturnDestination(event.target.value === '' ? '' : Number(event.target.value))}>
+                <option value="">Destination</option>
+                {(locations.data ?? [])
+                  .filter((location) => returnOutcome !== 'quarantined' || location.location_type === 'quarantine')
+                  .map((location) => (
+                    <option key={location.pk} value={location.pk}>
+                      {location.full_name}
+                    </option>
+                  ))}
+              </Form.Select>
+            )}
+            {returnOutcome === 'quarantined' && (
+              <>
+                <Form.Select className="mb-2" value={healthType} onChange={(event) => setHealthType(event.target.value === '' ? '' : Number(event.target.value))}>
+                  <option value="">Observation type</option>
+                  {(healthTypes.data ?? [])
+                    .filter((entry) => entry.active)
+                    .map((entry) => (
+                      <option key={entry.pk} value={entry.pk}>
+                        {entry.name}
+                      </option>
+                    ))}
+                </Form.Select>
+                <Form.Select className="mb-2" value={healthSeverity} onChange={(event) => setHealthSeverity(event.target.value as typeof healthSeverity)}>
+                  <option value="low">Low</option>
+                  <option value="moderate">Moderate</option>
+                  <option value="high">High</option>
+                  <option value="critical">Critical</option>
+                </Form.Select>
+              </>
+            )}
+            <Form.Control className="mb-2" placeholder="Return reason" value={returnReason} onChange={(event) => setReturnReason(event.target.value)} />
+            <Button
+              disabled={
+                returnLine === '' || !returnReason.trim() || (returnOutcome !== 'discarded' && returnDestination === '') || (returnOutcome === 'quarantined' && healthType === '')
+              }
+              onClick={() => returnMutation.mutate()}
+            >
+              Post return
+            </Button>
+          </Card>
+        </Col>
+        <Col lg={4}>
+          <Card body className="h-100">
+            <Card.Title>Refund paid value</Card.Title>
+            <Form.Select className="mb-2" value={refundPayment} onChange={(event) => setRefundPayment(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Payment</option>
+              {activePayments.map((payment) => (
+                <option key={payment.pk} value={payment.pk}>
+                  {formatMoney(payment.amount, payment.currency_code)} · {payment.paid_on}
+                </option>
+              ))}
+            </Form.Select>
+            <Form.Select className="mb-2" value={refundLine} onChange={(event) => setRefundLine(event.target.value === '' ? '' : Number(event.target.value))}>
+              <option value="">Fulfillment item</option>
+              {activeFulfillmentLines.map((line) => (
+                <option key={line.pk} value={line.pk}>
+                  Allocation #{line.allocation}
+                </option>
+              ))}
+            </Form.Select>
+            <Form.Control
+              className="mb-2"
+              type="number"
+              min="0.0001"
+              step="0.0001"
+              placeholder="Amount"
+              value={refundAmount}
+              onChange={(event) => setRefundAmount(event.target.value)}
+            />
+            <Form.Control className="mb-2" placeholder="Refund reason" value={refundReason} onChange={(event) => setRefundReason(event.target.value)} />
+            <Button disabled={refundPayment === '' || refundLine === '' || !refundAmount || !refundReason.trim()} onClick={() => refund.mutate()}>
+              Post refund
+            </Button>
+          </Card>
+        </Col>
+      </Row>
+      <Card body className="mb-3">
+        <Card.Title>Chronological audit history</Card.Title>
+        {audit.length === 0 && <p className="text-muted mb-0">No posted commerce yet.</p>}
+        {audit.map((entry) => (
+          <div className="d-flex justify-content-between border-bottom py-2" key={`${entry.kind}:${entry.pk}`}>
+            <span>
+              {formatDate(entry.at)} · {entry.label} · {entry.status}
+            </span>
+            {entry.status === 'posted' && (
+              <Button size="sm" variant="outline-danger" onClick={() => reverse.mutate({ kind: entry.kind, pk: entry.pk })}>
+                Reverse
+              </Button>
+            )}
+          </div>
+        ))}
+      </Card>
+    </>
+  )
+}
+
 function SalesOrderDetailView({ orderPk, workspace }: { orderPk: number; workspace: Workspace }) {
   const client = useQueryClient()
   const orderQuery = useQuery({ queryKey: queryKeys.sales.order(orderPk), queryFn: ({ signal }) => getSalesOrder(orderPk, signal) })
@@ -520,6 +898,7 @@ function SalesOrderDetailView({ orderPk, workspace }: { orderPk: number; workspa
         )}
       </Card>
       <OrderTotals order={order} />
+      {['confirmed', 'partially_fulfilled', 'fulfilled'].includes(order.status) && <CommercePanel order={order} />}
       {editable && <LineForm order={order} workspace={workspace} />}
       {order.lines.map((line) => (
         <Card body className="mb-3" key={line.pk}>

--- a/frontend/js/types/sales.ts
+++ b/frontend/js/types/sales.ts
@@ -14,7 +14,8 @@ type Customer = {
 type SalesOrderStatus = 'quote' | 'draft' | 'confirmed' | 'partially_fulfilled' | 'fulfilled' | 'cancelled'
 type SalesLineType = 'seedling' | 'tray'
 type SalesDiscountType = 'none' | 'fixed' | 'percentage'
-type SalesAllocationStatus = 'pending' | 'reserved' | 'released' | 'expired' | 'fulfilled'
+type SalesAllocationStatus = 'pending' | 'reserved' | 'released' | 'expired' | 'fulfilled' | 'returned'
+type CommerceStatus = 'posted' | 'reversed' | 'reversal'
 
 interface ReservationEvent {
   pk: number
@@ -91,6 +92,123 @@ interface SalesOrder {
   updated: string
   lines: Array<SalesOrderLine>
   margin: SalesMargin
+  commerce: SalesCommerceSummary
+}
+
+interface SalesCommerceSummary {
+  requested_quantity: number
+  reserved_quantity: number
+  fulfilled_quantity: number
+  returned_quantity: number
+  fulfilled_total_incl_tax: string
+  refunded_total_incl_tax: string
+  paid_total: string
+  net_paid_total: string
+  outstanding_total: string
+  overpaid_total: string
+  payment_status: 'unpaid' | 'partially_paid' | 'paid' | 'overpaid'
+  currency_code: string
+}
+
+interface FulfillmentLine {
+  pk: number
+  allocation: number
+  commercial_position: number
+  gross_ex_tax: string
+  discount_ex_tax: string
+  subtotal_ex_tax: string
+  tax_total: string
+  total_incl_tax: string
+  cogs_amount: string | null
+  cogs_provisional: boolean
+  currency_code: string
+  lifecycle_event: number | null
+  stock_movement: number | null
+}
+
+interface FulfillmentPackagingLine {
+  pk: number
+  lot: number
+  source: number
+  quantity: string
+  base_unit: string
+  unit_cost: string | null
+  cogs_amount: string | null
+  currency_code: string
+  stock_movement: number
+}
+
+interface Fulfillment {
+  pk: number
+  fulfillment_number: string
+  fulfilled_at: string
+  status: CommerceStatus
+  notes: string
+  operation_key: string
+  reversal_of: number | null
+  lines: Array<FulfillmentLine>
+  packaging_lines: Array<FulfillmentPackagingLine>
+}
+
+interface SalesPayment {
+  pk: number
+  paid_on: string
+  amount: string
+  currency_code: string
+  method: 'cash' | 'card' | 'bank_transfer' | 'other'
+  external_reference: string
+  notes: string
+  status: CommerceStatus
+  operation_key: string
+  reversal_of: number | null
+}
+
+interface SalesReturnLine {
+  pk: number
+  fulfillment_line: number
+  outcome: 'available' | 'quarantined' | 'discarded'
+  destination: number | null
+  lifecycle_event: number | null
+  return_movement: number | null
+  discard_movement: number | null
+}
+
+interface SalesReturn {
+  pk: number
+  returned_at: string
+  reason: string
+  notes: string
+  status: CommerceStatus
+  health_observation: number | null
+  quarantine_case: number | null
+  operation_key: string
+  reversal_of: number | null
+  lines: Array<SalesReturnLine>
+}
+
+interface SalesRefundLine {
+  pk: number
+  fulfillment_line: number
+  gross_ex_tax: string
+  discount_ex_tax: string
+  subtotal_ex_tax: string
+  tax_total: string
+  total_incl_tax: string
+}
+
+interface SalesRefund {
+  pk: number
+  payment: number
+  sales_return: number | null
+  refunded_at: string
+  amount: string
+  currency_code: string
+  reason: string
+  notes: string
+  status: CommerceStatus
+  operation_key: string
+  reversal_of: number | null
+  lines: Array<SalesRefundLine>
 }
 
 interface SalesOrderLineWrite {
@@ -114,13 +232,20 @@ interface AllocationPreview {
 export {
   AllocationPreview,
   Customer,
+  Fulfillment,
+  FulfillmentLine,
+  FulfillmentPackagingLine,
   SalesAllocation,
   SalesAllocationStatus,
   SalesDiscountType,
   SalesLineType,
+  SalesCommerceSummary,
   SalesMargin,
   SalesOrder,
   SalesOrderLine,
   SalesOrderLineWrite,
-  SalesOrderStatus
+  SalesOrderStatus,
+  SalesPayment,
+  SalesRefund,
+  SalesReturn
 }

--- a/labels/rest.py
+++ b/labels/rest.py
@@ -145,7 +145,7 @@ def _target_active(identity):
     if key == ('locations', 'location'):
         return target.active
     if key == ('seedtrays', 'seedtray'):
-        return target.inventory_unit.active
+        return True
     return True
 
 
@@ -162,6 +162,8 @@ def _resolution(code, workspace):  # pylint: disable=too-many-locals,too-many-br
     route = TARGET_ROUTES.get(key)
     capabilities = ['inspect', 'print'] if resolution_status == LabelCode.Status.ACTIVE else ['inspect']
     if resolution_status == LabelCode.Status.ACTIVE and key == ('plantings', 'specificplant'):
+        from sales.models import SalesOrderAllocation  # pylint: disable=import-outside-toplevel
+
         summary = derive_state(identity.target.lifecycle_events.all())
         if summary.state in ('growing', 'available', 'retained'):
             capabilities.append('bulk_select')
@@ -174,6 +176,23 @@ def _resolution(code, workspace):  # pylint: disable=too-many-locals,too-many-br
             ).exists()
             if not reserved and not is_quarantined(identity.target):
                 capabilities.append('order_allocate')
+        if workspace.mode == Workspace.Mode.NURSERY:
+            from sales.models import FulfillmentLine  # pylint: disable=import-outside-toplevel
+
+            if SalesOrderAllocation.objects.filter(
+                    plant=identity.target, status=SalesOrderAllocation.Status.RESERVED).exists():
+                capabilities.append('order_fulfill')
+            fulfilled = FulfillmentLine.objects.filter(
+                allocation__plant=identity.target,
+                fulfillment__reversal__isnull=True,
+                fulfillment__reversal_of__isnull=True,
+            ).order_by('-pk').first()
+            returned = fulfilled and fulfilled.return_lines.filter(
+                sales_return__reversal__isnull=True,
+                sales_return__reversal_of__isnull=True,
+            ).exists()
+            if fulfilled and not returned:
+                capabilities.append('order_return')
     if resolution_status == LabelCode.Status.ACTIVE and key == ('seedtrays', 'seedtray'):
         from inventory.ledger import unit_physical_state  # pylint: disable=import-outside-toplevel
         from sales.models import SalesOrderAllocation  # pylint: disable=import-outside-toplevel,reimported
@@ -185,6 +204,10 @@ def _resolution(code, workspace):  # pylint: disable=too-many-locals,too-many-br
         ).exists()
         if workspace.mode == Workspace.Mode.NURSERY and unit_physical_state(unit) == 'available' and not reserved:
             capabilities.append('order_allocate')
+        if workspace.mode == Workspace.Mode.NURSERY and reserved:
+            capabilities.append('order_fulfill')
+        if workspace.mode == Workspace.Mode.NURSERY and unit_physical_state(unit) == 'dispatched':
+            capabilities.append('order_return')
     active_cohort = resolution_status == LabelCode.Status.ACTIVE
     active_cohort = active_cohort and key == ('plantings', 'plantcohort')
     active_cohort = active_cohort and identity.target.quantity > 0

--- a/labels/test_rest.py
+++ b/labels/test_rest.py
@@ -1,5 +1,6 @@
 """REST contract tests for label resolution and print auditing."""
 
+from decimal import Decimal
 from uuid import uuid4
 
 from django.contrib.auth import get_user_model
@@ -12,6 +13,9 @@ from health.models import HealthObservation, HealthObservationType
 from health.operations import quarantine_observation
 from health.services import preview_observation, record_observation
 from plantings.lifecycle import EventType, OutcomeRequest, record_germination_event, record_lifecycle_event
+from sales.commerce import post_fulfillment
+from sales.models import SalesOrderLine
+from sales.services import allocate_targets, confirm_order, create_order
 
 from .models import LabelCode, LabelPrintJob, LabelTemplate
 from .services import ensure_identity, replace_code, void_code
@@ -78,6 +82,30 @@ class LabelResolutionTests(TestCase):
         record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
         resolved = self.resolve(self.code.code)
         self.assertIn('order_allocate', resolved.data['capabilities'])
+
+    def test_reserved_then_sold_plant_exposes_staging_only_commerce_modes(self):
+        """A scan advertises selection capabilities without changing stock."""
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        plant = self.identity.target
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        order = create_order(self.workspace, self.user)
+        line = SalesOrderLine.objects.create(
+            order=order, line_type=SalesOrderLine.LineType.SEEDLING,
+            variety=plant.batch.variety, description='Scanned seedling',
+            quantity=1, unit_price=Decimal('10'), tax_rate=Decimal('15'),
+        )
+        allocation = allocate_targets(line, self.user, plant_ids=[plant.pk])[0]
+        confirm_order(order, self.user)
+        reserved = self.resolve(self.code.code)
+        self.assertIn('order_fulfill', reserved.data['capabilities'])
+        post_fulfillment(
+            order, self.user, operation_key=uuid4(),
+            allocation_ids=[allocation.pk],
+        )
+        sold = self.resolve(self.code.code)
+        self.assertIn('order_return', sold.data['capabilities'])
 
     def test_unknown_replaced_void_and_wrong_workspace_are_explicit(self):
         """Every unusable scan explains its condition without target leakage."""


### PR DESCRIPTION
Nursery operators need to post exact dispatches, payments, returns, and refunds from the order they are reviewing, with costs and balances visible. Label scans now stage eligible allocations or sold items and defer every mutation to an explicit idempotent confirmation.

## Summary by Sourcery

Introduce a dedicated commerce panel and label-scanning flows to manage dispatches, payments, returns, refunds, and their audit history for sales orders.

New Features:
- Allow operators to post fulfillments, payments, returns, and refunds directly from the sales order detail view with live commerce totals and payment status.
- Enable label-based workflows to stage and confirm order fulfillment and item returns without immediate stock mutations.
- Expose new commerce-related label capabilities for nursery mode, including order fulfillment and return eligibility for plants and seed trays.

Enhancements:
- Extend sales domain types and API client to model fulfillments, payments, returns, refunds, and summarized commerce balances, including reversible status tracking.

Tests:
- Add REST contract tests ensuring reserved and sold plants expose appropriate commerce-related label capabilities without altering stock prematurely.