### PR TITLE
fix(plantings): allow garden cell germination

### DIFF
--- a/plantings/bulk_rest.py
+++ b/plantings/bulk_rest.py
@@ -238,6 +238,15 @@ class BulkPlantOperationViewSet(
     queryset = BulkPlantOperation.objects.prefetch_related('results')
     serializer_class = BulkPlantOperationSerializer
 
+    def get_required_workspace_modes(self):
+        """Keep nursery work gated while allowing shared tray germination."""
+        if all((
+            self.action in {'create', 'preview'},
+            self.request.data.get('action') == BulkPlantOperation.Action.GERMINATE,
+        )):
+            return (Workspace.Mode.GARDEN, Workspace.Mode.NURSERY)
+        return super().get_required_workspace_modes()
+
     def _request_values(self, request, require_key):
         serializer = BulkOperationRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/plantings/test_bulk_rest.py
+++ b/plantings/test_bulk_rest.py
@@ -274,6 +274,46 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
             3,
         )
 
+    def test_garden_profile_can_preview_and_record_cell_germination(self):
+        """The shared seed-tray screen can germinate plants in Garden mode."""
+        self.workspace.mode = Workspace.Mode.GARDEN
+        self.workspace.save(update_fields=['mode'])
+        allocation = make_seed_tray_cell_planting(quantity=1)
+        payload = self.payload(
+            BulkPlantOperation.Action.GERMINATE,
+            plants=[],
+            action_payload={
+                'cell_planting': allocation.pk,
+                'quantity': 1,
+                'notes': '',
+            },
+        )
+
+        preview = self.client.post(
+            '/plantings/bulk-operations/preview/', payload, format='json',
+        )
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(preview.data['eligible'], 1)
+
+        response = self.client.post(
+            '/plantings/bulk-operations/', payload, format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_garden_profile_cannot_use_nursery_bulk_actions(self):
+        """The germination exception does not expose other bulk nursery work."""
+        self.workspace.mode = Workspace.Mode.GARDEN
+        self.workspace.save(update_fields=['mode'])
+
+        response = self.client.post(
+            '/plantings/bulk-operations/preview/',
+            self.payload(BulkPlantOperation.Action.CULL),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, 403, response.data)
+
     def test_reviewed_stage_update_records_one_shared_observation(self):
         """Bulk stage work links every independently audited result to its fact."""
         stage = GrowthStage.objects.get(workspace=self.workspace, code='rooted')

--- a/workspaces/scoping.py
+++ b/workspaces/scoping.py
@@ -62,13 +62,18 @@ class RequireWorkspaceModeMixin:  # pylint: disable=too-few-public-methods
 
     required_workspace_modes = ()
 
+    def get_required_workspace_modes(self):
+        """Return the profiles permitted for the current view action."""
+        return self.required_workspace_modes
+
     def initial(self, request, *args, **kwargs):
         """Check the profile before the view does any work for the request."""
         super().initial(request, *args, **kwargs)
         workspace = get_current_workspace()
-        if workspace.mode not in self.required_workspace_modes:
+        required_workspace_modes = self.get_required_workspace_modes()
+        if workspace.mode not in required_workspace_modes:
             profiles = ' or '.join(
-                Workspace.Mode(mode).label for mode in self.required_workspace_modes
+                Workspace.Mode(mode).label for mode in required_workspace_modes
             )
             raise PermissionDenied(
                 f'This feature is available in the {profiles} profile.',


### PR DESCRIPTION
Seed-tray germination is shared by Garden and Nursery profiles, but its reviewed bulk endpoint rejected Garden requests before validation. Permit only the germination action in both profiles while retaining Nursery authorization for every other bulk operation.

## Summary by Sourcery

Allow garden cell germination while keeping other bulk plant operations restricted to Nursery profiles.

New Features:
- Allow Garden workspaces to preview and record seed-tray cell germination.

Bug Fixes:
- Permit shared germination operations in Garden profiles without broadening access to other nursery bulk actions.

Enhancements:
- Support dynamic workspace-mode authorization for view actions.

Tests:
- Add coverage for Garden germination access and denial of unrelated nursery bulk actions.