### PR TITLE
test: run the local suite on PostgreSQL

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -23,9 +23,14 @@ jobs:
           - 5432:5432
     env:
       DB_HOST: 127.0.0.1
+      DB_PORT: 5432
       DB_NAME: garden_tracker
       DB_USER: garden_tracker
       DB_PASS: garden_tracker
+      # CI provides the service, so it must never silently fall back.
+      GP_TEST_DB: postgresql
+      # PostgreSQL can run every test, so a skip means the suite lost coverage.
+      GP_FAIL_ON_SKIP: 1
     steps:
       - uses: actions/checkout@v7
       - name: Setup python

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /static/
 __pycache__/
 /db.sqlite3
+# Clones left behind when a --parallel run on SQLite dies in teardown.
+/default_*.sqlite3
 /frontend/static/
 /gp/local_settings.py
 /gp/secretkey.txt

--- a/README.md
+++ b/README.md
@@ -63,15 +63,17 @@ Features
   - `setup-venv.sh` creates a Python virtual environment, installs Python dependencies, builds the frontend (npm), creates SQLite development settings when needed, generates a secret key, applies migrations, and collects static files.
   - `setup-db.sh` applies `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` to explicitly selected PostgreSQL settings. `start-wsgi.sh` serves the app in deployments.
   - `check-code.sh` for style/lint checks (pycodestyle, pylint).
+  - `test-venv.sh` runs the backend suite, on PostgreSQL when one is reachable. `compose.yaml` provides that database.
 
 - Local-first defaults
   - `gp/local_settings.dev.py.template` is the canonical local configuration and uses `db.sqlite3`.
   - `gp/local_settings.postgresql.py.template` is available for deployments that use PostgreSQL.
+  - `gp/ci_settings.py` holds the PostgreSQL settings the test suite uses, in CI and locally. `GP_SITE_SETTINGS` names the module `gp/settings.py` reads site settings from, so selecting it for a test run leaves `gp/local_settings.py` untouched.
 
 Tech stack
 - Django (Python) backend, Django REST Framework for APIs
 - React + Bootstrap (JavaScript) frontend components
-- SQLite for local development; PostgreSQL for deployment
+- SQLite for local development; PostgreSQL for deployment and for running the tests
 - Node/npm for frontend build; esbuild configuration present
 - Shell scripts for environment setup and build automation
 
@@ -80,6 +82,7 @@ Prerequisites
 - Python 3.12+ (required by Django 6)
 - Node.js 22.22+ and npm (required by React Router)
 - Bash-compatible shell for `setup-venv.sh`
+- Docker with Compose, to run the PostgreSQL the test suite uses. Not needed to run the application itself; see "Running the tests".
 
 Quick start (recommended)
 1. Clone the repo:
