### PR TITLE
fix(costing): use valid germination trigger

### DIFF
--- a/costing/services.py
+++ b/costing/services.py
@@ -30,6 +30,7 @@ already an audited transition with a required reason.
 
 from decimal import Decimal
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from applications.models import FACTOR_DECIMAL_PLACES
@@ -318,6 +319,12 @@ def reallocate_batch(batch, user, trigger, reason=''):
     ordinary events, most of which change no allocation, and storing a row for
     every check would bury the runs that did something.
     """
+    try:
+        trigger = CostAllocationRun.Trigger(trigger)
+    except ValueError as exc:
+        raise ValidationError({
+            'trigger': f'Value {trigger!r} is not a valid choice.',
+        }) from exc
     batch = lock_batch_with_plants(batch)
     reverse, post = _plan(batch)
     if not reverse and not post:

--- a/costing/test_services.py
+++ b/costing/test_services.py
@@ -11,6 +11,7 @@ and germinations recorded against its cells.
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
@@ -234,6 +235,11 @@ class SingleSeedlingTests(CostingServiceTestCase):
         self.apply_media([self.cells[0]], '0.04')
         self.plant = self.germinate(self.sowing, self.cells[0])[0]
         self.reallocate()
+
+    def test_reallocation_validates_its_trigger_before_an_idempotent_return(self):
+        """An invalid caller cannot hide behind a plan that needs no writes."""
+        with self.assertRaisesMessage(ValidationError, 'not a valid choice'):
+            reallocate_batch(self.batch, self.user, 'unknown-trigger')
 
     def test_the_plant_carries_its_seed_and_its_media(self):
         """Four clusters at 0.25 and 40 ml of two-dollar media is 1.08."""

--- a/plantings/bulk_operations.py
+++ b/plantings/bulk_operations.py
@@ -503,10 +503,11 @@ def _apply_germination(operation, user, request):
         for _index in range(quantities[allocation.pk]):
             _create_germinated_plant(operation, user, request, allocation, notes)
 
+    from costing.models import CostAllocationRun  # pylint: disable=import-outside-toplevel
     from costing.services import reallocate_batch  # pylint: disable=import-outside-toplevel
 
     for batch in locked_batches:
-        reallocate_batch(batch, user, 'bulk-germination')
+        reallocate_batch(batch, user, CostAllocationRun.Trigger.GERMINATION)
 
 
 @transaction.atomic


### PR DESCRIPTION
Confirmed bulk germination reached costing with an ad-hoc trigger value that CostAllocationRun rejects whenever the real tray has allocations to rewrite. Use the canonical germination trigger and validate triggers before idempotent early returns so lightweight fixtures cannot hide this integration error again.

## Summary by Sourcery

Ensure germination costing uses valid triggers and consistently validates all reallocation requests.

Bug Fixes:
- Use the canonical germination trigger for bulk germination costing reallocations.
- Reject invalid costing triggers before idempotent early returns.

Tests:
- Add coverage confirming invalid triggers raise validation errors even when no allocation changes are required.