### PR TITLE
feat(garden): expose quick origins on planting cycles

### DIFF
--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -75,7 +75,7 @@ interface ProductionBatchSowing {
   planted: string
   quantity: number
   removed: boolean
-  seeds_used: number
+  seeds_used: number | null
   seed_lot: number | null
   seed_tray: number | null
   location: string | null

--- a/plantings/batch_rest.py
+++ b/plantings/batch_rest.py
@@ -25,6 +25,7 @@ from .batches import (
     batch_plants_with_active_location,
     batch_posted_harvest_count,
     batch_seeds_sown,
+    batch_sowing_count,
     batch_specific_plants,
     batch_unresolved_plant_ids,
     cancel_batch,
@@ -35,7 +36,7 @@ from .batches import (
     lock_batch_for_sowing,
     reopen_batch,
 )
-from .models import ProductionBatch, ProductionBatchTransition, SpecificPlantLocation
+from .models import GardenPlanting, ProductionBatch, ProductionBatchTransition, SpecificPlantLocation
 from .yields import batch_harvest_finished_count, batch_harvest_totals
 
 
@@ -104,10 +105,10 @@ class BatchSowingSerializer(serializers.Serializer):  # pylint: disable=abstract
 
     pk = serializers.IntegerField(read_only=True)
     sowing_type = serializers.CharField(read_only=True)
-    planted = serializers.DateTimeField(read_only=True)
+    planted = serializers.CharField(read_only=True)
     quantity = serializers.IntegerField(read_only=True)
     removed = serializers.BooleanField(read_only=True)
-    seeds_used = serializers.IntegerField(read_only=True)
+    seeds_used = serializers.IntegerField(read_only=True, allow_null=True)
     seed_lot = serializers.IntegerField(read_only=True, allow_null=True)
     seed_tray = serializers.IntegerField(read_only=True, allow_null=True)
     location = serializers.CharField(read_only=True, allow_null=True)
@@ -136,13 +137,28 @@ def _describe_cells(sowing):
 
 def _describe_sowing(sowing):
     """Return one sowing's batch-level summary in a display-neutral shape."""
+    if isinstance(sowing, GardenPlanting):
+        return {
+            'pk': sowing.pk,
+            'sowing_type': type(sowing).__name__,
+            'planted': sowing.recorded_on.isoformat(),
+            'quantity': sowing.quantity,
+            'removed': sowing.finished_on is not None,
+            'seeds_used': sowing.seed_packet_id,
+            'seed_lot': sowing.seed_packet.stock_lot_id if sowing.seed_packet_id else None,
+            'seed_tray': None,
+            'location': str(sowing.garden_square or sowing.location),
+            'notes': sowing.notes,
+            'cells': [],
+            'plants_observed': sowing.specific_plants.count(),
+        }
     is_tray = hasattr(sowing, 'cell_plantings')
     location = getattr(sowing, 'location', None)
     cells = _describe_cells(sowing) if is_tray else []
     return {
         'pk': sowing.pk,
         'sowing_type': type(sowing).__name__,
-        'planted': sowing.planted,
+        'planted': sowing.planted.isoformat(),
         'quantity': sowing.quantity,
         'removed': sowing.removed,
         'seeds_used': sowing.seeds_used_id,
@@ -163,6 +179,10 @@ def _batch_sowings(batch):
             'seeds_used',
         ).order_by('planted', 'pk')
         sowings.extend(_describe_sowing(sowing) for sowing in queryset)
+    sowings.extend(
+        _describe_sowing(sowing)
+        for sowing in batch.garden_plantings.select_related('seed_packet').order_by('recorded_on', 'pk')
+    )
     return sowings
 
 
@@ -247,10 +267,7 @@ class ProductionBatchSerializer(
 
     def get_sowing_count(self, batch):
         """Return how many sowings this batch groups."""
-        return sum(
-            model.objects.filter(batch=batch).count()
-            for model in SOWING_MODELS
-        )
+        return batch_sowing_count(batch)
 
     def get_seeds_sown(self, batch):
         """Return the seeds or seed clusters sown, not the plants raised."""

--- a/plantings/batches.py
+++ b/plantings/batches.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from .lifecycle import LifecycleState, is_final, lifecycle_summaries
 from .models import (
+    GardenPlanting,
     GardenRowDirectSowPlanting,
     GardenSquareDirectSowPlanting,
     Harvest,
@@ -62,7 +63,7 @@ def _sowing_querysets(batch):
 
 def batch_sowing_count(batch):
     """Return how many sowings of any kind belong to this batch."""
-    return sum(queryset.count() for queryset in _sowing_querysets(batch))
+    return sum(queryset.count() for queryset in _sowing_querysets(batch)) + batch.garden_plantings.count()
 
 
 def batch_seeds_sown(batch):
@@ -70,6 +71,7 @@ def batch_seeds_sown(batch):
     total = 0
     for queryset in _sowing_querysets(batch):
         total += queryset.aggregate(total=Sum('quantity'))['total'] or 0
+    total += batch.garden_plantings.aggregate(total=Sum('seed_quantity_used'))['total'] or 0
     return total
 
 
@@ -79,6 +81,10 @@ def batch_open_sowings(batch):
     for queryset in _sowing_querysets(batch):
         for pk in queryset.filter(removed=False).order_by('pk').values_list('pk', flat=True):
             open_sowings.append(f'{queryset.model.__name__} #{pk}')
+    for pk in batch.garden_plantings.filter(
+            tracking=GardenPlanting.Tracking.AGGREGATE,
+            finished_on__isnull=True).order_by('pk').values_list('pk', flat=True):
+        open_sowings.append(f'GardenPlanting #{pk}')
     return open_sowings
 
 

--- a/plantings/test_garden_quick_add.py
+++ b/plantings/test_garden_quick_add.py
@@ -118,6 +118,17 @@ class GardenQuickAddTests(APITestCase):
         self.assertEqual(layers.count(), 2)
         self.assertEqual([layer.amount for layer in layers], [6, 6])
 
+    def test_generated_cycle_exposes_the_quick_origin_in_advanced_detail(self):
+        """Switching presentation modes does not hide the technical origin."""
+        created = self.create_reviewed([self.entry()])
+
+        detail = self.client.get(f"/plantings/batches/{created.data[0]['batch']}/")
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertEqual(detail.data['sowing_count'], 1)
+        self.assertEqual(detail.data['sowings'][0]['sowing_type'], 'GardenPlanting')
+        self.assertIsNone(detail.data['sowings'][0]['seeds_used'])
+
     def test_existing_occupancy_warns_but_can_be_confirmed(self):
         """A reviewed companion planting remains intentional and permitted."""
         self.create_reviewed([self.entry()])


### PR DESCRIPTION
Generated garden records must remain inspectable through the shared advanced batch detail instead of becoming hidden technical state when presentation modes change.

## Summary by Sourcery

Expose quick-add garden planting origins through shared batch details and lifecycle summaries.

New Features:
- Expose generated garden planting origins in advanced batch sowing details.
- Include garden plantings in batch sowing counts, seed totals, and open-sowing status.

Bug Fixes:
- Keep generated planting-cycle records inspectable when switching presentation modes.

Enhancements:
- Support nullable seed usage values and display-neutral planting timestamps in batch details.

Tests:
- Add coverage verifying generated quick-add cycles appear as GardenPlanting entries in advanced batch detail.