### PR TITLE
feat(frontend): separate holding back from correcting

### DIFF
--- a/frontend/js/plantings/bulk_operations.tsx
+++ b/frontend/js/plantings/bulk_operations.tsx
@@ -10,6 +10,7 @@ import { queryKeys } from '../query'
 import { Location } from '../types/locations'
 import { BulkPlantAction, BulkPlantAtomicity, BulkPlantOperationRequest, BulkPlantPreview, NurseryRegisterFilters } from '../types/plantings'
 import { localDatetimeInputValue, parseLocalDatetimeInput } from '../utils'
+import { STATE_LABELS } from './lifecycle'
 import { EMPTY_SELECTION, RegisterSelection } from './register_list'
 
 const ACTIONS: Array<{ value: BulkPlantAction; label: string }> = [
@@ -18,7 +19,9 @@ const ACTIONS: Array<{ value: BulkPlantAction; label: string }> = [
   { value: 'grade', label: 'Update grade' },
   { value: 'repot', label: 'Pot on or repot' },
   { value: 'ready', label: 'Mark ready' },
+  { value: 'hold_back', label: 'Hold back from sale' },
   { value: 'retain', label: 'Retain' },
+  { value: 'end_retention', label: 'End retention' },
   { value: 'donate', label: 'Donate' },
   { value: 'fail', label: 'Record failed' },
   { value: 'cull', label: 'Cull' },
@@ -408,9 +411,9 @@ function BulkOperationPanel({ selection, filters, locations, setSelection, sourc
                   {preview.plants.slice(0, 100).map((row) => (
                     <tr key={row.plant}>
                       <td>#{row.plant}</td>
-                      <td>{row.before.lifecycle_state}</td>
+                      <td>{STATE_LABELS[row.before.lifecycle_state]}</td>
                       <td>
-                        {row.after.lifecycle_state}
+                        {STATE_LABELS[row.after.lifecycle_state]}
                         {row.after.location_type ? ` at ${row.after.location_type.replaceAll('_', ' ')}` : ''}
                       </td>
                       <td>{row.eligible ? 'Eligible' : row.conflicts.join(' ')}</td>

--- a/frontend/js/plantings/lifecycle.tsx
+++ b/frontend/js/plantings/lifecycle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Badge, Button, Table } from 'react-bootstrap'
 
 import { formatDateTime } from '../utils'
-import { PlantLifecycleEvent, PlantLifecycleEventType, PlantLifecycleState, PlantOutcomeAction, SpecificPlant } from '../types/plantings'
+import { AvailabilityInterval, PlantLifecycleEvent, PlantLifecycleEventType, PlantLifecycleState, PlantOutcomeAction, SpecificPlant } from '../types/plantings'
 
 // Every derived state and recorded fact the server can report, including the
 // ones sales and health produce. The Record types make tsc refuse a state or an
@@ -50,19 +50,47 @@ const EVENT_LABELS: Record<PlantLifecycleEventType, string> = {
   returned_quarantined: 'Returned quarantined',
   returned_discarded: 'Returned discarded',
   released_available: 'Released from quarantine',
+  held_back: 'Held back from sale',
+  retention_ended: 'Retention ended',
   corrected: 'Corrected'
 }
 
-// Actions offered on a plant that has not yet been resolved. `ready` is only
-// meaningful while a plant is still growing, so it is filtered out below.
+// Every action the server offers on a plant. Which of them apply depends on
+// the state, so nothing here is offered unconditionally; availableActions
+// below mirrors the server's ALLOWED_FROM.
 const OUTCOME_ACTIONS: Array<{ action: PlantOutcomeAction; label: string; variant: string }> = [
   { action: 'ready', label: 'Ready', variant: 'outline-success' },
+  { action: 'hold-back', label: 'Hold back', variant: 'outline-warning' },
   { action: 'retain', label: 'Retain', variant: 'outline-primary' },
+  { action: 'end-retention', label: 'End retention', variant: 'outline-primary' },
   { action: 'finish-harvest', label: 'Harvested', variant: 'outline-primary' },
   { action: 'fail', label: 'Failed', variant: 'outline-danger' },
   { action: 'cull', label: 'Cull', variant: 'outline-danger' },
   { action: 'donate', label: 'Donate', variant: 'outline-info' }
 ]
+
+// The backward facts. Each says the situation changed rather than that
+// something was recorded wrongly, and the server refuses one without a reason.
+const REASON_REQUIRED_ACTIONS: Array<PlantOutcomeAction> = ['hold-back', 'end-retention']
+
+const REASON_PROMPTS: Record<string, string> = {
+  'hold-back': 'Why is this plant being held back from sale?',
+  'end-retention': 'Why is this plant leaving retention?'
+}
+
+// The states each action may be recorded from, mirroring ALLOWED_FROM in
+// plantings/lifecycle.py. A plant offered an action the server refuses gets a
+// 400 with nothing on screen explaining it, so these are kept in step.
+const ACTION_STATES: Record<PlantOutcomeAction, Array<PlantLifecycleState>> = {
+  ready: ['growing'],
+  'hold-back': ['available'],
+  retain: ['growing', 'available', 'quarantined'],
+  'end-retention': ['retained'],
+  'finish-harvest': ['growing', 'available', 'retained'],
+  fail: ['growing', 'available', 'retained', 'quarantined'],
+  cull: ['growing', 'available', 'retained', 'quarantined'],
+  donate: ['growing', 'available', 'retained']
+}
 
 function LifecycleStateBadge({ state }: { state: PlantLifecycleState }) {
   return <Badge bg={STATE_VARIANTS[state]}>{STATE_LABELS[state]}</Badge>
@@ -73,18 +101,7 @@ function PlantLifecycleBadge({ plant }: { plant: SpecificPlant }) {
 }
 
 function availableActions(plant: SpecificPlant): Array<{ action: PlantOutcomeAction; label: string; variant: string }> {
-  if (plant.final_outcome !== null) {
-    // A retained plant is finished for availability but still growing, so it
-    // can still fail or be harvested out.
-    if (plant.lifecycle_state !== 'retained') {
-      return []
-    }
-    return OUTCOME_ACTIONS.filter((entry) => entry.action === 'fail' || entry.action === 'cull' || entry.action === 'finish-harvest')
-  }
-  if (plant.lifecycle_state === 'available') {
-    return OUTCOME_ACTIONS.filter((entry) => entry.action !== 'ready')
-  }
-  return OUTCOME_ACTIONS
+  return OUTCOME_ACTIONS.filter((entry) => ACTION_STATES[entry.action].includes(plant.lifecycle_state))
 }
 
 interface PlantOutcomeButtonsProps {
@@ -106,6 +123,33 @@ function PlantOutcomeButtons({ plant, onOutcome, disabled }: PlantOutcomeButtons
         </Button>
       ))}
     </div>
+  )
+}
+
+// A plant graded ready, held back, and graded ready again has more than one
+// span. Only the latest state would hide every offer but the current one,
+// which is exactly what the backward facts exist to keep.
+function PlantAvailabilitySpans({ intervals }: { intervals: Array<AvailabilityInterval> }) {
+  if (intervals.length === 0) {
+    return <p className="text-muted mb-0">Never offered.</p>
+  }
+  return (
+    <Table size="sm" className="mb-0">
+      <thead>
+        <tr>
+          <th>Offered from</th>
+          <th>Until</th>
+        </tr>
+      </thead>
+      <tbody>
+        {intervals.map((interval) => (
+          <tr key={interval.started}>
+            <td>{formatDateTime(interval.started)}</td>
+            <td>{interval.ended === null ? 'Still offered' : formatDateTime(interval.ended)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
   )
 }
 
@@ -137,7 +181,12 @@ function PlantLifecycleHistory({ events, onReverse }: PlantLifecycleHistoryProps
             {onReverse && (
               <td>
                 {event.reversed_by === null && event.event_type !== 'germinated' && event.event_type !== 'corrected' && (
-                  <Button size="sm" variant="outline-secondary" onClick={() => onReverse(event)}>
+                  <Button
+                    size="sm"
+                    variant="outline-secondary"
+                    title="Record that this fact was never true. If it was true and the situation has since changed, use the outcome buttons instead."
+                    onClick={() => onReverse(event)}
+                  >
                     Correct
                   </Button>
                 )}
@@ -150,4 +199,14 @@ function PlantLifecycleHistory({ events, onReverse }: PlantLifecycleHistoryProps
   )
 }
 
-export { EVENT_LABELS, STATE_LABELS, LifecycleStateBadge, PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons }
+export {
+  EVENT_LABELS,
+  REASON_PROMPTS,
+  REASON_REQUIRED_ACTIONS,
+  STATE_LABELS,
+  LifecycleStateBadge,
+  PlantAvailabilitySpans,
+  PlantLifecycleBadge,
+  PlantLifecycleHistory,
+  PlantOutcomeButtons
+}

--- a/frontend/js/plantings/plant_detail.tsx
+++ b/frontend/js/plantings/plant_detail.tsx
@@ -10,7 +10,7 @@ import { PlantCostBreakdown } from '../types/costing'
 import { SpecificPlantLocation } from '../types/plantings'
 import { Workspace } from '../types/workspace'
 import { formatDate, formatDateTime, formatMoney } from '../utils'
-import { LifecycleStateBadge, PlantLifecycleHistory } from './lifecycle'
+import { EVENT_LABELS, LifecycleStateBadge, PlantAvailabilitySpans, PlantLifecycleHistory } from './lifecycle'
 
 function locationLabel(location: SpecificPlantLocation): string {
   if (location.location_type === 'seed_tray_cell') {
@@ -196,8 +196,12 @@ function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
                 <dd className="col-sm-7">{formatDateTime(plant.germinated)}</dd>
                 <dt className="col-sm-5">Offerable</dt>
                 <dd className="col-sm-7">{plant.sellable ? 'Yes' : 'No'}</dd>
+                <dt className="col-sm-5">In this state since</dt>
+                <dd className="col-sm-7">{plant.state_since === null ? 'Not recorded' : formatDateTime(plant.state_since)}</dd>
                 <dt className="col-sm-5">Final outcome</dt>
-                <dd className="col-sm-7">{plant.final_outcome === null ? 'Not resolved' : `${plant.final_outcome} on ${formatDateTime(plant.final_outcome_at ?? '')}`}</dd>
+                <dd className="col-sm-7">
+                  {plant.final_outcome === null ? 'Not resolved' : `${EVENT_LABELS[plant.final_outcome]} on ${formatDateTime(plant.final_outcome_at ?? '')}`}
+                </dd>
               </dl>
               {plant.notes && <p className="mt-2 mb-0">{plant.notes}</p>}
             </Card.Body>
@@ -216,6 +220,14 @@ function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
             <Card.Header>Lifecycle history</Card.Header>
             <Card.Body>
               <PlantLifecycleHistory events={events} />
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col md={6}>
+          <Card>
+            <Card.Header>When it was offered</Card.Header>
+            <Card.Body>
+              <PlantAvailabilitySpans intervals={plant.availability_intervals} />
             </Card.Body>
           </Card>
         </Col>

--- a/frontend/js/plantings/register.tsx
+++ b/frontend/js/plantings/register.tsx
@@ -22,6 +22,8 @@ const ORDERING_OPTIONS: Array<{ value: NurseryRegisterOrdering; label: string }>
   { value: 'location', label: 'Location' },
   { value: 'standing_at', label: 'Where it is standing' },
   { value: 'state', label: 'State' },
+  { value: 'state_since', label: 'In this state longest' },
+  { value: 'first_ready', label: 'First offered' },
   { value: 'batch', label: 'Batch' },
   { value: '-cost', label: 'Most expensive first' },
   { value: 'expected_ready', label: 'Ready date' }

--- a/frontend/js/plantings/register_list.tsx
+++ b/frontend/js/plantings/register_list.tsx
@@ -121,6 +121,7 @@ function RegisterTable({ rows, selection, setSelection }: RegisterTableProps) {
             </td>
             <td>
               <LifecycleStateBadge state={row.lifecycle_state} />
+              {row.state_since !== null && <div className="text-muted small">since {formatDate(row.state_since)}</div>}
               {row.quarantined && (
                 <div>
                   <Badge bg="warning" text="dark">

--- a/frontend/js/seedtray/seedtray_details.tsx
+++ b/frontend/js/seedtray/seedtray_details.tsx
@@ -37,7 +37,7 @@ import {
   postSpecificPlantOutcome,
   reverseSpecificPlantEvent
 } from '../api/plantings'
-import { PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons } from '../plantings/lifecycle'
+import { PlantLifecycleBadge, PlantLifecycleHistory, PlantOutcomeButtons, REASON_PROMPTS, REASON_REQUIRED_ACTIONS } from '../plantings/lifecycle'
 import { ApiErrorAlert } from '../api_error_alert'
 import { SeedPacketDetails } from '../types/seeds'
 import { getSeedPacketsCurrent } from '../api/seeds'
@@ -600,7 +600,8 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
       ])
   })
   const outcomeMutation = useMutation({
-    mutationFn: ({ plantPk, outcome }: { plantPk: number; outcome: PlantOutcomeAction }) => postSpecificPlantOutcome(plantPk, outcome),
+    mutationFn: ({ plantPk, outcome, reason }: { plantPk: number; outcome: PlantOutcomeAction; reason?: string }) =>
+      postSpecificPlantOutcome(plantPk, outcome, reason ? { reason } : {}),
     onSuccess: (_event, variables) => invalidatePlantLifecycle(variables.plantPk)
   })
   const reverseMutation = useMutation({
@@ -733,12 +734,21 @@ function SeedTrayDetails({ seedTrayPk }: SeedTrayDetailsProps) {
     ])
   }
 
+  // A backward fact says the situation changed, so the server requires a
+  // reason for it. The correction below asks a deliberately different question:
+  // it claims the fact was never true at all.
   async function handleRecordOutcome(plant: SpecificPlant, outcome: PlantOutcomeAction) {
-    await outcomeMutation.mutateAsync({ plantPk: plant.pk, outcome })
+    if (!REASON_REQUIRED_ACTIONS.includes(outcome)) {
+      await outcomeMutation.mutateAsync({ plantPk: plant.pk, outcome })
+      return
+    }
+    const reason = globalThis.prompt(REASON_PROMPTS[outcome])
+    if (!reason || !reason.trim()) return
+    await outcomeMutation.mutateAsync({ plantPk: plant.pk, outcome, reason })
   }
 
   async function handleReverseEvent(plant: SpecificPlant, event: PlantLifecycleEvent) {
-    const reason = globalThis.prompt('Why was this recorded in error?')
+    const reason = globalThis.prompt('Why was this recorded in error? To record that the situation has since changed, use the outcome buttons instead.')
     if (!reason || !reason.trim()) return
     await reverseMutation.mutateAsync({ plantPk: plant.pk, event: event.pk, reason })
   }

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -261,11 +261,13 @@ type PlantLifecycleEventType =
   | 'returned_quarantined'
   | 'returned_discarded'
   | 'released_available'
+  | 'held_back'
+  | 'retention_ended'
   | 'corrected'
 
 type PlantLifecycleState = 'growing' | 'available' | 'retained' | 'donated' | 'failed' | 'lost' | 'culled' | 'harvested' | 'sold' | 'quarantined' | 'discarded'
 
-type PlantOutcomeAction = 'ready' | 'retain' | 'fail' | 'cull' | 'donate' | 'finish-harvest'
+type PlantOutcomeAction = 'ready' | 'retain' | 'fail' | 'cull' | 'donate' | 'finish-harvest' | 'hold-back' | 'end-retention'
 
 interface PlantLifecycleEvent {
   pk: number
@@ -311,10 +313,20 @@ interface SpecificPlant {
   quarantined: boolean
   final_outcome: PlantLifecycleEventType | null
   final_outcome_at: string | null
+  state_since: string | null
+  first_ready_at: string | null
+}
+
+// One span a plant spent on offer. A plant held back and graded ready again
+// has more than one, which is what the latest state alone cannot show.
+interface AvailabilityInterval {
+  started: string
+  ended: string | null
 }
 
 interface SpecificPlantDetail extends SpecificPlant {
   lifecycle_events: Array<PlantLifecycleEvent>
+  availability_intervals: Array<AvailabilityInterval>
   growth: NurseryGrowth
   nursery_observations: Array<NurseryObservation>
 }
@@ -380,6 +392,11 @@ interface NurseryRegisterRow {
   germinated: string
   age_days: number
   lifecycle_state: PlantLifecycleState
+  // When the current state began, and when the plant was first put on offer.
+  // A plant held back yesterday and one held back in March both read
+  // `growing`; these are what tell them apart.
+  state_since: string | null
+  first_ready_at: string | null
   sellable: boolean
   quarantined: boolean
   reserved: boolean
@@ -423,6 +440,10 @@ type NurseryRegisterOrdering =
   | '-cost'
   | 'state'
   | '-state'
+  | 'state_since'
+  | '-state_since'
+  | 'first_ready'
+  | '-first_ready'
   | 'batch'
   | '-batch'
   | 'expected_ready'
@@ -481,7 +502,7 @@ interface NurseryRegisterSelection {
   plants: Array<number>
 }
 
-type BulkPlantAction = 'germinate' | 'move' | 'stage' | 'grade' | 'repot' | 'ready' | 'retain' | 'donate' | 'fail' | 'cull' | 'finish_harvest'
+type BulkPlantAction = 'germinate' | 'move' | 'stage' | 'grade' | 'repot' | 'ready' | 'retain' | 'donate' | 'fail' | 'cull' | 'finish_harvest' | 'hold_back' | 'end_retention'
 type BulkPlantAtomicity = 'all_or_nothing' | 'eligible_only'
 
 interface BulkPlantOperationRequest {
@@ -911,6 +932,7 @@ interface NurseryPlanVariance {
 }
 
 export {
+  AvailabilityInterval,
   BatchAction,
   BulkPlantOutcome,
   HARVEST_UNIT_LABELS,

--- a/plantings/test_lifecycle_rest.py
+++ b/plantings/test_lifecycle_rest.py
@@ -14,7 +14,12 @@ from tests.factories import (
     make_specific_plant_location,
 )
 
-from .lifecycle import EventType, LifecycleState
+from .lifecycle import (
+    EventType,
+    LifecycleState,
+    OutcomeRequest,
+    record_lifecycle_event,
+)
 from .models import PlantLifecycleEvent, SpecificPlantLocation
 
 
@@ -386,6 +391,47 @@ class BackwardTransitionActionTests(PlantLifecycleRESTTestCase):
         )
         self.location.refresh_from_db()
         self.assertIsNone(self.location.ended)
+
+    def test_the_actions_each_state_accepts_are_the_ones_the_screen_offers(self):
+        """This repository has no JavaScript test runner, so the matrix that
+        `ACTION_STATES` in `frontend/js/plantings/lifecycle.tsx` mirrors is
+        pinned here. A button offered for a state the server refuses returns a
+        400 with nothing on screen explaining it, which is how a quarantined
+        plant came to show **Ready** and **Donate**.
+        """
+        histories = {
+            'growing': (),
+            'available': (EventType.READY,),
+            'retained': (EventType.RETAINED,),
+            'quarantined': (
+                EventType.READY, EventType.SOLD, EventType.RETURNED_QUARANTINED,
+            ),
+        }
+        accepted = {
+            'growing': {'ready', 'retain', 'finish-harvest', 'fail', 'cull', 'donate'},
+            'available': {
+                'hold-back', 'retain', 'finish-harvest', 'fail', 'cull', 'donate',
+            },
+            'retained': {'end-retention', 'finish-harvest', 'fail', 'cull', 'donate'},
+            'quarantined': {'retain', 'fail', 'cull'},
+        }
+        every_action = {
+            'ready', 'hold-back', 'retain', 'end-retention',
+            'finish-harvest', 'fail', 'cull', 'donate',
+        }
+        for state, priors in histories.items():
+            for outcome in sorted(every_action):
+                with self.subTest(state=state, outcome=outcome):
+                    plant = make_specific_plant()
+                    for prior in priors:
+                        record_lifecycle_event(
+                            plant, self.user, OutcomeRequest(prior),
+                        )
+                    response = self.post_outcome(
+                        plant.pk, outcome, {'reason': 'Recorded by test.'},
+                    )
+                    expected = 201 if outcome in accepted[state] else 400
+                    self.assertEqual(response.status_code, expected, response.data)
 
     def test_the_detail_reports_every_span_the_plant_was_offered(self):
         """Only the latest state would hide the second offer entirely."""


### PR DESCRIPTION
The tray screen offered **Correct** as the only way to take a plant off offer, behind the prompt "Why was this recorded in error?" — so an operator holding stock back had to answer a question about a mistake they had not made. Add **Hold back** and **End retention** beside it, each with its own prompt asking why the situation changed, and say in the Correct prompt and tooltip what that action is actually for.

`availableActions` had grown a set of special cases that did not match the server. A quarantined plant has no final outcome and is not available, so it fell through to the full button list and showed **Ready** and **Donate**, both of which the server refuses with a 400 that nothing on screen explains; a retained plant was refused **Donate**, which the server accepts. Replace the special cases with `ACTION_STATES`, a direct mirror of `ALLOWED_FROM`, and pin the matrix in a REST contract test since this repository has no JavaScript test runner.

The plant screen gains the offered spans and when the current state began, which is the whole point of recording a hold-back as a fact. The register shows how long a row has been in its state and can sort on it. Bulk previews and the final-outcome line rendered their values raw, so the new facts would have appeared as bare snake_case; both now go through the label maps that `tsc` keeps exhaustive.

## Summary by Sourcery

Introduce explicit hold-back and end-retention flows for plants, align frontend outcome buttons with backend-allowed actions, and expose availability history and state timing across plant detail, register, and bulk operations.

New Features:
- Add Hold back and End retention outcome actions with required operator reasons and tailored prompts when changing a plant’s availability or retention status.
- Show when a plant entered its current state, when it was first offered, and each span it has been on offer in the plant detail and nursery register views.
- Support hold-back and end-retention as bulk actions with labeled previews and consistent state labels across bulk operation screens.

Bug Fixes:
- Align available outcome buttons with the server’s allowed-from matrix so quarantined and retained plants no longer offer actions the API rejects and do offer those it accepts.

Enhancements:
- Refine the Correct action’s tooltip and confirmation text to distinguish correcting erroneous records from recording real-world changes via outcome buttons.
- Display human-readable lifecycle state labels instead of raw enum values in bulk operation previews.

Tests:
- Add a REST contract test that pins the matrix of which lifecycle outcome actions each state accepts, mirroring the frontend’s ACTION_STATES configuration.