### PR TITLE
data(health): backfill the release that closed a quarantine case

### DIFF
--- a/health/migrations/0004_backfill_released_quarantine.py
+++ b/health/migrations/0004_backfill_released_quarantine.py
@@ -1,0 +1,170 @@
+"""Give already-released quarantine returns the fact that released them.
+
+Releasing a case used to close it without recording anything against the plants
+it held, so every plant a customer returned into quarantine and an operator then
+released stayed in the `quarantined` lifecycle state: unsellable, and counted as
+live unresolved stock forever. The operator did decide to release it, and the
+`release` action says when and why, so the missing fact is derivable rather than
+a judgement call. Backfill it, and refuse to deploy over any plant whose history
+cannot be repaired truthfully.
+"""
+
+from django.db import migrations
+
+
+#: The facts lifecycle state is replayed from, frozen at this migration.
+STATE_EVENT_TYPES = (
+    'germinated',
+    'ready',
+    'retained',
+    'donated',
+    'failed',
+    'lost',
+    'culled',
+    'harvest_finished',
+    'sold',
+    'returned_available',
+    'returned_quarantined',
+    'returned_discarded',
+    'released_available',
+)
+
+RETURNED_QUARANTINED = 'returned_quarantined'
+RELEASED_AVAILABLE = 'released_available'
+RELEASE = 'release'
+
+
+def describe_rows(row_ids, count):
+    """Return a bounded description of rows that failed the audit."""
+    shown = sorted(row_ids)[:20]
+    suffix = '' if count <= len(shown) else f' (first 20 of {count})'
+    return f'{shown}{suffix}'
+
+
+def _stranded_returns(event_model):
+    """Return the quarantined return that still decides each stuck plant.
+
+    A plant is stuck when the last of its surviving state-changing facts is a
+    quarantined return, which is the same replay `plantings.lifecycle` performs
+    over the same events.
+    """
+    plant_ids = set(
+        event_model.objects
+        .filter(event_type=RETURNED_QUARANTINED, reversal__isnull=True)
+        .values_list('plant_id', flat=True)
+    )
+    if not plant_ids:
+        return {}
+    latest = {}
+    for event in event_model.objects.filter(
+            plant_id__in=plant_ids,
+            event_type__in=STATE_EVENT_TYPES,
+            reversal__isnull=True,
+    ).order_by('occurred_at', 'pk'):
+        latest[event.plant_id] = event
+    return {
+        plant_id: event
+        for plant_id, event in latest.items()
+        if event.event_type == RETURNED_QUARANTINED
+    }
+
+
+def _closing_releases(member_model, action_model, returns):
+    """Return the release action that closed each stuck plant's case.
+
+    A plant whose case is still open is absent: nothing was lost there, and the
+    ordinary health workflow now resolves it.
+    """
+    cases_by_plant = {}
+    for plant_id, case_id in member_model.objects.filter(
+            plant_id__in=list(returns),
+    ).values_list('plant_id', 'case_id'):
+        cases_by_plant.setdefault(plant_id, []).append(case_id)
+    every_case = {case_id for cases in cases_by_plant.values() for case_id in cases}
+    releases = {}
+    for action in action_model.objects.filter(
+            case_id__in=every_case, action=RELEASE,
+    ).order_by('occurred_at', 'pk'):
+        releases.setdefault(action.case_id, []).append(action)
+    closing = {}
+    for plant_id, returned in returns.items():
+        candidates = [
+            action
+            for case_id in cases_by_plant.get(plant_id, [])
+            for action in releases.get(case_id, [])
+            if action.occurred_at >= returned.occurred_at
+        ]
+        if candidates:
+            closing[plant_id] = max(
+                candidates, key=lambda action: (action.occurred_at, action.pk),
+            )
+    return closing
+
+
+def _unrepairable(event_model, closing):
+    """Return the plants whose release cannot be appended in order.
+
+    The backfilled fact happens when the operator released the case, so a plant
+    carrying anything later than that has a history no honest append can join.
+    """
+    latest_events = {}
+    for event in event_model.objects.filter(
+            plant_id__in=list(closing),
+    ).order_by('occurred_at', 'pk'):
+        latest_events[event.plant_id] = event
+    return {
+        plant_id
+        for plant_id, action in closing.items()
+        if latest_events[plant_id].occurred_at > action.occurred_at
+    }
+
+
+def backfill_released_quarantine(apps, _schema_editor):
+    """Record the release that closed each stranded plant's quarantine case."""
+    event_model = apps.get_model('plantings', 'PlantLifecycleEvent')
+    member_model = apps.get_model('health', 'QuarantineMember')
+    action_model = apps.get_model('health', 'QuarantineAction')
+    result_model = apps.get_model('health', 'QuarantineActionResult')
+
+    returns = _stranded_returns(event_model)
+    if not returns:
+        return
+    closing = _closing_releases(member_model, action_model, returns)
+    blocked = _unrepairable(event_model, closing)
+    if blocked:
+        raise RuntimeError(
+            'Quarantine release backfill failed. These plants were released '
+            'from quarantine but carry later facts, so the release cannot be '
+            'appended in the order it happened. Correct or re-record their '
+            'histories before retrying the migration: '
+            f'stranded SpecificPlant IDs: {describe_rows(blocked, len(blocked))}'
+        )
+    for plant_id, action in closing.items():
+        returned = returns[plant_id]
+        event = event_model.objects.create(
+            workspace_id=returned.workspace_id,
+            plant_id=plant_id,
+            batch_id=returned.batch_id,
+            event_type=RELEASED_AVAILABLE,
+            occurred_at=action.occurred_at,
+            reason=action.reason,
+            reference=f'quarantine-action:{action.pk}',
+            created_by_id=action.created_by_id,
+        )
+        result_model.objects.create(
+            action=action, plant_id=plant_id, lifecycle_event=event,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('health', '0003_healthtreatment_healthfollowup_quarantineaction_and_more'),
+        ('plantings', '0038_released_available_event'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_released_quarantine,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/health/test_migrations.py
+++ b/health/test_migrations.py
@@ -1,0 +1,150 @@
+"""Tests for the health data migrations run at deployment time."""
+
+# pylint: disable=duplicate-code
+
+from datetime import timedelta
+from importlib import import_module
+from uuid import uuid4
+
+from django.apps import apps as django_apps
+from django.test import TestCase
+from django.utils import timezone
+
+from plantings.lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_lifecycle_event,
+)
+from plantings.models import PlantLifecycleEvent
+from tests.factories import make_specific_plant
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import (
+    HealthObservation,
+    HealthObservationType,
+    QuarantineAction,
+    QuarantineActionResult,
+)
+from .operations import quarantine_observation
+from .services import preview_observation, record_observation
+
+
+class ReleasedQuarantineBackfillTests(TestCase):
+    """Plants a closed release left behind get the fact that released them."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        self.observation_type = HealthObservationType.objects.get(
+            workspace=self.workspace, code='pest-signs',
+        )
+        migration = import_module(
+            'health.migrations.0004_backfill_released_quarantine'
+        )
+        self.backfill = migration.backfill_released_quarantine
+
+    def returned_case(self, plant):
+        """Open a case over one plant a customer returned into quarantine."""
+        scopes = [{'type': 'plant', 'id': plant.pk}]
+        preview = preview_observation(self.workspace, scopes)
+        observation = record_observation(
+            self.workspace, None, scopes=scopes,
+            reviewed_digest=preview['digest'],
+            observation_type=self.observation_type,
+            severity=HealthObservation.Severity.HIGH,
+            notes='Returned as diseased.',
+        )
+        return quarantine_observation(
+            self.workspace, None, observation,
+            idempotency_key=uuid4(), reason='Returned as diseased.',
+        )[0]
+
+    def returned_plant(self):
+        """Return one plant whose last recorded fact is a quarantined return."""
+        plant = make_specific_plant(workspace=self.workspace)
+        for event_type in (
+                EventType.READY, EventType.SOLD, EventType.RETURNED_QUARANTINED):
+            record_lifecycle_event(plant, None, OutcomeRequest(event_type))
+        return plant
+
+    def strand(self, plant, when=None):
+        """Close a case the way releasing used to, recording no lifecycle fact."""
+        return QuarantineAction.objects.create(
+            workspace=self.workspace, case=self.returned_case(plant),
+            idempotency_key=uuid4(), action=QuarantineAction.Action.RELEASE,
+            occurred_at=when or timezone.now(), reason='Recovered in isolation.',
+        )
+
+    def test_a_stranded_plant_is_released_by_the_action_that_closed_its_case(self):
+        """The operator already decided; only the consequence went unrecorded."""
+        plant = self.returned_plant()
+        action = self.strand(plant)
+        self.backfill(django_apps, None)
+        summary = plant_lifecycle_summary(plant)
+        self.assertEqual(summary.state, LifecycleState.AVAILABLE)
+        self.assertTrue(summary.sellable)
+        event = plant.lifecycle_events.get(event_type=EventType.RELEASED_AVAILABLE)
+        self.assertEqual(event.occurred_at, action.occurred_at)
+        self.assertEqual(event.reason, action.reason)
+        self.assertEqual(event.reference, f'quarantine-action:{action.pk}')
+        self.assertEqual(event.batch, plant.batch)
+        result = QuarantineActionResult.objects.get(action=action)
+        self.assertEqual(result.plant, plant)
+        self.assertEqual(result.lifecycle_event, event)
+
+    def test_a_plant_whose_case_is_still_open_is_left_alone(self):
+        """Nothing was lost there: the health workflow now resolves it."""
+        plant = self.returned_plant()
+        self.returned_case(plant)
+        self.backfill(django_apps, None)
+        self.assertEqual(
+            plant_lifecycle_summary(plant).state, LifecycleState.QUARANTINED,
+        )
+        self.assertFalse(
+            plant.lifecycle_events
+            .filter(event_type=EventType.RELEASED_AVAILABLE)
+            .exists()
+        )
+
+    def test_a_plant_that_was_never_quarantined_is_untouched(self):
+        """The backfill reads the returns, not every plant on the bench."""
+        plant = make_specific_plant(workspace=self.workspace)
+        record_lifecycle_event(plant, None, OutcomeRequest(EventType.READY))
+        self.backfill(django_apps, None)
+        self.assertEqual(
+            list(plant.lifecycle_events.values_list('event_type', flat=True)),
+            [EventType.READY],
+        )
+
+    def test_a_history_the_release_cannot_join_blocks_the_deployment(self):
+        """An append out of order would be a worse lie than the missing fact."""
+        plant = self.returned_plant()
+        action = self.strand(plant)
+        PlantLifecycleEvent.objects.create(
+            workspace=self.workspace, plant=plant, batch=plant.batch,
+            event_type=EventType.TRANSPLANTED,
+            occurred_at=action.occurred_at + timedelta(days=1),
+        )
+        with self.assertRaisesMessage(
+            RuntimeError, f'stranded SpecificPlant IDs: [{plant.pk}]',
+        ):
+            self.backfill(django_apps, None)
+        self.assertFalse(
+            plant.lifecycle_events
+            .filter(event_type=EventType.RELEASED_AVAILABLE)
+            .exists()
+        )
+
+    def test_the_reported_ids_are_bounded(self):
+        """A wholesale failure names enough rows to act on, not every row."""
+        migration = import_module(
+            'health.migrations.0004_backfill_released_quarantine'
+        )
+        self.assertEqual(
+            migration.describe_rows(range(30), 30),
+            f'{list(range(20))} (first 20 of 30)',
+        )


### PR DESCRIPTION
Plants a release stranded in `quarantined` before the previous commit are still stranded: their case is closed, so the fixed workflow has no case left to release them through. The operator did decide to release them, and the release action records when, why, and by whom, so the missing fact is derivable rather than a judgement call.

Append it, with the `QuarantineActionResult` the code now writes, so a repaired history is indistinguishable from a recorded one. Plants whose case is still open are left alone because releasing them now works. A plant carrying a fact later than its release blocks the migration with bounded IDs instead, because appending the release in the order it happened is exactly what that history makes impossible.

## Summary by Sourcery

Backfill lifecycle release events for plants whose quarantine cases were previously closed without recording a release, while blocking deployment when histories cannot be truthfully repaired.

Enhancements:
- Add a Django data migration that derives and records RELEASED_AVAILABLE lifecycle events and corresponding QuarantineActionResult rows for stranded quarantined plants, based on historical quarantine release actions.
- Ensure the migration audits plant histories and raises a bounded, actionable error when later lifecycle events would make an in-order release append impossible.

Tests:
- Introduce migration tests that cover releasing stranded quarantined plants, leaving open or non-quarantined cases unchanged, blocking deployment on unrepairable histories, and bounding the reported plant IDs in failure messages.