### PR TITLE
feat(plantings): record backward lifecycle transitions

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -56,6 +56,8 @@ STATE_AFTER = {
     EventType.RETURNED_QUARANTINED: LifecycleState.QUARANTINED,
     EventType.RETURNED_DISCARDED: LifecycleState.DISCARDED,
     EventType.RELEASED_AVAILABLE: LifecycleState.AVAILABLE,
+    EventType.HELD_BACK: LifecycleState.GROWING,
+    EventType.RETENTION_ENDED: LifecycleState.GROWING,
 }
 
 #: The states each fact may be recorded from. `germinated` is absent because it
@@ -67,6 +69,14 @@ STATE_AFTER = {
 #: Donation, harvest, planting out and sale stay closed, because handing a plant
 #: the nursery has not cleared to somebody else is the thing quarantine exists to
 #: prevent — release it first and the ordinary transitions apply.
+#:
+#: `held_back` and `retention_ended` are the backward facts: taking stock off
+#: offer, and returning a plant kept for the operation's own use to production.
+#: Both land in `growing` rather than restoring whatever the plant was before,
+#: because deciding a plant is offerable is a judgement somebody makes, and the
+#: `ready` that follows records it. That also keeps `ready` permitted only from
+#: `growing`, so a repeated cycle reads as separate offers rather than as one
+#: fact recorded twice.
 ALLOWED_FROM = {
     EventType.READY: {LifecycleState.GROWING},
     EventType.TRANSPLANTED: {
@@ -112,6 +122,8 @@ ALLOWED_FROM = {
     EventType.RETURNED_QUARANTINED: {LifecycleState.SOLD},
     EventType.RETURNED_DISCARDED: {LifecycleState.SOLD},
     EventType.RELEASED_AVAILABLE: {LifecycleState.QUARANTINED},
+    EventType.HELD_BACK: {LifecycleState.AVAILABLE},
+    EventType.RETENTION_ENDED: {LifecycleState.RETAINED},
 }
 
 #: States that resolve a plant. Retained is final for availability without
@@ -135,7 +147,9 @@ SELLABLE_STATES = {LifecycleState.AVAILABLE}
 #: only `returned_discarded` is, because it is the only one that destroys the
 #: plant: an available or quarantined return is physically back on a bench, and
 #: `post_return` opens the location that says which one. `released_available`
-#: leaves the plant exactly where the quarantine put it until somebody moves it.
+#: leaves the plant exactly where the quarantine put it until somebody moves it,
+#: and neither backward fact is listed either: holding stock back or ending a
+#: retention changes what the nursery will do with a plant, not where it stands.
 CLOSES_LOCATION = {
     EventType.DONATED,
     EventType.FAILED,
@@ -159,6 +173,18 @@ OUTCOME_EVENTS = (
     EventType.CULLED,
     EventType.DONATED,
     EventType.HARVEST_FINISHED,
+    EventType.HELD_BACK,
+    EventType.RETENTION_ENDED,
+)
+
+#: Facts recording that a plant's condition changed backwards. They are not
+#: corrections: a correction says a fact was never true, while these say it was
+#: true and then the situation changed, so both intervals stay in the history.
+#: Each requires a stated reason, because a plant leaving offer without one is
+#: indistinguishable from a mis-click by the time anybody reads the trail.
+BACKWARD_EVENTS = (
+    EventType.HELD_BACK,
+    EventType.RETENTION_ENDED,
 )
 
 
@@ -390,8 +416,14 @@ def _require_chronology(events, occurred_at):
         })
 
 
-def validate_outcome(plant, event_type, occurred_at):
-    """Check one plant admits a fact before anything is written."""
+def validate_outcome(plant, event_type, occurred_at, reason=''):
+    """Check one plant admits a fact before anything is written.
+
+    The reason defaults to none so that a caller which forgets to pass one
+    refuses a backward fact rather than recording an unexplained withdrawal.
+    """
+    if event_type in BACKWARD_EVENTS:
+        _require_reason(reason)
     events = _plant_events(plant)
     _require_chronology(events, occurred_at)
     _require_transition(derive_state(events).state, event_type)
@@ -447,7 +479,7 @@ def record_lifecycle_event(plant, user, request):
     """Record one validated fact about a plant and close its location if final."""
     plant = _lock_plant(plant)
     request = request.at(timezone.now())
-    validate_outcome(plant, request.event_type, request.occurred_at)
+    validate_outcome(plant, request.event_type, request.occurred_at, request.reason)
     return _apply_outcome(plant, user, request)
 
 
@@ -529,7 +561,9 @@ def record_bulk_outcome(plant_ids, user, request):
     errors = []
     for plant in plants:
         try:
-            validate_outcome(plant, request.event_type, request.occurred_at)
+            validate_outcome(
+                plant, request.event_type, request.occurred_at, request.reason,
+            )
         except ValidationError as exc:
             errors.append(f'Plant {plant.pk}: {" ".join(exc.messages)}')
     if errors:

--- a/plantings/migrations/0039_backward_lifecycle_events.py
+++ b/plantings/migrations/0039_backward_lifecycle_events.py
@@ -1,0 +1,36 @@
+"""Record holding stock back and ending a retention as facts of their own."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [('plantings', '0038_released_available_event')]
+
+    operations = [
+        migrations.AlterField(
+            model_name='plantlifecycleevent',
+            name='event_type',
+            field=models.CharField(
+                choices=[
+                    ('germinated', 'Germinated'),
+                    ('ready', 'Ready for sale or use'),
+                    ('transplanted', 'Transplanted or planted out'),
+                    ('retained', 'Retained'),
+                    ('failed', 'Failed'),
+                    ('lost', 'Lost during stocktake'),
+                    ('culled', 'Culled'),
+                    ('donated', 'Donated'),
+                    ('harvest_finished', 'Harvest finished'),
+                    ('sold', 'Sold'),
+                    ('returned_available', 'Returned available'),
+                    ('returned_quarantined', 'Returned quarantined'),
+                    ('returned_discarded', 'Returned discarded'),
+                    ('released_available', 'Released from quarantine'),
+                    ('held_back', 'Held back from sale'),
+                    ('retention_ended', 'Retention ended'),
+                    ('corrected', 'Corrected'),
+                ],
+                max_length=24,
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -1308,6 +1308,8 @@ class PlantLifecycleEvent(WorkspaceOwnedModel):
         RETURNED_QUARANTINED = 'returned_quarantined', 'Returned quarantined'
         RETURNED_DISCARDED = 'returned_discarded', 'Returned discarded'
         RELEASED_AVAILABLE = 'released_available', 'Released from quarantine'
+        HELD_BACK = 'held_back', 'Held back from sale'
+        RETENTION_ENDED = 'retention_ended', 'Retention ended'
         CORRECTED = 'corrected', 'Corrected'
 
     plant = models.ForeignKey(

--- a/plantings/test_backward_transitions.py
+++ b/plantings/test_backward_transitions.py
@@ -1,0 +1,205 @@
+"""Tests for the backward lifecycle facts that are not corrections."""
+# pylint: disable=duplicate-code
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from tests.factories import make_specific_plant, make_specific_plant_location
+
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    plant_lifecycle_summary,
+    record_germination_event,
+    record_lifecycle_event,
+)
+
+
+class BackwardTransitionTests(TestCase):
+    """A condition that changes backwards is a fact, not a correction."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='grader')
+        self.plant = make_specific_plant()
+        record_germination_event(self.plant, self.user)
+
+    def held_back_plant(self):
+        """Return one plant graded ready and then taken off offer."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        record_lifecycle_event(
+            self.plant,
+            self.user,
+            OutcomeRequest(EventType.HELD_BACK, reason='Gone leggy in the heat.'),
+        )
+        return self.plant
+
+    def test_holding_a_plant_back_returns_it_to_production(self):
+        """Off offer is not resolved: the plant is growing again."""
+        plant = self.held_back_plant()
+        summary = plant_lifecycle_summary(plant)
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+        self.assertFalse(summary.sellable)
+        self.assertIsNone(summary.final_outcome)
+
+    def test_holding_a_plant_back_leaves_the_ready_fact_standing(self):
+        """The plant was ready; the history keeps saying so."""
+        plant = self.held_back_plant()
+        ready = plant.lifecycle_events.get(event_type=EventType.READY)
+        self.assertIsNone(ready.reversal_of)
+        self.assertFalse(hasattr(ready, 'reversal'))
+
+    def test_a_held_back_plant_can_be_offered_again(self):
+        """A repeated cycle reads as separate offers, not one fact twice."""
+        plant = self.held_back_plant()
+        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        self.assertEqual(
+            plant_lifecycle_summary(plant).state,
+            LifecycleState.AVAILABLE,
+        )
+        self.assertEqual(
+            list(
+                plant.lifecycle_events
+                .exclude(event_type=EventType.GERMINATED)
+                .values_list('event_type', flat=True)
+            ),
+            [EventType.READY, EventType.HELD_BACK, EventType.READY],
+        )
+
+    def test_a_held_back_plant_cannot_be_sold(self):
+        """Withdrawn stock is not offerable while it is withdrawn."""
+        plant = self.held_back_plant()
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.SOLD))
+        self.assertIn('event_type', caught.exception.message_dict)
+
+    def test_ending_a_retention_returns_the_plant_to_production(self):
+        """A mother plant coming back to stock is growing, not available."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.RETAINED))
+        record_lifecycle_event(
+            self.plant,
+            self.user,
+            OutcomeRequest(EventType.RETENTION_ENDED, reason='Back into sale stock.'),
+        )
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+        self.assertFalse(summary.sellable)
+        self.assertIsNone(summary.final_outcome)
+        self.assertIsNone(summary.final_outcome_at)
+
+    def test_a_plant_leaving_retention_is_graded_before_it_is_sold(self):
+        """Retention may never have been preceded by a ready decision."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.RETAINED))
+        record_lifecycle_event(
+            self.plant,
+            self.user,
+            OutcomeRequest(EventType.RETENTION_ENDED, reason='Back into sale stock.'),
+        )
+        with self.assertRaises(ValidationError):
+            record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.SOLD))
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.SOLD))
+        self.assertEqual(
+            plant_lifecycle_summary(self.plant).state,
+            LifecycleState.SOLD,
+        )
+
+    def test_a_backward_fact_requires_a_reason(self):
+        """Stock leaving offer unexplained is indistinguishable from a slip."""
+        for event_type, prior in (
+                (EventType.HELD_BACK, EventType.READY),
+                (EventType.RETENTION_ENDED, EventType.RETAINED)):
+            with self.subTest(event_type=event_type):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                record_lifecycle_event(plant, self.user, OutcomeRequest(prior))
+                with self.assertRaises(ValidationError) as caught:
+                    record_lifecycle_event(plant, self.user, OutcomeRequest(event_type))
+                self.assertEqual(
+                    caught.exception.message_dict['reason'],
+                    ['A reason is required.'],
+                )
+
+    def test_a_blank_reason_does_not_satisfy_the_requirement(self):
+        """Whitespace is not an explanation."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(
+                self.plant, self.user, OutcomeRequest(EventType.HELD_BACK, reason='   '),
+            )
+        self.assertIn('reason', caught.exception.message_dict)
+
+    def test_a_backward_fact_cannot_predate_the_fact_it_reverses(self):
+        """Chronology applies to a backward fact like any other."""
+        record_lifecycle_event(self.plant, self.user, OutcomeRequest(EventType.READY))
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(
+                self.plant,
+                self.user,
+                OutcomeRequest(
+                    EventType.HELD_BACK,
+                    occurred_at=timezone.now() - timedelta(days=7),
+                    reason='Gone leggy in the heat.',
+                ),
+            )
+        self.assertIn('occurred_at', caught.exception.message_dict)
+
+    def test_holding_back_is_rejected_from_every_other_state(self):
+        """Only stock that is on offer can be taken off it."""
+        for priors in (
+                (),
+                (EventType.RETAINED,),
+                (EventType.READY, EventType.SOLD),
+                (EventType.READY, EventType.SOLD, EventType.RETURNED_QUARANTINED)):
+            with self.subTest(priors=priors):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                for prior in priors:
+                    record_lifecycle_event(plant, self.user, OutcomeRequest(prior))
+                with self.assertRaises(ValidationError) as caught:
+                    record_lifecycle_event(
+                        plant,
+                        self.user,
+                        OutcomeRequest(EventType.HELD_BACK, reason='Gone leggy.'),
+                    )
+                self.assertIn('event_type', caught.exception.message_dict)
+
+    def test_ending_a_retention_is_rejected_without_one_to_end(self):
+        """The fact names a retention, so there has to be one."""
+        for priors in ((), (EventType.READY,)):
+            with self.subTest(priors=priors):
+                plant = make_specific_plant()
+                record_germination_event(plant, self.user)
+                for prior in priors:
+                    record_lifecycle_event(plant, self.user, OutcomeRequest(prior))
+                with self.assertRaises(ValidationError) as caught:
+                    record_lifecycle_event(
+                        plant,
+                        self.user,
+                        OutcomeRequest(EventType.RETENTION_ENDED, reason='Back to stock.'),
+                    )
+                self.assertIn('event_type', caught.exception.message_dict)
+
+    def test_a_backward_fact_leaves_the_plant_where_it_stands(self):
+        """Withdrawing stock changes the plan for it, not its bench."""
+        location = make_specific_plant_location(specific_plant=self.plant)
+        self.held_back_plant()
+        location.refresh_from_db()
+        self.assertIsNone(location.ended)
+
+    def test_a_rejection_names_the_backward_fact_it_refused(self):
+        """The message reads as a sentence for the new vocabulary too."""
+        with self.assertRaises(ValidationError) as caught:
+            record_lifecycle_event(
+                self.plant,
+                self.user,
+                OutcomeRequest(EventType.HELD_BACK, reason='Gone leggy.'),
+            )
+        self.assertEqual(
+            caught.exception.message_dict['event_type'],
+            ['A growing plant cannot be recorded as held back from sale.'],
+        )

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -199,6 +199,51 @@ class LifecycleStateAnnotationTests(TestCase):
                 )
             plants[name] = plant
 
