### PR TITLE
feat(garden): add the guided setup wizard

### DIFF
--- a/frontend/js/api/garden.ts
+++ b/frontend/js/api/garden.ts
@@ -1,5 +1,5 @@
-import { ConfirmGardenGeometry, GardenArea, GardenBed, GardenRow, GardenSquare } from '../types/garden'
-import { csrfPost, fetchAsJson } from '../utils'
+import { ConfirmGardenGeometry, GardenArea, GardenAreaCreate, GardenBed, GardenBedCreate, GardenRow, GardenRowCreate, GardenSquare, GardenSquareCreate } from '../types/garden'
+import { csrfDelete, csrfPost, fetchAsJson } from '../utils'
 
 async function getGardenAreas(signal?: AbortSignal): Promise<Array<GardenArea>> {
   return fetchAsJson<Array<GardenArea>>('/garden/areas/', signal)
@@ -17,8 +17,42 @@ async function getGardenSquares(signal?: AbortSignal): Promise<Array<GardenSquar
   return fetchAsJson<Array<GardenSquare>>('/garden/squares/', signal)
 }
 
+async function createGardenArea(area: GardenAreaCreate): Promise<GardenArea> {
+  return csrfPost('/garden/areas/', area).then((response) => response.json() as Promise<GardenArea>)
+}
+
+async function createGardenBed(bed: GardenBedCreate): Promise<GardenBed> {
+  return csrfPost('/garden/beds/', bed).then((response) => response.json() as Promise<GardenBed>)
+}
+
+// Rows and squares are posted as a list because a layout template is chosen as
+// one thing. The server writes the whole batch in one transaction, so a
+// template that collides on its last square leaves nothing behind.
+async function createGardenRows(rows: Array<GardenRowCreate>): Promise<Array<GardenRow>> {
+  return csrfPost('/garden/rows/', rows).then((response) => response.json() as Promise<Array<GardenRow>>)
+}
+
+async function createGardenSquares(squares: Array<GardenSquareCreate>): Promise<Array<GardenSquare>> {
+  return csrfPost('/garden/squares/', squares).then((response) => response.json() as Promise<Array<GardenSquare>>)
+}
+
+async function deleteGardenBed(pk: number): Promise<Response> {
+  return csrfDelete(`/garden/beds/${pk}/`)
+}
+
 async function confirmGardenGeometry(areaPk: number, data: ConfirmGardenGeometry): Promise<Response> {
   return csrfPost(`/garden/areas/${areaPk}/confirm-geometry/`, data)
 }
 
-export { confirmGardenGeometry, getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares }
+export {
+  confirmGardenGeometry,
+  createGardenArea,
+  createGardenBed,
+  createGardenRows,
+  createGardenSquares,
+  deleteGardenBed,
+  getGardenAreas,
+  getGardenBeds,
+  getGardenRows,
+  getGardenSquares
+}

--- a/frontend/js/api/locations.ts
+++ b/frontend/js/api/locations.ts
@@ -22,4 +22,11 @@ function updateLocation(pk: number, changes: LocationUpdate): Promise<Response> 
   return csrfPatch(`${LOCATIONS_URL}${pk}/`, changes)
 }
 
-export { createLocation, getLocationOccupancy, getLocations, updateLocation }
+// Installs the ordinary places a household garden needs — a shed, a seed store,
+// a potting bench, a holding area. Asking twice creates nothing the second
+// time, so the setup wizard can be left and resumed at this step.
+function installHouseholdLocations(): Promise<Array<Location>> {
+  return csrfPost('/garden/setup/household-locations/', {}).then((response) => response.json() as Promise<Array<Location>>)
+}
+
+export { createLocation, getLocationOccupancy, getLocations, installHouseholdLocations, updateLocation }

--- a/frontend/js/api/workspace.ts
+++ b/frontend/js/api/workspace.ts
@@ -7,7 +7,9 @@ function getWorkspace(signal?: AbortSignal): Promise<Workspace> {
   return fetchAsJson<Workspace>(WORKSPACE_URL, signal)
 }
 
-async function updateWorkspace(update: WorkspaceUpdate): Promise<Workspace> {
+// PATCH, so a caller sends only what it is changing. The settings screen sends
+// the whole profile; the setup wizard sends one field at a time.
+async function updateWorkspace(update: Partial<WorkspaceUpdate>): Promise<Workspace> {
   const response = await csrfPatch(WORKSPACE_URL, update)
   return response.json() as Promise<Workspace>
 }

--- a/frontend/js/garden.css
+++ b/frontend/js/garden.css
@@ -23,6 +23,19 @@
   stroke-width: 50;
 }
 
