### PR TITLE
feat(plantings): vary germination counts by cell

### DIFF
--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -297,8 +297,8 @@ def _preview_repot_application(workspace, plants, request):
 
 def _germination_preview(workspace, request, lock=False):
     """Validate every source allocation for a quantity germination."""
-    requested = request.action_payload['cell_plantings']
-    requested_ids = [allocation.pk for allocation in requested]
+    requested = request.action_payload['germinations']
+    requested_ids = [entry['cell_planting'].pk for entry in requested]
     queryset = SeedTrayCellPlanting.objects.filter(
         pk__in=requested_ids,
         seed_tray_planting__workspace=workspace,
@@ -310,10 +310,10 @@ def _germination_preview(workspace, request, lock=False):
     )
     available_ids = {allocation.pk for allocation in allocations}
     conflicts = []
-    if any(allocation.pk not in available_ids for allocation in requested):
+    if any(entry['cell_planting'].pk not in available_ids for entry in requested):
         conflicts.append('The cell allocation is unavailable in this workspace.')
-    quantity = request.action_payload['quantity']
-    selected = len(requested) * quantity
+    selected = sum(entry['quantity'] for entry in requested)
+    quantities = {entry['quantity'] for entry in requested}
     return {
         'action': request.action,
         'selected': selected,
@@ -323,7 +323,14 @@ def _germination_preview(workspace, request, lock=False):
         'capacity': [],
         'source': {
             'cell_plantings': requested_ids,
-            'quantity': quantity,
+            'quantity': quantities.pop() if len(quantities) == 1 else None,
+            'germinations': [
+                {
+                    'cell_planting': entry['cell_planting'].pk,
+                    'quantity': entry['quantity'],
+                }
+                for entry in requested
+            ],
             'conflicts': conflicts,
         },
     }
@@ -447,11 +454,37 @@ def _post_repot_application(workspace, user, plants, request):
     }
 
 
+def _create_germinated_plant(operation, user, request, allocation, notes):
+    """Create and audit one observed seedling at its source cell."""
+    plant = SpecificPlant.objects.create(
+        cell_planting=allocation,
+        germinated=request.occurred_at,
+        notes=notes,
+    )
+    location = SpecificPlantLocation.objects.create(
+        specific_plant=plant,
+        location_type=SpecificPlantLocation.SEED_TRAY_CELL,
+        seed_tray_cell=allocation.cell,
+        started=request.occurred_at,
+    )
+    event = record_germination_event(plant, user)
+    BulkPlantOperationResult.objects.create(
+        workspace=operation.workspace,
+        operation=operation,
+        plant=plant,
+        status=BulkPlantOperationResult.Status.APPLIED,
+        lifecycle_event=event,
+        location=location,
+    )
+
+
 def _apply_germination(operation, user, request):
     """Create auditable plants per cell and reallocate each affected batch once."""
-    allocation_ids = [
-        allocation.pk for allocation in request.action_payload['cell_plantings']
-    ]
+    quantities = {
+        entry['cell_planting'].pk: entry['quantity']
+        for entry in request.action_payload['germinations']
+    }
+    allocation_ids = list(quantities)
     allocations = list(
         SeedTrayCellPlanting.objects.select_for_update()
         .filter(pk__in=allocation_ids)
@@ -467,27 +500,8 @@ def _apply_germination(operation, user, request):
     ]
     notes = request.action_payload.get('notes', '')
     for allocation in allocations:
-        for _index in range(request.action_payload['quantity']):
-            plant = SpecificPlant.objects.create(
-                cell_planting=allocation,
-                germinated=request.occurred_at,
-                notes=notes,
-            )
-            location = SpecificPlantLocation.objects.create(
-                specific_plant=plant,
-                location_type=SpecificPlantLocation.SEED_TRAY_CELL,
-                seed_tray_cell=allocation.cell,
-                started=request.occurred_at,
-            )
-            event = record_germination_event(plant, user)
-            BulkPlantOperationResult.objects.create(
-                workspace=operation.workspace,
-                operation=operation,
-                plant=plant,
-                status=BulkPlantOperationResult.Status.APPLIED,
-                lifecycle_event=event,
-                location=location,
-            )
+        for _index in range(quantities[allocation.pk]):
+            _create_germinated_plant(operation, user, request, allocation, notes)
 
     from costing.services import reallocate_batch  # pylint: disable=import-outside-toplevel
 

