### PR TITLE
feat(reports): reconcile nursery profitability

### DIFF
--- a/plantings/migrations/0037_report_index.py
+++ b/plantings/migrations/0037_report_index.py
@@ -1,0 +1,17 @@
+"""Add the period access path used by production-loss reporting."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('plantings', '0036_commerce_lifecycle_events')]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='plantlifecycleevent',
+            index=models.Index(
+                fields=['workspace', 'occurred_at'], name='plant_event_report_idx',
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -1344,6 +1344,7 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
         ordering = ['occurred_at', 'pk']
         indexes = [
             models.Index(fields=['plant', 'occurred_at'], name='plant_lifecycle_replay_idx'),
+            models.Index(fields=['workspace', 'occurred_at'], name='plant_event_report_idx'),
         ]
         constraints = [
             models.UniqueConstraint(

--- a/reporting/commerce.py
+++ b/reporting/commerce.py
@@ -1,0 +1,625 @@
+"""Order, direct-cost profitability, and Nursery dashboard calculations."""
+
+# Financial rows deliberately retain every dimension and source identifier.
+# pylint: disable=too-many-locals,too-many-statements,too-many-branches
+
+from calendar import monthrange
+from collections import defaultdict
+from datetime import datetime, time, timedelta
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.db.models import Q
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from costing.models import CostAllocation
+from plantings.lifecycle import lifecycle_summaries
+from plantings.models import PlantLifecycleEvent, ProductionBatch, SpecificPlantLocation
+from sales.commerce import order_commerce_summary
+from sales.models import (
+    Fulfillment,
+    FulfillmentLine,
+    RefundLine,
+    SalesOrder,
+    SalesReturnLine,
+)
+
+from .common import Report, decimal_string
+from .inventory import inventory_balances
+from .production import production_batches
+
+
+ZERO = Decimal('0')
+LOSS_EVENTS = {
+    PlantLifecycleEvent.EventType.FAILED,
+    PlantLifecycleEvent.EventType.LOST,
+    PlantLifecycleEvent.EventType.CULLED,
+    PlantLifecycleEvent.EventType.DONATED,
+}
+RESTORES_COGS = {
+    SalesReturnLine.Outcome.AVAILABLE,
+    SalesReturnLine.Outcome.QUARANTINED,
+}
+
+
+def _local_today(workspace):
+    return timezone.now().astimezone(ZoneInfo(workspace.timezone)).date()
+
+
+def _month_filters(workspace, filters):
+    """Default financial periods to the current workspace-local month."""
+    result = dict(filters)
+    today = _local_today(workspace)
+    result.setdefault('date_from', today.replace(day=1).isoformat())
+    result.setdefault(
+        'date_to',
+        today.replace(day=monthrange(today.year, today.month)[1]).isoformat(),
+    )
+    return result
+
+
+def _date_bounds(workspace, filters):
+    zone = ZoneInfo(workspace.timezone)
+    start = datetime.combine(
+        datetime.fromisoformat(filters['date_from']).date(), time.min, zone,
+    )
+    end = datetime.combine(
+        datetime.fromisoformat(filters['date_to']).date() + timedelta(days=1),
+        time.min,
+        zone,
+    )
+    return start, end
+
+
+def order_report(workspace, filters):
+    """Report operational commitments, fulfillment, cash, and amount due."""
+    queryset = SalesOrder.objects.filter(workspace=workspace).select_related(
+        'customer',
+    ).prefetch_related('lines__allocations', 'fulfillments', 'returns', 'refunds', 'payments')
+    if filters.get('date_from'):
+        queryset = queryset.filter(order_date__gte=filters['date_from'])
+    if filters.get('date_to'):
+        queryset = queryset.filter(order_date__lte=filters['date_to'])
+    if filters.get('customer'):
+        queryset = queryset.filter(customer_id=filters['customer'])
+    if filters.get('order'):
+        queryset = queryset.filter(order_number__icontains=filters['order'])
+    if filters.get('fulfillment'):
+        queryset = queryset.filter(
+            fulfillments__fulfillment_number__icontains=filters['fulfillment'],
+        )
+    if filters.get('variety'):
+        queryset = queryset.filter(lines__variety_id=filters['variety'])
+    if filters.get('batch'):
+        queryset = queryset.filter(
+            lines__allocations__plant__batch_id=filters['batch'],
+        )
+    valid_statuses = {choice for choice, _label in SalesOrder.Status.choices}
+    if filters.get('status'):
+        if filters['status'] not in valid_statuses:
+            raise ValidationError({'status': 'Select a valid order status.'})
+        queryset = queryset.filter(status=filters['status'])
+    today = _local_today(workspace)
+    rows = []
+    for order in queryset.distinct().order_by('-order_date', '-pk'):
+        summary = order_commerce_summary(order)
+        overdue = bool(
+            order.requested_date and order.requested_date < today and (
+                order.status not in {
+                    SalesOrder.Status.FULFILLED, SalesOrder.Status.CANCELLED,
+                }
+            )
+        )
+        if 'overdue' in filters and overdue != filters['overdue']:
+            continue
+        effective_fulfillments = order.fulfillments.filter(
+            reversal_of__isnull=True, reversal__isnull=True,
+        )
+        effective_returns = order.returns.filter(
+            reversal_of__isnull=True, reversal__isnull=True,
+        )
+        effective_refunds = order.refunds.filter(
+            reversal_of__isnull=True, reversal__isnull=True,
+        )
+        rows.append({
+            'order_id': order.pk,
+            'order_number': order.order_number,
+            'order_date': order.order_date,
+            'requested_date': order.requested_date,
+            'customer_id': order.customer_id,
+            'customer_name': order.customer.name if order.customer_id else None,
+            'status': order.status,
+            'overdue': overdue,
+            'requested_quantity': summary['requested_quantity'],
+            'reserved_quantity': summary['reserved_quantity'],
+            'fulfilled_quantity': summary['fulfilled_quantity'],
+            'returned_quantity': summary['returned_quantity'],
+            'fulfillments': effective_fulfillments.count(),
+            'returns': effective_returns.count(),
+            'refunds': effective_refunds.count(),
+            'order_total_incl_tax': decimal_string(order.total_incl_tax, 4),
+            'fulfilled_total_incl_tax': summary['fulfilled_total_incl_tax'],
+            'refunded_total_incl_tax': summary['refunded_total_incl_tax'],
+            'paid_total': summary['paid_total'],
+            'net_paid_total': summary['net_paid_total'],
+            'outstanding_total': summary['outstanding_total'],
+            'overpaid_total': summary['overpaid_total'],
+            'payment_status': summary['payment_status'],
+            'currency_code': order.currency_code,
+        })
+    totals = defaultdict(lambda: defaultdict(Decimal))
+    for row in rows:
+        values = totals[row['currency_code']]
+        for key in (
+                'order_total_incl_tax', 'fulfilled_total_incl_tax',
+                'refunded_total_incl_tax', 'paid_total', 'net_paid_total',
+                'outstanding_total', 'overpaid_total'):
+            values[key] += Decimal(row[key])
+    return Report(
+        name='orders', filters=filters, rows=rows,
+        columns=tuple(rows[0]) if rows else (
+            'order_id', 'order_number', 'order_date', 'requested_date',
+            'customer_id', 'customer_name', 'status', 'overdue',
+            'requested_quantity', 'reserved_quantity', 'fulfilled_quantity',
+            'returned_quantity', 'fulfillments', 'returns', 'refunds',
+            'order_total_incl_tax', 'fulfilled_total_incl_tax',
+            'refunded_total_incl_tax', 'paid_total', 'net_paid_total',
+            'outstanding_total', 'overpaid_total', 'payment_status', 'currency_code',
+        ),
+        totals={
+            'orders': len(rows),
+            'open_orders': sum(row['status'] in {
+                SalesOrder.Status.CONFIRMED,
+                SalesOrder.Status.PARTIALLY_FULFILLED,
+            } for row in rows),
+            'overdue_orders': sum(row['overdue'] for row in rows),
+            'currencies': [{
+                'currency_code': currency,
+                **{key: decimal_string(value, 4) for key, value in values.items()},
+            } for currency, values in sorted(totals.items())],
+        },
+        reconciliation={
+            'cash_equation': 'net paid = effective payments - effective refunds',
+            'due_equation': 'amount due = max(order total - refunds - net paid, 0)',
+        },
+    )
+
+
+def _commerce_queryset(workspace, filters, start, end):
+    queryset = FulfillmentLine.objects.filter(
+        fulfillment__workspace=workspace,
+        fulfillment__fulfilled_at__gte=start,
+        fulfillment__fulfilled_at__lt=end,
+        fulfillment__reversal_of__isnull=True,
+        fulfillment__reversal__isnull=True,
+    ).select_related(
+        'fulfillment__order__customer', 'allocation__line',
+        'allocation__plant__batch', 'allocation__inventory_unit',
+    )
+    if filters.get('variety'):
+        queryset = queryset.filter(allocation__line__variety_id=filters['variety'])
+    if filters.get('batch'):
+        queryset = queryset.filter(allocation__plant__batch_id=filters['batch'])
+    if filters.get('customer'):
+        queryset = queryset.filter(fulfillment__order__customer_id=filters['customer'])
+    if filters.get('fulfillment'):
+        queryset = queryset.filter(
+            fulfillment__fulfillment_number__icontains=filters['fulfillment'],
+        )
+    if filters.get('order'):
+        queryset = queryset.filter(
+            fulfillment__order__order_number__icontains=filters['order'],
+        )
+    return queryset.order_by('fulfillment__fulfilled_at', 'pk')
+
+
+def _matches_place(line, filters, occurred_at):
+    if not filters.get('location') and not filters.get('garden_square'):
+        return True
+    if not line.allocation.plant_id:
+        return False
+    locations = SpecificPlantLocation.objects.filter(
+        specific_plant_id=line.allocation.plant_id,
+        started__lte=occurred_at,
+    ).filter(Q(ended__isnull=True) | Q(ended__gte=occurred_at))
+    if filters.get('location'):
+        locations = locations.filter(location_id=filters['location'])
+    if filters.get('garden_square'):
+        locations = locations.filter(garden_square_id=filters['garden_square'])
+    return locations.exists()
+
+
+def _base_financial_row(kind, occurred_at, currency, source_id):
+    return {
+        'kind': kind,
+        'occurred_at': occurred_at,
+        'source_id': source_id,
+        'fulfillment_id': None,
+        'fulfillment_number': None,
+        'fulfillment_line_id': None,
+        'order_id': None,
+        'order_number': None,
+        'customer_id': None,
+        'variety_id': None,
+        'batch_id': None,
+        'plant_id': None,
+        'inventory_unit_id': None,
+        'lot_id': None,
+        'gross_sales': decimal_string(ZERO, 4),
+        'discounts': decimal_string(ZERO, 4),
+        'refunds': decimal_string(ZERO, 4),
+        'net_sales': decimal_string(ZERO, 4),
+        'plant_cogs': decimal_string(ZERO, 4),
+        'tray_cogs': decimal_string(ZERO, 4),
+        'packaging_cogs': decimal_string(ZERO, 4),
+        'other_cogs': decimal_string(ZERO, 4),
+        'production_loss': decimal_string(ZERO, 4),
+        'currency_code': currency,
+        'provisional': False,
+        'unvalued': False,
+    }
+
+
+def _fulfillment_rows(lines, filters):
+    rows = []
+    included_fulfillments = {}
+    for line in lines:
+        if not _matches_place(line, filters, line.fulfillment.fulfilled_at):
+            continue
+        row = _base_financial_row(
+            'fulfillment', line.fulfillment.fulfilled_at,
+            line.currency_code, line.pk,
+        )
+        row.update({
+            'fulfillment_id': line.fulfillment_id,
+            'fulfillment_number': line.fulfillment.fulfillment_number,
+            'fulfillment_line_id': line.pk,
+            'order_id': line.fulfillment.order_id,
+            'order_number': line.fulfillment.order.order_number,
+            'customer_id': line.fulfillment.order.customer_id,
+            'variety_id': line.allocation.line.variety_id,
+            'batch_id': (
+                line.allocation.plant.batch_id if line.allocation.plant_id else None
+            ),
+            'plant_id': line.allocation.plant_id,
+            'inventory_unit_id': line.allocation.inventory_unit_id,
+            'gross_sales': decimal_string(line.gross_ex_tax, 4),
+            'discounts': decimal_string(line.discount_ex_tax, 4),
+            'net_sales': decimal_string(line.subtotal_ex_tax, 4),
+            'provisional': line.cogs_provisional,
+            'unvalued': line.cogs_amount is None,
+        })
+        if line.cogs_amount is not None:
+            key = 'plant_cogs' if line.allocation.plant_id else 'tray_cogs'
+            row[key] = decimal_string(line.cogs_amount, 4)
+        rows.append(row)
+        included_fulfillments[line.fulfillment_id] = line.fulfillment
+    return rows, included_fulfillments
+
+
+def _packaging_rows(fulfillments, filters):
+    rows = []
+    dimensioned = any(filters.get(key) for key in (
+        'variety', 'batch', 'location', 'garden_square',
+    ))
+    for fulfillment in fulfillments.values():
+        for line in fulfillment.packaging_lines.select_related('lot').all():
+            row = _base_financial_row(
+                'packaging', fulfillment.fulfilled_at,
+                line.currency_code, line.pk,
+            )
+            row.update({
+                'fulfillment_id': fulfillment.pk,
+                'fulfillment_number': fulfillment.fulfillment_number,
+                'order_id': fulfillment.order_id,
+                'order_number': fulfillment.order.order_number,
+                'customer_id': fulfillment.order.customer_id,
+                'lot_id': line.lot_id,
+                'packaging_cogs': decimal_string(line.cogs_amount or ZERO, 4),
+                'unvalued': line.cogs_amount is None,
+                'dimension_unattributed': dimensioned,
+            })
+            if not dimensioned:
+                rows.append(row)
+            else:
+                rows.append(row | {'packaging_cogs': decimal_string(ZERO, 4)})
+    return rows
+
+
+def _refund_rows(workspace, filters, start, end):
+    queryset = RefundLine.objects.filter(
+        refund__workspace=workspace,
+        refund__refunded_at__gte=start,
+        refund__refunded_at__lt=end,
+        refund__reversal_of__isnull=True,
+        refund__reversal__isnull=True,
+        fulfillment_line__fulfillment__reversal_of__isnull=True,
+        fulfillment_line__fulfillment__reversal__isnull=True,
+    ).select_related(
+        'refund__order', 'fulfillment_line__allocation__line',
+        'fulfillment_line__allocation__plant__batch',
+        'fulfillment_line__fulfillment',
+    )
+    if filters.get('variety'):
+        queryset = queryset.filter(
+            fulfillment_line__allocation__line__variety_id=filters['variety'],
+        )
+    if filters.get('batch'):
+        queryset = queryset.filter(
+            fulfillment_line__allocation__plant__batch_id=filters['batch'],
+        )
+    if filters.get('customer'):
+        queryset = queryset.filter(refund__order__customer_id=filters['customer'])
+    if filters.get('order'):
+        queryset = queryset.filter(refund__order__order_number__icontains=filters['order'])
+    if filters.get('fulfillment'):
+        queryset = queryset.filter(
+            fulfillment_line__fulfillment__fulfillment_number__icontains=filters['fulfillment'],
+        )
+    rows = []
+    for refund_line in queryset.order_by('refund__refunded_at', 'pk'):
+        line = refund_line.fulfillment_line
+        if not _matches_place(line, filters, line.fulfillment.fulfilled_at):
+            continue
+        row = _base_financial_row(
+            'refund', refund_line.refund.refunded_at,
+            refund_line.refund.currency_code, refund_line.pk,
+        )
+        row.update({
+            'fulfillment_id': line.fulfillment_id,
+            'fulfillment_number': line.fulfillment.fulfillment_number,
+            'fulfillment_line_id': line.pk,
+            'order_id': refund_line.refund.order_id,
+            'order_number': refund_line.refund.order.order_number,
+            'customer_id': refund_line.refund.order.customer_id,
+            'variety_id': line.allocation.line.variety_id,
+            'batch_id': line.allocation.plant.batch_id if line.allocation.plant_id else None,
+            'plant_id': line.allocation.plant_id,
+            'inventory_unit_id': line.allocation.inventory_unit_id,
+            'refunds': decimal_string(refund_line.subtotal_ex_tax, 4),
+            'net_sales': decimal_string(-refund_line.subtotal_ex_tax, 4),
+        })
+        rows.append(row)
+    return rows
+
+
+def _return_rows(workspace, filters, start, end):
+    queryset = SalesReturnLine.objects.filter(
+        sales_return__workspace=workspace,
+        sales_return__returned_at__gte=start,
+        sales_return__returned_at__lt=end,
+        sales_return__reversal_of__isnull=True,
+        sales_return__reversal__isnull=True,
+        outcome__in=RESTORES_COGS,
+        fulfillment_line__fulfillment__reversal_of__isnull=True,
+        fulfillment_line__fulfillment__reversal__isnull=True,
+    ).select_related(
+        'sales_return__order', 'fulfillment_line__fulfillment',
+        'fulfillment_line__allocation__line',
+        'fulfillment_line__allocation__plant__batch',
+    )
+    if filters.get('variety'):
+        queryset = queryset.filter(
+            fulfillment_line__allocation__line__variety_id=filters['variety'],
+        )
+    if filters.get('batch'):
+        queryset = queryset.filter(
+            fulfillment_line__allocation__plant__batch_id=filters['batch'],
+        )
+    if filters.get('customer'):
+        queryset = queryset.filter(sales_return__order__customer_id=filters['customer'])
+    if filters.get('order'):
+        queryset = queryset.filter(
+            sales_return__order__order_number__icontains=filters['order'],
+        )
+    if filters.get('fulfillment'):
+        queryset = queryset.filter(
+            fulfillment_line__fulfillment__fulfillment_number__icontains=filters['fulfillment'],
+        )
+    rows = []
+    for return_line in queryset.order_by('sales_return__returned_at', 'pk'):
+        line = return_line.fulfillment_line
+        if not _matches_place(line, filters, line.fulfillment.fulfilled_at):
+            continue
+        row = _base_financial_row(
+            'cogs_restoration', return_line.sales_return.returned_at,
+            line.currency_code, return_line.pk,
+        )
+        row.update({
+            'fulfillment_id': line.fulfillment_id,
+            'fulfillment_number': line.fulfillment.fulfillment_number,
+            'fulfillment_line_id': line.pk,
+            'order_id': return_line.sales_return.order_id,
+            'order_number': return_line.sales_return.order.order_number,
+            'customer_id': return_line.sales_return.order.customer_id,
+            'variety_id': line.allocation.line.variety_id,
+            'batch_id': line.allocation.plant.batch_id if line.allocation.plant_id else None,
+            'plant_id': line.allocation.plant_id,
+            'inventory_unit_id': line.allocation.inventory_unit_id,
+            'provisional': line.cogs_provisional,
+            'unvalued': line.cogs_amount is None,
+        })
+        if line.cogs_amount is not None:
+            key = 'plant_cogs' if line.allocation.plant_id else 'tray_cogs'
+            row[key] = decimal_string(-line.cogs_amount, 4)
+        rows.append(row)
+    return rows
+
+
+def _loss_rows(workspace, filters, start, end):
+    if any(filters.get(key) for key in ('customer', 'order', 'fulfillment')):
+        return []
+    layers = CostAllocation.objects.filter(
+        workspace=workspace, reversal_of__isnull=True, reversal__isnull=True,
+    ).select_related('batch__variety', 'specific_plant')
+    if filters.get('variety'):
+        layers = layers.filter(batch__variety_id=filters['variety'])
+    if filters.get('batch'):
+        layers = layers.filter(batch_id=filters['batch'])
+    plant_ids = list(layers.filter(
+        target_type=CostAllocation.TargetType.SPECIFIC_PLANT,
+    ).values_list('specific_plant_id', flat=True).distinct())
+    summaries = lifecycle_summaries(plant_ids)
+    rows = []
+    for layer in layers.order_by('pk'):
+        occurred_at = None
+        if layer.target_type == CostAllocation.TargetType.PRODUCTION_LOSS:
+            occurred_at = layer.created
+        elif layer.specific_plant_id:
+            summary = summaries[layer.specific_plant_id]
+            if summary.final_outcome in LOSS_EVENTS:
+                occurred_at = summary.final_outcome_at
+        if occurred_at is None or not start <= occurred_at < end:
+            continue
+        if filters.get('location') or filters.get('garden_square'):
+            locations = SpecificPlantLocation.objects.filter(
+                specific_plant_id=layer.specific_plant_id,
+                started__lte=occurred_at,
+            ).filter(Q(ended__isnull=True) | Q(ended__gte=occurred_at))
+            if filters.get('location'):
+                locations = locations.filter(location_id=filters['location'])
+            if filters.get('garden_square'):
+                locations = locations.filter(garden_square_id=filters['garden_square'])
+            if not locations.exists():
+                continue
+        row = _base_financial_row(
+            'production_loss', occurred_at, layer.currency_code, layer.pk,
+        )
+        row.update({
+            'variety_id': layer.batch.variety_id,
+            'batch_id': layer.batch_id,
+            'plant_id': layer.specific_plant_id,
+            'production_loss': decimal_string(layer.amount or ZERO, 4),
+            'provisional': layer.batch.output_finalized_at is None,
+            'unvalued': layer.amount is None,
+        })
+        rows.append(row)
+    return rows
+
+
+def profitability_report(workspace, filters):
+    """Calculate direct-cost P&L while keeping incomplete values outside margin."""
+    filters = _month_filters(workspace, filters)
+    start, end = _date_bounds(workspace, filters)
+    lines = list(_commerce_queryset(workspace, filters, start, end))
+    rows, fulfillments = _fulfillment_rows(lines, filters)
+    rows.extend(_packaging_rows(fulfillments, filters))
+    rows.extend(_refund_rows(workspace, filters, start, end))
+    rows.extend(_return_rows(workspace, filters, start, end))
+    rows.extend(_loss_rows(workspace, filters, start, end))
+    rows.sort(key=lambda row: (row['occurred_at'], row['kind'], row['source_id']))
+    money_fields = (
+        'gross_sales', 'discounts', 'refunds', 'net_sales', 'plant_cogs',
+        'tray_cogs', 'packaging_cogs', 'other_cogs', 'production_loss',
+    )
+    by_currency = defaultdict(lambda: defaultdict(Decimal))
+    for row in rows:
+        for field in money_fields:
+            if not row['provisional'] and not row['unvalued']:
+                by_currency[row['currency_code']][field] += Decimal(row[field])
+            elif field in {'gross_sales', 'discounts', 'refunds', 'net_sales'}:
+                by_currency[row['currency_code']][field] += Decimal(row[field])
+    provisional = [row for row in rows if row['provisional']]
+    unvalued = [row for row in rows if row['unvalued']]
+    unattributed = [row for row in rows if row.get('dimension_unattributed')]
+    currencies = set(by_currency)
+    incomplete = bool(provisional or unvalued or unattributed or len(currencies) != 1)
+    summaries = []
+    for currency, values in sorted(by_currency.items()):
+        direct_cogs = sum(
+            (values[field] for field in (
+                'plant_cogs', 'tray_cogs', 'packaging_cogs', 'other_cogs',
+            )), ZERO,
+        )
+        gross_profit = None
+        gross_margin = None
+        if not incomplete:
+            gross_profit = values['net_sales'] - direct_cogs - values['production_loss']
+            if values['net_sales'] != 0:
+                gross_margin = gross_profit / values['net_sales']
+        summaries.append({
+            'currency_code': currency,
+            **{field: decimal_string(values[field], 4) for field in money_fields},
+            'direct_cogs': decimal_string(direct_cogs, 4),
+            'gross_profit': decimal_string(gross_profit, 4),
+            'gross_margin': decimal_string(gross_margin, 6),
+        })
+    quality = []
+    for code, selected, message in (
+        ('provisional_cost', provisional, 'Provisional cost is excluded from finalized margin.'),
+        ('unvalued_cost', unvalued, 'Unknown cost is not treated as zero.'),
+        ('dimension_unattributed_cost', unattributed, 'Packaging cannot be exactly assigned to this production dimension.'),
+    ):
+        if selected:
+            quality.append({
+                'code': code, 'count': len(selected), 'message': message,
+                'drill_down': f'/reports/profitability/?{code}=true',
+            })
+    if len(currencies) > 1:
+        quality.append({
+            'code': 'mixed_currency', 'count': len(currencies),
+            'message': 'No exchange rate exists, so currencies are not consolidated.',
+            'drill_down': '/reports/profitability/',
+        })
+    return Report(
+        name='profitability', filters=filters, rows=rows,
+        columns=tuple(rows[0]) if rows else tuple(_base_financial_row(
+            'kind', timezone.now(), workspace.currency_code, 0,
+        )),
+        totals={
+            'currencies': summaries,
+            'provisional_rows': len(provisional),
+            'unvalued_rows': len(unvalued),
+            'dimension_unattributed_rows': len(unattributed),
+            'finalized_margin_available': not incomplete,
+        },
+        reconciliation={
+            'sales_equation': 'gross sales - discounts - refunds = net sales',
+            'cost_equation': 'direct COGS = plant + tray + packaging + other COGS',
+            'profit_equation': 'gross profit = net sales - direct COGS - production loss',
+        },
+        data_quality=quality,
+    )
+
+
+def dashboard_report(workspace, filters):
+    """Summarize the current operational month without storing dashboard state."""
+    filters = _month_filters(workspace, filters)
+    today = _local_today(workspace)
+    expiring = inventory_balances(workspace, {
+        'expires_before': (today + timedelta(days=30)).isoformat(),
+    })
+    low = inventory_balances(workspace, {'low_stock': True})
+    production = production_batches(workspace, {})
+    orders = order_report(workspace, {})
+    profit = profitability_report(workspace, filters)
+    recent = list(Fulfillment.objects.filter(
+        workspace=workspace,
+        reversal_of__isnull=True,
+        reversal__isnull=True,
+    ).select_related('order').order_by('-fulfilled_at', '-pk')[:10])
+    row = {
+        'expiring_lot_locations': len(expiring.rows),
+        'low_stock_lot_locations': len(low.rows),
+        'active_batches': ProductionBatch.objects.filter(
+            workspace=workspace, status=ProductionBatch.Status.ACTIVE,
+        ).count(),
+        'available_seedlings': production.totals['current_seedlings'],
+        'open_orders': orders.totals['open_orders'],
+        'provisional_batches': production.totals['provisional_batches'],
+        'period_profitability': profit.totals,
+        'recent_fulfillments': [{
+            'fulfillment_id': fulfillment.pk,
+            'fulfillment_number': fulfillment.fulfillment_number,
+            'fulfilled_at': fulfillment.fulfilled_at,
+            'order_id': fulfillment.order_id,
+            'order_number': fulfillment.order.order_number,
+        } for fulfillment in recent],
+    }
+    return Report(
+        name='dashboard', filters=filters, rows=[row], columns=tuple(row),
+        totals=row,
+        reconciliation=profit.reconciliation,
+        data_quality=expiring.data_quality + production.data_quality + profit.data_quality,
+    )

--- a/reporting/filters.py
+++ b/reporting/filters.py
@@ -94,3 +94,40 @@ class ProductionFilters(BaseReportFilters):  # pylint: disable=abstract-method
 
 class TraceFilters(BaseReportFilters):  # pylint: disable=abstract-method
     """Pagination-only schema for one exact traceability identity."""
+
+
+class CommerceFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Shared exact dimensions for order and profitability reports."""
+
+    date_from = serializers.DateField(required=False)
+    date_to = serializers.DateField(required=False)
+    variety = serializers.IntegerField(required=False, min_value=1)
+    batch = serializers.IntegerField(required=False, min_value=1)
+    customer = serializers.IntegerField(required=False, min_value=1)
+    location = serializers.IntegerField(required=False, min_value=1)
+    garden_square = serializers.IntegerField(required=False, min_value=1)
+    fulfillment = serializers.CharField(required=False, allow_blank=False)
+    order = serializers.CharField(required=False, allow_blank=False)
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        if attrs.get('date_from') and attrs.get('date_to'):
+            if attrs['date_to'] < attrs['date_from']:
+                raise serializers.ValidationError({
+                    'date_to': 'The end must not be before the start.',
+                })
+        return attrs
+
+
+class OrderFilters(CommerceFilters):  # pylint: disable=abstract-method
+    """Operational order-state filters."""
+
+    status = serializers.CharField(required=False)
+    overdue = serializers.BooleanField(required=False)
+
+
+class DashboardFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Optional period override for the Nursery dashboard."""
+
+    date_from = serializers.DateField(required=False)
+    date_to = serializers.DateField(required=False)

--- a/reporting/rest.py
+++ b/reporting/rest.py
@@ -7,13 +7,17 @@ from workspaces.scoping import RequireWorkspaceModeMixin
 
 from .common import csv_response, normalized_filters, report_response
 from .filters import (
+    CommerceFilters,
+    DashboardFilters,
     InventoryBalanceFilters,
     MovementFilters,
+    OrderFilters,
     ProductionFilters,
     SerializedTrayFilters,
     StocktakeVarianceFilters,
     TraceFilters,
 )
+from .commerce import dashboard_report, order_report, profitability_report
 from .production import production_batches
 from .traceability import lot_trace, plant_trace
 from .inventory import (
@@ -122,3 +126,15 @@ PlantTraceView = _trace_view('PlantTraceView', plant_trace)
 PlantTraceExportView = _trace_view('PlantTraceExportView', plant_trace, True)
 LotTraceView = _trace_view('LotTraceView', lot_trace)
 LotTraceExportView = _trace_view('LotTraceExportView', lot_trace, True)
+
+OrderView = _view('OrderView', OrderFilters, order_report)
+OrderExportView = _view('OrderExportView', OrderFilters, order_report, True)
+ProfitabilityView = _view(
+    'ProfitabilityView', CommerceFilters, profitability_report,
+)
+ProfitabilityExportView = _view(
+    'ProfitabilityExportView', CommerceFilters, profitability_report, True,
+)
+DashboardView = _view(
+    'DashboardView', DashboardFilters, dashboard_report,
+)

--- a/reporting/test_commerce.py
+++ b/reporting/test_commerce.py
@@ -1,0 +1,199 @@
+"""Financial report contracts from recognized commerce source rows."""
+
+# Test method names carry the contract.
+# pylint: disable=missing-function-docstring
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from sales.models import (
+    Customer,
+    Fulfillment,
+    FulfillmentLine,
+    Payment,
+    Refund,
+    RefundLine,
+    SalesOrder,
+    SalesOrderAllocation,
+    SalesOrderLine,
+    SalesReturn,
+    SalesReturnLine,
+)
+from tests.factories import make_specific_plant
+from workspaces.models import get_current_workspace
+
+
+FINGERPRINT = '0' * 64
+
+
+class CommerceReportTests(APITestCase):  # pylint: disable=too-many-instance-attributes
+    """P&L separates tax, cash, refunds, restored COGS, and incomplete cost."""
+
+    def setUp(self):
+        self.workspace = get_current_workspace()
+        self.workspace.mode = self.workspace.Mode.NURSERY
+        self.workspace.timezone = 'UTC'
+        self.workspace.save(update_fields=['mode', 'timezone'])
+        self.user = get_user_model().objects.create_user(username='finance-reporter')
+        self.client.force_authenticate(self.user)
+        self.customer = Customer.objects.create(
+            workspace=self.workspace, name='Nursery customer',
+        )
+        self.plant = make_specific_plant(workspace=self.workspace)
+        self.order = SalesOrder.objects.create(
+            workspace=self.workspace,
+            order_number='SO-PNL',
+            status=SalesOrder.Status.DRAFT,
+            order_date=date(2026, 8, 1),
+            requested_date=date(2026, 8, 10),
+            customer=self.customer,
+            currency_code='USD',
+        )
+        self.order_line = SalesOrderLine.objects.create(
+            order=self.order,
+            line_type=SalesOrderLine.LineType.SEEDLING,
+            variety=self.plant.batch.variety,
+            description='Seedling',
+            quantity=1,
+            unit_price=Decimal('10'),
+            tax_rate=Decimal('10'),
+            discount_type=SalesOrderLine.DiscountType.FIXED,
+            discount_value=Decimal('1'),
+        )
+        SalesOrder.objects.filter(pk=self.order.pk).update(
+            status=SalesOrder.Status.FULFILLED,
+        )
+        self.order.refresh_from_db()
+        self.allocation = SalesOrderAllocation.objects.create(
+            line=self.order_line,
+            plant=self.plant,
+            status=SalesOrderAllocation.Status.FULFILLED,
+            created_by=self.user,
+        )
+        self.fulfillment = Fulfillment.objects.create(
+            workspace=self.workspace,
+            order=self.order,
+            fulfillment_number='FUL-PNL',
+            fulfilled_at=timezone.datetime(2026, 8, 5, 12, tzinfo=timezone.UTC),
+            operation_key=uuid4(),
+            request_fingerprint=FINGERPRINT,
+            created_by=self.user,
+        )
+        self.fulfillment_line = FulfillmentLine.objects.create(
+            fulfillment=self.fulfillment,
+            allocation=self.allocation,
+            commercial_position=1,
+            gross_ex_tax=Decimal('10'),
+            discount_ex_tax=Decimal('1'),
+            subtotal_ex_tax=Decimal('9'),
+            tax_total=Decimal('1'),
+            total_incl_tax=Decimal('10'),
+            cogs_amount=Decimal('2'),
+            cogs_provisional=False,
+            currency_code='USD',
+        )
+
+    def _payment(self):
+        return Payment.objects.create(
+            workspace=self.workspace,
+            order=self.order,
+            paid_on=date(2026, 8, 6),
+            amount=Decimal('10'),
+            currency_code='USD',
+            method=Payment.Method.CARD,
+            operation_key=uuid4(),
+            request_fingerprint=FINGERPRINT,
+            created_by=self.user,
+        )
+
+    def test_profitability_excludes_tax_and_payments_from_revenue(self):
+        self._payment()
+        response = self.client.get('/reports/profitability/', {
+            'date_from': '2026-08-01', 'date_to': '2026-08-31',
+        })
+        self.assertEqual(response.status_code, 200, response.data)
+        totals = response.data['totals']['currencies'][0]
+        self.assertEqual(totals['gross_sales'], '10.0000')
+        self.assertEqual(totals['discounts'], '1.0000')
+        self.assertEqual(totals['net_sales'], '9.0000')
+        self.assertEqual(totals['plant_cogs'], '2.0000')
+        self.assertEqual(totals['gross_profit'], '7.0000')
+        self.assertNotIn('tax_total', totals)
+
+    def test_refund_and_available_return_use_their_own_dates(self):
+        payment = self._payment()
+        sales_return = SalesReturn.objects.create(
+            workspace=self.workspace,
+            order=self.order,
+            returned_at=timezone.datetime(2026, 8, 20, 12, tzinfo=timezone.UTC),
+            reason='Customer changed plans',
+            operation_key=uuid4(),
+            request_fingerprint=FINGERPRINT,
+            created_by=self.user,
+        )
+        SalesReturnLine.objects.create(
+            sales_return=sales_return,
+            fulfillment_line=self.fulfillment_line,
+            outcome=SalesReturnLine.Outcome.AVAILABLE,
+        )
+        refund = Refund.objects.create(
+            workspace=self.workspace,
+            order=self.order,
+            payment=payment,
+            sales_return=sales_return,
+            refunded_at=timezone.datetime(2026, 8, 21, 12, tzinfo=timezone.UTC),
+            amount=Decimal('1.10'),
+            currency_code='USD',
+            reason='Partial refund',
+            operation_key=uuid4(),
+            request_fingerprint=FINGERPRINT,
+            created_by=self.user,
+        )
+        RefundLine.objects.create(
+            refund=refund,
+            fulfillment_line=self.fulfillment_line,
+            gross_ex_tax=Decimal('1.10'),
+            discount_ex_tax=Decimal('0.10'),
+            subtotal_ex_tax=Decimal('1'),
+            tax_total=Decimal('0.10'),
+            total_incl_tax=Decimal('1.10'),
+        )
+        response = self.client.get('/reports/profitability/', {
+            'date_from': '2026-08-01', 'date_to': '2026-08-31',
+        })
+        totals = response.data['totals']['currencies'][0]
+        self.assertEqual(totals['refunds'], '1.0000')
+        self.assertEqual(totals['net_sales'], '8.0000')
+        self.assertEqual(totals['plant_cogs'], '0.0000')
+        kinds = {row['kind'] for row in response.data['results']}
+        self.assertEqual(kinds, {'fulfillment', 'refund', 'cogs_restoration'})
+
+    def test_unknown_cogs_prevents_finalized_margin(self):
+        self.fulfillment_line.cogs_amount = None
+        self.fulfillment_line.save(update_fields=['cogs_amount'])
+        response = self.client.get('/reports/profitability/', {
+            'date_from': '2026-08-01', 'date_to': '2026-08-31',
+        })
+        self.assertFalse(response.data['totals']['finalized_margin_available'])
+        self.assertIsNone(response.data['totals']['currencies'][0]['gross_profit'])
+        self.assertEqual(response.data['data_quality'][0]['code'], 'unvalued_cost')
+
+    def test_order_report_and_dashboard_keep_cash_separate(self):
+        self._payment()
+        orders = self.client.get('/reports/orders/', {'order': 'SO-PNL'})
+        self.assertEqual(orders.status_code, 200, orders.data)
+        self.assertEqual(orders.data['results'][0]['paid_total'], '10.0000')
+        self.assertEqual(orders.data['results'][0]['outstanding_total'], '0.0000')
+        dashboard = self.client.get('/reports/dashboard/', {
+            'date_from': '2026-08-01', 'date_to': '2026-08-31',
+        })
+        self.assertEqual(dashboard.status_code, 200, dashboard.data)
+        self.assertEqual(
+            dashboard.data['results'][0]['recent_fulfillments'][0]['fulfillment_number'],
+            'FUL-PNL',
+        )

--- a/reporting/test_inventory.py
+++ b/reporting/test_inventory.py
@@ -7,6 +7,8 @@ from datetime import date
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
@@ -174,3 +176,32 @@ class InventoryReportTests(APITestCase):
         self.client.force_authenticate(user=None)
         response = self.client.get('/reports/inventory-balances/')
         self.assertEqual(response.status_code, 403)
+
+    def test_movement_report_query_count_does_not_grow_with_rows(self):
+        lot = make_stock_lot(
+            workspace=self.workspace, location=self.location,
+            quantity=Decimal('100'),
+        )
+        with CaptureQueriesContext(connection) as small:
+            response = self.client.get('/reports/inventory-movements/', {
+                'lot': lot.pk,
+            })
+        self.assertEqual(response.status_code, 200)
+        StockMovement.objects.bulk_create([
+            StockMovement(
+                workspace=self.workspace,
+                lot=lot,
+                movement_type=StockMovement.MovementType.CONSUMPTION,
+                quantity=Decimal('1'),
+                source=self.location,
+                occurred_at=timezone.now(),
+                reference=f'PERF-{index}',
+            )
+            for index in range(20)
+        ])
+        with CaptureQueriesContext(connection) as large:
+            response = self.client.get('/reports/inventory-movements/', {
+                'lot': lot.pk,
+            })
+        self.assertEqual(response.status_code, 200)
+        self.assertLessEqual(len(large), len(small) + 1)

--- a/reporting/urls.py
+++ b/reporting/urls.py
@@ -3,16 +3,21 @@
 from django.urls import path
 
 from .rest import (
+    DashboardView,
     InventoryBalanceExportView,
     InventoryBalanceView,
     MovementExportView,
     MovementView,
+    OrderExportView,
+    OrderView,
     LotTraceExportView,
     LotTraceView,
     PlantTraceExportView,
     PlantTraceView,
     ProductionExportView,
     ProductionView,
+    ProfitabilityExportView,
+    ProfitabilityView,
     SerializedTrayExportView,
     SerializedTrayView,
     StocktakeVarianceExportView,
@@ -21,6 +26,7 @@ from .rest import (
 
 
 urlpatterns = [
+    path('dashboard/', DashboardView.as_view()),
     path('inventory-balances/', InventoryBalanceView.as_view()),
     path('inventory-balances/export/', InventoryBalanceExportView.as_view()),
     path('serialized-trays/', SerializedTrayView.as_view()),
@@ -31,6 +37,10 @@ urlpatterns = [
     path('stocktake-variances/export/', StocktakeVarianceExportView.as_view()),
     path('production-batches/', ProductionView.as_view()),
     path('production-batches/export/', ProductionExportView.as_view()),
+    path('orders/', OrderView.as_view()),
+    path('orders/export/', OrderExportView.as_view()),
+    path('profitability/', ProfitabilityView.as_view()),
+    path('profitability/export/', ProfitabilityExportView.as_view()),
     path('traceability/plants/<int:identity>/', PlantTraceView.as_view()),
     path(
         'traceability/plants/<int:identity>/export/',

--- a/sales/migrations/0003_report_indexes.py
+++ b/sales/migrations/0003_report_indexes.py
@@ -1,0 +1,42 @@
+"""Add date and operational-state access paths used by Nursery reports."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('sales', '0002_fulfillmentnumbersequence_and_more')]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='salesorder',
+            index=models.Index(
+                fields=['workspace', 'status', 'requested_date'],
+                name='sales_order_report_idx',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='fulfillment',
+            index=models.Index(
+                fields=['workspace', 'fulfilled_at'], name='sales_fulfill_date_idx',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='payment',
+            index=models.Index(
+                fields=['workspace', 'paid_on'], name='sales_payment_date_idx',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='salesreturn',
+            index=models.Index(
+                fields=['workspace', 'returned_at'], name='sales_return_date_idx',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='refund',
+            index=models.Index(
+                fields=['workspace', 'refunded_at'], name='sales_refund_date_idx',
+            ),
+        ),
+    ]

--- a/sales/models.py
+++ b/sales/models.py
@@ -109,6 +109,9 @@ class SalesOrder(WorkspaceOwnedModel):
 
     class Meta:
         ordering = ['-created', '-pk']
+        indexes = [
+            models.Index(fields=['workspace', 'status', 'requested_date'], name='sales_order_report_idx'),
+        ]
         constraints = [
             models.UniqueConstraint(fields=['workspace', 'order_number'], name='sales_order_workspace_number_unique'),
         ]
@@ -383,6 +386,9 @@ class Fulfillment(ImmutableCommerceModel):
 
     class Meta:
         ordering = ['fulfilled_at', 'pk']
+        indexes = [
+            models.Index(fields=['workspace', 'fulfilled_at'], name='sales_fulfill_date_idx'),
+        ]
         constraints = [
             models.UniqueConstraint(
                 fields=['workspace', 'fulfillment_number'],
@@ -516,6 +522,9 @@ class Payment(ImmutableCommerceModel):
 
     class Meta:
         ordering = ['paid_on', 'pk']
+        indexes = [
+            models.Index(fields=['workspace', 'paid_on'], name='sales_payment_date_idx'),
+        ]
         constraints = [
             models.CheckConstraint(
                 condition=models.Q(amount__gt=0),
@@ -552,6 +561,9 @@ class SalesReturn(ImmutableCommerceModel):
 
     class Meta:
         ordering = ['returned_at', 'pk']
+        indexes = [
+            models.Index(fields=['workspace', 'returned_at'], name='sales_return_date_idx'),
+        ]
         constraints = [models.UniqueConstraint(
             fields=['workspace', 'operation_key'],
             name='sales_return_workspace_operation_unique',
@@ -628,6 +640,9 @@ class Refund(ImmutableCommerceModel):
 
     class Meta:
         ordering = ['refunded_at', 'pk']
+        indexes = [
+            models.Index(fields=['workspace', 'refunded_at'], name='sales_refund_date_idx'),
+        ]
         constraints = [
             models.CheckConstraint(
                 condition=models.Q(amount__gt=0),


### PR DESCRIPTION
Nursery decisions need fulfillment-period revenue, refunds, exact direct cost, physical-return inventory restoration, production loss, and operational cash to remain separately auditable. Report indexes keep the dated source scans practical.

## Summary by Sourcery

Introduce nursery commerce reporting for orders, profitability, and dashboard summaries, backed by optimized query paths and performance safeguards.

New Features:
- Add shared commerce, order, profitability, and dashboard report endpoints with flexible date and dimension filters for nursery operations.
- Provide a profitability report that reconciles revenue, refunds, direct costs, production loss, and data quality flags per currency.
- Expose a nursery dashboard report aggregating inventory, production, order, profitability, and recent fulfillment metrics.

Enhancements:
- Introduce reusable commerce filter schemas and dashboard period override filters for reporting APIs.
- Optimize nursery financial and production-loss reporting with new database indexes on sales and plant lifecycle models.
- Guard inventory movement reports against N+1 query growth via a performance regression test.

Tests:
- Add commerce reporting tests to verify profitability, refund timing, cost completeness handling, and dashboard cash separation.