+/* A row is a strip of a bed, drawn under any squares so both can be read when
+   a bed is described both ways. */
+.garden-row {
+  fill: #a3b18a;
+  fill-opacity: 0.45;
+  stroke: #6c757d;
+  stroke-width: 10;
+}
+
+.garden-setup-preview {
+  max-width: 40rem;
+}
+
 .garden-square-control {
   cursor: pointer;
   outline: none;

--- a/frontend/js/garden.tsx
+++ b/frontend/js/garden.tsx
@@ -3,46 +3,29 @@ import 'bootstrap/dist/css/bootstrap.css'
 import './garden.css'
 
 import React, { useMemo, useState } from 'react'
-import type { KeyboardEvent } from 'react'
-import { Button, Modal } from 'react-bootstrap'
+import { Alert, Button, Modal } from 'react-bootstrap'
 import Select from 'react-select'
 import { useQuery } from '@tanstack/react-query'
-import { useNavigate, useParams } from 'react-router'
+import { Link, useNavigate, useParams } from 'react-router'
 
-import { GardenArea, GardenBed, GardenSquare } from './types/garden'
+import { GardenArea, GardenBed, GardenRow, GardenSquare } from './types/garden'
 import { GardenSquarePlanting } from './types/plantings'
-import { getGardenAreas, getGardenBeds, getGardenSquares } from './api/garden'
+import { getGardenAreas, getGardenBeds, getGardenRows, getGardenSquares } from './api/garden'
 import { getHarvests, getPlantingGardenSquaresCurrent } from './api/plantings'
 import { HarvestForm, HarvestFormBatch, HarvestFormPlant } from './plantings/harvest_form'
 import { InputApplicationForm } from './applications/application_form'
 import { ConfirmGeometryForm } from './garden/geometry'
+import { GardenCanvas } from './garden/canvas'
 import { HarvestTable } from './plantings/harvest_list'
 import { SelectOption } from './types/others'
 import { queryKeys } from './query'
 
-const OUTLINE_WIDTH = 100
-
 interface GardenAreaDisplayProps {
   area: GardenArea
   gardenBeds: Array<GardenBed>
+  rows: Array<GardenRow>
   squares: Array<GardenSquare>
   plantings: Array<GardenSquarePlanting>
-}
-
-interface GardenSquareElementProps {
-  area: GardenArea
-  bed: GardenBed
-  square: GardenSquare
-  plantings: Array<GardenSquarePlanting>
-  onSelect: (squarePk: number) => void
-}
-
-interface GardenBedElementProps {
-  area: GardenArea
-  bed: GardenBed
-  squares: Array<GardenSquare>
-  plantingsBySquare: Map<number, Array<GardenSquarePlanting>>
-  onSelectSquare: (squarePk: number) => void
 }
 
 interface GardenSquareDetailsModalProps {
@@ -51,10 +34,6 @@ interface GardenSquareDetailsModalProps {
   square: GardenSquare
   plantings: Array<GardenSquarePlanting>
   onClose: () => void
-}
-
-function calculateSvgY(area: GardenArea, offsetY: number, placementY: number, sizeY: number): number {
-  return OUTLINE_WIDTH + area.size_y - (offsetY + placementY + sizeY)
 }
 
 function plantingName(planting: GardenSquarePlanting): string {
@@ -78,46 +57,6 @@ function formatDateRange(early?: string, late?: string): string | undefined {
     return early
   }
   return `${early} to ${late}`
-}
-
-function GardenSquareElement({ area, bed, square, plantings, onSelect }: GardenSquareElementProps) {
-  const description = squareDescription(square, plantings)
-  const className = plantings.length > 0 ? 'garden-square garden-square--planted' : 'garden-square garden-square--empty'
-
-  function handleKeyDown(event: KeyboardEvent<SVGGElement>) {
-    if (event.key !== 'Enter' && event.key !== ' ') {
-      return
-    }
-
-    event.preventDefault()
-    onSelect(square.pk)
-  }
-
-  return (
-    <g className="garden-square-control" role="button" tabIndex={0} aria-label={description} aria-haspopup="dialog" onClick={() => onSelect(square.pk)} onKeyDown={handleKeyDown}>
-      <title>{description}</title>
-      <rect
-        className={className}
-        x={OUTLINE_WIDTH + bed.placement_x + square.placement_x}
-        y={calculateSvgY(area, bed.placement_y, square.placement_y, square.size_y)}
-        width={square.size_x}
-        height={square.size_y}
-      />
-    </g>
-  )
-}
-
-function GardenBedElement({ area, bed, squares, plantingsBySquare, onSelectSquare }: GardenBedElementProps) {
-  return (
-    <g>
-      <rect className="garden-bed" x={OUTLINE_WIDTH + bed.placement_x} y={calculateSvgY(area, 0, bed.placement_y, bed.size_y)} width={bed.size_x} height={bed.size_y}>
-        <title>{bed.name}</title>
-      </rect>
-      {squares.map((square) => (
-        <GardenSquareElement key={square.pk} area={area} bed={bed} square={square} plantings={plantingsBySquare.get(square.pk) ?? []} onSelect={onSelectSquare} />
-      ))}
-    </g>
-  )
 }
 
 // Everything a harvest form needs about this square is already in the current
@@ -256,7 +195,7 @@ function GardenSquareDetailsModal({ area, bed, square, plantings, onClose }: Gar
   )
 }
 
-function GardenAreaDisplay({ area, gardenBeds, squares, plantings }: GardenAreaDisplayProps) {
+function GardenAreaDisplay({ area, gardenBeds, rows, squares, plantings }: GardenAreaDisplayProps) {
   const [selectedSquarePk, setSelectedSquarePk] = useState<number>()
   const plantingsBySquare = useMemo(() => {
     const groupedPlantings = new Map<number, Array<GardenSquarePlanting>>()
@@ -267,39 +206,20 @@ function GardenAreaDisplay({ area, gardenBeds, squares, plantings }: GardenAreaD
     }
     return groupedPlantings
   }, [plantings])
-  const squaresByBed = useMemo(() => {
-    const groupedSquares = new Map<number, Array<GardenSquare>>()
-    for (const square of squares) {
-      const bedSquares = groupedSquares.get(square.bed) ?? []
-      bedSquares.push(square)
-      groupedSquares.set(square.bed, bedSquares)
-    }
-    return groupedSquares
-  }, [squares])
   const selectedSquare = squares.find((square) => square.pk === selectedSquarePk)
   const selectedBed = selectedSquare === undefined ? undefined : gardenBeds.find((bed) => bed.pk === selectedSquare.bed)
-  const viewWidth = area.size_x + OUTLINE_WIDTH * 2
-  const viewHeight = area.size_y + OUTLINE_WIDTH * 2
-  const titleId = `garden-area-${area.pk}-title`
 
   return (
     <>
-      <div className="garden-area-container">
-        <svg className="garden-area-display" viewBox={`0 0 ${viewWidth} ${viewHeight}`} role="group" aria-labelledby={titleId}>
-          <title id={titleId}>{area.name} garden layout</title>
-          <rect className="garden-area-outline" x={OUTLINE_WIDTH / 2} y={OUTLINE_WIDTH / 2} width={area.size_x + OUTLINE_WIDTH} height={area.size_y + OUTLINE_WIDTH} />
-          {gardenBeds.map((bed) => (
-            <GardenBedElement
-              key={bed.pk}
-              area={area}
-              bed={bed}
-              squares={squaresByBed.get(bed.pk) ?? []}
-              plantingsBySquare={plantingsBySquare}
-              onSelectSquare={setSelectedSquarePk}
-            />
-          ))}
-        </svg>
-      </div>
+      <GardenCanvas
+        area={area}
+        beds={gardenBeds}
+        rows={rows}
+        squares={squares}
+        describeSquare={(square) => squareDescription(square, plantingsBySquare.get(square.pk) ?? [])}
+        squareClassName={(square) => ((plantingsBySquare.get(square.pk) ?? []).length > 0 ? 'garden-square garden-square--planted' : 'garden-square garden-square--empty')}
+        onSelectSquare={setSelectedSquarePk}
+      />
       {selectedSquare !== undefined && (
         <GardenSquareDetailsModal
           area={area}
@@ -325,6 +245,10 @@ function GardenDisplay() {
     queryKey: queryKeys.garden.beds,
     queryFn: ({ signal }) => getGardenBeds(signal)
   })
+  const { data: rows = [] } = useQuery({
+    queryKey: queryKeys.garden.rows,
+    queryFn: ({ signal }) => getGardenRows(signal)
+  })
   const { data: squares = [] } = useQuery({
     queryKey: queryKeys.garden.squares,
     queryFn: ({ signal }) => getGardenSquares(signal)
@@ -349,16 +273,36 @@ function GardenDisplay() {
   if (areaId !== undefined) {
     const area = areas.find((candidate) => candidate.pk === selectedArea)
     if (area) {
-      areaView = <GardenAreaDisplay key={area.pk} area={area} gardenBeds={beds.filter((bed) => bed.area === area.pk)} squares={squares} plantings={plantings} />
+      const areaBeds = beds.filter((bed) => bed.area === area.pk)
+      const bedPks = new Set(areaBeds.map((bed) => bed.pk))
+      areaView = <GardenAreaDisplay key={area.pk} area={area} gardenBeds={areaBeds} rows={rows.filter((row) => bedPks.has(row.bed))} squares={squares} plantings={plantings} />
     } else if (!areasPending) {
       areaView = <div>Garden area not found.</div>
     }
+  }
+
+  // A workspace with no garden yet has nothing to select between, and the bare
+  // empty picker that used to stand here said so to nobody. Setup is the only
+  // way to create an area, so it is what this screen offers instead.
+  if (areas.length === 0 && !areasPending) {
+    return (
+      <Alert variant="info">
+        <Alert.Heading>There is no garden here yet</Alert.Heading>
+        <p>Set up a garden to lay out an area, its beds, and where things are kept. It takes a few minutes and you can leave it and come back.</p>
+        <Link className="btn btn-primary" to="/setup">
+          Set up my garden
+        </Link>
+      </Alert>
+    )
   }
 
   return (
     <>
       <Select onChange={updateSelectedGardenArea} options={areaOptions} value={areaOptions.find((option) => option.value === selectedArea)} />
       <div>{areaView}</div>
+      <p className="mt-3">
+        <Link to="/setup">Add another garden area</Link>
+      </p>
     </>
   )
 }

--- a/frontend/js/garden/canvas.tsx
+++ b/frontend/js/garden/canvas.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import type { KeyboardEvent } from 'react'
+
+import { GardenBed, GardenRow, GardenSquare } from '../types/garden'
+
+// The drawn area sits inside a margin so its outline is not clipped by the
+// viewBox, and every child is offset by the same amount.
+const OUTLINE_WIDTH = 100
+
+// What the canvas needs to know about an area to draw it. The Gardens screen
+// passes a saved area; the setup wizard passes one it has not written yet, so
+// this is deliberately narrower than GardenArea.
+interface CanvasArea {
+  pk?: number
+  name: string
+  size_x: number
+  size_y: number
+}
+
+interface GardenCanvasProps {
+  area: CanvasArea
+  beds: Array<GardenBed>
+  rows?: Array<GardenRow>
+  squares: Array<GardenSquare>
+  // Absent when nothing is selectable, which is how the wizard previews a
+  // layout that has no squares to open yet.
+  describeSquare?: (square: GardenSquare) => string
+  squareClassName?: (square: GardenSquare) => string
+  onSelectSquare?: (squarePk: number) => void
+}
+
+interface GardenBedElementProps {
+  area: CanvasArea
+  bed: GardenBed
+  rows: Array<GardenRow>
+  squares: Array<GardenSquare>
+  describeSquare: (square: GardenSquare) => string
+  squareClassName: (square: GardenSquare) => string
+  onSelectSquare?: (squarePk: number) => void
+}
+
+interface GardenSquareElementProps {
+  area: CanvasArea
+  bed: GardenBed
+  square: GardenSquare
+  description: string
+  className: string
+  onSelect?: (squarePk: number) => void
+}
+
+// Model coordinates grow upwards from the bottom left; SVG grows downwards
+// from the top left, so every y is flipped through the area's height.
+function calculateSvgY(area: CanvasArea, offsetY: number, placementY: number, sizeY: number): number {
+  return OUTLINE_WIDTH + area.size_y - (offsetY + placementY + sizeY)
+}
+
+function groupByParent<T extends { bed: number }>(children: Array<T>): Map<number, Array<T>> {
+  const grouped = new Map<number, Array<T>>()
+  for (const child of children) {
+    const siblings = grouped.get(child.bed) ?? []
+    siblings.push(child)
+    grouped.set(child.bed, siblings)
+  }
+  return grouped
+}
+
+function GardenSquareElement({ area, bed, square, description, className, onSelect }: GardenSquareElementProps) {
+  const x = OUTLINE_WIDTH + bed.placement_x + square.placement_x
+  const y = calculateSvgY(area, bed.placement_y, square.placement_y, square.size_y)
+
+  if (onSelect === undefined) {
+    return (
+      <g>
+        <title>{description}</title>
+        <rect className={className} x={x} y={y} width={square.size_x} height={square.size_y} />
+      </g>
+    )
+  }
+
+  function handleKeyDown(event: KeyboardEvent<SVGGElement>) {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
+
+    event.preventDefault()
+    onSelect?.(square.pk)
+  }
+
+  return (
+    <g className="garden-square-control" role="button" tabIndex={0} aria-label={description} aria-haspopup="dialog" onClick={() => onSelect(square.pk)} onKeyDown={handleKeyDown}>
+      <title>{description}</title>
+      <rect className={className} x={x} y={y} width={square.size_x} height={square.size_y} />
+    </g>
+  )
+}
+
+function GardenBedElement({ area, bed, rows, squares, describeSquare, squareClassName, onSelectSquare }: GardenBedElementProps) {
+  return (
+    <g>
+      <rect className="garden-bed" x={OUTLINE_WIDTH + bed.placement_x} y={calculateSvgY(area, 0, bed.placement_y, bed.size_y)} width={bed.size_x} height={bed.size_y}>
+        <title>{bed.name}</title>
+      </rect>
+      {rows.map((row) => (
+        <rect
+          key={row.pk}
+          className="garden-row"
+          x={OUTLINE_WIDTH + bed.placement_x + row.placement_x}
+          y={calculateSvgY(area, bed.placement_y, row.placement_y, row.size_y)}
+          width={row.size_x}
+          height={row.size_y}
+        >
+          <title>{row.name}</title>
+        </rect>
+      ))}
+      {squares.map((square) => (
+        <GardenSquareElement
+          key={square.pk}
+          area={area}
+          bed={bed}
+          square={square}
+          description={describeSquare(square)}
+          className={squareClassName(square)}
+          onSelect={onSelectSquare}
+        />
+      ))}
+    </g>
+  )
+}
+
+// The one place an area, its beds, its rows, and its squares are drawn. The
+// Gardens screen and the setup preview both render through it so that what a
+// gardener is shown before saving is what they get afterwards.
+function GardenCanvas({
+  area,
+  beds,
+  rows = [],
+  squares,
+  describeSquare = (square) => square.name,
+  squareClassName = () => 'garden-square garden-square--empty',
+  onSelectSquare
+}: GardenCanvasProps) {
+  const rowsByBed = React.useMemo(() => groupByParent(rows), [rows])
+  const squaresByBed = React.useMemo(() => groupByParent(squares), [squares])
+  const viewWidth = area.size_x + OUTLINE_WIDTH * 2
+  const viewHeight = area.size_y + OUTLINE_WIDTH * 2
+  const titleId = `garden-area-${area.pk ?? 'preview'}-title`
+
+  return (
+    <div className="garden-area-container">
+      <svg className="garden-area-display" viewBox={`0 0 ${viewWidth} ${viewHeight}`} role="group" aria-labelledby={titleId}>
+        <title id={titleId}>{area.name} garden layout</title>
+        <rect className="garden-area-outline" x={OUTLINE_WIDTH / 2} y={OUTLINE_WIDTH / 2} width={area.size_x + OUTLINE_WIDTH} height={area.size_y + OUTLINE_WIDTH} />
+        {beds.map((bed) => (
+          <GardenBedElement
+            key={bed.pk}
+            area={area}
+            bed={bed}
+            rows={rowsByBed.get(bed.pk) ?? []}
+            squares={squaresByBed.get(bed.pk) ?? []}
+            describeSquare={describeSquare}
+            squareClassName={squareClassName}
+            onSelectSquare={onSelectSquare}
+          />
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+export { CanvasArea, GardenCanvas, OUTLINE_WIDTH, calculateSvgY }

--- a/frontend/js/garden/setup.tsx
+++ b/frontend/js/garden/setup.tsx
@@ -1,0 +1,650 @@
+import React from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Alert, Button, Card, Col, Form, ListGroup, Row } from 'react-bootstrap'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
+
+import {
+  confirmGardenGeometry,
+  createGardenArea,
+  createGardenBed,
+  createGardenRows,
+  createGardenSquares,
+  getGardenAreas,
+  getGardenBeds,
+  getGardenRows,
+  getGardenSquares
+} from '../api/garden'
+import { createLocation, installHouseholdLocations } from '../api/locations'
+import { updateWorkspace } from '../api/workspace'
+import { GardenArea, GardenLengthUnit } from '../types/garden'
+import { Location, LocationType } from '../types/locations'
+import { MeasurementSystem, Workspace } from '../types/workspace'
+import { LAYOUT_TEMPLATES, LayoutPlan, LayoutTemplate, expandTemplate, templateInfo } from './templates'
+import { GardenCanvas } from './canvas'
+import { errorsByField } from '../utils'
+import { queryKeys } from '../query'
+
+// The wizard never asks a gardener what a grid step should be. One step is one
+// centimetre in a metric workspace and one inch in an imperial one, which is
+// fine enough for a bed and coarse enough that a whole garden stays a sensible
+// number of steps. Everything the gardener types is in metres or feet and is
+// converted here.
+interface GridUnits {
+  step: GardenLengthUnit
+  entry: string
+  abbreviation: string
+  stepsPerEntryUnit: number
+}
+
+const GRID_UNITS: Record<MeasurementSystem, GridUnits> = {
+  metric: { step: 'cm', entry: 'metres', abbreviation: 'm', stepsPerEntryUnit: 100 },
+  imperial: { step: 'in', entry: 'feet', abbreviation: 'ft', stepsPerEntryUnit: 12 }
+}
+
+type Step = 'basics' | 'area' | 'layout' | 'places' | 'done'
+
+const STEP_VALUES: Array<Step> = ['basics', 'area', 'layout', 'places', 'done']
+
+function parseStep(value: string | null, fallback: Step): Step {
+  return STEP_VALUES.find((step) => step === value) ?? fallback
+}
+
+const STEPS: Array<{ value: Step; label: string }> = [
+  { value: 'basics', label: 'Your garden' },
+  { value: 'area', label: 'The space' },
+  { value: 'layout', label: 'Beds and rows' },
+  { value: 'places', label: 'Where things are kept' },
+  { value: 'done', label: 'Done' }
+]
+
+function toSteps(value: string, units: GridUnits): number {
+  const entered = Number(value)
+  if (!Number.isFinite(entered) || entered <= 0) {
+    return 0
+  }
+  return Math.max(1, Math.round(entered * units.stepsPerEntryUnit))
+}
+
+function fromSteps(value: number, units: GridUnits): string {
+  return String(Math.round((value / units.stepsPerEntryUnit) * 100) / 100)
+}
+
+// A location code has to be unique in the workspace and is shown to the
+// gardener, so it is derived from what they typed rather than generated. A
+// collision comes back as a field error on `code`, which is honest: they
+// already have a place called that.
+function codeFromName(name: string): string {
+  return name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 64)
+}
+
+function StepList({ current }: { current: Step }) {
+  const currentIndex = STEPS.findIndex((step) => step.value === current)
+  return (
+    <ListGroup horizontal="md" className="mb-4">
+      {STEPS.map((step, index) => (
+        <ListGroup.Item key={step.value} active={index === currentIndex} disabled={index > currentIndex}>
+          {index + 1}. {step.label}
+        </ListGroup.Item>
+      ))}
+    </ListGroup>
+  )
+}
+
+function BasicsStep({ workspace, onDone }: { workspace: Workspace; onDone: () => void }) {
+  const queryClient = useQueryClient()
+  const [name, setName] = React.useState(workspace.name)
+  const [timezone, setTimezone] = React.useState(workspace.timezone)
+  const [measurementSystem, setMeasurementSystem] = React.useState<MeasurementSystem>(workspace.measurement_system)
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({})
+
+  const mutation = useMutation({
+    mutationFn: () => updateWorkspace({ name, timezone, measurement_system: measurementSystem }),
+    onSuccess: (updated) => {
+      // Written straight into the cache, as the settings screen does, so the
+      // navigation bar carries the new name from the next step onwards.
+      queryClient.setQueryData(queryKeys.workspace.current, updated)
+      setFieldErrors({})
+      onDone()
+    },
+    onError: (error) => setFieldErrors(errorsByField(error))
+  })
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>What should this garden be called?</Card.Title>
+        <Card.Text className="text-muted">These are recorded before anything is dated or measured, because everything after this is written in them.</Card.Text>
+        <Form
+          onSubmit={(event) => {
+            event.preventDefault()
+            mutation.mutate()
+          }}
+        >
+          <Form.Group className="mb-3" controlId="setup-name">
+            <Form.Label>Garden name</Form.Label>
+            <Form.Control value={name} onChange={(event) => setName(event.target.value)} isInvalid={'name' in fieldErrors} required maxLength={255} />
+            <Form.Control.Feedback type="invalid">{fieldErrors.name}</Form.Control.Feedback>
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="setup-timezone">
+            <Form.Label>Time zone</Form.Label>
+            <Form.Control value={timezone} onChange={(event) => setTimezone(event.target.value)} isInvalid={'timezone' in fieldErrors} required maxLength={64} />
+            <Form.Text>An IANA name, such as UTC or Pacific/Auckland. Dates you record are read in it.</Form.Text>
+            <Form.Control.Feedback type="invalid">{fieldErrors.timezone}</Form.Control.Feedback>
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="setup-measurement">
+            <Form.Label>Measurements</Form.Label>
+            <Form.Select value={measurementSystem} onChange={(event) => setMeasurementSystem(event.target.value as MeasurementSystem)}>
+              <option value="metric">Metric — metres and centimetres</option>
+              <option value="imperial">Imperial — feet and inches</option>
+            </Form.Select>
+          </Form.Group>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? 'Saving…' : 'Continue'}
+          </Button>
+        </Form>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function AreaStep({ workspace, onCreated }: { workspace: Workspace; onCreated: (area: GardenArea) => void }) {
+  const queryClient = useQueryClient()
+  const units = GRID_UNITS[workspace.measurement_system]
+  const [name, setName] = React.useState('Back garden')
+  const [width, setWidth] = React.useState('10')
+  const [length, setLength] = React.useState('8')
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({})
+  const sizeX = toSteps(width, units)
+  const sizeY = toSteps(length, units)
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const area = await createGardenArea({ name, size_x: sizeX, size_y: sizeY })
+      // Stated in the same breath as the dimensions, because the integers
+      // above mean nothing until something says what one of them measures.
+      await confirmGardenGeometry(area.pk, { length_unit: units.step, cell_length: '1', notes: 'Recorded during guided setup.' })
+      return area
+    },
+    onSuccess: (area) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.garden.all })
+      setFieldErrors({})
+      onCreated(area)
+    },
+    onError: (error) => setFieldErrors(errorsByField(error))
+  })
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>How big is the space?</Card.Title>
+        <Card.Text className="text-muted">Roughly is fine. This is the ground the beds are placed on, and it can be corrected later.</Card.Text>
+        <Form
+          onSubmit={(event) => {
+            event.preventDefault()
+            mutation.mutate()
+          }}
+        >
+          <Form.Group className="mb-3" controlId="setup-area-name">
+            <Form.Label>Name for this space</Form.Label>
+            <Form.Control value={name} onChange={(event) => setName(event.target.value)} isInvalid={'name' in fieldErrors} required />
+            <Form.Control.Feedback type="invalid">{fieldErrors.name}</Form.Control.Feedback>
+          </Form.Group>
+          <Row>
+            <Col md={6}>
+              <Form.Group className="mb-3" controlId="setup-area-width">
+                <Form.Label>Width in {units.entry}</Form.Label>
+                <Form.Control type="number" min="0.1" step="0.1" value={width} onChange={(event) => setWidth(event.target.value)} isInvalid={'size_x' in fieldErrors} required />
+                <Form.Control.Feedback type="invalid">{fieldErrors.size_x}</Form.Control.Feedback>
+              </Form.Group>
+            </Col>
+            <Col md={6}>
+              <Form.Group className="mb-3" controlId="setup-area-length">
+                <Form.Label>Length in {units.entry}</Form.Label>
+                <Form.Control type="number" min="0.1" step="0.1" value={length} onChange={(event) => setLength(event.target.value)} isInvalid={'size_y' in fieldErrors} required />
+                <Form.Control.Feedback type="invalid">{fieldErrors.size_y}</Form.Control.Feedback>
+              </Form.Group>
+            </Col>
+          </Row>
+          <p className="text-muted">
+            That is {sizeX} × {sizeY} {units.step === 'cm' ? 'centimetres' : 'inches'}, which is what beds are measured against.
+          </p>
+          <Button type="submit" disabled={mutation.isPending || sizeX === 0 || sizeY === 0}>
+            {mutation.isPending ? 'Creating…' : 'Create this space'}
+          </Button>
+        </Form>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function LayoutStep({ area, workspace, onDone }: { area: GardenArea; workspace: Workspace; onDone: () => void }) {
+  const queryClient = useQueryClient()
+  const units = GRID_UNITS[workspace.measurement_system]
+  const [plan, setPlan] = React.useState<LayoutPlan>({
+    template: 'raised_bed',
+    name: 'Bed 1',
+    placement_x: 0,
+    placement_y: 0,
+    size_x: Math.min(area.size_x, units.stepsPerEntryUnit * 2),
+    size_y: Math.min(area.size_y, units.stepsPerEntryUnit),
+    divisions: 4,
+    columns: 4
+  })
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({})
+  const [laid, setLaid] = React.useState(0)
+
+  const { data: beds = [] } = useQuery({ queryKey: queryKeys.garden.beds, queryFn: ({ signal }) => getGardenBeds(signal) })
+  const { data: rows = [] } = useQuery({ queryKey: queryKeys.garden.rows, queryFn: ({ signal }) => getGardenRows(signal) })
+  const { data: squares = [] } = useQuery({ queryKey: queryKeys.garden.squares, queryFn: ({ signal }) => getGardenSquares(signal) })
+
+  const info = templateInfo(plan.template)
+  const expanded = expandTemplate(plan)
+  const areaBeds = beds.filter((bed) => bed.area === area.pk)
+  const bedPks = new Set(areaBeds.map((bed) => bed.pk))
+  // The bed being planned is drawn with a negative key so it cannot collide
+  // with a saved one, and its children hang off the same key.
+  const previewBedPk = -1
+  const previewBeds = [
+    ...areaBeds,
+    {
+      pk: previewBedPk,
+      area: area.pk,
+      name: plan.name,
+      kind: expanded.kind,
+      placement_x: plan.placement_x,
+      placement_y: plan.placement_y,
+      size_x: plan.size_x,
+      size_y: plan.size_y
+    }
+  ]
+  const previewRows = [...rows.filter((row) => bedPks.has(row.bed)), ...expanded.rows.map((row, index) => ({ ...row, pk: -(index + 1), bed: previewBedPk }))]
+  const previewSquares = [
+    ...squares.filter((square) => bedPks.has(square.bed)),
+    ...expanded.squares.map((square, index) => ({ ...square, pk: -(index + 1), bed: previewBedPk, area: area.pk }))
+  ]
+
+  const dividedButEmpty = info.divides !== 'none' && expanded.rows.length === 0 && expanded.squares.length === 0
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const bed = await createGardenBed({
+        area: area.pk,
+        name: plan.name,
+        kind: expanded.kind,
+        placement_x: plan.placement_x,
+        placement_y: plan.placement_y,
+        size_x: plan.size_x,
+        size_y: plan.size_y
+      })
+      if (expanded.rows.length > 0) {
+        await createGardenRows(expanded.rows.map((row) => ({ ...row, bed: bed.pk })))
+      }
+      if (expanded.squares.length > 0) {
+        await createGardenSquares(expanded.squares.map((square) => ({ ...square, bed: bed.pk })))
+      }
+      return bed
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.garden.all })
+      setFieldErrors({})
+      setLaid((count) => count + 1)
+      setPlan((current) => ({
+        ...current,
+        name: `Bed ${laid + 2}`,
+        placement_y: Math.min(area.size_y, current.placement_y + current.size_y + Math.round(units.stepsPerEntryUnit / 2))
+      }))
+    },
+    onError: (error) => setFieldErrors(errorsByField(error))
+  })
+
+  function updateSize(field: 'size_x' | 'size_y' | 'placement_x' | 'placement_y', value: string) {
+    setPlan((current) => ({ ...current, [field]: field.startsWith('size') ? toSteps(value, units) : Math.max(0, Math.round(Number(value) * units.stepsPerEntryUnit)) }))
+  }
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>What is growing in it?</Card.Title>
+        <Card.Text className="text-muted">Add a bed, see where it lands, then save it. You can add as many as you like, or skip this and come back.</Card.Text>
+        {laid > 0 && (
+          <Alert variant="success">
+            {laid} {laid === 1 ? 'bed has' : 'beds have'} been laid out.
+          </Alert>
+        )}
+        {'non_field_errors' in fieldErrors && <Alert variant="danger">{fieldErrors.non_field_errors}</Alert>}
+        <Row>
+          <Col lg={6}>
+            <Form
+              onSubmit={(event) => {
+                event.preventDefault()
+                mutation.mutate()
+              }}
+            >
+              <Form.Group className="mb-3" controlId="setup-template">
+                <Form.Label>Kind of bed</Form.Label>
+                <Form.Select value={plan.template} onChange={(event) => setPlan((current) => ({ ...current, template: event.target.value as LayoutTemplate }))}>
+                  {LAYOUT_TEMPLATES.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label} — {option.description}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+              <Form.Group className="mb-3" controlId="setup-bed-name">
+                <Form.Label>Name</Form.Label>
+                <Form.Control value={plan.name} onChange={(event) => setPlan((current) => ({ ...current, name: event.target.value }))} isInvalid={'name' in fieldErrors} required />
+                <Form.Control.Feedback type="invalid">{fieldErrors.name}</Form.Control.Feedback>
+              </Form.Group>
+              <Row>
+                <Col sm={6}>
+                  <Form.Group className="mb-3" controlId="setup-bed-width">
+                    <Form.Label>Width in {units.entry}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min="0.1"
+                      step="0.1"
+                      value={fromSteps(plan.size_x, units)}
+                      onChange={(event) => updateSize('size_x', event.target.value)}
+                      required
+                    />
+                  </Form.Group>
+                </Col>
+                <Col sm={6}>
+                  <Form.Group className="mb-3" controlId="setup-bed-length">
+                    <Form.Label>Length in {units.entry}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min="0.1"
+                      step="0.1"
+                      value={fromSteps(plan.size_y, units)}
+                      onChange={(event) => updateSize('size_y', event.target.value)}
+                      required
+                    />
+                  </Form.Group>
+                </Col>
+              </Row>
+              <Row>
+                <Col sm={6}>
+                  <Form.Group className="mb-3" controlId="setup-bed-x">
+                    <Form.Label>From the left, in {units.entry}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      value={fromSteps(plan.placement_x, units)}
+                      onChange={(event) => updateSize('placement_x', event.target.value)}
+                      isInvalid={'placement_x' in fieldErrors}
+                    />
+                    <Form.Control.Feedback type="invalid">{fieldErrors.placement_x}</Form.Control.Feedback>
+                  </Form.Group>
+                </Col>
+                <Col sm={6}>
+                  <Form.Group className="mb-3" controlId="setup-bed-y">
+                    <Form.Label>From the bottom, in {units.entry}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      value={fromSteps(plan.placement_y, units)}
+                      onChange={(event) => updateSize('placement_y', event.target.value)}
+                      isInvalid={'placement_y' in fieldErrors}
+                    />
+                    <Form.Control.Feedback type="invalid">{fieldErrors.placement_y}</Form.Control.Feedback>
+                  </Form.Group>
+                </Col>
+              </Row>
+              {info.divides !== 'none' && (
+                <Row>
+                  <Col sm={6}>
+                    <Form.Group className="mb-3" controlId="setup-divisions">
+                      <Form.Label>{info.divides === 'rows' ? 'How many rows' : 'Cells up the bed'}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={plan.divisions}
+                        onChange={(event) => setPlan((current) => ({ ...current, divisions: Number(event.target.value) }))}
+                      />
+                    </Form.Group>
+                  </Col>
+                  {info.divides === 'grid' && (
+                    <Col sm={6}>
+                      <Form.Group className="mb-3" controlId="setup-columns">
+                        <Form.Label>Cells across the bed</Form.Label>
+                        <Form.Control
+                          type="number"
+                          min="1"
+                          step="1"
+                          value={plan.columns}
+                          onChange={(event) => setPlan((current) => ({ ...current, columns: Number(event.target.value) }))}
+                        />
+                      </Form.Group>
+                    </Col>
+                  )}
+                </Row>
+              )}
+              {dividedButEmpty && <Alert variant="warning">This bed is too small to divide that many ways. Make it longer, or ask for fewer.</Alert>}
+              <Button type="submit" disabled={mutation.isPending || dividedButEmpty}>
+                {mutation.isPending ? 'Saving…' : 'Add this bed'}
+              </Button>{' '}
+              <Button variant="secondary" onClick={onDone} disabled={mutation.isPending}>
+                {laid > 0 ? 'Continue' : 'Skip beds for now'}
+              </Button>
+            </Form>
+          </Col>
+          <Col lg={6}>
+            <h3 className="h6">Before you save</h3>
+            <p className="text-muted">
+              The bed you are describing is drawn with what is already here. {expanded.rows.length > 0 && `${expanded.rows.length} rows. `}
+              {expanded.squares.length > 0 && `${expanded.squares.length} cells.`}
+            </p>
+            <div className="garden-setup-preview">
+              <GardenCanvas area={area} beds={previewBeds} rows={previewRows} squares={previewSquares} />
+            </div>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function ExtraPlaceForm({ label, type, onCreated }: { label: string; type: LocationType; onCreated: (location: Location) => void }) {
+  const queryClient = useQueryClient()
+  const [name, setName] = React.useState('')
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({})
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const response = await createLocation({ name, code: codeFromName(name), location_type: type })
+      return (await response.json()) as Location
+    },
+    onSuccess: (location) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.locations.all })
+      setFieldErrors({})
+      setName('')
+      onCreated(location)
+    },
+    onError: (error) => setFieldErrors(errorsByField(error))
+  })
+
+  return (
+    <Form
+      className="mb-3"
+      onSubmit={(event) => {
+        event.preventDefault()
+        mutation.mutate()
+      }}
+    >
+      <Form.Group controlId={`setup-extra-${type}`}>
+        <Form.Label>{label}</Form.Label>
+        <Row>
+          <Col sm={8}>
+            <Form.Control
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              isInvalid={'name' in fieldErrors || 'code' in fieldErrors}
+              placeholder="Leave blank if you have none"
+            />
+            <Form.Control.Feedback type="invalid">{fieldErrors.name ?? fieldErrors.code}</Form.Control.Feedback>
+          </Col>
+          <Col sm={4}>
+            <Button type="submit" variant="outline-secondary" disabled={mutation.isPending || name.trim() === ''}>
+              Add
+            </Button>
+          </Col>
+        </Row>
+      </Form.Group>
+    </Form>
+  )
+}
+
+function PlacesStep({ onDone }: { onDone: () => void }) {
+  const queryClient = useQueryClient()
+  const [installed, setInstalled] = React.useState<Array<Location>>([])
+  const [extras, setExtras] = React.useState<Array<Location>>([])
+
+  const mutation = useMutation({
+    mutationFn: installHouseholdLocations,
+    onSuccess: (locations) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.locations.all })
+      setInstalled(locations)
+    }
+  })
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>Where do you keep things?</Card.Title>
+        <Card.Text className="text-muted">
+          Seed packets, trays, and anything you feed the garden with have to be somewhere. These are the ordinary places a garden has; adding them now means nothing is blocked
+          later. Asking twice creates nothing new.
+        </Card.Text>
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          {mutation.isPending ? 'Adding…' : 'Add the usual places'}
+        </Button>
+        {installed.length > 0 && (
+          <ListGroup className="mt-3">
+            {installed.map((location) => (
+              <ListGroup.Item key={location.pk}>{location.full_name}</ListGroup.Item>
+            ))}
+          </ListGroup>
+        )}
+        <hr />
+        <h3 className="h6">Anything else?</h3>
+        <ExtraPlaceForm label="A greenhouse or tunnel" type="greenhouse" onCreated={(location) => setExtras((current) => [...current, location])} />
+        <ExtraPlaceForm label="Pots or containers" type="container" onCreated={(location) => setExtras((current) => [...current, location])} />
+        {extras.length > 0 && (
+          <ListGroup className="mb-3">
+            {extras.map((location) => (
+              <ListGroup.Item key={location.pk}>{location.full_name}</ListGroup.Item>
+            ))}
+          </ListGroup>
+        )}
+        <Button variant="secondary" onClick={onDone}>
+          Continue
+        </Button>
+      </Card.Body>
+    </Card>
+  )
+}
+
+function DoneStep({ area }: { area?: GardenArea }) {
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>Your garden is ready</Card.Title>
+        <Card.Text className="text-muted">Nothing here is final. Everything you have just described can be added to or corrected.</Card.Text>
+        <ListGroup>
+          <ListGroup.Item action as={Link} to="/plantings/garden-squares">
+            Sow some seed
+          </ListGroup.Item>
+          <ListGroup.Item action as={Link} to="/plants">
+            Add a plant you already have
+          </ListGroup.Item>
+          <ListGroup.Item action as={Link} to={area === undefined ? '/gardens' : `/gardens/${area.pk}`}>
+            Look at the garden
+          </ListGroup.Item>
+        </ListGroup>
+      </Card.Body>
+    </Card>
+  )
+}
+
+// The wizard commits real records as it goes and keeps the area it is working
+// on in the URL, so leaving at any point and coming back resumes where the
+// records say it got to rather than replaying anything.
+function GardenSetup({ workspace }: { workspace: Workspace }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { areaId } = useParams()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const areaPk = areaId === undefined ? undefined : Number(areaId)
+  // The step lives in the address beside the area, so reloading on "where do
+  // you keep things" comes back to it rather than to the beds behind it. The
+  // area alone would only ever resume at the layout step.
+  const step = parseStep(searchParams.get('step'), areaPk === undefined ? 'basics' : 'layout')
+
+  function setStep(next: Step) {
+    setSearchParams({ step: next }, { replace: true })
+  }
+
+  const { data: areas = [], isPending } = useQuery({ queryKey: queryKeys.garden.areas, queryFn: ({ signal }) => getGardenAreas(signal) })
+  const area = areaPk === undefined ? undefined : areas.find((candidate) => candidate.pk === areaPk)
+
+  const stateMutation = useMutation({
+    mutationFn: (state: Workspace['garden_setup_state']) => updateWorkspace({ garden_setup_state: state }),
+    onSuccess: (updated) => queryClient.setQueryData(queryKeys.workspace.current, updated)
+  })
+
+  function leave(state: Workspace['garden_setup_state'], to: string) {
+    stateMutation.mutate(state, { onSettled: () => navigate(to) })
+  }
+
+  if (areaPk !== undefined && area === undefined && !isPending) {
+    return (
+      <Alert variant="warning">
+        That garden area no longer exists. <Link to="/setup">Start again</Link>.
+      </Alert>
+    )
+  }
+
+  return (
+    <>
+      <h1 className="h3">Set up your garden</h1>
+      <StepList current={step} />
+      {step === 'basics' && <BasicsStep workspace={workspace} onDone={() => setStep('area')} />}
+      {step === 'area' && (
+        <AreaStep
+          workspace={workspace}
+          onCreated={(created) => {
+            // Replaced rather than pushed, so Back does not return to a form
+            // that would create a second area for the same answers.
+            navigate(`/setup/${created.pk}?step=layout`, { replace: true })
+          }}
+        />
+      )}
+      {step === 'layout' &&
+        (area === undefined ? <p>Loading the space you were working on…</p> : <LayoutStep area={area} workspace={workspace} onDone={() => setStep('places')} />)}
+      {step === 'places' && <PlacesStep onDone={() => setStep('done')} />}
+      {step === 'done' && <DoneStep area={area} />}
+      <p className="mt-4">
+        {step === 'done' ? (
+          <Button variant="primary" onClick={() => leave('complete', area === undefined ? '/gardens' : `/gardens/${area.pk}`)}>
+            Finish
+          </Button>
+        ) : (
+          <Button variant="link" className="px-0" onClick={() => leave('skipped', '/gardens')}>
+            Skip setup for now
+          </Button>
+        )}
+      </p>
+    </>
+  )
+}
+
+export { GRID_UNITS, GardenSetup, codeFromName, toSteps }

