### PR TITLE
build(deps): add tblib so parallel test failures are reportable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ psycopg[binary,pool]==3.3.4
 
 uwsgi==2.0.31
 
+# Testing. Without tblib, a test that fails inside a --parallel worker cannot be
+# pickled back to the parent, and the run dies with "cannot pickle 'traceback'
+# object" instead of naming the failure.
+tblib==3.2.0
+
 # Checker
 pycodestyle
 pylint==4.0.*


### PR DESCRIPTION
Django's parallel test runner pickles results back from each worker process. Without tblib a traceback cannot be pickled, so the first failing test in any worker takes the whole run down with

    TypeError: cannot pickle 'traceback' object

and never names the test that failed. Installing it is the difference between a --parallel run that reports a failure and one that only reports that reporting failed.