### PR TITLE
fix(health): record the lifecycle consequence of a release

### DIFF
--- a/health/operations.py
+++ b/health/operations.py
@@ -19,6 +19,7 @@ from plantings.cohorts import change_cohort
 from plantings.lifecycle import (
     EventType,
     FINAL_STATES,
+    LifecycleState,
     OutcomeRequest,
     plant_lifecycle_summary,
     record_lifecycle_event,
@@ -240,6 +241,34 @@ def quarantine_observation(
     return case, action
 
 
+def _release_members(user, action, plants):
+    """Record recovery for the members quarantine holds as a lifecycle state.
+
+    A case opened over an observation quarantines plants that are still growing,
+    available or retained; there quarantine is an availability overlay and the
+    lifecycle state is deliberately untouched, so releasing has no lifecycle
+    consequence to record. Only a customer return puts a plant into
+    `quarantined` itself, and those are the plants a release resolves — as a
+    fact saying the plant recovered, not as a correction denying it was ever
+    quarantined.
+
+    Cohorts are skipped because they carry no lifecycle state of their own.
+    """
+    for plant in plants:
+        if plant_lifecycle_summary(plant).state != LifecycleState.QUARANTINED:
+            continue
+        event = record_lifecycle_event(
+            plant, user,
+            OutcomeRequest(
+                EventType.RELEASED_AVAILABLE, occurred_at=action.occurred_at,
+                reason=action.reason, reference=f'quarantine-action:{action.pk}',
+            ),
+        )
+        QuarantineActionResult.objects.create(
+            action=action, plant=plant, lifecycle_event=event,
+        )
+
+
 def _cull_members(workspace, user, action, plants, cohorts):
     for plant in plants:
         event = record_lifecycle_event(
@@ -333,7 +362,9 @@ def act_on_quarantine(
     )
     if destination:
         _move_members(workspace, user, action, plants, cohorts, destination, reason)
-    if action_name == QuarantineAction.Action.CULL:
+    if action_name == QuarantineAction.Action.RELEASE:
+        _release_members(user, action, plants)
+    elif action_name == QuarantineAction.Action.CULL:
         _cull_members(workspace, user, action, plants, cohorts)
     elif action_name == QuarantineAction.Action.ESCALATE:
         _escalate_case(workspace, user, action, plants, cohorts)

--- a/health/test_observations.py
+++ b/health/test_observations.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
+from plantings.lifecycle import EventType, OutcomeRequest, record_lifecycle_event
 from plantings.models import PlantCohort, SpecificPlantLocation
 from tests.api import RESTContractTestCase
 from tests.factories import (
@@ -265,3 +266,77 @@ class HealthObservationRestTests(RESTContractTestCase):
             if row['target_type'] == 'specificplant'
         )
         self.assertEqual(plant_link['active_health_alerts'], 1)
+
+
+class QuarantineActionRestTests(RESTContractTestCase):
+    """A returned quarantined plant is resolved through the health endpoints."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        self.observation_type = HealthObservationType.objects.get(
+            workspace=self.workspace, code='pest-signs',
+        )
+
+    def returned_case(self):
+        """Return one open case over a plant a customer returned quarantined."""
+        plant = make_specific_plant(workspace=self.workspace)
+        for event_type in (
+                EventType.READY, EventType.SOLD, EventType.RETURNED_QUARANTINED):
+            record_lifecycle_event(plant, None, OutcomeRequest(event_type))
+        scopes = [{'type': 'plant', 'id': plant.pk}]
+        preview = self.client.post(
+            '/health/observations/preview/', {'scopes': scopes}, format='json',
+        )
+        observation = self.client.post('/health/observations/', {
+            'scopes': scopes,
+            'reviewed_digest': preview.data['digest'],
+            'observation_type': self.observation_type.pk,
+            'severity': 'high',
+        }, format='json')
+        case = self.client.post(
+            f"/health/observations/{observation.data['pk']}/quarantine/",
+            {'idempotency_key': str(uuid4()), 'reason': 'Returned as diseased.'},
+            format='json',
+        )
+        self.assertEqual(case.status_code, 201, case.data)
+        return plant, case.data['pk']
+
+    def register_row(self, plant):
+        """Return the plant as the nursery register reports it."""
+        response = self.client.get(f'/plantings/register/?plant={plant.pk}')
+        self.assertEqual(response.status_code, 200, response.data)
+        return next(
+            row for row in response.data['results'] if row['pk'] == plant.pk
+        )
+
+    def test_release_returns_the_plant_to_saleable_stock(self):
+        plant, case_pk = self.returned_case()
+        self.assertEqual(self.register_row(plant)['lifecycle_state'], 'quarantined')
+        response = self.client.post(
+            f'/health/quarantines/{case_pk}/release/',
+            {'idempotency_key': str(uuid4()), 'reason': 'Recovered in isolation.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertFalse(response.data['active'])
+        row = self.register_row(plant)
+        self.assertEqual(row['lifecycle_state'], 'available')
+        self.assertTrue(row['sellable'])
+        self.assertFalse(row['quarantined'])
+
+    def test_cull_resolves_the_plant_the_return_could_not(self):
+        plant, case_pk = self.returned_case()
+        response = self.client.post(
+            f'/health/quarantines/{case_pk}/cull/',
+            {'idempotency_key': str(uuid4()), 'reason': 'Disease confirmed.'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertFalse(response.data['active'])
+        row = self.register_row(plant)
+        self.assertEqual(row['lifecycle_state'], 'culled')
+        self.assertEqual(row['final_outcome'], 'culled')
+        self.assertFalse(row['sellable'])

--- a/health/test_operations.py
+++ b/health/test_operations.py
@@ -20,7 +20,13 @@ from applications.services import (
 )
 from inventory.units import UnitCode
 from plantings.cohorts import change_cohort
-from plantings.lifecycle import EventType, OutcomeRequest, record_lifecycle_event
+from plantings.lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_lifecycle_event,
+)
 from plantings.models import CohortOperation, PlantCohort, SpecificPlantLocation
 from plantings.register import RegisterFilters, register_queryset
 from tests.factories import (
@@ -72,6 +78,16 @@ class HealthOperationTests(TestCase):
             idempotency_key=uuid4(), reason='Prevent spread while reviewed.',
         )[0]
 
+    def returned_plant(self):
+        """Return one plant a customer returned into quarantine."""
+        plant = make_specific_plant(workspace=self.workspace)
+        for event_type in (
+                EventType.READY, EventType.SOLD, EventType.RETURNED_QUARANTINED):
+            record_lifecycle_event(
+                plant, None, OutcomeRequest(event_type, reason='Commerce.'),
+            )
+        return plant
+
     def test_quarantine_changes_register_availability_without_lifecycle_change(self):
         plant = make_specific_plant(workspace=self.workspace)
         record_lifecycle_event(
@@ -93,6 +109,23 @@ class HealthOperationTests(TestCase):
         self.assertFalse(after.quarantined)
         self.assertTrue(after.sellable)
 
+    def test_releasing_an_overlay_quarantine_records_no_lifecycle_fact(self):
+        plant = make_specific_plant(workspace=self.workspace)
+        record_lifecycle_event(
+            plant, None, OutcomeRequest(EventType.READY, reason='Ready for sale.'),
+        )
+        case = self.quarantine(self.observe('plant', plant))
+        action = act_on_quarantine(
+            self.workspace, None, case,
+            action_name=QuarantineAction.Action.RELEASE,
+            idempotency_key=uuid4(), reason='Inspection found no remaining issue.',
+        )
+        self.assertEqual(
+            list(plant.lifecycle_events.values_list('event_type', flat=True)),
+            [EventType.READY],
+        )
+        self.assertFalse(action.results.exists())
+
     def test_overlapping_cases_must_each_be_released(self):
         plant = make_specific_plant(workspace=self.workspace)
         observation = self.observe('plant', plant)
@@ -108,6 +141,105 @@ class HealthOperationTests(TestCase):
             action_name='release', idempotency_key=uuid4(), reason='Second issue resolved.',
         )
         self.assertFalse(is_quarantined(plant))
+
+    def test_releasing_a_returned_plant_records_its_recovery(self):
+        plant = self.returned_plant()
+        case = self.quarantine(self.observe('plant', plant))
+        action = act_on_quarantine(
+            self.workspace, None, case,
+            action_name=QuarantineAction.Action.RELEASE,
+            idempotency_key=uuid4(), reason='Reassessed as healthy stock.',
+        )
+        row = register_queryset(self.workspace, RegisterFilters()).get(pk=plant.pk)
+        self.assertEqual(row.lifecycle_state, LifecycleState.AVAILABLE)
+        self.assertTrue(row.sellable)
+        self.assertFalse(row.quarantined)
+        result = action.results.get()
+        self.assertEqual(result.plant, plant)
+        self.assertEqual(
+            result.lifecycle_event.event_type, EventType.RELEASED_AVAILABLE,
+        )
+        self.assertEqual(
+            result.lifecycle_event.reference, f'quarantine-action:{action.pk}',
+        )
+        self.assertEqual(result.lifecycle_event.reason, 'Reassessed as healthy stock.')
+
+    def test_a_release_keeps_the_quarantine_it_resolved_on_the_record(self):
+        plant = self.returned_plant()
+        case = self.quarantine(self.observe('plant', plant))
+        act_on_quarantine(
+            self.workspace, None, case,
+            action_name=QuarantineAction.Action.RELEASE,
+            idempotency_key=uuid4(), reason='Reassessed as healthy stock.',
+        )
+        self.assertEqual(
+            list(
+                plant.lifecycle_events.order_by('occurred_at', 'pk')
+                .values_list('event_type', flat=True)
+            ),
+            [
+                EventType.READY,
+                EventType.SOLD,
+                EventType.RETURNED_QUARANTINED,
+                EventType.RELEASED_AVAILABLE,
+            ],
+        )
+
+    def test_culling_a_returned_plant_resolves_it_and_closes_its_location(self):
+        plant = self.returned_plant()
+        bench = make_location(workspace=self.workspace, location_type='quarantine')
+        make_specific_plant_location(
+            specific_plant=plant,
+            location_type=SpecificPlantLocation.LOCATION,
+            seed_tray_cell=None,
+            location=bench,
+        )
+        case = self.quarantine(self.observe('plant', plant))
+        action = act_on_quarantine(
+            self.workspace, None, case,
+            action_name=QuarantineAction.Action.CULL,
+            idempotency_key=uuid4(), reason='Disease confirmed on reassessment.',
+        )
+        summary = plant_lifecycle_summary(plant)
+        self.assertEqual(summary.state, LifecycleState.CULLED)
+        self.assertEqual(summary.final_outcome, EventType.CULLED)
+        self.assertFalse(
+            SpecificPlantLocation.objects
+            .filter(specific_plant=plant, ended__isnull=True)
+            .exists()
+        )
+        result = action.results.get()
+        self.assertEqual(result.lifecycle_event.event_type, EventType.CULLED)
+
+    def test_a_release_resolves_only_the_members_quarantine_held(self):
+        returned = self.returned_plant()
+        live = make_specific_plant(workspace=self.workspace)
+        record_lifecycle_event(live, None, OutcomeRequest(EventType.READY))
+        scopes = [
+            {'type': 'plant', 'id': returned.pk},
+            {'type': 'plant', 'id': live.pk},
+        ]
+        preview = preview_observation(self.workspace, scopes)
+        observation = record_observation(
+            self.workspace, None, scopes=scopes,
+            reviewed_digest=preview['digest'],
+            observation_type=self.observation_type,
+            severity=HealthObservation.Severity.HIGH,
+            notes='Both benches inspected.',
+        )
+        action = act_on_quarantine(
+            self.workspace, None, self.quarantine(observation),
+            action_name=QuarantineAction.Action.RELEASE,
+            idempotency_key=uuid4(), reason='Nothing found on reassessment.',
+        )
+        self.assertEqual([result.plant for result in action.results.all()], [returned])
+        self.assertEqual(
+            plant_lifecycle_summary(live).state, LifecycleState.AVAILABLE,
+        )
+        self.assertEqual(
+            list(live.lifecycle_events.values_list('event_type', flat=True)),
+            [EventType.READY],
+        )
 
     def test_quarantine_move_preserves_physical_location_history(self):
         plant = make_specific_plant(workspace=self.workspace)


### PR DESCRIPTION
Releasing a quarantine case appended the action row that closes the case and recorded nothing against the plants it held. For a plant a customer returned into quarantine that left the case closed, the overlay cleared, and the plant still in the `quarantined` lifecycle state, no longer visible to the health system that had been tracking it. Culling it was refused outright.

Give `act_on_quarantine` a release branch that mirrors `_cull_members`, recording the fact and linking it through `QuarantineActionResult`. It records for exactly the members whose lifecycle state is `quarantined`: a case opened over an observation quarantines plants that are still growing, available or retained, where quarantine is an availability overlay the lifecycle deliberately does not see, and promoting one of those to available would invent a `ready` decision nobody made.

Also adds the first REST coverage of the release and cull endpoints.

## Summary by Sourcery

Record lifecycle recovery or culling outcomes when acting on quarantine cases, and add REST test coverage for these health endpoints.

New Features:
- Introduce recording of release actions on quarantined plants as lifecycle events linked through quarantine action results.
- Expose and verify REST API behaviour for releasing and culling quarantined cases via health endpoints.

Bug Fixes:
- Ensure releasing quarantine cases for customer-returned plants updates their lifecycle state and leaves the quarantine history intact.
- Prevent release actions from silently losing track of returned quarantined plants by only resolving members whose lifecycle state is quarantined.

Enhancements:
- Align quarantine release handling with existing cull member logic to consistently capture lifecycle consequences for affected plants.
- Extend health operations tests to cover lifecycle summaries, register state, and location closure when resolving quarantined returns.