### PR TITLE
feat(plantings): report availability intervals

### DIFF
--- a/plantings/lifecycle.py
+++ b/plantings/lifecycle.py
@@ -195,6 +195,7 @@ class LifecycleSummary(NamedTuple):
     sellable: bool
     final_outcome: object = None
     final_outcome_at: object = None
+    state_since: object = None
 
 
 class OutcomeRequest(NamedTuple):
@@ -245,27 +246,35 @@ def states_without_exits(state_after=None, allowed_from=None, final_states=None)
     }
 
 
-def derive_state(events):
-    """Replay one plant's facts into its current summary.
+def _surviving_state_events(events):
+    """Return one plant's state-changing facts a correction has not struck.
 
-    Reversed events and the corrections that reverse them are both skipped, so
-    a correction restores whatever the surviving facts imply.
+    Reversed events and the corrections that reverse them are both dropped, so
+    a correction restores whatever the surviving facts imply. Everything that
+    replays a history starts here, so no two readings can disagree about which
+    facts still count.
     """
     corrected_ids = {
         event.reversal_of_id
         for event in events
         if event.reversal_of_id is not None
     }
+    return [
+        event
+        for event in sorted(events, key=lambda event: (event.occurred_at, event.pk))
+        if event.pk not in corrected_ids and event.event_type in STATE_AFTER
+    ]
+
+
+def derive_state(events):
+    """Replay one plant's facts into its current summary."""
     state = LifecycleState.GROWING
     outcome = None
     outcome_at = None
-    for event in sorted(events, key=lambda event: (event.occurred_at, event.pk)):
-        if event.pk in corrected_ids:
-            continue
-        next_state = STATE_AFTER.get(event.event_type)
-        if next_state is None:
-            continue
-        state = next_state
+    state_since = None
+    for event in _surviving_state_events(events):
+        state = STATE_AFTER[event.event_type]
+        state_since = event.occurred_at
         if is_final(state):
             outcome, outcome_at = event.event_type, event.occurred_at
         else:
@@ -275,12 +284,52 @@ def derive_state(events):
         sellable=state in SELLABLE_STATES,
         final_outcome=outcome,
         final_outcome_at=outcome_at,
+        state_since=state_since,
     )
+
+
+class AvailabilityInterval(NamedTuple):
+    """One span a plant spent offerable, open-ended while it still is."""
+
+    started: object
+    ended: object = None
+
+
+def availability_intervals(events):
+    """Return every span this plant was offerable, oldest first.
+
+    A plant graded ready, held back, and graded ready again produces two
+    spans, so a screen can report how long stock has actually been on offer
+    rather than only the state the newest fact left behind. A correction
+    strikes its target out of the replay, so a `ready` recorded in error
+    leaves no span at all, while holding back leaves a closed one.
+    """
+    intervals = []
+    started = None
+    for event in _surviving_state_events(events):
+        offerable = STATE_AFTER[event.event_type] in SELLABLE_STATES
+        if offerable and started is None:
+            started = event.occurred_at
+        elif not offerable and started is not None:
+            intervals.append(AvailabilityInterval(started, event.occurred_at))
+            started = None
+    if started is not None:
+        intervals.append(AvailabilityInterval(started))
+    return intervals
 
 
 #: The facts `derive_state` reads. Every other event type records something that
 #: happened without changing the condition it leaves behind.
 STATE_EVENT_TYPES = tuple(STATE_AFTER)
+
+#: The facts that put a plant on offer. Derived rather than listed, so a fact
+#: added to `STATE_AFTER` with a sellable destination cannot be missed by the
+#: first-offered date the register reports.
+OFFERING_EVENTS = tuple(
+    event_type
+    for event_type, state in STATE_AFTER.items()
+    if state in SELLABLE_STATES
+)
 
 
 def effective_state_events(plant_ref):
@@ -309,13 +358,28 @@ def with_lifecycle_state(queryset):
     result filterable, sortable, countable, and pageable in the database. The
     two derivations share `STATE_AFTER`, `FINAL_STATES`, and `SELLABLE_STATES`
     so neither can quietly describe a different vocabulary from the other.
