### PR TITLE
feat(plantings): offer backward transitions through the plant APIs

### DIFF
--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -14,8 +14,8 @@ from locations.occupancy import capacity_chain, location_occupancy
 
 from .batches import lock_batch_with_plants
 from .lifecycle import (
+    STATE_AFTER,
     EventType,
-    LifecycleState,
     OutcomeRequest,
     is_final,
     plant_lifecycle_summary,
@@ -40,6 +40,8 @@ ACTION_EVENTS = {
     BulkPlantOperation.Action.FAIL: EventType.FAILED,
     BulkPlantOperation.Action.CULL: EventType.CULLED,
     BulkPlantOperation.Action.FINISH_HARVEST: EventType.HARVEST_FINISHED,
+    BulkPlantOperation.Action.HOLD_BACK: EventType.HELD_BACK,
+    BulkPlantOperation.Action.END_RETENTION: EventType.RETENTION_ENDED,
 }
 
 
@@ -107,7 +109,12 @@ def _plant_conflicts(plant, request):
     """Return conflicts independent of aggregate destination capacity."""
     try:
         if request.action in ACTION_EVENTS:
-            validate_outcome(plant, ACTION_EVENTS[request.action], request.occurred_at)
+            validate_outcome(
+                plant,
+                ACTION_EVENTS[request.action],
+                request.occurred_at,
+                request.reason,
+            )
         elif request.action == BulkPlantOperation.Action.MOVE:
             active = (
                 SpecificPlantLocation.objects
@@ -189,16 +196,12 @@ def _load_plants(workspace, plant_ids, lock):
 
 
 def _projected_state(request):
-    """Return the state an eligible lifecycle action leaves behind."""
-    event = ACTION_EVENTS.get(request.action)
-    return {
-        EventType.READY: LifecycleState.AVAILABLE,
-        EventType.RETAINED: LifecycleState.RETAINED,
-        EventType.DONATED: LifecycleState.DONATED,
-        EventType.FAILED: LifecycleState.FAILED,
-        EventType.CULLED: LifecycleState.CULLED,
-        EventType.HARVEST_FINISHED: LifecycleState.HARVESTED,
-    }.get(event)
+    """Return the state an eligible lifecycle action leaves behind.
+
+    Read from `STATE_AFTER` rather than repeated here, so the preview cannot
+    describe a different outcome from the one the write actually derives.
+    """
+    return STATE_AFTER.get(ACTION_EVENTS.get(request.action))
 
 
 def _plant_preview(workspace, request, lock=False):  # pylint: disable=too-many-locals

--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -516,6 +516,10 @@ def reverse_lifecycle_event(event, user, reason, occurred_at=None):
     The original stays visible; the plant's state is re-derived from the facts
     that survive. A closed location is not reopened, because where a plant has
     been remains true — record the replacement location instead.
+
+    This says the fact was never true. Where it was true and the situation
+    then changed, record that instead: `BACKWARD_EVENTS` names the facts for
+    it, and they leave both intervals in the history rather than erasing one.
     """
     _require_reason(reason)
     plant = _lock_plant(event.plant)

--- a/plantings/lifecycle_rest.py
+++ b/plantings/lifecycle_rest.py
@@ -95,7 +95,12 @@ class BulkOutcomeSerializer(OutcomeSerializer):  # pylint: disable=abstract-meth
 
 
 class ReverseEventSerializer(ActionSerializer):  # pylint: disable=abstract-method
-    """Validate which recorded fact was wrong and why."""
+    """Validate which recorded fact was wrong and why.
+
+    The reason answers "why was this recorded in error", not "why did the
+    situation change". A plant that genuinely was ready and is now being held
+    back uses `hold-back`, which keeps both intervals in the history.
+    """
 
     event = serializers.IntegerField()
     reason = serializers.CharField(allow_blank=False, trim_whitespace=True)
@@ -209,9 +214,25 @@ class PlantOutcomeViewSetMixin:
         """Record the final harvest that ends this plant's cultivation."""
         return self._record_outcome(request, EventType.HARVEST_FINISHED)
 
+    @action(detail=True, methods=['post'], url_path='hold-back')
+    def hold_back(self, request, pk=None):  # pylint: disable=unused-argument
+        """Take this plant off offer without denying it was ever ready."""
+        return self._record_outcome(request, EventType.HELD_BACK)
+
+    @action(detail=True, methods=['post'], url_path='end-retention')
+    def end_retention(self, request, pk=None):  # pylint: disable=unused-argument
+        """Return a retained plant to production, to be graded ready again."""
+        return self._record_outcome(request, EventType.RETENTION_ENDED)
+
     @action(detail=True, methods=['post'], url_path='reverse-event')
     def reverse_event(self, request, pk=None):  # pylint: disable=unused-argument
-        """Correct a mistaken fact by appending its reversal."""
+        """Correct a mistaken fact by appending its reversal.
+
+        This is for a fact that was never true. Where the fact was true and
+        the situation then changed, record the change: `hold-back` withdraws
+        stock from offer and `end-retention` returns a retained plant to
+        production, and both leave the original fact standing.
+        """
         values = _action_values(request, ReverseEventSerializer)
         plant = self.get_object()
         event = get_object_or_404(

--- a/plantings/migrations/0040_backward_bulk_actions.py
+++ b/plantings/migrations/0040_backward_bulk_actions.py
@@ -1,0 +1,32 @@
+"""Offer the backward lifecycle facts through the reviewed bulk path."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [('plantings', '0039_backward_lifecycle_events')]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bulkplantoperation',
+            name='action',
+            field=models.CharField(
+                choices=[
+                    ('germinate', 'Germinate'),
+                    ('move', 'Move or transplant'),
+                    ('stage', 'Update growth stage'),
+                    ('grade', 'Update grade'),
+                    ('repot', 'Pot on or repot'),
+                    ('ready', 'Ready'),
+                    ('retain', 'Retain'),
+                    ('donate', 'Donate'),
+                    ('fail', 'Fail'),
+                    ('cull', 'Cull'),
+                    ('finish_harvest', 'Finish harvest'),
+                    ('hold_back', 'Hold back'),
+                    ('end_retention', 'End retention'),
+                ],
+                max_length=24,
+            ),
+        ),
+    ]

--- a/plantings/models.py
+++ b/plantings/models.py
@@ -1429,6 +1429,8 @@ class BulkPlantOperation(WorkspaceOwnedModel):
         FAIL = 'fail', 'Fail'
         CULL = 'cull', 'Cull'
         FINISH_HARVEST = 'finish_harvest', 'Finish harvest'
+        HOLD_BACK = 'hold_back', 'Hold back'
+        END_RETENTION = 'end_retention', 'End retention'
 
     class Atomicity(models.TextChoices):
         """How conflicts in a confirmed selection are handled."""

--- a/plantings/test_bulk_rest.py
+++ b/plantings/test_bulk_rest.py
@@ -24,7 +24,12 @@ from tests.factories import (
 )
 from workspaces.models import Workspace
 
-from .lifecycle import EventType, OutcomeRequest, record_lifecycle_event
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    record_lifecycle_event,
+)
 from .bulk_operations import BulkOperationConflict, concrete_request, execute_bulk_operation
 from .growth import current_growth
 from .models import (
@@ -85,6 +90,51 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
         self.assertEqual(response.data['conflicts'], 1)
         self.assertEqual(PlantLifecycleEvent.objects.count(), before)
         self.assertFalse(BulkPlantOperation.objects.exists())
+
+    def test_holding_a_selection_back_projects_and_records_growing(self):
+        """The preview's resulting state comes from the same map the write does."""
+        for plant in self.plants:
+            record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        payload = self.payload(
+            BulkPlantOperation.Action.HOLD_BACK,
+            reason='The whole batch has gone leggy.',
+        )
+        preview = self.client.post(
+            '/plantings/bulk-operations/preview/', payload, format='json',
+        )
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(preview.data['eligible'], 3)
+        self.assertEqual(
+            {row['after']['lifecycle_state'] for row in preview.data['plants']},
+            {LifecycleState.GROWING},
+        )
+        response = self.client.post(
+            '/plantings/bulk-operations/', payload, format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(
+            PlantLifecycleEvent.objects.filter(
+                event_type=EventType.HELD_BACK,
+            ).count(),
+            3,
+        )
+
+    def test_a_bulk_backward_action_without_a_reason_conflicts_on_review(self):
+        """The missing reason surfaces in the preview, not at apply time."""
+        for plant in self.plants:
+            record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        payload = self.payload(BulkPlantOperation.Action.HOLD_BACK, reason='')
+        response = self.client.post(
+            '/plantings/bulk-operations/preview/', payload, format='json',
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data['eligible'], 0)
+        self.assertEqual(response.data['conflicts'], 3)
+        self.assertFalse(
+            PlantLifecycleEvent.objects.filter(
+                event_type=EventType.HELD_BACK,
+            ).exists(),
+        )
 
     def test_all_or_nothing_conflict_applies_and_audits_nothing(self):
         """A rejected confirmed attempt is not retained as an operation."""

--- a/plantings/test_lifecycle_rest.py
+++ b/plantings/test_lifecycle_rest.py
@@ -199,18 +199,28 @@ class PlantOutcomeActionTests(PlantLifecycleRESTTestCase):
     """Each explicit outcome action appends one auditable event."""
 
     def test_every_outcome_action_records_its_event(self):
-        """The named actions cover the recordable dispositions."""
+        """The named actions cover the recordable dispositions.
+
+        The backward facts carry the state they are recorded from, because
+        holding back names an offer and ending a retention names a retention.
+        """
         actions = {
-            'ready': EventType.READY,
-            'retain': EventType.RETAINED,
-            'fail': EventType.FAILED,
-            'cull': EventType.CULLED,
-            'donate': EventType.DONATED,
-            'finish-harvest': EventType.HARVEST_FINISHED,
+            'ready': ((), EventType.READY),
+            'retain': ((), EventType.RETAINED),
+            'fail': ((), EventType.FAILED),
+            'cull': ((), EventType.CULLED),
+            'donate': ((), EventType.DONATED),
+            'finish-harvest': ((), EventType.HARVEST_FINISHED),
+            'hold-back': (('ready',), EventType.HELD_BACK),
+            'end-retention': (('retain',), EventType.RETENTION_ENDED),
         }
-        for outcome, event_type in actions.items():
+        for outcome, (priors, event_type) in actions.items():
             with self.subTest(outcome=outcome):
                 plant = make_specific_plant()
+                for prior in priors:
+                    self.assertEqual(
+                        self.post_outcome(plant.pk, prior).status_code, 201,
+                    )
                 response = self.post_outcome(
                     plant.pk,
                     outcome,
@@ -319,6 +329,79 @@ class PlantEventReversalActionTests(PlantLifecycleRESTTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class BackwardTransitionActionTests(PlantLifecycleRESTTestCase):
+    """Withdrawing stock is offered beside the correction, not through it."""
+
+    def test_holding_back_returns_the_plant_to_production(self):
+        """The plant stops being sellable without becoming resolved."""
+        self.post_outcome(self.plant.pk, 'ready')
+        response = self.post_outcome(
+            self.plant.pk, 'hold-back', {'reason': 'Gone leggy in the heat.'},
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        data = self.get_plant(self.plant.pk)
+        self.assertEqual(data['lifecycle_state'], LifecycleState.GROWING)
+        self.assertFalse(data['sellable'])
+        self.assertIsNone(data['final_outcome'])
+
+    def test_holding_back_leaves_the_ready_fact_uncorrected(self):
+        """This is the whole distinction: the plant really was ready."""
+        ready = self.post_outcome(self.plant.pk, 'ready').data
+        self.post_outcome(
+            self.plant.pk, 'hold-back', {'reason': 'Gone leggy in the heat.'},
+        )
+        history = {
+            event['pk']: event
+            for event in self.get_plant(self.plant.pk)['lifecycle_events']
+        }
+        self.assertIsNone(history[ready['pk']]['reversed_by'])
+        self.assertEqual(
+            [event['event_type'] for event in history.values()],
+            [EventType.READY, EventType.HELD_BACK],
+        )
+
+    def test_a_backward_action_requires_a_reason(self):
+        """The API refuses an unexplained withdrawal, as the service does."""
+        for outcome, prior in (('hold-back', 'ready'), ('end-retention', 'retain')):
+            with self.subTest(outcome=outcome):
+                plant = make_specific_plant()
+                self.post_outcome(plant.pk, prior)
+                response = self.post_outcome(plant.pk, outcome)
+                self.assertEqual(response.status_code, 400, response.data)
+                self.assertIn('reason', response.data)
+
+    def test_a_backward_action_is_refused_from_the_wrong_state(self):
+        """Only stock on offer can be held back."""
+        response = self.post_outcome(
+            self.plant.pk, 'hold-back', {'reason': 'Gone leggy in the heat.'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('event_type', response.data)
+
+    def test_a_backward_action_leaves_the_location_alone(self):
+        """Withdrawing stock changes the plan for it, not its bench."""
+        self.post_outcome(self.plant.pk, 'ready')
+        self.post_outcome(
+            self.plant.pk, 'hold-back', {'reason': 'Gone leggy in the heat.'},
+        )
+        self.location.refresh_from_db()
+        self.assertIsNone(self.location.ended)
+
+    def test_a_held_back_plant_is_offered_again_by_grading_it(self):
+        """A repeated cycle is three facts, not one fact recorded twice."""
+        self.post_outcome(self.plant.pk, 'ready')
+        self.post_outcome(
+            self.plant.pk, 'hold-back', {'reason': 'Gone leggy in the heat.'},
+        )
+        self.assertEqual(self.post_outcome(self.plant.pk, 'ready').status_code, 201)
+        data = self.get_plant(self.plant.pk)
+        self.assertEqual(data['lifecycle_state'], LifecycleState.AVAILABLE)
+        self.assertEqual(
+            [event['event_type'] for event in data['lifecycle_events']],
+            [EventType.READY, EventType.HELD_BACK, EventType.READY],
+        )
+
+
 class BulkPlantOutcomeActionTests(PlantLifecycleRESTTestCase):
     """A selected list of plants yields one event per plant."""
 
@@ -393,3 +476,33 @@ class BulkPlantOutcomeActionTests(PlantLifecycleRESTTestCase):
         })
         self.assertEqual(response.status_code, 400)
         self.assertIn('event_type', response.data)
+
+    def test_a_backward_fact_is_bulk_recordable_with_a_reason(self):
+        """Grading a whole batch down is the case this exists for."""
+        for plant_id in self.plant_ids:
+            self.post_outcome(plant_id, 'ready')
+        response = self._post_bulk({
+            'plants': self.plant_ids,
+            'event_type': EventType.HELD_BACK,
+            'reason': 'The whole batch has gone leggy.',
+        })
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(len(response.data), len(self.plant_ids))
+        for event in response.data:
+            self.assertEqual(event['event_type'], EventType.HELD_BACK)
+
+    def test_a_bulk_backward_fact_without_a_reason_records_nothing(self):
+        """The reason rule holds for the selection as it does for one plant."""
+        for plant_id in self.plant_ids:
+            self.post_outcome(plant_id, 'ready')
+        response = self._post_bulk({
+            'plants': self.plant_ids,
+            'event_type': EventType.HELD_BACK,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('plants', response.data)
+        self.assertFalse(
+            PlantLifecycleEvent.objects.filter(
+                event_type=EventType.HELD_BACK,
+            ).exists(),
+        )


### PR DESCRIPTION
`held_back` and `retention_ended` were recordable only by calling the service directly. Give them the same surfaces every other outcome has: a named detail action, a place in the reviewed bulk path, and the bulk-outcome selection they already qualified for through `OUTCOME_EVENTS`.

The bulk preview had its own copy of `STATE_AFTER`, listing six of the thirteen state-changing facts. It returned nothing for the new ones, so the "after" column silently fell back to the plant's current state and showed a review that disagreed with the write it was previewing. Read the projection from `STATE_AFTER` instead, so the two cannot diverge again.

The reason now reaches `validate_outcome` from the bulk path too, which puts a missing one in front of the operator as a per-plant conflict during review rather than as a failure at apply time.

`reverse-event` keeps its behaviour and gains documentation saying what it is for: a fact that was never true, as distinct from one that was true and then stopped being so.

## Summary by Sourcery

Expose backward lifecycle outcomes (holding back and ending retention) through both single-plant and reviewed bulk APIs while aligning bulk preview state projection with the core lifecycle mapping.

New Features:
- Add per-plant REST actions to hold back ready plants and end retention for retained plants, recording corresponding lifecycle events.
- Allow backward lifecycle facts to be applied via the reviewed bulk operations flow, including UI-facing bulk actions for hold-back and end-retention.

Bug Fixes:
- Ensure bulk operation previews derive projected lifecycle state from the central STATE_AFTER mapping so previews and applied outcomes stay consistent.
- Surface missing reasons for backward lifecycle bulk actions as per-plant conflicts during preview instead of failing at apply time.

Enhancements:
- Clarify and extend documentation around reverse-event to distinguish corrections of erroneous facts from legitimate backward lifecycle transitions.
- Extend outcome validation to consider the provided reason for backward events and enforce appropriate preconditions on plant state.

Tests:
- Add REST lifecycle tests covering backward per-plant actions, their state effects, and required reasons.
- Add bulk REST tests verifying backward actions are previewed and applied correctly, including reason handling and event recording behavior.