--- a/plantings/bulk_rest.py
+++ b/plantings/bulk_rest.py
@@ -36,22 +36,43 @@ from .rest import SpecificPlantMoveSerializer
 MAX_BULK_PLANTS = 5000
 
 
+class GerminationSourceSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.Serializer,
+):  # pylint: disable=abstract-method
+    """Validate one selected cell and its observed seedling count."""
+
+    cell_planting = serializers.PrimaryKeyRelatedField(
+        queryset=SeedTrayCellPlanting.objects.all(),
+    )
+    quantity = serializers.IntegerField(min_value=1, max_value=MAX_BULK_PLANTS)
+    workspace_field_lookups = {
+        'cell_planting': 'seed_tray_planting__workspace',
+    }
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
 class GerminationPayloadSerializer(
     CurrentWorkspaceSerializerMixin,
     serializers.Serializer,
 ):  # pylint: disable=abstract-method
-    """Validate the tray-cell source and number of plants observed."""
+    """Validate legacy uniform counts or per-cell germination observations."""
 
     cell_planting = serializers.PrimaryKeyRelatedField(
-        queryset=SeedTrayCellPlanting.objects.all(),
-        required=False,
+        queryset=SeedTrayCellPlanting.objects.all(), required=False,
     )
     cell_plantings = serializers.PrimaryKeyRelatedField(
-        queryset=SeedTrayCellPlanting.objects.all(),
-        many=True,
-        required=False,
+        queryset=SeedTrayCellPlanting.objects.all(), many=True, required=False,
     )
-    quantity = serializers.IntegerField(min_value=1, max_value=MAX_BULK_PLANTS)
+    quantity = serializers.IntegerField(
+        min_value=1, max_value=MAX_BULK_PLANTS, required=False,
+    )
+    germinations = GerminationSourceSerializer(many=True, required=False)
     notes = serializers.CharField(allow_blank=True, required=False, default='')
     workspace_field_lookups = {
         'cell_planting': 'seed_tray_planting__workspace',
@@ -59,25 +80,38 @@ class GerminationPayloadSerializer(
     }
 
     def validate(self, attrs):
-        """Normalize one or many cell allocations into one bounded selection."""
+        """Normalize every accepted request shape to per-cell quantities."""
         singular = attrs.pop('cell_planting', None)
-        allocations = attrs.get('cell_plantings', [])
-        if singular is not None and allocations:
+        allocations = attrs.pop('cell_plantings', [])
+        germinations = attrs.get('germinations', [])
+        selections_supplied = sum((singular is not None, bool(allocations), bool(germinations)))
+        if selections_supplied != 1:
             raise ValidationError({
-                'cell_plantings': 'Choose either one cell allocation or a list, not both.',
+                'germinations': 'Choose exactly one cell selection format.',
             })
-        if singular is not None:
-            allocations = [singular]
-        if not allocations:
-            raise ValidationError({'cell_plantings': 'Choose at least one cell allocation.'})
-        allocation_ids = [allocation.pk for allocation in allocations]
+        legacy_quantity = attrs.pop('quantity', None)
+        if germinations:
+            if legacy_quantity is not None:
+                raise ValidationError({
+                    'quantity': 'Set quantity on each selected cell.',
+                })
+        else:
+            if legacy_quantity is None:
+                raise ValidationError({'quantity': 'This field is required.'})
+            if singular is not None:
+                allocations = [singular]
+            germinations = [
+                {'cell_planting': allocation, 'quantity': legacy_quantity}
+                for allocation in allocations
+            ]
+        allocation_ids = [entry['cell_planting'].pk for entry in germinations]
         if len(set(allocation_ids)) != len(allocation_ids):
-            raise ValidationError({'cell_plantings': 'Each cell allocation may only be selected once.'})
-        if len(allocations) * attrs['quantity'] > MAX_BULK_PLANTS:
+            raise ValidationError({'germinations': 'Each cell allocation may only be selected once.'})
+        if sum(entry['quantity'] for entry in germinations) > MAX_BULK_PLANTS:
             raise ValidationError({
-                'quantity': f'A germination operation may create at most {MAX_BULK_PLANTS} plants.',
+                'germinations': f'A germination operation may create at most {MAX_BULK_PLANTS} plants.',
             })
-        attrs['cell_plantings'] = allocations
+        attrs['germinations'] = germinations
         return attrs
 
     def create(self, validated_data):

--- a/plantings/test_bulk_rest.py
+++ b/plantings/test_bulk_rest.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import close_old_connections
-from django.db.models import F
+from django.db.models import Count, F
 from django.test import TransactionTestCase, skipUnlessDBFeature
 from django.utils import timezone
 
@@ -276,8 +276,8 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
             3,
         )
 
