### PR TITLE
feat(plantings): germinate multiple tray cells

### DIFF
--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -296,25 +296,34 @@ def _preview_repot_application(workspace, plants, request):
 
 
 def _germination_preview(workspace, request, lock=False):
-    """Validate the source allocation for a quantity germination."""
-    allocation = request.action_payload['cell_planting']
-    queryset = SeedTrayCellPlanting.objects.filter(pk=allocation.pk)
+    """Validate every source allocation for a quantity germination."""
+    requested = request.action_payload['cell_plantings']
+    requested_ids = [allocation.pk for allocation in requested]
+    queryset = SeedTrayCellPlanting.objects.filter(
+        pk__in=requested_ids,
+        seed_tray_planting__workspace=workspace,
+    )
     if lock:
         queryset = queryset.select_for_update()
-    allocation = queryset.select_related('seed_tray_planting__batch').first()
+    allocations = list(
+        queryset.select_related('seed_tray_planting__batch').order_by('pk')
+    )
+    available_ids = {allocation.pk for allocation in allocations}
     conflicts = []
-    if allocation is None or allocation.seed_tray_planting.workspace_id != workspace.pk:
+    if any(allocation.pk not in available_ids for allocation in requested):
         conflicts.append('The cell allocation is unavailable in this workspace.')
+    quantity = request.action_payload['quantity']
+    selected = len(requested) * quantity
     return {
         'action': request.action,
-        'selected': request.action_payload['quantity'],
-        'eligible': 0 if conflicts else request.action_payload['quantity'],
+        'selected': selected,
+        'eligible': 0 if conflicts else selected,
         'conflicts': len(conflicts),
         'plants': [],
         'capacity': [],
         'source': {
-            'cell_planting': request.action_payload['cell_planting'].pk,
-            'quantity': request.action_payload['quantity'],
+            'cell_plantings': requested_ids,
+            'quantity': quantity,
             'conflicts': conflicts,
         },
     }
@@ -439,37 +448,51 @@ def _post_repot_application(workspace, user, plants, request):
 
 
 def _apply_germination(operation, user, request):
