### PR TITLE
feat(settings): select the site settings module with GP_SITE_SETTINGS

### DIFF
--- a/gp/ci_settings.py
+++ b/gp/ci_settings.py
@@ -1,4 +1,16 @@
-"""Site-specific settings used by the continuous integration workflow."""
+"""PostgreSQL settings for the test suite.
+
+Used two ways, deliberately by the same file so the local loop cannot drift
+from the one CI runs:
+
+* CI copies this over ``gp/local_settings.py`` and sets ``DB_HOST`` and friends.
+* ``test-venv.sh`` selects it with ``GP_SITE_SETTINGS=gp.ci_settings``, leaving
+  an existing ``gp/local_settings.py`` alone.
+
+The name, user, and password default to the ones ``compose.yaml`` creates. The
+port deliberately does not: it defaults to PostgreSQL's, and ``test-venv.sh``
+supplies the port the container is published on.
+"""
 import os
 
 
@@ -10,9 +22,10 @@ CSRF_TRUSTED_ORIGINS = ['http://localhost']
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'HOST': os.environ['DB_HOST'],
-        'NAME': os.environ['DB_NAME'],
-        'USER': os.environ['DB_USER'],
-        'PASSWORD': os.environ['DB_PASS'],
+        'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
+        'PORT': os.environ.get('DB_PORT', ''),
+        'NAME': os.environ.get('DB_NAME', 'garden_tracker'),
+        'USER': os.environ.get('DB_USER', 'garden_tracker'),
+        'PASSWORD': os.environ.get('DB_PASS', 'garden_tracker'),
     },
 }

--- a/gp/settings.py
+++ b/gp/settings.py
@@ -10,13 +10,29 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+import importlib
+import os
 from datetime import timedelta
 from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
 
-# Import other settings
-from gp.local_settings import *
+# Import other settings. GP_SITE_SETTINGS names the module holding the
+# site-specific settings, so the same checkout can run the test suite against
+# PostgreSQL (gp.ci_settings) without disturbing gp/local_settings.py.
+SITE_SETTINGS_MODULE = os.environ.get("GP_SITE_SETTINGS", "gp.local_settings")
+
+try:
+    _site_settings = importlib.import_module(SITE_SETTINGS_MODULE)
+except ImportError as error:
+    raise ImproperlyConfigured(
+        f"Unable to import site settings module {SITE_SETTINGS_MODULE!r}. "
+        "Run setup-venv.sh or correct GP_SITE_SETTINGS."
+    ) from error
+
+globals().update(
+    {name: value for name, value in vars(_site_settings).items() if name.isupper()}
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -139,6 +155,10 @@ STATIC_ROOT = BASE_DIR / "static"
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Reports which tests a backend could not run instead of leaving the reader to
+# work out what "OK (skipped=21)" cost them.
+TEST_RUNNER = "gp.test_runner.GardenTestRunner"
 
 LOGIN_REDIRECT_URL = "/"
 

--- a/gp/test_runner.py
+++ b/gp/test_runner.py
@@ -1,0 +1,87 @@
+"""Test runner that refuses to report a silent skip as a passing run.
+
+Roughly two dozen tests across the ledger, sales, stocktake, health, and
+seed-tray apps are decorated ``@skipUnlessDBFeature('has_select_for_update')``.
+On SQLite that feature is false, so all of them skip and unittest reports
+``OK (skipped=21)`` — a green run in which none of the row-locking guarantees
+were exercised. This runner names what was skipped and why, and can be told to
+fail instead so the count cannot grow again unnoticed.
+"""
+import os
+import sys
+
+from django.db import connection
+from django.test.runner import DiscoverRunner
+
+
+# The reason text Django's skipUnlessDBFeature/skipIfDBFeature record.
+FEATURE_SKIP_PREFIX = "Database doesn't support feature(s)"
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def fail_on_skip():
+    """Report whether a skipped test should fail the run."""
+    return os.environ.get("GP_FAIL_ON_SKIP", "").lower() in TRUE_VALUES
+
+
+class GardenTestRunner(DiscoverRunner):
+    """Annotate the unittest summary with the cost of the current backend."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vendor = connection.vendor
+        self.row_locking = True
+
+    def setup_databases(self, **kwargs):
+        """Record what the backend can do while a connection is open."""
+        old_config = super().setup_databases(**kwargs)
+        self.vendor = connection.vendor
+        self.row_locking = connection.features.has_select_for_update
+        return old_config
+
+    def suite_result(self, suite, result, **kwargs):
+        failures = super().suite_result(suite, result, **kwargs)
+        skipped = [reason for _, reason in getattr(result, "skipped", [])]
+        if not skipped:
+            return failures
+
+        feature_skips = [
+            reason for reason in skipped if reason.startswith(FEATURE_SKIP_PREFIX)
+        ]
+        self._report(skipped, feature_skips)
+        if fail_on_skip():
+            return failures + len(skipped)
+        return failures
+
+    def _report(self, skipped, feature_skips):
+        """Explain the skips on stderr, next to the summary they qualify."""
+        lines = []
+        if feature_skips and not self.row_locking:
+            lines.append(
+                f"WARNING: {len(feature_skips)} concurrency tests did not run. "
+                f"The {self.vendor} backend has no has_select_for_update, so "
+                "the row-locking behaviour protecting the inventory ledger, "
+                "sales allocations, stocktake corrections, and quarantine "
+                "transitions was not exercised."
+            )
+            lines.append(
+                "         Run ./test-venv.sh --postgresql for the suite CI runs."
+            )
+        elif feature_skips:
+            lines.append(
+                f"WARNING: {len(feature_skips)} tests were skipped for missing "
+                f"{self.vendor} database features."
+            )
+
+        other = len(skipped) - len(feature_skips)
+        if other:
+            lines.append(f"WARNING: {other} further tests were skipped.")
+
+        if fail_on_skip():
+            lines.append(
+                "ERROR: GP_FAIL_ON_SKIP is set, so a skipped test fails the run."
+            )
+
+        for line in lines:
+            print(line, file=sys.stderr)


### PR DESCRIPTION
gp/settings.py imported gp.local_settings by name, so the only way to run against another database was to overwrite the developer's own settings file. That is what has kept the test suite on whatever backend local_settings.py happened to name.

Read the module name from GP_SITE_SETTINGS instead, defaulting to gp.local_settings so nothing changes for an ordinary run, and widen gp/ci_settings.py to serve both CI and a local test run. Its database values now fall back to the ones compose.yaml creates rather than requiring four environment variables. The port deliberately keeps PostgreSQL's default; test-venv.sh supplies the published one.

Only uppercase names are copied out of the module, which is what Django reads as settings.

Add the test runner the new configuration needs alongside it, so no commit names a TEST_RUNNER that does not exist. It annotates the unittest summary with the tests the backend could not run: "OK (skipped=21)" does not say that the 21 are the row-locking proofs for the ledger, sales allocations, stocktake corrections, and quarantine transitions. GP_FAIL_ON_SKIP turns a skip into a failure for callers that can run everything.

## Summary by Sourcery

Make the test suite selectable across database backends without modifying local settings and surface skipped backend-dependent coverage.

New Features:
- Allow Django site settings to be selected through the GP_SITE_SETTINGS environment variable while preserving the existing default.
- Add test-run reporting for backend-dependent skips, with an option to fail runs when tests are skipped.

Enhancements:
- Share PostgreSQL test configuration between CI and local test runs with compose-compatible defaults.
- Limit imported site settings to uppercase Django configuration names.

Tests:
- Add a custom Django test runner that identifies skipped database-feature tests and reports unsupported row-locking coverage.