### PR TITLE
feat(seeds): expose the lot codes printed on a packet

### DIFF
--- a/seeds/services.py
+++ b/seeds/services.py
@@ -312,6 +312,8 @@ def packet_inventory_snapshot(packet):
         empty = remaining == 0
     return {
         'lot': packet.stock_lot_id,
+        'lot_identifier': packet.stock_lot.identifier,
+        'supplier_lot_reference': packet.stock_lot.supplier_lot_reference,
         'location': packet.storage_location_id,
         'quantity_certainty': certainty,
         'received_quantity': initial,

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -384,6 +384,35 @@ class SeedPacketInventoryWorkflowTests(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_packet_payload_carries_the_lot_codes_printed_on_the_packet(self):
+        """The sowing picker can match a packet by the codes a gardener can read."""
+        packet = self.post_draft(
+            self.create_draft(QuantityCertainty.EXACT, '10')['pk'],
+        )
+
+        inventory = packet['inventory']
+        self.assertEqual(
+            inventory['supplier_lot_reference'],
+            'SUPPLIER-LOT-1',
+        )
+        self.assertTrue(inventory['lot_identifier'])
+
+        # The picker reads the list route, not the detail one it was posted to.
+        listed = self.client.get('/seeds/packets/')
+        self.assertEqual(listed.status_code, 200)
+        entry = next(
+            candidate for candidate in listed.data
+            if candidate['pk'] == packet['pk']
+        )
+        self.assertEqual(
+            entry['inventory']['supplier_lot_reference'],
+            'SUPPLIER-LOT-1',
+        )
+        self.assertEqual(
+            entry['inventory']['lot_identifier'],
+            inventory['lot_identifier'],
+        )
+
     def test_seed_drafts_are_flagged_and_refused_by_the_general_receipt_api(self):
         """The general receiving screen can neither see nor post a seed draft."""
         draft = self.create_draft(QuantityCertainty.EXACT, '10')


### PR DESCRIPTION
The sowing pickers can only match a packet by variety name today, but a gardener holding the packet reads its codes off the label. The snapshot already dereferences stock_lot for base_unit and acquisition_total, so carrying the two references costs nothing extra: the viewset's queryset already select_relates stock_lot__item.

supplier_lot_reference is blank on plenty of packets; consumers must treat it as optional rather than assume a value.

## Summary by Sourcery

Expose packet lot codes in the seed packet inventory payload so sowing pickers can match packets using the printed codes.

New Features:
- Include lot_identifier and supplier_lot_reference fields in the packet inventory snapshot payload.

Tests:
- Add tests verifying that packet inventory responses on both detail and list endpoints carry the lot codes printed on the packet.