@@ -158,6 +161,22 @@ Development notes
     ```
     Restart the application afterward. Rotation invalidates existing sessions, password-reset links, and other values signed with the old key.
 
+- Running the tests:
+  - Start the test database, then run the suite:
+    ```bash
+    docker compose up -d db
+    ./test-venv.sh
+    ```
+    `compose.yaml` runs the same PostgreSQL 18 image CI does, published on `127.0.0.1:55432` so it cannot collide with a server already using 5432. It stores nothing between `docker compose down` and the next `up`; the suite creates and drops its own `test_garden_tracker` inside it.
+  - Run PostgreSQL. Roughly two dozen tests are decorated `@skipUnlessDBFeature('has_select_for_update')` and cover the row locking that protects the inventory ledger, sales allocations, stocktake corrections, and quarantine transitions. SQLite reports that feature as false, so all of them skip and the run still reports `OK`.
+  - `./test-venv.sh` uses PostgreSQL whenever one answers and otherwise falls back to `gp/local_settings.py`, warning both times: once about the fallback, and once after the summary naming how many tests the backend could not run.
+    - `--postgresql` requires it and fails with setup instructions when no server answers. Use it in scripts.
+    - `--sqlite` keeps the old behaviour for a quick check of something unrelated to locking.
+    - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, and `DB_PASS` select another server. `GP_TEST_DB` presets the same choice as the flags, and `GP_FAIL_ON_SKIP=1` turns any skipped test into a failure, as CI sets.
+    - Remaining arguments go to `manage.py test`, so `./test-venv.sh sales.test_concurrency -v 2` works as usual.
+  - The PostgreSQL run defaults to `--parallel auto`; pass your own `--parallel` to override it. Parallel runs on the SQLite path still crash in teardown, which is why it is not the default there.
+  - Run the suite before each commit, as the project's commit rule asks.
+
 - Linting and checks:
   - `./check-code.sh` runs pycodestyle and pylint (uses `venv`).
 
@@ -222,12 +241,13 @@ Project layout (high level)
 - locations/ — the shared catalog of physical places, referenced by stock, trays, and plants
 - work/ — Nursery task rules, source projections, acknowledged work, and action history
 - garden/, plants/, seeds/, plantings/, supplies/ — Django apps with models, views, rest.py, urls
-- setup-venv.sh, setup-db.sh, build-frontend.sh, start-wsgi.sh — helper scripts
+- setup-venv.sh, setup-db.sh, build-frontend.sh, start-wsgi.sh, test-venv.sh — helper scripts
+- compose.yaml — the throwaway PostgreSQL the test suite runs against
 - requirements.txt, package.json — dependency manifests
 
 Contributing
 - Fork, create a feature branch, add tests, and open a PR.
-- Run backend tests with `./test-venv.sh` and linting with `./check-code.sh` before submitting.
+- Run backend tests with `./test-venv.sh` and linting with `./check-code.sh` before submitting. Start the test database first (`docker compose up -d db`) so the concurrency tests actually run; see "Running the tests".
 - Consider adding a CONTRIBUTING.md and CODE_OF_CONDUCT.md if you want contribution guidelines formalised.
 
 License

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,35 @@
+# Throwaway PostgreSQL for the local test suite.
+#
+# This is not a development or deployment database: it holds nothing between
+# `docker compose down` and the next `up`, and the suite creates and drops its
+# own `test_garden_tracker` inside it.
+services:
+  db:
+    image: postgres:18
+    environment:
+      POSTGRES_DB: garden_tracker
+      POSTGRES_USER: garden_tracker
+      POSTGRES_PASSWORD: garden_tracker
+    # Published on 55432 so the container cannot collide with a PostgreSQL
+    # already listening on 5432. Override with DB_PORT, which test-venv.sh
+    # reads as well, to move both ends together.
+    ports:
+      - "127.0.0.1:${DB_PORT:-55432}:5432"
+    # Durability is worthless for a database whose contents are discarded after
+    # every run, and turning it off is most of the difference between a loop
+    # that gets run before each commit and one that does not. Locking and
+    # transaction semantics, which is what the concurrency tests exercise, are
+    # unaffected.
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U garden_tracker -d garden_tracker"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/test-venv.sh
+++ b/test-venv.sh
@@ -1,3 +1,80 @@
 #!/bin/bash -e
 
-venv/bin/python manage.py test "$@"
+# Run the backend test suite.
+#
+# It runs on PostgreSQL whenever a server is reachable, because that is what CI
+# runs and because roughly two dozen concurrency tests skip on any backend
+# without has_select_for_update. Start one with `docker compose up -d db`.
+#
+#   ./test-venv.sh                 # PostgreSQL if reachable, otherwise fall back
+#   ./test-venv.sh --postgresql    # require PostgreSQL; fail if it is absent
+#   ./test-venv.sh --sqlite        # use gp/local_settings.py as it stands
+#
+# DB_HOST, DB_PORT, DB_NAME, DB_USER, and DB_PASS select the server, and
+# GP_TEST_DB presets the same choice as the flags. Remaining arguments are
+# passed to `manage.py test`.
+
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_PORT="${DB_PORT:-55432}"
+DB_NAME="${DB_NAME:-garden_tracker}"
+GP_TEST_DB="${GP_TEST_DB:-auto}"
+
+args=()
+for arg in "$@"
+do
+	case "$arg" in
+		--postgresql) GP_TEST_DB=postgresql ;;
+		--sqlite) GP_TEST_DB=sqlite ;;
+		*) args+=("$arg") ;;
+	esac
+done
+
+postgresql_reachable() {
+	# timeout is GNU coreutils and is absent on a stock macOS, where a bare
+	# connect is still the right test; without it the probe would report every
+	# server unreachable and quietly send the run back to SQLite.
+	if command -v timeout >/dev/null
+	then
+		timeout 2 bash -c "exec 3<>/dev/tcp/$DB_HOST/$DB_PORT" 2>/dev/null
+	else
+		bash -c "exec 3<>/dev/tcp/$DB_HOST/$DB_PORT" 2>/dev/null
+	fi
+}
+
+case "$GP_TEST_DB" in
+	auto)
+		if postgresql_reachable
+		then
+			GP_TEST_DB=postgresql
+		else
+			echo "WARNING: no PostgreSQL server at $DB_HOST:$DB_PORT; using gp/local_settings.py." >&2
+			echo "         Start one with 'docker compose up -d db' to run the concurrency tests." >&2
+			GP_TEST_DB=sqlite
+		fi
+		;;
+	postgresql)
+		if ! postgresql_reachable
+		then
+			echo "ERROR: no PostgreSQL server at $DB_HOST:$DB_PORT." >&2
+			echo "  Start one with: docker compose up -d db" >&2
+			echo "  Or point DB_HOST and DB_PORT at an existing server." >&2
+			exit 1
+		fi
+		;;
+	sqlite) ;;
+	*)
+		echo "ERROR: GP_TEST_DB must be auto, postgresql, or sqlite." >&2
+		exit 1
+		;;
+esac
+
+if [ "$GP_TEST_DB" = "postgresql" ]
+then
+	echo "Running the suite on PostgreSQL ($DB_NAME@$DB_HOST:$DB_PORT)."
+	export GP_SITE_SETTINGS="${GP_SITE_SETTINGS:-gp.ci_settings}"
+	export DB_HOST DB_PORT DB_NAME
+	# --parallel first so an explicit one in "$@" overrides it.
+	exec venv/bin/python manage.py test --parallel auto "${args[@]}"
+fi
+
+exec venv/bin/python manage.py test "${args[@]}"


### PR DESCRIPTION
CI runs PostgreSQL 18; local development runs SQLite. Twenty-one tests are decorated skipUnlessDBFeature('has_select_for_update'), so on SQLite every one of them skips and the suite still reports OK. The tests that skip are the ones guarding the inventory ledger, sales allocations, stocktake corrections, and quarantine transitions -- the behaviour most worth running. A developer watched a green suite while those guarantees went entirely unexercised.

test-venv.sh now uses PostgreSQL whenever one answers and falls back to gp/local_settings.py with a warning when none does, so the loop that matches CI is the default without making a database a prerequisite for a first checkout. --postgresql requires it, --sqlite keeps the old path. compose.yaml provides the server on 127.0.0.1:55432, a port chosen so it cannot collide with a PostgreSQL already serving 5432, and runs it without durability because its contents never outlive the run.

The PostgreSQL path defaults to --parallel auto, which the SQLite path cannot use: it dies in teardown and leaves default_N.sqlite3 files in the repository root, so gitignore them too.

On eight cores: 1183 tests, no skips, 460s of test time and 8m13s wall, against a serial baseline of 980s that skipped 21. CI keeps the count honest with GP_FAIL_ON_SKIP.

## Summary by Sourcery

Run backend tests on PostgreSQL by default when available, while preserving an explicit SQLite fallback for environments without a database.

New Features:
- Run the local backend test suite against PostgreSQL when available, with explicit PostgreSQL and SQLite modes.
- Provide a disposable PostgreSQL 18 Compose service for local testing.
- Add environment controls for selecting the test database and optionally failing on skipped tests.,

Bug Fixes:
- Prevent local test runs from silently passing while concurrency and row-locking tests are skipped on SQLite.

Enhancements:
- Enable automatic parallel execution for PostgreSQL test runs while retaining serial execution for SQLite.
- Align CI test configuration with local PostgreSQL runs and enforce complete test coverage in CI.

CI:
- Configure CI to use PostgreSQL explicitly and fail when tests are skipped.

Documentation:
- Document PostgreSQL-backed local testing, database selection options, Compose setup, and test-running prerequisites.

Chores:
- Ignore generated SQLite databases left by local test runs.],