--- a/frontend/js/garden/templates.ts
+++ b/frontend/js/garden/templates.ts
@@ -1,0 +1,135 @@
+import { GardenBedKind, GardenChildCreate } from '../types/garden'
+
+// The layouts a household garden is actually made of. A template is a shape
+// plus what the gardener called it; the geometry it expands into is ordinary
+// beds, rows, and squares, so nothing here creates a private idea of a place.
+type LayoutTemplate = 'in_ground_bed' | 'raised_bed' | 'rows' | 'square_foot_grid'
+
+interface LayoutTemplateInfo {
+  value: LayoutTemplate
+  label: string
+  description: string
+  kind: GardenBedKind
+  // Whether the gardener is asked how many strips or cells to divide the bed
+  // into. A plain bed is undivided until they say otherwise.
+  divides: 'none' | 'rows' | 'grid'
+}
+
+const LAYOUT_TEMPLATES: Array<LayoutTemplateInfo> = [
+  {
+    value: 'in_ground_bed',
+    label: 'In-ground bed',
+    description: 'A patch of open ground, undivided.',
+    kind: 'in_ground',
+    divides: 'none'
+  },
+  {
+    value: 'raised_bed',
+    label: 'Raised bed',
+    description: 'A built bed, undivided.',
+    kind: 'raised',
+    divides: 'none'
+  },
+  {
+    value: 'rows',
+    label: 'Rows',
+    description: 'A bed divided into strips running its width.',
+    kind: 'in_ground',
+    divides: 'rows'
+  },
+  {
+    value: 'square_foot_grid',
+    label: 'Square-foot grid',
+    description: 'A bed marked out in equal cells.',
+    kind: 'raised',
+    divides: 'grid'
+  }
+]
+
+interface LayoutPlan {
+  template: LayoutTemplate
+  name: string
+  placement_x: number
+  placement_y: number
+  size_x: number
+  size_y: number
+  // How many strips a rows template lays, or how many cells across and up a
+  // grid template marks out. Ignored by the undivided templates.
+  divisions: number
+  columns: number
+}
+
+interface ExpandedLayout {
+  kind: GardenBedKind
+  rows: Array<Omit<GardenChildCreate, 'bed'>>
+  squares: Array<Omit<GardenChildCreate, 'bed'>>
+}
+
+function templateInfo(template: LayoutTemplate): LayoutTemplateInfo {
+  // The list is the only source of templates, so a value outside it cannot be
+  // chosen; falling back to the first keeps the type honest without inventing
+  // a shape nobody asked for.
+  return LAYOUT_TEMPLATES.find((candidate) => candidate.value === template) ?? LAYOUT_TEMPLATES[0]
+}
+
+// Strips run the width of the bed and are spaced evenly up it, leaving the
+// remainder as the path between them rather than silently widening the last
+// strip. A bed too short to hold the strips asked for produces none, and the
+// caller reports that rather than laying a zero-height row the server would
+// refuse.
+function expandRows(plan: LayoutPlan): Array<Omit<GardenChildCreate, 'bed'>> {
+  const divisions = Math.max(1, Math.floor(plan.divisions))
+  const pitch = Math.floor(plan.size_y / divisions)
+  if (pitch < 1) {
+    return []
+  }
+
+  const height = Math.max(1, Math.floor(pitch / 2))
+  return Array.from({ length: divisions }, (_unused, index) => ({
+    name: `Row ${index + 1}`,
+    placement_x: 0,
+    placement_y: index * pitch,
+    size_x: plan.size_x,
+    size_y: height
+  }))
+}
+
+// Cells tile from the bed's origin and are all the same size, so a bed that is
+// not an exact multiple keeps its remainder as unmarked ground at the far edge
+// instead of being covered by a short final cell.
+function expandGrid(plan: LayoutPlan): Array<Omit<GardenChildCreate, 'bed'>> {
+  const columns = Math.max(1, Math.floor(plan.columns))
+  const rowCount = Math.max(1, Math.floor(plan.divisions))
+  const cellWidth = Math.floor(plan.size_x / columns)
+  const cellHeight = Math.floor(plan.size_y / rowCount)
+  if (cellWidth < 1 || cellHeight < 1) {
+    return []
+  }
+
+  const squares: Array<Omit<GardenChildCreate, 'bed'>> = []
+  for (let row = 0; row < rowCount; row += 1) {
+    for (let column = 0; column < columns; column += 1) {
+      squares.push({
+        name: `${String.fromCharCode(65 + (row % 26))}${column + 1}`,
+        placement_x: column * cellWidth,
+        placement_y: row * cellHeight,
+        size_x: cellWidth,
+        size_y: cellHeight
+      })
+    }
+  }
+  return squares
+}
+
+// Turns one chosen template into the geometry it stands for. Placements are
+// relative to the bed, which is where the server measures them from too.
+function expandTemplate(plan: LayoutPlan): ExpandedLayout {
+  const info = templateInfo(plan.template)
+  return {
+    kind: info.kind,
+    rows: info.divides === 'rows' ? expandRows(plan) : [],
+    squares: info.divides === 'grid' ? expandGrid(plan) : []
+  }
+}
+
+export { ExpandedLayout, LAYOUT_TEMPLATES, LayoutPlan, LayoutTemplate, LayoutTemplateInfo, expandTemplate, templateInfo }