+
+    `first_ready_at` is the oldest surviving offering fact, which is the start
+    of the first span `availability_intervals` reports, and `last_state_at`
+    says when the current state began. Between them a screen can tell stock
+    held back yesterday from stock held back in March.
     """
     events = effective_state_events(OuterRef('pk'))
+    offers = (
+        PlantLifecycleEvent.objects
+        .filter(
+            plant=OuterRef('pk'),
+            event_type__in=OFFERING_EVENTS,
+            reversal__isnull=True,
+        )
+        .order_by('occurred_at', 'pk')
+    )
     return (
         queryset
         .annotate(
             last_state_event=Subquery(events.values('event_type')[:1]),
             last_state_at=Subquery(events.values('occurred_at')[:1]),
+            first_ready_at=Subquery(offers.values('occurred_at')[:1]),
         )
         .annotate(
             lifecycle_state=Case(

--- a/plantings/lifecycle_rest.py
+++ b/plantings/lifecycle_rest.py
@@ -19,6 +19,7 @@ from .lifecycle import (
     OUTCOME_EVENTS,
     EventType,
     OutcomeRequest,
+    availability_intervals,
     plant_lifecycle_summary,
     record_bulk_outcome,
     record_lifecycle_event,
@@ -150,6 +151,8 @@ class PlantLifecycleSerializerMixin:
         'sellable',
         'final_outcome',
         'final_outcome_at',
+        'state_since',
+        'first_ready_at',
     ]
 
     def _summary(self, plant):
@@ -158,6 +161,14 @@ class PlantLifecycleSerializerMixin:
         if cached is None:
             cached = plant_lifecycle_summary(plant)
             setattr(plant, '_lifecycle_summary', cached)
+        return cached
+
+    def _intervals(self, plant):
+        """Derive one plant's offered spans at most once per response."""
+        cached = getattr(plant, '_lifecycle_intervals', None)
+        if cached is None:
+            cached = availability_intervals(list(plant.lifecycle_events.all()))
+            setattr(plant, '_lifecycle_intervals', cached)
         return cached
 
     def get_lifecycle_state(self, plant):
@@ -175,6 +186,26 @@ class PlantLifecycleSerializerMixin:
     def get_final_outcome_at(self, plant):
         """Return when this plant was resolved, if it has been."""
         return self._summary(plant).final_outcome_at
+
+    def get_state_since(self, plant):
+        """Return when the plant's current state began."""
+        return self._summary(plant).state_since
+
+    def get_first_ready_at(self, plant):
+        """Return when this plant was first offered, if it ever was."""
+        intervals = self._intervals(plant)
+        return intervals[0].started if intervals else None
+
+    def get_availability_intervals(self, plant):
+        """Return every span this plant was offered, oldest first.
+
+        A held-back plant offered again has more than one, so the repeated
+        cycle stays readable where only the latest state would hide it.
+        """
+        return [
+            {'started': interval.started, 'ended': interval.ended}
+            for interval in self._intervals(plant)
+        ]
 
 
 class PlantOutcomeViewSetMixin:

--- a/plantings/register.py
+++ b/plantings/register.py
@@ -46,6 +46,8 @@ ORDERINGS = {
     'standing_at': ('standing_at_label', 'pk'),
     'cost': ('cost', 'pk'),
     'state': ('lifecycle_state', 'pk'),
+    'state_since': ('last_state_at', 'pk'),
+    'first_ready': ('first_ready_at', 'pk'),
     'batch': ('batch_code', 'pk'),
     'germinated': ('germinated', 'pk'),
     'expected_ready': ('current_expected_ready', 'pk'),

--- a/plantings/register_rest.py
+++ b/plantings/register_rest.py
@@ -82,6 +82,12 @@ class NurseryRegisterSerializer(serializers.Serializer):  # pylint: disable=abst
     germinated = serializers.DateTimeField(read_only=True)
     age_days = serializers.SerializerMethodField()
     lifecycle_state = serializers.CharField(read_only=True)
+    state_since = serializers.DateTimeField(
+        source='last_state_at',
+        read_only=True,
+        allow_null=True,
+    )
+    first_ready_at = serializers.DateTimeField(read_only=True, allow_null=True)
     sellable = serializers.BooleanField(read_only=True)
     quarantined = serializers.BooleanField(read_only=True)
     reserved = serializers.BooleanField(read_only=True)

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -474,6 +474,8 @@ class SpecificPlantSerializer(PlantLifecycleSerializerMixin, CurrentWorkspaceSer
     sellable = serializers.SerializerMethodField()
     final_outcome = serializers.SerializerMethodField()
     final_outcome_at = serializers.SerializerMethodField()
+    state_since = serializers.SerializerMethodField()
+    first_ready_at = serializers.SerializerMethodField()
     label_code = serializers.SerializerMethodField()
 
     class Meta:
@@ -545,12 +547,13 @@ class SpecificPlantDetailSerializer(SpecificPlantSerializer):
     """Add the chronological lifecycle history one plant screen needs."""
 
     lifecycle_events = PlantLifecycleEventSerializer(many=True, read_only=True)
+    availability_intervals = serializers.SerializerMethodField()
     growth = serializers.SerializerMethodField()
     nursery_observations = serializers.SerializerMethodField()
 
     class Meta(SpecificPlantSerializer.Meta):
         fields = SpecificPlantSerializer.Meta.fields + [
-            'lifecycle_events', 'growth', 'nursery_observations',
+            'lifecycle_events', 'availability_intervals', 'growth', 'nursery_observations',
         ]
 
     def get_growth(self, plant):

--- a/plantings/test_backward_transitions.py
+++ b/plantings/test_backward_transitions.py
@@ -13,9 +13,11 @@ from .lifecycle import (
     EventType,
     LifecycleState,
     OutcomeRequest,
+    availability_intervals,
     plant_lifecycle_summary,
     record_germination_event,
     record_lifecycle_event,
+    reverse_lifecycle_event,
 )
 
 
@@ -203,3 +205,117 @@ class BackwardTransitionTests(TestCase):
             caught.exception.message_dict['event_type'],
             ['A growing plant cannot be recorded as held back from sale.'],
         )
+
+
+class AvailabilityIntervalTests(TestCase):
+    """A repeated cycle is reported as spans, not as one latest state."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username='interval')
+        self.start = timezone.now() - timedelta(days=30)
+        self.plant = make_specific_plant(germinated=self.start)
+        record_germination_event(self.plant, self.user)
+
+    def record(self, event_type, day, reason=''):
+        """Record one fact a fixed number of days into the history."""
+        return record_lifecycle_event(
+            self.plant,
+            self.user,
+            OutcomeRequest(
+                event_type,
+                occurred_at=self.start + timedelta(days=day),
+                reason=reason,
+            ),
+        )
+
+    def intervals(self):
+        """Return the plant's offered spans as recorded so far."""
+        return availability_intervals(list(self.plant.lifecycle_events.all()))
+
+    def test_a_plant_never_offered_has_no_intervals(self):
+        """Growing stock has not been on offer at all."""
+        self.assertEqual(self.intervals(), [])
+
+    def test_an_offered_plant_has_one_open_interval(self):
+        """Stock currently on offer has no end date yet."""
+        self.record(EventType.READY, 1)
+        intervals = self.intervals()
+        self.assertEqual(len(intervals), 1)
+        self.assertEqual(intervals[0].started, self.start + timedelta(days=1))
+        self.assertIsNone(intervals[0].ended)
+
+    def test_holding_back_closes_the_interval_it_ends(self):
+        """The plant was ready for exactly that long, and the span says so."""
+        self.record(EventType.READY, 1)
+        self.record(EventType.HELD_BACK, 5, reason='Gone leggy in the heat.')
+        self.assertEqual(
+            self.intervals(),
+            [(self.start + timedelta(days=1), self.start + timedelta(days=5))],
+        )
+
+    def test_a_repeated_cycle_reports_every_offer(self):
+        """This is what only the latest state cannot show."""
+        self.record(EventType.READY, 1)
+        self.record(EventType.HELD_BACK, 5, reason='Gone leggy in the heat.')
+        self.record(EventType.READY, 12)
+        self.record(EventType.HELD_BACK, 20, reason='Wanted for next season.')
+        self.record(EventType.READY, 25)
+        intervals = self.intervals()
+        self.assertEqual(len(intervals), 3)
+        self.assertEqual(
+            [interval.ended for interval in intervals],
+            [
+                self.start + timedelta(days=5),
+                self.start + timedelta(days=20),
+                None,
+            ],
+        )
+
+    def test_a_correction_leaves_no_interval_where_holding_back_leaves_one(self):
+        """The two mechanisms are told apart by what the history keeps."""
+        mistake = self.record(EventType.READY, 1)
+        reverse_lifecycle_event(
+            mistake,
+            self.user,
+            'Recorded against the wrong plant.',
+            occurred_at=self.start + timedelta(days=2),
+        )
+        self.assertEqual(self.intervals(), [])
+
+        other = make_specific_plant(germinated=self.start)
+        record_germination_event(other, self.user)
+        for event_type, day, reason in (
+                (EventType.READY, 1, ''),
+                (EventType.HELD_BACK, 2, 'Gone leggy in the heat.')):
+            record_lifecycle_event(
+                other,
+                self.user,
+                OutcomeRequest(
+                    event_type,
+                    occurred_at=self.start + timedelta(days=day),
+                    reason=reason,
+                ),
+            )
+        self.assertEqual(
+            len(availability_intervals(list(other.lifecycle_events.all()))),
+            1,
+        )
+
+    def test_a_sale_closes_the_interval_and_a_return_opens_another(self):
+        """Every fact reaching a sellable state starts a span, not only ready."""
+        self.record(EventType.READY, 1)
+        self.record(EventType.SOLD, 5)
+        self.record(EventType.RETURNED_AVAILABLE, 9)
+        intervals = self.intervals()
+        self.assertEqual(len(intervals), 2)
+        self.assertEqual(intervals[0].ended, self.start + timedelta(days=5))
+        self.assertEqual(intervals[1].started, self.start + timedelta(days=9))
+
+    def test_the_summary_reports_when_the_current_state_began(self):
+        """A screen can tell stock held back yesterday from stock held in March."""
+        self.record(EventType.READY, 1)
+        self.record(EventType.HELD_BACK, 5, reason='Gone leggy in the heat.')
+        summary = plant_lifecycle_summary(self.plant)
+        self.assertEqual(summary.state, LifecycleState.GROWING)
+        self.assertEqual(summary.state_since, self.start + timedelta(days=5))

--- a/plantings/test_lifecycle.py
+++ b/plantings/test_lifecycle.py
@@ -30,6 +30,7 @@ from .lifecycle import (
     LifecycleState,
     OutcomeRequest,
     STATE_AFTER,
+    availability_intervals,
     lifecycle_summaries,
     plant_lifecycle_summary,
     record_bulk_outcome,
@@ -281,7 +282,14 @@ class LifecycleStateAnnotationTests(TestCase):
             SpecificPlant.objects.filter(pk__in=[plant.pk for plant in plants]),
         )
         return {
-            row.pk: (row.lifecycle_state, row.sellable, row.final_outcome, row.final_outcome_at)
+            row.pk: (
+                row.lifecycle_state,
+                row.sellable,
+                row.final_outcome,
+                row.final_outcome_at,
+                row.last_state_at,
+                row.first_ready_at,
+            )
             for row in queryset
         }
 
@@ -293,22 +301,35 @@ class LifecycleStateAnnotationTests(TestCase):
         for name, plant in plants.items():
             with self.subTest(history=name):
                 summary = replayed[plant.pk]
+                intervals = availability_intervals(list(plant.lifecycle_events.all()))
                 self.assertEqual(
                     annotated[plant.pk],
-                    (summary.state, summary.sellable, summary.final_outcome, summary.final_outcome_at),
+                    (
+                        summary.state,
+                        summary.sellable,
+                        summary.final_outcome,
+                        summary.final_outcome_at,
+                        summary.state_since,
+                        intervals[0].started if intervals else None,
+                    ),
                 )
 
     def test_the_population_exercises_every_derived_state(self):
         """A new state cannot be added without being compared here."""
         plants = self.population()
-        derived = {state for state, _, _, _ in self.annotated(plants.values()).values()}
+        derived = {state for state, *_ in self.annotated(plants.values()).values()}
         self.assertEqual(derived, {state.value for state in LifecycleState})
 
     def test_a_correction_returns_the_annotation_to_the_surviving_facts(self):
         """A reversed outcome stops counting the moment it is corrected."""
         plants = self.population()
-        annotated = self.annotated([plants['corrected']])[plants['corrected'].pk]
-        self.assertEqual(annotated, (LifecycleState.AVAILABLE, True, None, None))
+        plant = plants['corrected']
+        ready_at = plant.lifecycle_events.get(event_type=EventType.READY).occurred_at
+        annotated = self.annotated([plant])[plant.pk]
+        self.assertEqual(
+            annotated,
+            (LifecycleState.AVAILABLE, True, None, None, ready_at, ready_at),
+        )
 
 
 class LifecycleTransitionTests(TestCase):

--- a/plantings/test_lifecycle_rest.py
+++ b/plantings/test_lifecycle_rest.py
@@ -387,6 +387,21 @@ class BackwardTransitionActionTests(PlantLifecycleRESTTestCase):
         self.location.refresh_from_db()
         self.assertIsNone(self.location.ended)
 
+    def test_the_detail_reports_every_span_the_plant_was_offered(self):
+        """Only the latest state would hide the second offer entirely."""
+        self.post_outcome(self.plant.pk, 'ready')
+        self.post_outcome(
+            self.plant.pk, 'hold-back', {'reason': 'Gone leggy in the heat.'},
+        )
+        self.post_outcome(self.plant.pk, 'ready')
+        data = self.get_plant(self.plant.pk)
+        intervals = data['availability_intervals']
+        self.assertEqual(len(intervals), 2)
+        self.assertIsNotNone(intervals[0]['ended'])
+        self.assertIsNone(intervals[1]['ended'])
+        self.assertEqual(data['first_ready_at'], intervals[0]['started'])
+        self.assertEqual(data['state_since'], intervals[1]['started'])
+
     def test_a_held_back_plant_is_offered_again_by_grading_it(self):
         """A repeated cycle is three facts, not one fact recorded twice."""
         self.post_outcome(self.plant.pk, 'ready')

--- a/plantings/test_register.py
+++ b/plantings/test_register.py
@@ -161,6 +161,7 @@ class RegisterContractTests(RegisterTestCase):
             'expected_ready',
             'final_outcome',
             'final_outcome_at',
+            'first_ready_at',
             'garden_square',
             'germinated',
             'grade',
@@ -183,6 +184,7 @@ class RegisterContractTests(RegisterTestCase):
             'stage_overdue',
             'standing_at',
             'standing_at_label',
+            'state_since',
             'variety',
             'variety_name',
         ])


