### PR TITLE
feat(plantings): give quarantined plants a way out

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -55,10 +55,18 @@ STATE_AFTER = {
     EventType.RETURNED_AVAILABLE: LifecycleState.AVAILABLE,
     EventType.RETURNED_QUARANTINED: LifecycleState.QUARANTINED,
     EventType.RETURNED_DISCARDED: LifecycleState.DISCARDED,
+    EventType.RELEASED_AVAILABLE: LifecycleState.AVAILABLE,
 }
 
 #: The states each fact may be recorded from. `germinated` is absent because it
 #: is only valid for a plant with no history at all.
+#:
+#: A quarantined plant is one a customer returned as diseased or damaged, so it
+#: accepts the facts an assessment can honestly reach: release when it recovers,
+#: retention when it needs growing on instead, and the three ways of losing it.
+#: Donation, harvest, planting out and sale stay closed, because handing a plant
+#: the nursery has not cleared to somebody else is the thing quarantine exists to
+#: prevent — release it first and the ordinary transitions apply.
 ALLOWED_FROM = {
     EventType.READY: {LifecycleState.GROWING},
     EventType.TRANSPLANTED: {
@@ -66,21 +74,28 @@ ALLOWED_FROM = {
         LifecycleState.AVAILABLE,
         LifecycleState.RETAINED,
     },
-    EventType.RETAINED: {LifecycleState.GROWING, LifecycleState.AVAILABLE},
+    EventType.RETAINED: {
+        LifecycleState.GROWING,
+        LifecycleState.AVAILABLE,
+        LifecycleState.QUARANTINED,
+    },
     EventType.FAILED: {
         LifecycleState.GROWING,
         LifecycleState.AVAILABLE,
         LifecycleState.RETAINED,
+        LifecycleState.QUARANTINED,
     },
     EventType.LOST: {
         LifecycleState.GROWING,
         LifecycleState.AVAILABLE,
         LifecycleState.RETAINED,
+        LifecycleState.QUARANTINED,
     },
     EventType.CULLED: {
         LifecycleState.GROWING,
         LifecycleState.AVAILABLE,
         LifecycleState.RETAINED,
+        LifecycleState.QUARANTINED,
     },
     EventType.DONATED: {
         LifecycleState.GROWING,
@@ -96,6 +111,7 @@ ALLOWED_FROM = {
     EventType.RETURNED_AVAILABLE: {LifecycleState.SOLD},
     EventType.RETURNED_QUARANTINED: {LifecycleState.SOLD},
     EventType.RETURNED_DISCARDED: {LifecycleState.SOLD},
+    EventType.RELEASED_AVAILABLE: {LifecycleState.QUARANTINED},
 }
 
 #: States that resolve a plant. Retained is final for availability without
@@ -115,7 +131,11 @@ FINAL_STATES = {
 SELLABLE_STATES = {LifecycleState.AVAILABLE}
 
 #: Facts that end a plant's presence in a physical location. A retained plant
-#: keeps growing where it is, so it is not listed.
+#: keeps growing where it is, so it is not listed. Of the three return outcomes
+#: only `returned_discarded` is, because it is the only one that destroys the
+#: plant: an available or quarantined return is physically back on a bench, and
+#: `post_return` opens the location that says which one. `released_available`
+#: leaves the plant exactly where the quarantine put it until somebody moves it.
 CLOSES_LOCATION = {
     EventType.DONATED,
     EventType.FAILED,
@@ -126,7 +146,11 @@ CLOSES_LOCATION = {
     EventType.RETURNED_DISCARDED,
 }
 
-#: Facts an operator may record directly against a plant.
+#: Facts an operator may record directly against a plant. `released_available`
+#: is absent on purpose: releasing is the health workflow's decision, and
+#: `act_on_quarantine` closes the case in the same transaction that records it.
+#: Recorded directly it would leave a plant available while its case stayed open
+#: and the quarantine overlay kept refusing the sale.
 OUTCOME_EVENTS = (
     EventType.READY,
     EventType.RETAINED,
@@ -170,6 +194,29 @@ class OutcomeRequest(NamedTuple):
 def is_final(state):
     """Return whether a derived state resolves the plant."""
     return state in FINAL_STATES
+
+
+def states_without_exits(state_after=None, allowed_from=None, final_states=None):
+    """Return the reachable non-final states that no fact may be recorded from.
+
+    A state that neither resolves a plant nor admits any next fact is a dead
+    end: the plant is stuck there, counted as live unresolved stock forever, and
+    the only way out is a correction claiming it was never there at all. That is
+    what `quarantined` was until releasing became a fact of its own.
+
+    The three vocabularies default to this module's, and are arguments so a
+    proposed one can be checked before it ships.
+    """
+    state_after = STATE_AFTER if state_after is None else state_after
+    allowed_from = ALLOWED_FROM if allowed_from is None else allowed_from
+    final_states = FINAL_STATES if final_states is None else final_states
+    # A plant with no history at all is growing, so growing is always reachable.
+    reachable = {LifecycleState.GROWING, *state_after.values()}
+    with_exits = {state for sources in allowed_from.values() for state in sources}
+    return {
+        state for state in reachable
+        if state not in final_states and state not in with_exits
+    }
 
 
 def derive_state(events):

--- a/plantings/migrations/0038_released_available_event.py
+++ b/plantings/migrations/0038_released_available_event.py
@@ -1,0 +1,34 @@
+"""Record releasing a returned plant from quarantine as its own fact."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [('plantings', '0037_report_index')]
+
+    operations = [
+        migrations.AlterField(
+            model_name='plantlifecycleevent',
+            name='event_type',
+            field=models.CharField(
+                choices=[
+                    ('germinated', 'Germinated'),
+                    ('ready', 'Ready for sale or use'),
+                    ('transplanted', 'Transplanted or planted out'),
+                    ('retained', 'Retained'),
+                    ('failed', 'Failed'),
+                    ('lost', 'Lost during stocktake'),
+                    ('culled', 'Culled'),
+                    ('donated', 'Donated'),
+                    ('harvest_finished', 'Harvest finished'),
+                    ('sold', 'Sold'),
+                    ('returned_available', 'Returned available'),
+                    ('returned_quarantined', 'Returned quarantined'),
+                    ('returned_discarded', 'Returned discarded'),
+                    ('released_available', 'Released from quarantine'),
+                    ('corrected', 'Corrected'),
+                ],
+                max_length=24,
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -1307,6 +1307,7 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
         RETURNED_AVAILABLE = 'returned_available', 'Returned available'
         RETURNED_QUARANTINED = 'returned_quarantined', 'Returned quarantined'
         RETURNED_DISCARDED = 'returned_discarded', 'Returned discarded'
+        RELEASED_AVAILABLE = 'released_available', 'Released from quarantine'
         CORRECTED = 'corrected', 'Corrected'
 
     plant = models.ForeignKey(

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -7,7 +7,12 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import close_old_connections
-from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+from django.test import (
+    SimpleTestCase,
+    TestCase,
+    TransactionTestCase,
+    skipUnlessDBFeature,
+)
 from django.utils import timezone
 
 from tests.factories import (
@@ -19,9 +24,12 @@ from tests.factories import (
 from workspaces.models import Workspace
 
 from .lifecycle import (
+    ALLOWED_FROM,
     EventType,
+    FINAL_STATES,
     LifecycleState,
     OutcomeRequest,
+    STATE_AFTER,
     lifecycle_summaries,
     plant_lifecycle_summary,
     record_bulk_outcome,
@@ -29,6 +37,7 @@ from .lifecycle import (
     record_lifecycle_event,
     record_transplant_event,
     reverse_lifecycle_event,
+    states_without_exits,
     with_lifecycle_state,
 )
 from .models import PlantLifecycleEvent, SpecificPlant, SpecificPlantLocation
@@ -336,6 +345,130 @@ class LifecycleTransitionTests(TestCase):
                 ),
             )
         self.assertIn('occurred_at', caught.exception.message_dict)
+
+
+class QuarantinedTransitionTests(TestCase):
+    """A returned quarantined plant can be assessed and resolved."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='assessor')
+
+    def quarantined_plant(self):
+        """Return one plant a customer returned into quarantine."""
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.SOLD))
+        record_lifecycle_event(
+            plant, self.user, OutcomeRequest(EventType.RETURNED_QUARANTINED),
+        )
+        return plant
+
+    def test_releasing_a_recovered_plant_makes_it_available_again(self):
+        """Recovery is a fact of its own, not a denial of the quarantine."""
+        plant = self.quarantined_plant()
+        record_lifecycle_event(
+            plant, self.user, OutcomeRequest(EventType.RELEASED_AVAILABLE),
+        )
+        summary = plant_lifecycle_summary(plant)
+        self.assertEqual(summary.state, LifecycleState.AVAILABLE)
+        self.assertTrue(summary.sellable)
+        self.assertIsNone(summary.final_outcome)
+        self.assertEqual(
+            list(
+                plant.lifecycle_events
+                .filter(event_type=EventType.RETURNED_QUARANTINED)
+                .values_list('reversal_of', flat=True)
+            ),
+            [None],
+        )
+
+    def test_a_plant_that_does_not_recover_can_be_resolved(self):
+        """Quarantine ends in an outcome without denying it happened."""
+        for event_type, expected in (
+                (EventType.CULLED, LifecycleState.CULLED),
+                (EventType.FAILED, LifecycleState.FAILED),
+                (EventType.LOST, LifecycleState.LOST),
+                (EventType.RETAINED, LifecycleState.RETAINED)):
+            with self.subTest(event_type=event_type):
+                plant = self.quarantined_plant()
+                record_lifecycle_event(plant, self.user, OutcomeRequest(event_type))
+                summary = plant_lifecycle_summary(plant)
+                self.assertEqual(summary.state, expected)
+                self.assertEqual(summary.final_outcome, event_type)
+
+    def test_a_quarantined_plant_cannot_be_cleared_except_by_release(self):
+        """Handing on an uncleared plant is what quarantine exists to stop.
+
+        `ready` is refused with them because release is the fact that says a
+        quarantined plant is offerable again.
+        """
+        for event_type in (
+                EventType.DONATED,
+                EventType.HARVEST_FINISHED,
+                EventType.SOLD,
+                EventType.READY):
+            with self.subTest(event_type=event_type):
+                plant = self.quarantined_plant()
+                with self.assertRaises(ValidationError) as caught:
+                    record_lifecycle_event(plant, self.user, OutcomeRequest(event_type))
+                self.assertIn('event_type', caught.exception.message_dict)
+
+    def test_a_quarantined_plant_cannot_be_planted_out(self):
+        """Planting out spreads whatever the quarantine is holding back."""
+        plant = self.quarantined_plant()
+        with self.assertRaises(ValidationError):
+            record_transplant_event(plant, self.user, timezone.now())
+
+    def test_release_is_rejected_from_every_other_state(self):
+        """Release names a quarantine; nothing else has one to end."""
+        plant = make_specific_plant()
+        record_germination_event(plant, self.user)
+        for prior in (None, EventType.READY, EventType.SOLD):
+            with self.subTest(prior=prior):
+                if prior is not None:
+                    record_lifecycle_event(plant, self.user, OutcomeRequest(prior))
+                with self.assertRaises(ValidationError) as caught:
+                    record_lifecycle_event(
+                        plant, self.user, OutcomeRequest(EventType.RELEASED_AVAILABLE),
+                    )
+                self.assertIn('event_type', caught.exception.message_dict)
+
+    def test_a_released_plant_can_be_sold_again(self):
+        """Release restores the plant to ordinary saleable stock."""
+        plant = self.quarantined_plant()
+        record_lifecycle_event(
+            plant, self.user, OutcomeRequest(EventType.RELEASED_AVAILABLE),
+        )
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.SOLD))
+        self.assertEqual(plant_lifecycle_summary(plant).state, LifecycleState.SOLD)
+
+
+class LifecycleReachabilityTests(SimpleTestCase):
+    """No state may be added without a way out of it."""
+
+    def test_every_non_final_state_accepts_at_least_one_fact(self):
+        """A plant is never stuck somewhere only a correction can undo."""
+        self.assertEqual(states_without_exits(), set())
+
+    def test_a_state_added_without_a_transition_is_reported(self):
+        """The invariant catches the omission rather than assuming care."""
+        state_after = {**STATE_AFTER, EventType.CORRECTED: LifecycleState.QUARANTINED}
+        allowed_from = {
+            event_type: {
+                state for state in sources if state != LifecycleState.QUARANTINED
+            }
+            for event_type, sources in ALLOWED_FROM.items()
+        }
+        self.assertEqual(
+            states_without_exits(
+                state_after=state_after,
+                allowed_from=allowed_from,
+                final_states=FINAL_STATES,
+            ),
+            {LifecycleState.QUARANTINED},
+        )
 
 
 class LifecycleLocationClosureTests(TestCase):


### PR DESCRIPTION
`quarantined` was the only non-final lifecycle state that no fact could be recorded from, so a plant a customer returned as diseased could never be resolved: it stayed unsellable, and stayed counted as live unresolved stock in the batch reports and the production-loss reconciliation forever. The only route out was correcting the return itself, which claims the quarantine never happened.

Add `released_available` as its own fact rather than reusing `returned_available`, because a customer handing a plant back in saleable condition and the nursery assessing a plant it already holds as recovered are different claims about who decided what. Permit `culled`, `failed`, `lost` and `retained` from `quarantined` too, so a plant that does not recover can be resolved without denying it was ever quarantined. Releasing stays out of `OUTCOME_EVENTS`: it is the health workflow's decision, and recording it directly would leave a plant available while its case stayed open.

`states_without_exits` states the invariant this restores, so a future state cannot be added without a way out of it.

## Summary by Sourcery

Allow quarantined plants to be resolved by introducing an explicit release-from-quarantine lifecycle event and enforcing that every non-final lifecycle state has at least one valid outgoing transition.

New Features:
- Add a RELEASED_AVAILABLE lifecycle event to represent plants being released from quarantine back to available stock.

Bug Fixes:
- Fix quarantined plants being stuck indefinitely by giving them explicit resolution paths and removing the need to correct the original quarantine event.

Enhancements:
- Allow quarantined plants to transition to culled, failed, lost, or retained states so they can be resolved without correcting the quarantine event.
- Exclude release-from-quarantine from directly recordable outcome events to keep quarantine decisions tied to the health workflow.
- Introduce a reachability invariant and helper to detect lifecycle states that have no valid exits, and add tests to enforce it.

Tests:
- Add lifecycle tests covering quarantined plant transitions, including release, non-recovery outcomes, forbidden actions, and post-release sale.
- Add reachability tests ensuring all non-final lifecycle states accept at least one fact and that missing transitions are reported.
- Refactor lifecycle tests to use SimpleTestCase where database access is unnecessary.