--- a/frontend/js/locations.tsx
+++ b/frontend/js/locations.tsx
@@ -6,13 +6,14 @@ import { Alert, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
 import { createLocation, getLocationOccupancy, getLocations, updateLocation } from './api/locations'
 import { queryKeys } from './query'
 import { CapacityBasis, Location, LocationCreate, LocationType } from './types/locations'
-import { ApiError } from './utils'
+import { errorsByField } from './utils'
 
 const TYPE_LABELS: Record<LocationType, string> = {
   site: 'Site',
   greenhouse: 'Greenhouse',
   tunnel: 'Tunnel',
   bench: 'Bench',
+  container: 'Pot or container',
   bay: 'Bay',
   receiving: 'Receiving',
   storage: 'Storage',
@@ -31,7 +32,21 @@ const HIDDEN_TYPES: Array<LocationType> = ['seed_packet']
 
 // The types an operator can choose. Adjustment is a ledger balancing point the
 // stock workflows create against, not somewhere anything physically stands.
-const SELECTABLE_TYPES: Array<LocationType> = ['site', 'greenhouse', 'tunnel', 'bench', 'bay', 'receiving', 'storage', 'growing', 'dispatch', 'hold', 'staging', 'quarantine']
+const SELECTABLE_TYPES: Array<LocationType> = [
+  'site',
+  'greenhouse',
+  'tunnel',
+  'bench',
+  'container',
+  'bay',
+  'receiving',
+  'storage',
+  'growing',
+  'dispatch',
+  'hold',
+  'staging',
+  'quarantine'
+]
 
 const BASIS_LABELS: Record<CapacityBasis, string> = {
   none: 'Not tracked',
@@ -207,18 +222,6 @@ function LocationForm({ parents, onCreated }: LocationFormProps) {
 
 // DRF reports field errors as {field: [message]}; flatten to the first message
 // per field so a form control can show it beneath itself.
-function errorsByField(error: unknown): Record<string, string> {
-  const body = error instanceof ApiError ? error.body : null
-  if (!body || typeof body !== 'object') return {}
-  const errors: Record<string, string> = {}
-  for (const [field, detail] of Object.entries(body as Record<string, unknown>)) {
-    errors[field] = Array.isArray(detail) ? String(detail[0]) : String(detail)
-  }
-  return errors
-}
-
-// Capacities arrive at their stored scale, so a bench holding two trays says
-// "2.000". Only strip after a decimal point exists, or 100 would become 1.
 function trimZeros(value: string | null): string {
   if (value === null) return ''
   return value.includes('.') ? value.replace(/0+$/, '').replace(/\.$/, '') : value

--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -11,6 +11,7 @@ import { PlantsView } from './plants.js'
 import { SeedStockTable, SeedSuppliersTable, SeedTable } from './seeds.js'
 import { GardenSquarePlantingTable, SeedTrayPlantingTable } from './planting.js'
 import { GardenDisplay } from './garden.js'
+import { GardenSetup } from './garden/setup.js'
 import { SeedTrayModelsTable, SeedTraysTable } from './seedtrays.js'
 import { ApiErrorAlert } from './api_error_alert.js'
 import { queryClient, queryKeys } from './query.js'
@@ -108,6 +109,10 @@ function FrontEndPage() {
       <Routes>
         <Route path="/gardens" element={<GardenDisplay />} />
         <Route path="/gardens/:areaId" element={<GardenDisplay />} />
+        {/* Ungated: laying out ground matters in both profiles, and a nursery
+            with no geometry is as stuck as a garden with none. */}
+        <Route path="/setup" element={<GardenSetup workspace={workspace} />} />
+        <Route path="/setup/:areaId" element={<GardenSetup workspace={workspace} />} />
         <Route path="/plants" element={<PlantsView />} />
         <Route path="/seeds/suppliers" element={<SeedSuppliersTable />} />
         <Route path="/seeds" element={<SeedTable />} />

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -31,6 +31,13 @@ function GPTopBar({ workspace }: GPTopBarProps) {
           <Nav.Link as={NavLink} to="/gardens">
             Gardens
           </Nav.Link>
+          {/* Offered until the gardener finishes it or says no. Skipping is
+              recorded, so declining once takes this away for good. */}
+          {workspace.garden_setup_state === 'pending' && (
+            <Nav.Link as={NavLink} to="/setup">
+              Set up garden
+            </Nav.Link>
+          )}
           <Nav.Link as={NavLink} to="/plants">
             Plants
           </Nav.Link>

--- a/frontend/js/query.ts
+++ b/frontend/js/query.ts
@@ -57,6 +57,7 @@ const queryKeys = {
   garden: {
     all: ['garden'] as const,
     areas: ['garden', 'areas'] as const,
+    area: (pk: number) => ['garden', 'areas', pk] as const,
     beds: ['garden', 'beds'] as const,
     rows: ['garden', 'rows'] as const,
     squares: ['garden', 'squares'] as const

--- a/frontend/js/types/garden.ts
+++ b/frontend/js/types/garden.ts
@@ -19,10 +19,15 @@ interface ConfirmGardenGeometry {
   notes?: string
 }
 
+// What the gardener said they were making. It changes nothing about how the
+// rectangle is measured; it only lets a screen name what it is drawing.
+type GardenBedKind = 'in_ground' | 'raised' | 'container'
+
 interface GardenBed {
   pk: number
   area: number
   name: string
+  kind: GardenBedKind
   placement_x: number
   placement_y: number
   size_x: number
@@ -50,4 +55,48 @@ interface GardenSquare {
   size_y: number
 }
 
-export { ConfirmGardenGeometry, GardenArea, GardenBed, GardenLengthUnit, GardenRow, GardenSquare }
+interface GardenAreaCreate {
+  name: string
+  size_x: number
+  size_y: number
+}
+
+interface GardenBedCreate {
+  area: number
+  name: string
+  kind: GardenBedKind
+  placement_x: number
+  placement_y: number
+  size_x: number
+  size_y: number
+}
+
+// A row and a square are placed the same way; only the bed they divide and the
+// shape they take differ, so one create shape serves both.
+interface GardenChildCreate {
+  bed: number
+  name: string
+  placement_x: number
+  placement_y: number
+  size_x: number
+  size_y: number
+}
+
+type GardenRowCreate = GardenChildCreate
+
+type GardenSquareCreate = GardenChildCreate
+
+export {
+  ConfirmGardenGeometry,
+  GardenArea,
+  GardenAreaCreate,
+  GardenBed,
+  GardenBedCreate,
+  GardenBedKind,
+  GardenChildCreate,
+  GardenLengthUnit,
+  GardenRow,
+  GardenRowCreate,
+  GardenSquare,
+  GardenSquareCreate
+}

--- a/frontend/js/types/locations.ts
+++ b/frontend/js/types/locations.ts
@@ -1,5 +1,19 @@
 type LocationType =
-  'site' | 'greenhouse' | 'tunnel' | 'bench' | 'bay' | 'receiving' | 'storage' | 'growing' | 'dispatch' | 'hold' | 'staging' | 'quarantine' | 'adjustment' | 'seed_packet'
+  | 'site'
+  | 'greenhouse'
+  | 'tunnel'
+  | 'bench'
+  | 'container'
+  | 'bay'
+  | 'receiving'
+  | 'storage'
+  | 'growing'
+  | 'dispatch'
+  | 'hold'
+  | 'staging'
+  | 'quarantine'
+  | 'adjustment'
+  | 'seed_packet'
 
 // The dimension a location's usable space is measured in. Only this one
 // dimension is compared against capacity_value; unlike dimensions are never

--- a/frontend/js/types/workspace.ts
+++ b/frontend/js/types/workspace.ts
@@ -1,6 +1,11 @@
 type WorkspaceMode = 'garden' | 'nursery'
 type MeasurementSystem = 'metric' | 'imperial'
 
+// Whether guided garden setup has been finished or declined. It records the
+// gardener's answer, not the state of their data: an established workspace is
+// never offered setup because it already has a garden.
+type GardenSetupState = 'pending' | 'skipped' | 'complete'
+
 interface Workspace {
   name: string
   mode: WorkspaceMode
@@ -12,6 +17,7 @@ interface Workspace {
   override_tolerance_percent: string
   override_tolerance_floor: string
   stocktake_two_person_required: boolean
+  garden_setup_state: GardenSetupState
   created: string
   updated: string
 }
@@ -28,6 +34,7 @@ type WorkspaceUpdate = Pick<
   | 'override_tolerance_percent'
   | 'override_tolerance_floor'
   | 'stocktake_two_person_required'
+  | 'garden_setup_state'
 >
 
-export { MeasurementSystem, Workspace, WorkspaceMode, WorkspaceUpdate }
+export { GardenSetupState, MeasurementSystem, Workspace, WorkspaceMode, WorkspaceUpdate }

--- a/frontend/js/utils.tsx
+++ b/frontend/js/utils.tsx
@@ -258,8 +258,28 @@ function formatMoney(value: string | number | null | undefined, currencyCode: st
   return `${whole}.${trimmed.padEnd(2, '0')} ${currencyCode}`
 }
 
+// DRF reports a rejected write as {field: [message]}. Forms want one message
+// per field, so this flattens it and drops anything that is not shaped that
+// way — a network failure has already been published to the global alert.
+function errorsByField(error: unknown): Record<string, string> {
+  if (!(error instanceof ApiError) || typeof error.body !== 'object' || error.body === null) {
+    return {}
+  }
+
+  const fields: Record<string, string> = {}
+  for (const [field, messages] of Object.entries(error.body as Record<string, unknown>)) {
+    if (Array.isArray(messages) && messages.length > 0) {
+      fields[field] = String(messages[0])
+    } else if (typeof messages === 'string') {
+      fields[field] = messages
+    }
+  }
+  return fields
+}
+
 export {
   ApiError,
+  errorsByField,
   csrfDelete,
   csrfPost,
   csrfPatch,

--- a/frontend/js/workspace.tsx
+++ b/frontend/js/workspace.tsx
@@ -6,6 +6,10 @@ import { updateWorkspace } from './api/workspace'
 import { queryKeys } from './query'
 import { Workspace, WorkspaceMode, WorkspaceUpdate } from './types/workspace'
 
+// The guided setup owns garden_setup_state; this screen edits everything else,
+// and must not send that field back and undo a gardener's answer.
+type WorkspaceProfile = Omit<WorkspaceUpdate, 'garden_setup_state'>
+
 interface WorkspaceSettingsProps {
   workspace: Workspace
 }
@@ -26,7 +30,7 @@ function WorkspaceModeRoute({ workspace, enabledModes, children }: WorkspaceMode
 
 function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
   const queryClient = useQueryClient()
-  const [form, setForm] = React.useState<WorkspaceUpdate>({
+  const [form, setForm] = React.useState<WorkspaceProfile>({
     name: workspace.name,
     mode: workspace.mode,
     currency_code: workspace.currency_code,
@@ -58,7 +62,7 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
     })
   }, [workspace])
 
-  function updateField<Field extends keyof WorkspaceUpdate>(field: Field, value: WorkspaceUpdate[Field]) {
+  function updateField<Field extends keyof WorkspaceProfile>(field: Field, value: WorkspaceProfile[Field]) {
     setForm((current) => ({ ...current, [field]: value }))
   }
 
@@ -129,7 +133,7 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
         </Form.Group>
         <Form.Group className="mb-3" controlId="workspace-measurement">
           <Form.Label>Display measurements</Form.Label>
-          <Form.Select value={form.measurement_system} onChange={(event) => updateField('measurement_system', event.target.value as WorkspaceUpdate['measurement_system'])}>
+          <Form.Select value={form.measurement_system} onChange={(event) => updateField('measurement_system', event.target.value as WorkspaceProfile['measurement_system'])}>
             <option value="metric">Metric</option>
             <option value="imperial">Imperial</option>
           </Form.Select>


### PR DESCRIPTION
A new user reached an empty Gardens screen: a picker with nothing in it above an empty div, and no way to create an area, a bed, a row, or a square. Garden geometry could only be made by curl, since the garden admin is a docstring. This is the pathway from an empty workspace to a garden that can hold a planting.

`garden/setup.tsx` walks five steps at `#/setup`: the workspace profile, the space and what one of its grid steps measures, the beds on it, the places things are kept, and where to go next. Each step writes its records as it goes, and both the area and the step live in the address, so leaving and coming back resumes where the records got to rather than replaying anything or landing a step behind.

One grid step is a centimetre in a metric workspace and an inch in an imperial one. The gardener types metres or feet; nothing asks them what a grid step should be, and the scale is confirmed in the same breath as the dimensions so nothing later has to guess what the integers meant.

`garden/templates.ts` expands a chosen layout — plain ground, a raised bed, rows, or a square-foot grid — into the geometry it stands for, and posts the children as one array against the transaction the server now provides. The preview is therefore instant and cannot show something the save would not produce, because `garden/canvas.tsx` draws it. Extracting that canvas out of `garden.tsx` is what makes the two the same picture, and it draws rows, which the Gardens screen never did.

The empty Gardens screen now says so and offers setup, and offers another area once there is one. The navigation offers setup until the gardener finishes it or declines it; declining is recorded, so it is only asked once.

`errorsByField` moves into `utils.tsx`. It was already duplicated in `locations.tsx` and `plants.tsx`, and the wizard would have been a fourth copy; `locations.tsx` now uses the shared one.

## Summary by Sourcery

Guide gardeners from an empty workspace to a usable garden layout through a resumable setup flow.

New Features:
- Add a guided garden setup wizard that creates a workspace profile, garden area, beds, rows or grid squares, and storage locations.
- Provide reusable garden layout templates with live previews and support metric or imperial measurements.
- Add setup-aware navigation and garden screen guidance for empty workspaces and additional garden areas.

Bug Fixes:
- Prevent workspace settings updates from overwriting guided setup status.

Enhancements:
- Centralize garden rendering for saved layouts and setup previews, including row display.
- Record setup completion or dismissal and preserve wizard progress through the URL.
- Add container locations as an available location type and share field-error handling across forms.