### PR TITLE
build(deps): bump django to 6.1 and drf to 3.18.0

### DIFF
--- a/frontend/js/inventory/receipt_list.tsx
+++ b/frontend/js/inventory/receipt_list.tsx
@@ -38,10 +38,25 @@ function invalidateReceipts(queryClient: ReturnType<typeof useQueryClient>) {
 function documentErrors(body: unknown): Array<string> {
   if (typeof body !== 'object' || body === null) return []
   return Object.entries(body as Record<string, unknown>).flatMap(([field, value]) => {
-    if (field === 'lines' && Array.isArray(value)) return []
+    if (field === 'lines' && typeof value === 'object' && value !== null) return []
     const messages = Array.isArray(value) ? value : [value]
     return messages.filter((message): message is string => typeof message === 'string')
   })
+}
+
+// DRF 3.18 reports nested list errors as an object keyed by the index of each
+// line that failed — {"0": {...}} — where earlier versions returned one entry
+// per submitted line. Both are flattened back to a positional array so the
+// editor can keep rendering errors against the row they belong to.
+function positionalLines(lines: unknown): Array<unknown> {
+  if (Array.isArray(lines)) return lines
+  if (typeof lines !== 'object' || lines === null) return []
+  const positional: Array<unknown> = []
+  for (const [index, entry] of Object.entries(lines as Record<string, unknown>)) {
+    if (!/^\d+$/.test(index)) return []
+    positional[Number(index)] = entry
+  }
+  return positional
 }
 
 // Positional, because the server returns line errors aligned with the lines the
@@ -49,9 +64,7 @@ function documentErrors(body: unknown): Array<string> {
 // one, so both are flattened to the first message.
 function lineFieldErrors(body: unknown): Array<Record<string, string>> {
   if (typeof body !== 'object' || body === null) return []
-  const lines = (body as Record<string, unknown>).lines
-  if (!Array.isArray(lines)) return []
-  return lines.map((entry) => {
+  return positionalLines((body as Record<string, unknown>).lines).map((entry) => {
     if (typeof entry !== 'object' || entry === null) return {}
     return Object.fromEntries(
       Object.entries(entry as Record<string, unknown>).map(([field, value]) => {

--- a/inventory/test_ledger_rest.py
+++ b/inventory/test_ledger_rest.py
@@ -631,6 +631,21 @@ class StockReceiptDraftTests(LedgerRestFixture):
         self.assertEqual(StockMovement.objects.filter(lot=lot).count(), 0)
         self.assertEqual(posted.data['movement_ids'], [])
 
+    def test_line_errors_are_keyed_by_the_index_of_the_failing_line(self):
+        """The editor files a message against the row that earned it."""
+        rejected = self.client.post(
+            self.receipt_url,
+            self.receipt_payload(lines=[
+                self.line_payload(),
+                self.line_payload(quantity='0.000000000'),
+            ]),
+            format='json',
+        )
+
+        self.assertEqual(rejected.status_code, 400, rejected.data)
+        self.assertEqual(list(rejected.json()['lines']), ['1'])
+        self.assertIn('quantity', rejected.json()['lines']['1'])
+
     def test_receipt_lines_reject_inactive_items_conversions_and_locations(self):
         """Retired catalog entries stay visible in history but unselectable."""
         conversion = self.bag_conversion()

--- a/plantings/test_quantities.py
+++ b/plantings/test_quantities.py
@@ -155,11 +155,13 @@ class PositiveQuantityAPITests(TestCase):  # pylint: disable=too-many-public-met
                 self.assertEqual(
                     response.json(),
                     {
-                        'cell_plantings': [{
-                            'quantity': [
-                                'Ensure this value is greater than or equal to 1.'
-                            ],
-                        }],
+                        'cell_plantings': {
+                            '0': {
+                                'quantity': [
+                                    'Ensure this value is greater than or equal to 1.'
+                                ],
+                            },
+                        },
                     },
                 )
 

--- a/plantings/tests.py
+++ b/plantings/tests.py
@@ -285,7 +285,7 @@ class SeedTrayPlantingMembershipTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'cell_plantings': [{'cell': ['This field is required.']}]},
+            {'cell_plantings': {'0': {'cell': ['This field is required.']}}},
         )
         self.assertEqual(self.planting.cell_plantings.get(), self.cell_planting)
 
@@ -298,7 +298,7 @@ class SeedTrayPlantingMembershipTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'cell_plantings': [{'quantity': ['This field is required.']}]},
+            {'cell_plantings': {'0': {'quantity': ['This field is required.']}}},
         )
         self.assertEqual(self.planting.cell_plantings.get(), self.cell_planting)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django==6.0.7
-djangorestframework==3.17.2
+django==6.1
+djangorestframework==3.18.0
 drf-nested-routers==0.95.3
 markdown==3.10.3
 


### PR DESCRIPTION
Django 6.1 removes django.utils.cache.cc_delim_re, which DRF 3.17.2 imports at module load, so the two upgrades only work together: on 6.1 alone every management command dies during import, which is why the dependabot bump could not even start the test suite.

DRF 3.18 also reports nested list-serializer errors as an object keyed by the index of the entry that failed, where earlier releases returned one entry per submitted item. The planting assertions move to the new shape, and the receipt editor normalizes both shapes back to a positional array so a line error keeps landing on its own row instead of disappearing when Array.isArray no longer holds.

## Summary by Sourcery

Upgrade Django and Django REST Framework while adapting nested validation handling to preserve positional line errors.

Bug Fixes:
- Preserve receipt line validation errors on their corresponding editor rows across DRF error response formats.

Enhancements:
- Update planting and receipt validation expectations for DRF 3.18 indexed nested-list errors.

Build:
- Upgrade Django to 6.1 and Django REST Framework to 3.18.0 together.

Tests:
- Add coverage confirming receipt errors are keyed by the failing line index.