-    """Create individually auditable plants and reallocate their batch once."""
-    allocation = SeedTrayCellPlanting.objects.select_for_update().get(
-        pk=request.action_payload['cell_planting'].pk,
+    """Create auditable plants per cell and reallocate each affected batch once."""
+    allocation_ids = [
+        allocation.pk for allocation in request.action_payload['cell_plantings']
+    ]
+    allocations = list(
+        SeedTrayCellPlanting.objects.select_for_update()
+        .filter(pk__in=allocation_ids)
+        .select_related('seed_tray_planting__batch', 'cell')
+        .order_by('pk')
     )
-    batch = lock_batch_with_plants(allocation.seed_tray_planting.batch)
+    batches = {
+        allocation.seed_tray_planting.batch_id: allocation.seed_tray_planting.batch
+        for allocation in allocations
+    }
+    locked_batches = [
+        lock_batch_with_plants(batches[batch_id]) for batch_id in sorted(batches)
+    ]
     notes = request.action_payload.get('notes', '')
-    for _index in range(request.action_payload['quantity']):
-        plant = SpecificPlant.objects.create(
-            cell_planting=allocation,
-            germinated=request.occurred_at,
-            notes=notes,
-        )
-        location = SpecificPlantLocation.objects.create(
-            specific_plant=plant,
-            location_type=SpecificPlantLocation.SEED_TRAY_CELL,
-            seed_tray_cell=allocation.cell,
-            started=request.occurred_at,
-        )
-        event = record_germination_event(plant, user)
-        BulkPlantOperationResult.objects.create(
-            workspace=operation.workspace,
-            operation=operation,
-            plant=plant,
-            status=BulkPlantOperationResult.Status.APPLIED,
-            lifecycle_event=event,
-            location=location,
-        )
+    for allocation in allocations:
+        for _index in range(request.action_payload['quantity']):
+            plant = SpecificPlant.objects.create(
+                cell_planting=allocation,
+                germinated=request.occurred_at,
+                notes=notes,
+            )
+            location = SpecificPlantLocation.objects.create(
+                specific_plant=plant,
+                location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+                seed_tray_cell=allocation.cell,
+                started=request.occurred_at,
+            )
+            event = record_germination_event(plant, user)
+            BulkPlantOperationResult.objects.create(
+                workspace=operation.workspace,
+                operation=operation,
+                plant=plant,
+                status=BulkPlantOperationResult.Status.APPLIED,
+                lifecycle_event=event,
+                location=location,
+            )
 
     from costing.services import reallocate_batch  # pylint: disable=import-outside-toplevel
 
-    reallocate_batch(batch, user, 'bulk-germination')
+    for batch in locked_batches:
+        reallocate_batch(batch, user, 'bulk-germination')
 
 
 @transaction.atomic

--- a/plantings/bulk_rest.py
+++ b/plantings/bulk_rest.py
@@ -44,12 +44,41 @@ class GerminationPayloadSerializer(
 
     cell_planting = serializers.PrimaryKeyRelatedField(
         queryset=SeedTrayCellPlanting.objects.all(),
+        required=False,
+    )
+    cell_plantings = serializers.PrimaryKeyRelatedField(
+        queryset=SeedTrayCellPlanting.objects.all(),
+        many=True,
+        required=False,
     )
     quantity = serializers.IntegerField(min_value=1, max_value=MAX_BULK_PLANTS)
     notes = serializers.CharField(allow_blank=True, required=False, default='')
     workspace_field_lookups = {
         'cell_planting': 'seed_tray_planting__workspace',
+        'cell_plantings': 'seed_tray_planting__workspace',
     }
+
+    def validate(self, attrs):
+        """Normalize one or many cell allocations into one bounded selection."""
+        singular = attrs.pop('cell_planting', None)
+        allocations = attrs.get('cell_plantings', [])
+        if singular is not None and allocations:
+            raise ValidationError({
+                'cell_plantings': 'Choose either one cell allocation or a list, not both.',
+            })
+        if singular is not None:
+            allocations = [singular]
+        if not allocations:
+            raise ValidationError({'cell_plantings': 'Choose at least one cell allocation.'})
+        allocation_ids = [allocation.pk for allocation in allocations]
+        if len(set(allocation_ids)) != len(allocation_ids):
+            raise ValidationError({'cell_plantings': 'Each cell allocation may only be selected once.'})
+        if len(allocations) * attrs['quantity'] > MAX_BULK_PLANTS:
+            raise ValidationError({
+                'quantity': f'A germination operation may create at most {MAX_BULK_PLANTS} plants.',
+            })
+        attrs['cell_plantings'] = allocations
+        return attrs
 
     def create(self, validated_data):
         raise NotImplementedError

--- a/plantings/test_bulk_rest.py
+++ b/plantings/test_bulk_rest.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import close_old_connections
+from django.db.models import F
 from django.test import TransactionTestCase, skipUnlessDBFeature
 from django.utils import timezone
 
@@ -18,6 +19,7 @@ from tests.factories import (
     make_location,
     make_inventory_item,
     make_stock_lot,
+    make_seed_tray_cell,
     make_seed_tray_cell_planting,
     make_specific_plant,
     make_specific_plant_location,
@@ -272,6 +274,56 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
                 ended__isnull=True,
             ).count(),
             3,
+        )
+
+    def test_multi_cell_germination_creates_unique_plants_in_each_cell(self):
+        """One reviewed action preserves the physical origin of every seedling."""
+        first = make_seed_tray_cell_planting(quantity=2)
+        second = make_seed_tray_cell_planting(
+            seed_tray_planting=first.seed_tray_planting,
+            cell=make_seed_tray_cell(
+                tray=first.seed_tray_planting.seed_tray,
+                x_position=1,
+            ),
+            quantity=2,
+        )
+        payload = self.payload(
+            BulkPlantOperation.Action.GERMINATE,
+            plants=[],
+            action_payload={
+                'cell_plantings': [second.pk, first.pk],
+                'quantity': 1,
+                'notes': 'Tray check.',
+            },
+        )
+
+        preview = self.client.post(
+            '/plantings/bulk-operations/preview/', payload, format='json',
+        )
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(preview.data['selected'], 2)
+        self.assertEqual(
+            preview.data['source']['cell_plantings'],
+            [second.pk, first.pk],
+        )
+
+        response = self.client.post(
+            '/plantings/bulk-operations/', payload, format='json',
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        plant_ids = [result['plant'] for result in response.data['results']]
+        plants = SpecificPlant.objects.filter(pk__in=plant_ids)
+        self.assertEqual(plants.count(), 2)
+        self.assertEqual(
+            set(plants.values_list('cell_planting_id', flat=True)),
+            {first.pk, second.pk},
+        )
+        self.assertEqual(
+            SpecificPlantLocation.objects.filter(
+                specific_plant__in=plants,
+                seed_tray_cell_id=F('specific_plant__cell_planting__cell_id'),
+            ).count(),
+            2,
         )
 
     def test_garden_profile_can_preview_and_record_cell_germination(self):


### PR DESCRIPTION
Tray observations often cover several cells at once. Accept a bounded list of cell allocations in one atomic germination operation, preserve each new plant's physical origin, and reallocate every affected batch once while retaining the legacy single-cell request contract.

## Summary by Sourcery

Enable atomic germination across multiple seed-tray cells while preserving legacy requests and batch accounting.

New Features:
- Support germinating a bounded selection of seed-tray cell allocations in a single atomic operation while preserving each plant’s cell origin.

Enhancements:
- Retain compatibility with the legacy single-cell germination request and reallocate each affected batch once per operation.

Tests:
- Add coverage for multi-cell germination, including preview totals, per-cell plant creation, and physical location preservation.