### PR TITLE
feat(reports): establish inventory reporting

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -9,6 +9,6 @@ pycodestyle --ignore=E501 */*.py
 # machine, so linting it would gate the build on an untracked file. When a new
 # app is added, add it here — applications/ was missed and went unlinted from
 # the day it landed until the seed-tray generation work noticed.
-pylint applications/ costing/ frontend/ garden/ health/ inventory/ labels/ locations/ plantings/ plants/ sales/ seeds/ seedtrays/ supplies/ tests/ work/ workspaces/
+pylint applications/ costing/ frontend/ garden/ health/ inventory/ labels/ locations/ plantings/ plants/ reporting/ sales/ seeds/ seedtrays/ supplies/ tests/ work/ workspaces/
 
 deactivate

--- a/gp/settings.py
+++ b/gp/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     "labels",
     "work",
     "health",
+    "reporting",
     "rest_framework",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/gp/urls.py
+++ b/gp/urls.py
@@ -37,4 +37,5 @@ urlpatterns = [
     path("labels/", include('labels.urls')),
     path("work/", include('work.urls')),
     path("health/", include('health.urls')),
+    path("reports/", include('reporting.urls')),
 ]

--- a/inventory/migrations/0011_report_indexes.py
+++ b/inventory/migrations/0011_report_indexes.py
@@ -1,0 +1,23 @@
+"""Add access paths used by high-cardinality inventory reports."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('inventory', '0010_stocktaketarget_review_revision_and_more')]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='stocklot',
+            index=models.Index(
+                fields=['workspace', 'expires_on'], name='stock_lot_expiry_idx',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='stockmovement',
+            index=models.Index(
+                fields=['workspace', 'occurred_at'], name='stock_move_date_idx',
+            ),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -693,6 +693,9 @@ class StockLot(WorkspaceOwnedModel):
 
     class Meta:
         ordering = ['item__name', 'identifier', 'pk']
+        indexes = [
+            models.Index(fields=['workspace', 'expires_on'], name='stock_lot_expiry_idx'),
+        ]
         constraints = [
             models.UniqueConstraint(
                 fields=['workspace', 'item', 'identifier'],
@@ -1405,6 +1408,9 @@ class StockMovement(WorkspaceOwnedModel):
 
     class Meta:
         ordering = ['occurred_at', 'pk']
+        indexes = [
+            models.Index(fields=['workspace', 'occurred_at'], name='stock_move_date_idx'),
+        ]
         constraints = [
             models.CheckConstraint(
                 condition=models.Q(quantity__gt=0),

--- a/reporting/__init__.py
+++ b/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only operational and financial reporting for Nursery workspaces."""

--- a/reporting/apps.py
+++ b/reporting/apps.py
@@ -1,0 +1,10 @@
+"""Application configuration for centralized Nursery reports."""
+
+from django.apps import AppConfig
+
+
+class ReportingConfig(AppConfig):
+    """Configure the report service application."""
+
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'reporting'

--- a/reporting/common.py
+++ b/reporting/common.py
@@ -1,0 +1,132 @@
+"""Shared report envelopes, pagination, decimal rendering, and CSV exports."""
+
+import csv
+import json
+from dataclasses import dataclass, field
+from decimal import Decimal
+from io import StringIO
+
+from django.core.paginator import EmptyPage, Paginator
+from django.http import HttpResponse
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+
+REPORT_VERSION = 'nursery-reports.v1'
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+
+def decimal_string(value, places):
+    """Render a decimal at a stable scale without passing floats through APIs."""
+    if value is None:
+        return None
+    return f'{Decimal(value):.{places}f}'
+
+
+def normalized_filters(serializer):
+    """Return validated filters in a JSON-safe, stable representation."""
+    result = {}
+    for key, value in serializer.validated_data.items():
+        if key in {'page', 'page_size'}:
+            continue
+        if value in (None, '', (), []):
+            continue
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
+        result[key] = value
+    return result
+
+
+@dataclass
+class Report:  # pylint: disable=too-many-instance-attributes
+    """One fully calculated report shared by JSON and CSV renderers."""
+
+    name: str
+    filters: dict
+    columns: tuple
+    rows: list
+    totals: dict = field(default_factory=dict)
+    reconciliation: dict = field(default_factory=dict)
+    data_quality: list = field(default_factory=list)
+    generated_at: object = field(default_factory=timezone.now)
+    version: str = REPORT_VERSION
+
+
+def _positive_integer(params, name, default, maximum=None):
+    raw = params.get(name)
+    if raw in (None, ''):
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValidationError({name: 'Use a positive integer.'}) from exc
+    if value <= 0:
+        raise ValidationError({name: 'Use a positive integer.'})
+    if maximum is not None:
+        value = min(value, maximum)
+    return value
+
+
+def report_response(request, report):
+    """Paginate rows without changing the separately calculated report totals."""
+    page_size = _positive_integer(
+        request.query_params, 'page_size', DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+    )
+    page_number = _positive_integer(request.query_params, 'page', 1)
+    paginator = Paginator(report.rows, page_size)
+    try:
+        page = paginator.page(page_number)
+    except EmptyPage as exc:
+        raise ValidationError({'page': 'That page contains no results.'}) from exc
+
+    def page_url(number):
+        if number is None:
+            return None
+        params = request.query_params.copy()
+        params['page'] = number
+        params['page_size'] = page_size
+        return request.build_absolute_uri(f'{request.path}?{params.urlencode()}')
+
+    return Response({
+        'report': report.name,
+        'version': report.version,
+        'generated_at': report.generated_at,
+        'filters': report.filters,
+        'totals': report.totals,
+        'reconciliation': report.reconciliation,
+        'data_quality': report.data_quality,
+        'count': paginator.count,
+        'next': page_url(page.next_page_number() if page.has_next() else None),
+        'previous': page_url(
+            page.previous_page_number() if page.has_previous() else None,
+        ),
+        'results': list(page.object_list),
+    })
+
+
+def csv_response(report):
+    """Return a versioned CSV with metadata followed by stable tabular headers."""
+    stream = StringIO(newline='')
+    writer = csv.writer(stream)
+    writer.writerow(('report', 'version', 'generated_at', 'filters'))
+    writer.writerow((
+        report.name,
+        report.version,
+        report.generated_at.isoformat(),
+        json.dumps(report.filters, sort_keys=True, separators=(',', ':')),
+    ))
+    writer.writerow(())
+    writer.writerow(report.columns)
+    for row in report.rows:
+        writer.writerow([
+            json.dumps(row.get(column), sort_keys=True, separators=(',', ':'))
+            if isinstance(row.get(column), (dict, list)) else row.get(column)
+            for column in report.columns
+        ])
+    response = HttpResponse(stream.getvalue(), content_type='text/csv; charset=utf-8')
+    response['Content-Disposition'] = f'attachment; filename="{report.name}-v1.csv"'
+    response['X-Report-Version'] = report.version
+    response['X-Report-Generated-At'] = report.generated_at.isoformat()
+    return response

--- a/reporting/filters.py
+++ b/reporting/filters.py
@@ -1,0 +1,72 @@
+"""Strict validated query schemas for Nursery reports."""
+
+from rest_framework import serializers
+
+
+class BaseReportFilters(serializers.Serializer):  # pylint: disable=abstract-method
+    """Pagination is rendered centrally and never changes report calculations."""
+
+    page = serializers.IntegerField(required=False, min_value=1)
+    page_size = serializers.IntegerField(required=False, min_value=1)
+
+    def to_internal_value(self, data):
+        """Reject misspelled filters instead of silently changing report scope."""
+        unknown = sorted(set(data) - set(self.fields))
+        if unknown:
+            raise serializers.ValidationError({
+                name: 'Unknown report filter.' for name in unknown
+            })
+        return super().to_internal_value(data)
+
+
+class InventoryBalanceFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Filters for exact lot/location balances."""
+
+    item = serializers.IntegerField(required=False, min_value=1)
+    lot = serializers.IntegerField(required=False, min_value=1)
+    location = serializers.IntegerField(required=False, min_value=1)
+    expires_before = serializers.DateField(required=False)
+    low_stock = serializers.BooleanField(required=False)
+
+
+class SerializedTrayFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Filters for serialized tray state."""
+
+    item = serializers.IntegerField(required=False, min_value=1)
+    location = serializers.IntegerField(required=False, min_value=1)
+    physical_state = serializers.ChoiceField(
+        required=False,
+        choices=('available', 'quarantined', 'lost', 'retired', 'dispatched', 'returned'),
+    )
+    in_use = serializers.BooleanField(required=False)
+
+
+class MovementFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Filters for immutable movement history."""
+
+    date_from = serializers.DateTimeField(required=False)
+    date_to = serializers.DateTimeField(required=False)
+    item = serializers.IntegerField(required=False, min_value=1)
+    lot = serializers.IntegerField(required=False, min_value=1)
+    location = serializers.IntegerField(required=False, min_value=1)
+    movement_type = serializers.CharField(required=False)
+    reference = serializers.CharField(required=False, allow_blank=False)
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        if attrs.get('date_from') and attrs.get('date_to'):
+            if attrs['date_to'] < attrs['date_from']:
+                raise serializers.ValidationError({
+                    'date_to': 'The end must not be before the start.',
+                })
+        return attrs
+
+
+class StocktakeVarianceFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Filters for review and posted stocktake differences."""
+
+    date_from = serializers.DateTimeField(required=False)
+    date_to = serializers.DateTimeField(required=False)
+    stocktake = serializers.IntegerField(required=False, min_value=1)
+    location = serializers.IntegerField(required=False, min_value=1)
+    kind = serializers.CharField(required=False)

--- a/reporting/inventory.py
+++ b/reporting/inventory.py
@@ -1,0 +1,440 @@
+"""Inventory report calculations derived from immutable stock facts."""
+
+from collections import defaultdict
+from decimal import Decimal
+
+from django.db.models import Q
+
+from inventory.models import (
+    InventoryItem,
+    InventoryUnit,
+    StockLot,
+    StockMovement,
+    StocktakeLine,
+    StocktakeVariance,
+)
+from locations.models import Location
+from sales.models import SalesOrderAllocation
+from seedtrays.models import SeedTrayGeneration
+
+from .common import Report, decimal_string
+
+
+QUANTITY_ZERO = Decimal('0')
+MONEY_ZERO = Decimal('0')
+
+
+def _quality(code, count, message, url):
+    return {'code': code, 'count': count, 'message': message, 'drill_down': url}
+
+
+def inventory_balances(workspace, filters):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    """Derive on-hand, reserved, and available stock by exact lot and place."""
+    lots = StockLot.objects.filter(workspace=workspace).select_related('item')
+    if filters.get('item'):
+        lots = lots.filter(item_id=filters['item'])
+    if filters.get('lot'):
+        lots = lots.filter(pk=filters['lot'])
+    if filters.get('expires_before'):
+        lots = lots.filter(expires_on__lte=filters['expires_before'])
+    lots = list(lots.order_by('item__name', 'identifier', 'pk'))
+    lot_ids = [lot.pk for lot in lots]
+    lots_by_id = {lot.pk: lot for lot in lots}
+
+    balances = defaultdict(Decimal)
+    location_ids = set()
+    movements = StockMovement.objects.filter(
+        workspace=workspace, lot_id__in=lot_ids,
+    ).values('lot_id', 'source_id', 'destination_id', 'quantity')
+    for movement in movements:
+        if movement['source_id']:
+            balances[(movement['lot_id'], movement['source_id'])] -= movement['quantity']
+            location_ids.add(movement['source_id'])
+        if movement['destination_id']:
+            balances[(movement['lot_id'], movement['destination_id'])] += movement['quantity']
+            location_ids.add(movement['destination_id'])
+
+    reserved = defaultdict(int)
+    reservations = SalesOrderAllocation.objects.filter(
+        status=SalesOrderAllocation.Status.RESERVED,
+        inventory_unit__workspace=workspace,
+        inventory_unit__source_lot_id__in=lot_ids,
+        inventory_unit__current_location__isnull=False,
+    ).values_list(
+        'inventory_unit__source_lot_id', 'inventory_unit__current_location_id',
+    )
+    for lot_id, location_id in reservations:
+        reserved[(lot_id, location_id)] += 1
+    locations = {
+        row.pk: row for row in Location.objects.filter(pk__in=location_ids)
+    }
+
+    item_available = defaultdict(Decimal)
+    for (lot_id, _location_id), physical in balances.items():
+        lot = lots_by_id[lot_id]
+        item_available[lot.item_id] += physical - reserved[(lot_id, _location_id)]
+
+    rows = []
+    for lot in lots:
+        for (lot_id, location_id), physical in balances.items():
+            if lot_id != lot.pk or physical == 0:
+                continue
+            if filters.get('location') and location_id != filters['location']:
+                continue
+            reserved_quantity = Decimal(reserved[(lot_id, location_id)])
+            available = physical - reserved_quantity
+            low_stock = lot.item.reorder_level is not None and (
+                item_available[lot.item_id] <= lot.item.reorder_level
+            )
+            if 'low_stock' in filters and filters['low_stock'] != low_stock:
+                continue
+            physical_value = None
+            reserved_value = None
+            available_value = None
+            if lot.base_unit_cost is not None:
+                physical_value = physical * lot.base_unit_cost
+                reserved_value = reserved_quantity * lot.base_unit_cost
+                available_value = available * lot.base_unit_cost
+            rows.append({
+                'item_id': lot.item_id,
+                'item_name': lot.item.name,
+                'lot_id': lot.pk,
+                'lot_identifier': lot.identifier,
+                'location_id': location_id,
+                'location_name': locations[location_id].name,
+                'expires_on': lot.expires_on,
+                'physical_quantity': decimal_string(physical, 9),
+                'reserved_quantity': decimal_string(reserved_quantity, 9),
+                'available_quantity': decimal_string(available, 9),
+                'base_unit': lot.item.base_unit,
+                'unit_cost': decimal_string(lot.base_unit_cost, 12),
+                'physical_value': decimal_string(physical_value, 4),
+                'reserved_value': decimal_string(reserved_value, 4),
+                'available_value': decimal_string(available_value, 4),
+                'currency_code': lot.currency_code,
+                'low_stock': low_stock,
+                'quantity_certainty': lot.quantity_certainty,
+                'unvalued': lot.base_unit_cost is None,
+            })
+
+    quantity_totals = defaultdict(lambda: [Decimal('0'), Decimal('0'), Decimal('0')])
+    value_totals = defaultdict(lambda: [Decimal('0'), Decimal('0'), Decimal('0')])
+    for row in rows:
+        quantities = quantity_totals[row['base_unit']]
+        quantities[0] += Decimal(row['physical_quantity'])
+        quantities[1] += Decimal(row['reserved_quantity'])
+        quantities[2] += Decimal(row['available_quantity'])
+        if not row['unvalued']:
+            values = value_totals[row['currency_code']]
+            values[0] += Decimal(row['physical_value'])
+            values[1] += Decimal(row['reserved_value'])
+            values[2] += Decimal(row['available_value'])
+    unvalued = sum(row['unvalued'] for row in rows)
+    uncertain = sum(row['quantity_certainty'] != 'exact' for row in rows)
+    quality = []
+    if unvalued:
+        quality.append(_quality(
+            'unvalued_inventory', unvalued,
+            'One or more on-hand lots have no acquisition cost.',
+            '/reports/inventory-balances/?unvalued=true',
+        ))
+    if uncertain:
+        quality.append(_quality(
+            'uncertain_quantity', uncertain,
+            'One or more balances originate from estimated or unknown stock.',
+            '/reports/inventory-balances/?uncertain=true',
+        ))
+    totals = {
+        'quantities': [{
+            'base_unit': unit,
+            'physical': decimal_string(values[0], 9),
+            'reserved': decimal_string(values[1], 9),
+            'available': decimal_string(values[2], 9),
+        } for unit, values in sorted(quantity_totals.items())],
+        'valuations': [{
+            'currency_code': currency,
+            'physical': decimal_string(values[0], 4),
+            'reserved': decimal_string(values[1], 4),
+            'available': decimal_string(values[2], 4),
+        } for currency, values in sorted(value_totals.items())],
+        'unvalued_rows': unvalued,
+    }
+    return Report(
+        name='inventory-balances', filters=filters, rows=rows,
+        columns=tuple(rows[0]) if rows else (
+            'item_id', 'item_name', 'lot_id', 'lot_identifier', 'location_id',
+            'location_name', 'expires_on', 'physical_quantity',
+            'reserved_quantity', 'available_quantity', 'base_unit', 'unit_cost',
+            'physical_value', 'reserved_value', 'available_value',
+            'currency_code', 'low_stock', 'quantity_certainty', 'unvalued',
+        ),
+        totals=totals,
+        reconciliation={'quantity_equation': 'physical = reserved + available'},
+        data_quality=quality,
+    )
+
+
+def serialized_trays(workspace, filters):  # pylint: disable=too-many-locals
+    """Report exact tray identities, physical state, use, and reservation."""
+    units = InventoryUnit.objects.filter(
+        workspace=workspace, item__category=InventoryItem.Category.TRAY,
+    ).select_related('item', 'source_lot', 'current_location', 'seed_tray')
+    if filters.get('item'):
+        units = units.filter(item_id=filters['item'])
+    if filters.get('location'):
+        units = units.filter(current_location_id=filters['location'])
+    units = list(units.order_by('asset_code', 'pk'))
+    unit_ids = [unit.pk for unit in units]
+    latest = {}
+    for movement in StockMovement.objects.filter(
+            unit_id__in=unit_ids, reversal_of__isnull=True,
+            reversal__isnull=True).order_by('unit_id', 'occurred_at', 'pk'):
+        latest[movement.unit_id] = movement
+    reserved = set(SalesOrderAllocation.objects.filter(
+        status=SalesOrderAllocation.Status.RESERVED,
+        inventory_unit_id__in=unit_ids,
+    ).values_list('inventory_unit_id', flat=True))
+    active_generations = {
+        row.tray_id: row for row in SeedTrayGeneration.objects.filter(
+            tray__inventory_unit_id__in=unit_ids,
+            status=SeedTrayGeneration.Status.OPEN,
+        )
+    }
+    occupied_trays = set()
+    from plantings.models import SeedTrayPlanting, SpecificPlantLocation  # pylint: disable=import-outside-toplevel
+    occupied_trays.update(SeedTrayPlanting.objects.filter(
+        seed_tray__inventory_unit_id__in=unit_ids, removed=False,
+    ).values_list('seed_tray_id', flat=True))
+    occupied_trays.update(SpecificPlantLocation.objects.filter(
+        seed_tray_cell__tray__inventory_unit_id__in=unit_ids, ended__isnull=True,
+    ).values_list('seed_tray_cell__tray_id', flat=True))
+
+    rows = []
+    for unit in units:
+        movement = latest.get(unit.pk)
+        if unit.current_location_id:
+            if unit.current_location.location_type == Location.LocationType.QUARANTINE:
+                state = 'quarantined'
+            elif movement and movement.movement_type in {
+                    StockMovement.MovementType.ADJUSTMENT_GAIN,
+                    StockMovement.MovementType.CUSTOMER_RETURN}:
+                state = 'returned'
+            else:
+                state = 'available'
+        else:
+            state = {
+                StockMovement.MovementType.ADJUSTMENT_LOSS: 'lost',
+                StockMovement.MovementType.WASTE: 'retired',
+                StockMovement.MovementType.SALE: 'dispatched',
+            }.get(getattr(movement, 'movement_type', None), 'retired')
+        tray = unit.seed_tray
+        in_use = tray.pk in occupied_trays
+        if filters.get('physical_state') and state != filters['physical_state']:
+            continue
+        if 'in_use' in filters and in_use != filters['in_use']:
+            continue
+        generation = active_generations.get(tray.pk)
+        rows.append({
+            'unit_id': unit.pk,
+            'asset_code': unit.asset_code,
+            'item_id': unit.item_id,
+            'item_name': unit.item.name,
+            'source_lot_id': unit.source_lot_id,
+            'tray_id': tray.pk,
+            'location_id': unit.current_location_id,
+            'location_name': (
+                unit.current_location.name if unit.current_location_id else None
+            ),
+            'physical_state': state,
+            'in_use': in_use,
+            'reserved': unit.pk in reserved,
+            'available': state in {'available', 'returned'} and unit.pk not in reserved,
+            'generation_id': getattr(generation, 'pk', None),
+            'generation_code': getattr(generation, 'code', None),
+            'acquisition_cost': decimal_string(unit.acquisition_cost, 4),
+            'currency_code': unit.currency_code,
+            'unvalued': unit.acquisition_cost is None,
+        })
+    unvalued = sum(row['unvalued'] for row in rows)
+    quality = []
+    if unvalued:
+        quality.append(_quality(
+            'unvalued_serialized_stock', unvalued,
+            'One or more trays have no reconciled acquisition cost.',
+            '/reports/serialized-trays/?unvalued=true',
+        ))
+    return Report(
+        name='serialized-trays', filters=filters, rows=rows,
+        columns=tuple(rows[0]) if rows else (
+            'unit_id', 'asset_code', 'item_id', 'item_name', 'source_lot_id',
+            'tray_id', 'location_id', 'location_name', 'physical_state',
+            'in_use', 'reserved', 'available', 'generation_id',
+            'generation_code', 'acquisition_cost', 'currency_code', 'unvalued',
+        ),
+        totals={
+            'units': len(rows),
+            'available': sum(row['available'] for row in rows),
+            'reserved': sum(row['reserved'] for row in rows),
+            'in_use': sum(row['in_use'] for row in rows),
+            'unvalued': unvalued,
+        },
+        reconciliation={'identity_equation': 'units = one row per serialized tray'},
+        data_quality=quality,
+    )
+
+
+def movement_history(workspace, filters):
+    """Return immutable stock movement history with exact provenance."""
+    queryset = StockMovement.objects.filter(workspace=workspace).select_related(
+        'lot__item', 'unit', 'source', 'destination',
+    )
+    if filters.get('date_from'):
+        queryset = queryset.filter(occurred_at__gte=filters['date_from'])
+    if filters.get('date_to'):
+        queryset = queryset.filter(occurred_at__lte=filters['date_to'])
+    if filters.get('item'):
+        queryset = queryset.filter(lot__item_id=filters['item'])
+    if filters.get('lot'):
+        queryset = queryset.filter(lot_id=filters['lot'])
+    if filters.get('location'):
+        queryset = queryset.filter(
+            Q(source_id=filters['location']) | Q(destination_id=filters['location']),
+        )
+    if filters.get('movement_type'):
+        valid = {choice for choice, _label in StockMovement.MovementType.choices}
+        if filters['movement_type'] not in valid:
+            from rest_framework.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
+            raise ValidationError({'movement_type': 'Select a valid movement type.'})
+        queryset = queryset.filter(movement_type=filters['movement_type'])
+    if filters.get('reference'):
+        queryset = queryset.filter(reference__icontains=filters['reference'])
+    rows = [{
+        'movement_id': row.pk,
+        'occurred_at': row.occurred_at,
+        'movement_type': row.movement_type,
+        'item_id': row.lot.item_id,
+        'item_name': row.lot.item.name,
+        'lot_id': row.lot_id,
+        'lot_identifier': row.lot.identifier,
+        'unit_id': row.unit_id,
+        'asset_code': row.unit.asset_code if row.unit_id else None,
+        'quantity': decimal_string(row.quantity, 9),
+        'base_unit': row.lot.item.base_unit,
+        'source_id': row.source_id,
+        'source_name': row.source.name if row.source_id else None,
+        'destination_id': row.destination_id,
+        'destination_name': row.destination.name if row.destination_id else None,
+        'reference': row.reference,
+        'reason': row.reason,
+        'reversal_of_id': row.reversal_of_id,
+        'receipt_line_id': row.receipt_line_id,
+        'stocktake_line_id': row.stocktake_line_id,
+    } for row in queryset.order_by('-occurred_at', '-pk')]
+    return Report(
+        name='inventory-movements', filters=filters, rows=rows,
+        columns=tuple(rows[0]) if rows else (
+            'movement_id', 'occurred_at', 'movement_type', 'item_id',
+            'item_name', 'lot_id', 'lot_identifier', 'unit_id', 'asset_code',
+            'quantity', 'base_unit', 'source_id', 'source_name',
+            'destination_id', 'destination_name', 'reference', 'reason',
+            'reversal_of_id', 'receipt_line_id', 'stocktake_line_id',
+        ),
+        totals={'movements': len(rows)},
+        reconciliation={'history': 'reversals remain separate immutable rows'},
+    )
+
+
+def stocktake_variances(workspace, filters):
+    """Unify current generic variances and legacy exact-lot count differences."""
+    current = StocktakeVariance.objects.filter(
+        target__stocktake__workspace=workspace,
+    ).select_related(
+        'target__stocktake', 'target__expected_location',
+        'target__accepted_count__observed_location',
+    )
+    legacy = StocktakeLine.objects.filter(
+        stocktake__workspace=workspace,
+        variance_base_quantity__isnull=False,
+    ).exclude(variance_base_quantity=0).select_related(
+        'stocktake', 'lot__item', 'location',
+    )
+    if filters.get('stocktake'):
+        current = current.filter(target__stocktake_id=filters['stocktake'])
+        legacy = legacy.filter(stocktake_id=filters['stocktake'])
+    if filters.get('date_from'):
+        current = current.filter(target__stocktake__counted_at__gte=filters['date_from'])
+        legacy = legacy.filter(stocktake__counted_at__gte=filters['date_from'])
+    if filters.get('date_to'):
+        current = current.filter(target__stocktake__counted_at__lte=filters['date_to'])
+        legacy = legacy.filter(stocktake__counted_at__lte=filters['date_to'])
+    if filters.get('location'):
+        current = current.filter(Q(
+            target__expected_location_id=filters['location'],
+        ) | Q(
+            target__accepted_count__observed_location_id=filters['location'],
+        ))
+        legacy = legacy.filter(location_id=filters['location'])
+    if filters.get('kind'):
+        current = current.filter(kind=filters['kind'])
+        if filters['kind'] != 'quantity':
+            legacy = legacy.none()
+    rows = [{
+        'source_kind': 'target',
+        'variance_id': row.pk,
+        'stocktake_id': row.target.stocktake_id,
+        'counted_at': row.target.stocktake.counted_at,
+        'status': row.target.stocktake.status,
+        'target_type': row.target.target_type,
+        'target_id': row.target.target_object_id,
+        'display': row.target.display,
+        'kind': row.kind,
+        'expected': row.expected,
+        'observed': row.observed,
+        'expected_location_id': row.target.expected_location_id,
+        'observed_location_id': (
+            row.target.accepted_count.observed_location_id
+            if row.target.accepted_count_id else None
+        ),
+        'source_changed': row.source_changed,
+        'resolution_action': row.resolution_action,
+        'resolved_at': row.resolved_at,
+    } for row in current.order_by('-target__stocktake__counted_at', 'pk')]
+    rows.extend({
+        'source_kind': 'lot_line',
+        'variance_id': row.pk,
+        'stocktake_id': row.stocktake_id,
+        'counted_at': row.stocktake.counted_at,
+        'status': row.stocktake.status,
+        'target_type': 'lot',
+        'target_id': row.lot_id,
+        'display': f'{row.lot.item.name}: {row.lot.identifier}',
+        'kind': 'quantity',
+        'expected': {'quantity': decimal_string(row.expected_base_quantity, 9)},
+        'observed': {'quantity': decimal_string(row.counted_base_quantity, 9)},
+        'expected_location_id': row.location_id,
+        'observed_location_id': row.location_id,
+        'source_changed': False,
+        'resolution_action': 'posted' if row.stocktake.posted_at else '',
+        'resolved_at': row.stocktake.posted_at,
+    } for row in legacy.order_by('-stocktake__counted_at', 'pk'))
+    rows.sort(key=lambda row: (row['counted_at'], row['variance_id']), reverse=True)
+    unresolved = sum(not row['resolved_at'] for row in rows)
+    quality = []
+    if unresolved:
+        quality.append(_quality(
+            'unresolved_stocktake_variance', unresolved,
+            'One or more stocktake differences have no posted resolution.',
+            '/reports/stocktake-variances/?resolved=false',
+        ))
+    return Report(
+        name='stocktake-variances', filters=filters, rows=rows,
+        columns=tuple(rows[0]) if rows else (
+            'source_kind', 'variance_id', 'stocktake_id', 'counted_at',
+            'status', 'target_type', 'target_id', 'display', 'kind', 'expected',
+            'observed', 'expected_location_id', 'observed_location_id',
+            'source_changed', 'resolution_action', 'resolved_at',
+        ),
+        totals={'variances': len(rows), 'unresolved': unresolved},
+        reconciliation={'sources': 'target variances + legacy lot lines'},
+        data_quality=quality,
+    )

--- a/reporting/rest.py
+++ b/reporting/rest.py
@@ -1,0 +1,83 @@
+"""Read-only HTTP views for centralized Nursery reports."""
+
+from rest_framework.views import APIView
+
+from workspaces.models import Workspace
+from workspaces.scoping import RequireWorkspaceModeMixin
+
+from .common import csv_response, normalized_filters, report_response
+from .filters import (
+    InventoryBalanceFilters,
+    MovementFilters,
+    SerializedTrayFilters,
+    StocktakeVarianceFilters,
+)
+from .inventory import (
+    inventory_balances,
+    movement_history,
+    serialized_trays,
+    stocktake_variances,
+)
+
+
+class ReportView(RequireWorkspaceModeMixin, APIView):  # pylint: disable=not-callable
+    """Validate a report's filters and render JSON or its matching export."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    http_method_names = ['get', 'head', 'options']
+    filter_class = None
+    builder = None
+    export = False
+
+    def get(self, request):  # pylint: disable=not-callable
+        """Render one validated report as paginated JSON or CSV."""
+        serializer = self.filter_class(  # pylint: disable=not-callable
+            data=request.query_params,
+        )
+        serializer.is_valid(raise_exception=True)
+        filters = normalized_filters(serializer)
+        report = self.builder(  # pylint: disable=not-callable
+            self._workspace(), filters,
+        )
+        if self.export:
+            return csv_response(report)
+        return report_response(request, report)
+
+    @staticmethod
+    def _workspace():
+        from workspaces.models import get_current_workspace  # pylint: disable=import-outside-toplevel
+        return get_current_workspace()
+
+
+def _view(name, filters, builder, export=False):
+    """Create one small configured view class without duplicating dispatch code."""
+    return type(name, (ReportView,), {
+        'filter_class': filters,
+        'builder': staticmethod(builder),
+        'export': export,
+    })
+
+
+InventoryBalanceView = _view(
+    'InventoryBalanceView', InventoryBalanceFilters, inventory_balances,
+)
+InventoryBalanceExportView = _view(
+    'InventoryBalanceExportView', InventoryBalanceFilters, inventory_balances, True,
+)
+SerializedTrayView = _view(
+    'SerializedTrayView', SerializedTrayFilters, serialized_trays,
+)
+SerializedTrayExportView = _view(
+    'SerializedTrayExportView', SerializedTrayFilters, serialized_trays, True,
+)
+MovementView = _view('MovementView', MovementFilters, movement_history)
+MovementExportView = _view(
+    'MovementExportView', MovementFilters, movement_history, True,
+)
+StocktakeVarianceView = _view(
+    'StocktakeVarianceView', StocktakeVarianceFilters, stocktake_variances,
+)
+StocktakeVarianceExportView = _view(
+    'StocktakeVarianceExportView', StocktakeVarianceFilters,
+    stocktake_variances, True,
+)

--- a/reporting/test_inventory.py
+++ b/reporting/test_inventory.py
@@ -1,0 +1,176 @@
+"""Contracts for versioned, workspace-safe inventory reports."""
+
+# Test names state their contracts more clearly than repeated docstrings.
+# pylint: disable=missing-function-docstring
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from inventory.models import (
+    StockMovement,
+    Stocktake,
+    StocktakeTarget,
+    StocktakeVariance,
+)
+from sales.models import SalesOrder, SalesOrderAllocation, SalesOrderLine
+from tests.factories import make_inventory_item, make_location, make_seed_tray, make_stock_lot
+from workspaces.models import get_current_workspace
+
+
+class InventoryReportTests(APITestCase):
+    """Inventory JSON and CSV share exact derived rows and warnings."""
+
+    def setUp(self):
+        self.workspace = get_current_workspace()
+        self.workspace.mode = self.workspace.Mode.NURSERY
+        self.workspace.save(update_fields=['mode'])
+        self.user = get_user_model().objects.create_user(username='reporter')
+        self.client.force_authenticate(self.user)
+        self.location = make_location(workspace=self.workspace)
+
+    def test_balance_reconciles_reservations_and_unknown_cost(self):
+        tray = make_seed_tray(workspace=self.workspace)
+        unit = tray.inventory_unit
+        order = SalesOrder.objects.create(
+            workspace=self.workspace,
+            order_number='SO-REPORT',
+            status=SalesOrder.Status.DRAFT,
+            order_date=date(2026, 8, 1),
+            currency_code=self.workspace.currency_code,
+        )
+        line = SalesOrderLine.objects.create(
+            order=order,
+            line_type=SalesOrderLine.LineType.TRAY,
+            tray_item=unit.item,
+            description='Tray',
+            quantity=1,
+            unit_price=Decimal('0'),
+            tax_rate=Decimal('0'),
+        )
+        SalesOrderAllocation.objects.create(
+            line=line,
+            inventory_unit=unit,
+            status=SalesOrderAllocation.Status.RESERVED,
+            created_by=self.user,
+        )
+        response = self.client.get('/reports/inventory-balances/', {
+            'lot': unit.source_lot_id,
+        })
+        self.assertEqual(response.status_code, 200, response.data)
+        row = response.data['results'][0]
+        self.assertEqual(row['physical_quantity'], '1.000000000')
+        self.assertEqual(row['reserved_quantity'], '1.000000000')
+        self.assertEqual(row['available_quantity'], '0.000000000')
+        self.assertEqual(response.data['reconciliation']['quantity_equation'], 'physical = reserved + available')
+
+        unknown_item = make_inventory_item(
+            workspace=self.workspace,
+            name='Unknown legacy medium',
+        )
+        make_stock_lot(
+            workspace=self.workspace,
+            item=unknown_item,
+            location=self.location,
+            base_unit_cost=None,
+            acquisition_total=None,
+        )
+        response = self.client.get('/reports/inventory-balances/', {
+            'item': unknown_item.pk,
+        })
+        self.assertIsNone(response.data['results'][0]['physical_value'])
+        self.assertEqual(response.data['data_quality'][0]['code'], 'unvalued_inventory')
+
+    def test_csv_uses_same_filters_and_stable_headers(self):
+        item = make_inventory_item(workspace=self.workspace, name='Compost')
+        lot = make_stock_lot(
+            workspace=self.workspace, item=item, location=self.location,
+            quantity=Decimal('5'), base_unit_cost=Decimal('2'),
+            acquisition_total=Decimal('10'),
+        )
+        response = self.client.get('/reports/inventory-balances/export/', {
+            'lot': lot.pk,
+        })
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('report,version,generated_at,filters', content)
+        self.assertIn('inventory-balances,nursery-reports.v1', content)
+        self.assertIn('item_id,item_name,lot_id,lot_identifier', content)
+        self.assertIn(lot.identifier, content)
+
+    def test_movement_filters_paginate_without_changing_totals(self):
+        lot = make_stock_lot(
+            workspace=self.workspace, location=self.location,
+            quantity=Decimal('3'),
+        )
+        StockMovement.objects.create(
+            workspace=self.workspace,
+            lot=lot,
+            movement_type=StockMovement.MovementType.CONSUMPTION,
+            quantity=Decimal('1'),
+            source=self.location,
+            occurred_at=timezone.now(),
+            reference='REPORT-CONSUME',
+        )
+        response = self.client.get('/reports/inventory-movements/', {
+            'lot': lot.pk, 'page_size': 1,
+        })
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data['totals']['movements'], 2)
+        self.assertIsNotNone(response.data['next'])
+        bad = self.client.get('/reports/inventory-movements/', {'movment_type': 'sale'})
+        self.assertEqual(bad.status_code, 400)
+
+    def test_serialized_tray_and_stocktake_variance_are_traceable(self):
+        tray = make_seed_tray(workspace=self.workspace)
+        response = self.client.get('/reports/serialized-trays/', {
+            'item': tray.inventory_unit.item_id,
+        })
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['results'][0]['tray_id'], tray.pk)
+        self.assertEqual(response.data['results'][0]['source_lot_id'], tray.inventory_unit.source_lot_id)
+
+        stocktake = Stocktake.objects.create(
+            workspace=self.workspace,
+            status=Stocktake.Status.OPEN,
+            counted_at=timezone.now(),
+            created_by=self.user,
+        )
+        target = StocktakeTarget.objects.create(
+            stocktake=stocktake,
+            target_type=StocktakeTarget.TargetType.TRAY,
+            target_key=f'tray:{tray.pk}',
+            target_object_id=tray.pk,
+            display='Test tray',
+            expected_location=tray.inventory_unit.current_location,
+            expected_state='available',
+            expected_snapshot={'state': 'available'},
+            source_revision='revision',
+        )
+        StocktakeVariance.objects.create(
+            target=target,
+            kind=StocktakeVariance.Kind.STATE,
+            expected={'state': 'available'},
+            observed={'state': 'missing'},
+        )
+        response = self.client.get('/reports/stocktake-variances/', {
+            'stocktake': stocktake.pk,
+        })
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['results'][0]['target_id'], tray.pk)
+        self.assertEqual(response.data['totals']['unresolved'], 1)
+
+    def test_reports_require_nursery_mode_and_authentication(self):
+        self.workspace.mode = self.workspace.Mode.GARDEN
+        self.workspace.save(update_fields=['mode'])
+        response = self.client.get('/reports/inventory-balances/')
+        self.assertEqual(response.status_code, 403)
+        self.workspace.mode = self.workspace.Mode.NURSERY
+        self.workspace.save(update_fields=['mode'])
+        self.client.force_authenticate(user=None)
+        response = self.client.get('/reports/inventory-balances/')
+        self.assertEqual(response.status_code, 403)

--- a/reporting/urls.py
+++ b/reporting/urls.py
@@ -1,0 +1,26 @@
+"""URL routes for Nursery operational and financial reports."""
+
+from django.urls import path
+
+from .rest import (
+    InventoryBalanceExportView,
+    InventoryBalanceView,
+    MovementExportView,
+    MovementView,
+    SerializedTrayExportView,
+    SerializedTrayView,
+    StocktakeVarianceExportView,
+    StocktakeVarianceView,
+)
+
+
+urlpatterns = [
+    path('inventory-balances/', InventoryBalanceView.as_view()),
+    path('inventory-balances/export/', InventoryBalanceExportView.as_view()),
+    path('serialized-trays/', SerializedTrayView.as_view()),
+    path('serialized-trays/export/', SerializedTrayExportView.as_view()),
+    path('inventory-movements/', MovementView.as_view()),
+    path('inventory-movements/export/', MovementExportView.as_view()),
+    path('stocktake-variances/', StocktakeVarianceView.as_view()),
+    path('stocktake-variances/export/', StocktakeVarianceExportView.as_view()),
+]


### PR DESCRIPTION
Nursery operators need one versioned, workspace-safe contract for balances, serialized trays, movement history, stocktake variances, and CSV exports before financial and traceability reports can build on the same calculations.

## Summary by Sourcery

Introduce a dedicated reporting service for nursery inventory, exposing versioned, workspace-safe JSON and CSV reports for balances, serialized trays, movement history, and stocktake variances.

New Features:
- Add nursery inventory reporting endpoints for balances, serialized trays, movement history, and stocktake variances with shared JSON and CSV rendering.
- Introduce validated filter schemas and pagination for all inventory reports to ensure stable, predictable query contracts.

Enhancements:
- Add database indexes on stock lot expiry and stock movement dates to support high-cardinality inventory reporting queries.
- Register the new reporting app in Django settings, URL routing, and linting configuration.
- Define a centralized report envelope with metadata, totals, reconciliation, and data-quality warnings shared across all report formats.

Tests:
- Add API tests covering inventory report behaviour, CSV exports, pagination stability, traceability of trays and stocktake variances, and mode/authentication requirements.