+        plants['held_back'] = self.germinated_plant(start)
+        record_lifecycle_event(
+            plants['held_back'],
+            self.user,
+            OutcomeRequest(EventType.READY, occurred_at=start + timedelta(days=1)),
+        )
+        record_lifecycle_event(
+            plants['held_back'],
+            self.user,
+            OutcomeRequest(
+                EventType.HELD_BACK,
+                occurred_at=start + timedelta(days=2),
+                reason='Gone leggy in the heat.',
+            ),
+        )
+
+        plants['offered_again'] = self.germinated_plant(start)
+        for day, event_type, reason in (
+                (1, EventType.READY, ''),
+                (2, EventType.HELD_BACK, 'Gone leggy in the heat.'),
+                (3, EventType.READY, '')):
+            record_lifecycle_event(
+                plants['offered_again'],
+                self.user,
+                OutcomeRequest(
+                    event_type, occurred_at=start + timedelta(days=day), reason=reason,
+                ),
+            )
+
+        plants['retention_ended'] = self.germinated_plant(start)
+        record_lifecycle_event(
+            plants['retention_ended'],
+            self.user,
+            OutcomeRequest(EventType.RETAINED, occurred_at=start + timedelta(days=1)),
+        )
+        record_lifecycle_event(
+            plants['retention_ended'],
+            self.user,
+            OutcomeRequest(
+                EventType.RETENTION_ENDED,
+                occurred_at=start + timedelta(days=2),
+                reason='Back into sale stock.',
+            ),
+        )
+
         plants['transplanted'] = self.germinated_plant(start)
         record_lifecycle_event(
             plants['transplanted'],


### PR DESCRIPTION
The only way to record a plant coming off offer was to reverse the `ready` fact, which appends a `corrected` event meaning "this was recorded in error." Holding a leggy batch back and returning a mother plant to sale stock are not errors, so the history was being made to say something untrue about routine nursery decisions, and the interval the plant was actually ready disappeared from it.

Add `held_back` and `retention_ended` as facts of their own. Both derive to `growing` rather than restoring whatever the plant was before, because deciding a plant is offerable is a judgement somebody makes and the `ready` that follows records it. That leaves `ready` permitted only from `growing`, so a repeated cycle reads as separate offers rather than as one fact recorded twice.

`retention_ended` deliberately does not mirror task 91's `released_available`, which returns straight to `available`: a quarantine release is an assessment of saleability, while ending a retention is not, and `retained` is reachable from `growing`, so a plant may never have been graded ready at all.

Both require a stated reason. `_require_reason` moves into `validate_outcome`, which every write path already funnels through, and the reason argument defaults to none so a caller that forgets to pass one refuses the fact rather than recording an unexplained withdrawal.

Neither fact needs a new `LifecycleState`, so the reachability invariant, the disposition map in costing, the register totals, and the frontend state labels are all untouched.

## Summary by Sourcery

Introduce explicit backward lifecycle events for plants leaving offer or retention, ensuring they are recorded as factual state changes with reasons rather than corrections.

New Features:
- Add HELD_BACK and RETENTION_ENDED lifecycle events to represent stock taken off offer and plants returning from retention to production.

Enhancements:
- Route backward lifecycle events to the growing state, preserving prior READY or RETAINED facts in history and keeping location handling unchanged.
- Enforce that backward lifecycle events always carry a non-blank reason, with validation wired through existing outcome checking APIs.

Deployment:
- Add a migration updating PlantLifecycleEvent event_type choices to include the new backward lifecycle events.

Tests:
- Add dedicated tests covering backward transitions, chronology and state rules, reason requirements, location behaviour, and error messaging for the new lifecycle events.