### PR TITLE
feat(frontend): name the commerce lifecycle facts

### DIFF
--- a/frontend/js/plantings/lifecycle.tsx
+++ b/frontend/js/plantings/lifecycle.tsx
@@ -4,14 +4,21 @@ import { Badge, Button, Table } from 'react-bootstrap'
 import { formatDateTime } from '../utils'
 import { PlantLifecycleEvent, PlantLifecycleEventType, PlantLifecycleState, PlantOutcomeAction, SpecificPlant } from '../types/plantings'
 
+// Every derived state and recorded fact the server can report, including the
+// ones sales and health produce. The Record types make tsc refuse a state or an
+// event that nothing here knows how to name.
 const STATE_LABELS: Record<PlantLifecycleState, string> = {
   growing: 'Growing',
   available: 'Available',
   retained: 'Retained',
   donated: 'Donated',
   failed: 'Failed',
+  lost: 'Lost',
   culled: 'Culled',
-  harvested: 'Harvested'
+  harvested: 'Harvested',
+  sold: 'Sold',
+  quarantined: 'Returned quarantined',
+  discarded: 'Returned discarded'
 }
 
 const STATE_VARIANTS: Record<PlantLifecycleState, string> = {
@@ -20,8 +27,12 @@ const STATE_VARIANTS: Record<PlantLifecycleState, string> = {
   retained: 'primary',
   donated: 'info',
   failed: 'danger',
+  lost: 'dark',
   culled: 'dark',
-  harvested: 'primary'
+  harvested: 'primary',
+  sold: 'info',
+  quarantined: 'warning',
+  discarded: 'dark'
 }
 
 const EVENT_LABELS: Record<PlantLifecycleEventType, string> = {
@@ -30,9 +41,15 @@ const EVENT_LABELS: Record<PlantLifecycleEventType, string> = {
   transplanted: 'Planted out',
   retained: 'Retained',
   failed: 'Failed',
+  lost: 'Lost during stocktake',
   culled: 'Culled',
   donated: 'Donated',
   harvest_finished: 'Harvest finished',
+  sold: 'Sold',
+  returned_available: 'Returned available',
+  returned_quarantined: 'Returned quarantined',
+  returned_discarded: 'Returned discarded',
+  released_available: 'Released from quarantine',
   corrected: 'Corrected'
 }
 

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -243,9 +243,27 @@ interface SpecificPlantMove {
   override_reason?: string
 }
 
-type PlantLifecycleEventType = 'germinated' | 'ready' | 'transplanted' | 'retained' | 'failed' | 'culled' | 'donated' | 'harvest_finished' | 'corrected'
+// These mirror plantings.models.PlantLifecycleEvent.EventType and
+// plantings.lifecycle.LifecycleState in full, including the commerce facts the
+// server records from sales and health rather than from a button here.
+type PlantLifecycleEventType =
+  | 'germinated'
+  | 'ready'
+  | 'transplanted'
+  | 'retained'
+  | 'failed'
+  | 'lost'
+  | 'culled'
+  | 'donated'
+  | 'harvest_finished'
+  | 'sold'
+  | 'returned_available'
+  | 'returned_quarantined'
+  | 'returned_discarded'
+  | 'released_available'
+  | 'corrected'
 
-type PlantLifecycleState = 'growing' | 'available' | 'retained' | 'donated' | 'failed' | 'culled' | 'harvested'
+type PlantLifecycleState = 'growing' | 'available' | 'retained' | 'donated' | 'failed' | 'lost' | 'culled' | 'harvested' | 'sold' | 'quarantined' | 'discarded'
 
 type PlantOutcomeAction = 'ready' | 'retain' | 'fail' | 'cull' | 'donate' | 'finish-harvest'
 


### PR DESCRIPTION
`EVENT_LABELS` and `STATE_LABELS` were never extended past the outcomes task 41 shipped, so a plant timeline rendered a blank cell for `sold` and for every return, and the new release fact would have joined them.

Add the whole set rather than only the new one, and widen the unions behind them, so the `Record<>` types make the compiler refuse a state or an event that nothing here knows how to name.

## Summary by Sourcery

Extend frontend plant lifecycle types and labels to cover all server-side commerce and health lifecycle events and states.

New Features:
- Add support for commerce-related lifecycle events and states such as sold, returns, releases, and loss in the plantings timeline.

Enhancements:
- Align PlantLifecycleEventType and PlantLifecycleState unions with the full backend lifecycle model to ensure all reported facts are named and typed.
- Update lifecycle state and event display labels and variants so every server-reported state/event renders with an appropriate label and styling in the UI.