### PR DESCRIPTION
A plant graded ready, held back, and graded ready again showed one state and one date. The two offers, and the gap between them, were only recoverable by reading the raw event table — which is exactly the information the backward facts were added to preserve.

Derive the spans instead. `availability_intervals` replays the surviving facts and reports every period the plant was offerable, open-ended while it still is; a correction strikes its target out, so a `ready` recorded in error leaves no span, while holding back leaves a closed one. That difference is now observable rather than argued for.

`derive_state` and the new derivation share `_surviving_state_events`, so the "which facts still count" rule is written once. The summary gains `state_since`, and the SQL annotation gains `first_ready_at` from `OFFERING_EVENTS` — derived from `STATE_AFTER` and `SELLABLE_STATES` rather than listed, so a future fact reaching `available` cannot be missed. The parity test now compares all six values, not four.

The register exposes `state_since` and `first_ready_at` as columns and as orderings, so stock held back yesterday sorts apart from stock held back in March. The plant detail carries the full interval list.

## Summary by Sourcery

Track and expose when plants are first offered for sale and how long they remain offerable across repeated cycles, and surface these intervals and timestamps through annotations, serializers, and the nursery register.

New Features:
- Introduce availability interval derivation that replays surviving lifecycle events to compute each span a plant was offerable.
- Expose the list of availability intervals, the timestamp when the current state began, and when a plant was first offered via REST plant detail endpoints and serializers.
- Add register columns and sort orders for state_since and first_ready to distinguish how long stock has been in its current state.

Enhancements:
- Refactor lifecycle state derivation to share a surviving-events helper and to track when the current state began.
- Extend lifecycle annotations with first_ready_at and last_state_at derived from consistent rules shared with in-memory derivations.

Tests:
- Add unit and API tests covering availability interval derivation, first-offer timestamps, state_since, and alignment between database annotations and in-code derivations.