-    def test_multi_cell_germination_creates_unique_plants_in_each_cell(self):
-        """One reviewed action preserves the physical origin of every seedling."""
+    def test_multi_cell_germination_supports_different_counts_per_cell(self):
+        """One action preserves each seedling's origin and observed cell count."""
         first = make_seed_tray_cell_planting(quantity=2)
         second = make_seed_tray_cell_planting(
             seed_tray_planting=first.seed_tray_planting,
@@ -291,8 +291,10 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
             BulkPlantOperation.Action.GERMINATE,
             plants=[],
             action_payload={
-                'cell_plantings': [second.pk, first.pk],
-                'quantity': 1,
+                'germinations': [
+                    {'cell_planting': second.pk, 'quantity': 2},
+                    {'cell_planting': first.pk, 'quantity': 1},
+                ],
                 'notes': 'Tray check.',
             },
         )
@@ -301,10 +303,13 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
             '/plantings/bulk-operations/preview/', payload, format='json',
         )
         self.assertEqual(preview.status_code, 200, preview.data)
-        self.assertEqual(preview.data['selected'], 2)
+        self.assertEqual(preview.data['selected'], 3)
         self.assertEqual(
-            preview.data['source']['cell_plantings'],
-            [second.pk, first.pk],
+            preview.data['source']['germinations'],
+            [
+                {'cell_planting': second.pk, 'quantity': 2},
+                {'cell_planting': first.pk, 'quantity': 1},
+            ],
         )
 
         response = self.client.post(
@@ -313,17 +318,22 @@ class BulkPlantOperationRESTTests(RESTContractTestCase):
         self.assertEqual(response.status_code, 201, response.data)
         plant_ids = [result['plant'] for result in response.data['results']]
         plants = SpecificPlant.objects.filter(pk__in=plant_ids)
-        self.assertEqual(plants.count(), 2)
+        self.assertEqual(plants.count(), 3)
         self.assertEqual(
-            set(plants.values_list('cell_planting_id', flat=True)),
-            {first.pk, second.pk},
+            list(
+                plants.values('cell_planting_id')
+                .annotate(count=Count('pk'))
+                .order_by('cell_planting_id')
+                .values_list('cell_planting_id', 'count')
+            ),
+            sorted([(first.pk, 1), (second.pk, 2)]),
         )
         self.assertEqual(
             SpecificPlantLocation.objects.filter(
                 specific_plant__in=plants,
                 seed_tray_cell_id=F('specific_plant__cell_planting__cell_id'),
             ).count(),
-            2,
+            3,
         )
 
     def test_garden_profile_can_preview_and_record_cell_germination(self):


### PR DESCRIPTION
Multi-germ observations can produce different seedling counts in adjacent cells. Normalize legacy and new requests into per-cell quantities, bound the combined plant count, and create every distinct plant atomically against the correct source allocation.

## Summary by Sourcery

Allow germination operations to record and create cell-specific seedling counts while retaining compatibility with legacy requests.

New Features:
- Support germination requests with distinct observed seedling quantities for each selected tray cell.

Bug Fixes:
- Ensure multi-cell germination operations create the requested number of plants at the correct source cell while enforcing the overall plant limit.

Enhancements:
- Normalize legacy uniform germination payloads and new per-cell payloads into a common representation.
- Preserve per-cell germination quantities in previews and audit each created plant against its source allocation.

Tests:
- Update multi-cell germination coverage to verify differing per-cell counts and resulting plant origins.