### PR TITLE
feat(tax): decide when a supply falls due under each GST basis

### DIFF
--- a/tax/recognition.py
+++ b/tax/recognition.py
@@ -1,0 +1,368 @@
+"""When a supply is brought to account for GST, under each accounting basis.
+
+This module is the whole of task 117's accounting judgement, and it holds no
+database access at all. Facts come in as frozen dataclasses and recognition
+events go out; the ORM read that gathers the facts lives in `services`. Keeping
+the split means the basis-by-order-shape matrix — prepaid, part-paid,
+invoiced-but-unpaid, fulfilled, returned, refunded, across three bases — is a
+fast unit test rather than eighteen fixtures.
+
+The three bases, and what each one waits for:
+
+* **Payments** recognises on money received. An order invoiced and delivered
+  but unpaid produces nothing at all, which is the point of the basis.
+* **Invoice** recognises on the earlier of an invoice issued and a payment
+  received. This repository has no invoice document yet — task 118 owns it — so
+  a fulfillment stands in for the invoice date. Every event says so through
+  `time_of_supply_source` and `proxy`, so task 118 can find exactly the events
+  it supersedes rather than re-deriving all of them.
+* **Hybrid** is invoice for output tax and payments for input tax. Only output
+  tax is decided here, so hybrid and invoice behave identically in this module;
+  the difference shows up on the purchase side.
+
+Recognition is capped at the order's own value. Cash beyond it is not
+consideration for a supply — it is an overpayment — and it is reported rather
+than quietly inflating a return.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Mapping, Tuple
+
+from inventory.ledger import distribute_exactly, quantize_money
+
+
+PERCENT_DIVISOR = Decimal('100')
+ZERO = Decimal('0.0000')
+
+#: Accounting bases, matching ``GstRegistration.Basis``. Restated as plain
+#: strings so this module stays free of the model layer; a test keeps them in
+#: step, the way ``costing`` keeps its source tuples honest.
+PAYMENTS = 'payments'
+INVOICE = 'invoice'
+HYBRID = 'hybrid'
+BASES = (PAYMENTS, INVOICE, HYBRID)
+
+#: Tax codes, matching ``SalesOrderLine.TaxTreatment``. Only a standard-rated
+#: supply carries output tax; the other codes are the reason a zero-rated sale
+#: can be told apart from an exempt one, which a rate of zero cannot do.
+STANDARD = 'standard'
+ZERO_RATED = 'zero_rated'
+EXEMPT = 'exempt'
+OUT_OF_SCOPE = 'out_of_scope'
+UNCLASSIFIED = 'unclassified'
+
+#: Codes that count towards taxable turnover for the registration threshold.
+#: Exempt and out-of-scope supplies do not, and an unclassified supply is not
+#: assumed either way — it is reported as a gap.
+TURNOVER_CODES = (STANDARD, ZERO_RATED)
+
+#: Payments are ranked before fulfillments on the same day, so a deposit and a
+#: same-day delivery split deterministically. The totals are identical either
+#: way; only the attribution moves, and an arbitrary attribution that changed
+#: between runs would make a report impossible to reconcile.
+PAYMENT_RANK = 0
+FULFILLMENT_RANK = 1
+
+
+@dataclass(frozen=True)
+class LineFact:
+    """One sales order line's commercial terms, as snapshotted."""
+
+    line_id: int
+    tax_rate: Decimal
+    tax_code: str
+    gross_incl_tax: Decimal
+
+
+@dataclass(frozen=True)
+class FulfillmentFact:
+    """One effective fulfillment and the gross value it delivered per line."""
+
+    fulfillment_id: int
+    supply_date: date
+    line_grosses: Mapping[int, Decimal]
+
+
+@dataclass(frozen=True)
+class PaymentFact:
+    """One effective payment. It carries no line linkage and no tax split."""
+
+    payment_id: int
+    paid_on: date
+    gross: Decimal
+
+
+@dataclass(frozen=True)
+class RefundPortion:
+    """One refunded line's share, read straight off its RefundLine."""
+
+    line_id: int
+    gross: Decimal
+    tax: Decimal
+
+
+@dataclass(frozen=True)
+class RefundFact:
+    """One effective refund, already classified against the lines it credits."""
+
+    refund_id: int
+    refunded_on: date
+    portions: Tuple[RefundPortion, ...]
+
+
+@dataclass(frozen=True)
+class OrderFacts:
+    """Everything about one order that bears on when GST falls due."""
+
+    order_id: int
+    currency_code: str
+    lines: Tuple[LineFact, ...]
+    fulfillments: Tuple[FulfillmentFact, ...] = ()
+    payments: Tuple[PaymentFact, ...] = ()
+    refunds: Tuple[RefundFact, ...] = ()
+    #: Returns with no refund against them. A return moves plants, not money,
+    #: so no GST adjustment is due — but the credit note is outstanding work
+    #: somebody has to do, and it is reported rather than assumed away.
+    unrefunded_return_ids: Tuple[int, ...] = ()
+
+
+# A recognition event has to carry every fact a return column and its
+# drill-down need, and there is no grouping of them that is not arbitrary.
+@dataclass(frozen=True)
+class RecognitionEvent:  # pylint: disable=too-many-instance-attributes
+    """One line's worth of supply or credit, at the date it falls due."""
+
+    kind: str
+    supply_date: date
+    source_type: str
+    source_id: int
+    line_id: int
+    tax_code: str
+    tax_rate: Decimal
+    gross: Decimal
+    tax: Decimal
+    time_of_supply_source: str
+    proxy: bool = False
+
+    @property
+    def taxable(self):
+        """The ex-GST value, derived as the residual so the row always balances."""
+        return self.gross - self.tax
+
+
+SUPPLY = 'supply'
+SUPPLY_CREDIT = 'supply_credit'
+
+
+@dataclass(frozen=True)
+class Recognition:
+    """What one order contributes to GST returns, and what it cannot answer."""
+
+    events: Tuple[RecognitionEvent, ...] = ()
+    #: Cash received beyond the order's own value. Not consideration for any
+    #: supply, so it carries no GST until it is matched or refunded.
+    unmatched_overpayment: Decimal = ZERO
+    #: Value that has not yet reached a time of supply. Under the payments
+    #: basis this is the unpaid balance; under invoice it is the undelivered,
+    #: unpaid remainder.
+    unrecognised_gross: Decimal = ZERO
+    #: Credits that exceeded the supply they were credited against. Should be
+    #: zero — `post_refund` caps refunds — so a non-zero value is a defect
+    #: worth reporting rather than absorbing.
+    over_credited: Decimal = ZERO
+    unrefunded_return_ids: Tuple[int, ...] = field(default_factory=tuple)
+
+    @property
+    def supply_events(self):
+        """Every event that brings a supply to account."""
+        return tuple(event for event in self.events if event.kind == SUPPLY)
+
+    @property
+    def credit_events(self):
+        """Every event that credits a supply already brought to account."""
+        return tuple(event for event in self.events if event.kind == SUPPLY_CREDIT)
+
+    @property
+    def recognised_gross(self):
+        """Gross value brought to account, net of credits."""
+        supplied = sum((event.gross for event in self.supply_events), ZERO)
+        credited = sum((event.gross for event in self.credit_events), ZERO)
+        return quantize_money(supplied - credited)
+
+
+def line_tax(gross, tax_rate, tax_code):
+    """Return the GST inside a tax-inclusive amount.
+
+    Only a standard-rated supply carries tax. Branching on the code rather than
+    on the rate means an exempt line that somehow carries a rate cannot produce
+    output tax, and it keeps a zero-rated line at exactly zero rather than at a
+    rounded zero.
+    """
+    if tax_code != STANDARD:
+        return ZERO
+    rate = Decimal(tax_rate)
+    return quantize_money(Decimal(gross) * rate / (PERCENT_DIVISOR + rate))
+
+
+def order_recognition(facts, basis, *, as_at=None):
+    """Return when each part of one order falls due under an accounting basis.
+
+    ``as_at`` stops the clock: only triggers on or before that date are
+    processed, which is what makes a basis-change adjustment computable from
+    the same rules rather than from a second implementation of them.
+    """
+    if basis not in BASES:
+        raise ValueError(f'Unknown accounting basis: {basis!r}')
+    lines = {line.line_id: line for line in facts.lines}
+    remaining = {line.line_id: quantize_money(line.gross_incl_tax) for line in facts.lines}
+    events = []
+    overpaid = ZERO
+
+    for _, _, _, trigger in _ordered_triggers(facts, basis, as_at):
+        if isinstance(trigger, PaymentFact):
+            recognised, unmatched = _recognise_payment(trigger, lines, remaining)
+            overpaid += unmatched
+        else:
+            recognised = _recognise_fulfillment(trigger, lines, remaining, basis)
+        events.extend(recognised)
+
+    credit_events, over_credited = _recognise_refunds(facts, events, as_at)
+    events.extend(credit_events)
+    events.sort(key=lambda event: (event.supply_date, event.source_type, event.source_id, event.line_id))
+    return Recognition(
+        events=tuple(events),
+        unmatched_overpayment=quantize_money(overpaid),
+        unrecognised_gross=quantize_money(sum(remaining.values(), ZERO)),
+        over_credited=quantize_money(over_credited),
+        unrefunded_return_ids=tuple(facts.unrefunded_return_ids),
+    )
+
+
+def _ordered_triggers(facts, basis, as_at):
+    """Return every event that can bring a supply to account, in a stable order."""
+    triggers = [
+        (payment.paid_on, PAYMENT_RANK, payment.payment_id, payment)
+        for payment in facts.payments
+    ]
+    if basis in (INVOICE, HYBRID):
+        triggers.extend(
+            (item.supply_date, FULFILLMENT_RANK, item.fulfillment_id, item)
+            for item in facts.fulfillments
+        )
+    if as_at is not None:
+        triggers = [trigger for trigger in triggers if trigger[0] <= as_at]
+    return sorted(triggers, key=lambda trigger: trigger[:3])
+
+
+def _recognise_payment(payment, lines, remaining):
+    """Apportion one payment across the lines that still owe a time of supply.
+
+    A payment has no line linkage and no tax split, so the split has to be
+    derived. Weighting by each line's remaining tax-inclusive value and using
+    the ledger's own largest-remainder split means the shares sum back to
+    exactly the payment and do not churn when recomputed.
+    """
+    outstanding = quantize_money(sum(remaining.values(), ZERO))
+    gross = quantize_money(payment.gross)
+    if outstanding <= 0:
+        return [], gross
+    applied = min(gross, outstanding)
+    ordered = [line_id for line_id in remaining if remaining[line_id] > 0]
+    shares = distribute_exactly(applied, [remaining[line_id] for line_id in ordered])
+    events = []
+    for line_id, share in zip(ordered, shares):
+        if share <= 0:
+            continue
+        remaining[line_id] = quantize_money(remaining[line_id] - share)
+        events.append(_supply_event(
+            lines[line_id], share, payment.paid_on, 'payment', payment.payment_id,
+        ))
+    return events, quantize_money(gross - applied)
+
+
+def _recognise_fulfillment(fulfillment, lines, remaining, basis):
+    """Bring the value one fulfillment delivered to account, less anything prepaid.
+
+    Under the invoice and hybrid bases a fulfillment stands in for the invoice
+    task 118 will issue. It recognises what it delivered, capped by what that
+    line still owes: a deposit taken earlier has already brought part of it to
+    account, and recognising the delivery in full would double-count it.
+    """
+    events = []
+    for line_id, delivered in fulfillment.line_grosses.items():
+        outstanding = remaining.get(line_id, ZERO)
+        share = min(quantize_money(delivered), outstanding)
+        if share <= 0:
+            continue
+        remaining[line_id] = quantize_money(outstanding - share)
+        events.append(_supply_event(
+            lines[line_id],
+            share,
+            fulfillment.supply_date,
+            'fulfillment',
+            fulfillment.fulfillment_id,
+            proxy=basis in (INVOICE, HYBRID),
+        ))
+    return events
+
+
+def _recognise_refunds(facts, supply_events, as_at):
+    """Credit refunded value at the refund date, capped by what was supplied.
+
+    The amounts are read straight off the refund's own lines rather than
+    re-derived. `proportional_refund` already split the refund preserving each
+    source line's tax ratio, so reading it back reconciles to the refund row
+    exactly and cannot drift by a rounding step.
+    """
+    supplied = {}
+    for event in supply_events:
+        supplied[event.line_id] = supplied.get(event.line_id, ZERO) + event.gross
+    events = []
+    over_credited = ZERO
+    for refund in facts.refunds:
+        if as_at is not None and refund.refunded_on > as_at:
+            continue
+        for portion in refund.portions:
+            available = supplied.get(portion.line_id, ZERO)
+            gross = quantize_money(portion.gross)
+            credited = min(gross, available)
+            over_credited += gross - credited
+            if credited <= 0:
+                continue
+            supplied[portion.line_id] = quantize_money(available - credited)
+            tax = quantize_money(portion.tax)
+            if credited < gross:
+                tax = quantize_money(tax * credited / gross)
+            events.append(RecognitionEvent(
+                kind=SUPPLY_CREDIT,
+                supply_date=refund.refunded_on,
+                source_type='refund',
+                source_id=refund.refund_id,
+                line_id=portion.line_id,
+                tax_code='',
+                tax_rate=ZERO,
+                gross=credited,
+                tax=tax,
+                time_of_supply_source='refund',
+            ))
+    return events, over_credited
+
+
+def _supply_event(line, gross, supply_date, source_type, source_id, *, proxy=False):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """Build one supply event, deriving its tax from the line's own code."""
+    gross = quantize_money(gross)
+    return RecognitionEvent(
+        kind=SUPPLY,
+        supply_date=supply_date,
+        source_type=source_type,
+        source_id=source_id,
+        line_id=line.line_id,
+        tax_code=line.tax_code,
+        tax_rate=Decimal(line.tax_rate),
+        gross=gross,
+        tax=line_tax(gross, line.tax_rate, line.tax_code),
+        time_of_supply_source=source_type,
+        proxy=proxy,
+    )

--- a/tax/test_recognition.py
+++ b/tax/test_recognition.py
@@ -1,0 +1,449 @@
+"""The basis-by-order-shape matrix task 117's verification section asks for.
+
+Six order shapes — prepaid, part-paid, invoiced but unpaid, fulfilled and
+paid, returned without a refund, and refunded — across the payments, invoice
+and hybrid bases. Every case asserts the exact date GST falls due and the
+exact amount, because a return is wrong if either is off by one.
+
+These are pure: no database, no fixtures. That is the reason there can be
+eighteen of them.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.test import SimpleTestCase
+
+from .recognition import (
+    BASES,
+    HYBRID,
+    INVOICE,
+    PAYMENTS,
+    STANDARD,
+    SUPPLY,
+    SUPPLY_CREDIT,
+    ZERO_RATED,
+    FulfillmentFact,
+    LineFact,
+    OrderFacts,
+    PaymentFact,
+    RefundFact,
+    RefundPortion,
+    line_tax,
+    order_recognition,
+)
+
+
+RATE = Decimal('15.0000')
+MARCH = date(2026, 3, 10)
+APRIL = date(2026, 4, 20)
+MAY = date(2026, 5, 5)
+
+
+def standard_line(line_id, gross):
+    """A standard-rated line whose entered price includes GST."""
+    return LineFact(line_id=line_id, tax_rate=RATE, tax_code=STANDARD, gross_incl_tax=Decimal(gross))
+
+
+def order(lines, **facts):
+    """Assemble one order's facts around its lines."""
+    return OrderFacts(order_id=1, currency_code='NZD', lines=tuple(lines), **facts)
+
+
+def totals(recognition):
+    """Return the gross and tax a recognition brings to account, net of credits."""
+    gross = sum((event.gross for event in recognition.supply_events), Decimal('0.0000'))
+    tax = sum((event.tax for event in recognition.supply_events), Decimal('0.0000'))
+    credit_gross = sum((event.gross for event in recognition.credit_events), Decimal('0.0000'))
+    credit_tax = sum((event.tax for event in recognition.credit_events), Decimal('0.0000'))
+    return gross - credit_gross, tax - credit_tax
+
+
+def dates_of(recognition, kind=SUPPLY):
+    """Return the dates GST fell due, as a set, for one kind of event."""
+    return {event.supply_date for event in recognition.events if event.kind == kind}
+
+
+class LineTaxTests(SimpleTestCase):
+    """A rate of zero cannot tell a zero-rated supply from an exempt one."""
+
+    def test_a_standard_line_carries_the_gst_inside_its_price(self):
+        """15% of a 115.00 inclusive price is 15.00, not 17.25."""
+        self.assertEqual(line_tax(Decimal('115.0000'), RATE, STANDARD), Decimal('15.0000'))
+
+    def test_a_zero_rated_line_carries_no_tax(self):
+        """An export is taxable at zero, so it counts as turnover but adds no tax."""
+        self.assertEqual(line_tax(Decimal('115.0000'), Decimal('0'), ZERO_RATED), Decimal('0.0000'))
+
+    def test_the_code_decides_rather_than_the_rate(self):
+        """An exempt line carrying a stray rate must still produce no output tax."""
+        self.assertEqual(line_tax(Decimal('115.0000'), RATE, 'exempt'), Decimal('0.0000'))
+
+    def test_taxable_is_the_residual_so_a_row_always_balances(self):
+        """Deriving taxable the other way leaves rows that do not sum to gross."""
+        recognition = order_recognition(
+            order([standard_line(1, '100.0000')], payments=(PaymentFact(1, MARCH, Decimal('100.0000')),)),
+            PAYMENTS,
+        )
+        for event in recognition.events:
+            self.assertEqual(event.taxable + event.tax, event.gross)
+
+
+class UnknownBasisTests(SimpleTestCase):
+    """A typo in a basis must not silently recognise nothing."""
+
+    def test_an_unknown_basis_is_refused(self):
+        """Defaulting to one of the three would produce a plausible wrong return."""
+        with self.assertRaises(ValueError):
+            order_recognition(order([standard_line(1, '100.0000')]), 'accrual')
+
+
+class PrepaidOrderTests(SimpleTestCase):
+    """Money first, plants later. Every basis recognises at the payment."""
+
+    def facts(self):
+        """A customer pays in March for plants delivered in April."""
+        return order(
+            [standard_line(1, '115.0000')],
+            payments=(PaymentFact(payment_id=7, paid_on=MARCH, gross=Decimal('115.0000')),),
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+        )
+
+    def test_every_basis_recognises_at_the_payment(self):
+        """Payment is the earlier trigger, so the invoice basis agrees with payments."""
+        for basis in BASES:
+            with self.subTest(basis=basis):
+                recognition = order_recognition(self.facts(), basis)
+                self.assertEqual(dates_of(recognition), {MARCH})
+                self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+
+    def test_the_delivery_adds_nothing(self):
+        """Recognising the delivery again would double the return."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertEqual(len(recognition.supply_events), 1)
+        self.assertEqual(recognition.unrecognised_gross, Decimal('0.0000'))
+
+
+class PartiallyPaidOrderTests(SimpleTestCase):
+    """A deposit, a delivery, then the balance — the case bases disagree on."""
+
+    def facts(self):
+        """40.00 down in March, delivered in April, 75.00 balance in May."""
+        return order(
+            [standard_line(1, '115.0000')],
+            payments=(
+                PaymentFact(7, MARCH, Decimal('40.0000')),
+                PaymentFact(8, MAY, Decimal('75.0000')),
+            ),
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+        )
+
+    def test_payments_basis_recognises_at_each_payment(self):
+        """Two returns carry this order, and neither is the delivery period."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        self.assertEqual(dates_of(recognition), {MARCH, MAY})
+        self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+
+    def test_invoice_basis_recognises_the_deposit_then_the_balance_on_delivery(self):
+        """The delivery is the earlier trigger for everything not already prepaid."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertEqual(dates_of(recognition), {MARCH, APRIL})
+        by_date = {event.supply_date: event.gross for event in recognition.supply_events}
+        self.assertEqual(by_date[MARCH], Decimal('40.0000'))
+        self.assertEqual(by_date[APRIL], Decimal('75.0000'))
+
+    def test_hybrid_matches_invoice_for_output_tax(self):
+        """Hybrid differs only on input tax, which this module does not decide."""
+        self.assertEqual(
+            [event.supply_date for event in order_recognition(self.facts(), HYBRID).supply_events],
+            [event.supply_date for event in order_recognition(self.facts(), INVOICE).supply_events],
+        )
+
+    def test_the_may_payment_adds_nothing_under_the_invoice_basis(self):
+        """The delivery already brought the balance to account in April."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertNotIn(MAY, dates_of(recognition))
+
+
+class InvoicedButUnpaidOrderTests(SimpleTestCase):
+    """Delivered, never paid. This is what the payments basis exists for."""
+
+    def facts(self):
+        """Plants delivered in April against an invoice nobody has settled."""
+        return order(
+            [standard_line(1, '115.0000')],
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+        )
+
+    def test_payments_basis_recognises_nothing(self):
+        """No money has been received, so no GST is payable yet."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        self.assertEqual(recognition.supply_events, ())
+        self.assertEqual(recognition.unrecognised_gross, Decimal('115.0000'))
+
+    def test_invoice_basis_recognises_the_whole_supply_on_delivery(self):
+        """GST falls due whether or not the customer ever pays."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertEqual(dates_of(recognition), {APRIL})
+        self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+
+    def test_the_fulfillment_is_flagged_as_an_invoice_date_proxy(self):
+        """Task 118 has to find exactly these events to supersede them."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertTrue(all(event.proxy for event in recognition.supply_events))
+        self.assertEqual(
+            {event.time_of_supply_source for event in recognition.supply_events},
+            {'fulfillment'},
+        )
+
+    def test_a_payment_trigger_is_never_a_proxy(self):
+        """A payment date is a fact; only the invoice date is being stood in for."""
+        facts = order(
+            [standard_line(1, '115.0000')],
+            payments=(PaymentFact(7, MARCH, Decimal('115.0000')),),
+        )
+        recognition = order_recognition(facts, INVOICE)
+        self.assertFalse(any(event.proxy for event in recognition.supply_events))
+
+
+class FulfilledAndPaidOrderTests(SimpleTestCase):
+    """Delivered in April, paid in May — the bases part company by a period."""
+
+    def facts(self):
+        """The ordinary trade sale: goods first, payment on terms."""
+        return order(
+            [standard_line(1, '115.0000')],
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+            payments=(PaymentFact(7, MAY, Decimal('115.0000')),),
+        )
+
+    def test_payments_basis_recognises_in_may(self):
+        """The money arrived in May, so that is the return it belongs to."""
+        self.assertEqual(dates_of(order_recognition(self.facts(), PAYMENTS)), {MAY})
+
+    def test_invoice_basis_recognises_in_april(self):
+        """The delivery is the earlier trigger, a whole period sooner."""
+        self.assertEqual(dates_of(order_recognition(self.facts(), INVOICE)), {APRIL})
+
+    def test_both_bases_recognise_the_same_total(self):
+        """A change of basis moves when GST falls due, never how much."""
+        self.assertEqual(
+            totals(order_recognition(self.facts(), PAYMENTS)),
+            totals(order_recognition(self.facts(), INVOICE)),
+        )
+
+
+class ReturnedWithoutRefundTests(SimpleTestCase):
+    """A return moves plants, not money, so no GST adjustment is due."""
+
+    def facts(self):
+        """Delivered, paid, and physically returned with no money moved back."""
+        return order(
+            [standard_line(1, '115.0000')],
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+            payments=(PaymentFact(7, APRIL, Decimal('115.0000')),),
+            unrefunded_return_ids=(4,),
+        )
+
+    def test_no_basis_credits_anything(self):
+        """The consideration has not changed, so neither has the GST on it."""
+        for basis in BASES:
+            with self.subTest(basis=basis):
+                recognition = order_recognition(self.facts(), basis)
+                self.assertEqual(recognition.credit_events, ())
+                self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+
+    def test_the_outstanding_credit_note_is_reported(self):
+        """Somebody still owes a credit note; silence would hide the work."""
+        for basis in BASES:
+            with self.subTest(basis=basis):
+                recognition = order_recognition(self.facts(), basis)
+                self.assertEqual(recognition.unrefunded_return_ids, (4,))
+
+
+class RefundedOrderTests(SimpleTestCase):
+    """A refund is the credit adjustment, read off the refund's own lines."""
+
+    def facts(self, refund_gross='115.0000', refund_tax='15.0000'):
+        """Delivered and paid in April, refunded in May."""
+        return order(
+            [standard_line(1, '115.0000')],
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+            payments=(PaymentFact(7, APRIL, Decimal('115.0000')),),
+            refunds=(RefundFact(
+                refund_id=3,
+                refunded_on=MAY,
+                portions=(RefundPortion(1, Decimal(refund_gross), Decimal(refund_tax)),),
+            ),),
+        )
+
+    def test_a_full_refund_credits_the_whole_supply(self):
+        """The order nets to nothing, in both value and tax, under every basis."""
+        for basis in BASES:
+            with self.subTest(basis=basis):
+                recognition = order_recognition(self.facts(), basis)
+                self.assertEqual(totals(recognition), (Decimal('0.0000'), Decimal('0.0000')))
+
+    def test_the_credit_falls_in_the_refund_period_not_the_supply_period(self):
+        """April's return stands; May's return carries the correction."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertEqual(dates_of(recognition, SUPPLY), {APRIL})
+        self.assertEqual(dates_of(recognition, SUPPLY_CREDIT), {MAY})
+
+    def test_a_partial_refund_credits_only_what_was_refunded(self):
+        """The refund's own split is trusted; re-deriving it would drift."""
+        recognition = order_recognition(
+            self.facts(refund_gross='46.0000', refund_tax='6.0000'), INVOICE,
+        )
+        self.assertEqual(totals(recognition), (Decimal('69.0000'), Decimal('9.0000')))
+
+    def test_a_credit_cannot_exceed_the_supply_it_credits(self):
+        """Otherwise a refund would create a GST claim out of nothing."""
+        recognition = order_recognition(
+            self.facts(refund_gross='200.0000', refund_tax='26.0870'), INVOICE,
+        )
+        self.assertEqual(totals(recognition), (Decimal('0.0000'), Decimal('0.0000')))
+        self.assertEqual(recognition.over_credited, Decimal('85.0000'))
+
+    def test_a_refund_under_the_payments_basis_credits_the_payment(self):
+        """Money went back out, so the payments basis credits it too."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        self.assertEqual(dates_of(recognition, SUPPLY_CREDIT), {MAY})
+
+
+class MixedRateApportionmentTests(SimpleTestCase):
+    """A partial payment has no line linkage, so the split has to be derived."""
+
+    def facts(self):
+        """One standard-rated line and one zero-rated line, part paid."""
+        return order(
+            [
+                standard_line(1, '115.0000'),
+                LineFact(line_id=2, tax_rate=Decimal('0'), tax_code=ZERO_RATED, gross_incl_tax=Decimal('85.0000')),
+            ],
+            payments=(PaymentFact(7, MARCH, Decimal('100.0000')),),
+        )
+
+    def test_the_payment_is_split_by_remaining_value(self):
+        """115 and 85 of a 200 order take 57.50 and 42.50 of a 100 payment."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        by_line = {event.line_id: event.gross for event in recognition.supply_events}
+        self.assertEqual(by_line, {1: Decimal('57.5000'), 2: Decimal('42.5000')})
+
+    def test_the_shares_sum_back_to_the_payment_exactly(self):
+        """A remainder dropped here would understate the return by cents."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        self.assertEqual(
+            sum(event.gross for event in recognition.supply_events), Decimal('100.0000'),
+        )
+
+    def test_only_the_standard_rated_share_carries_tax(self):
+        """15/115 of 57.50 is 7.50; the zero-rated share adds nothing."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        by_line = {event.line_id: event.tax for event in recognition.supply_events}
+        self.assertEqual(by_line, {1: Decimal('7.5000'), 2: Decimal('0.0000')})
+
+    def test_an_indivisible_payment_still_sums_back_exactly(self):
+        """Three equal lines and a penny that will not divide by three."""
+        facts = order(
+            [standard_line(index, '100.0000') for index in (1, 2, 3)],
+            payments=(PaymentFact(7, MARCH, Decimal('0.0001')),),
+        )
+        recognition = order_recognition(facts, PAYMENTS)
+        self.assertEqual(
+            sum(event.gross for event in recognition.supply_events), Decimal('0.0001'),
+        )
+
+
+class OverpaymentTests(SimpleTestCase):
+    """Cash beyond the order's value is not consideration for any supply."""
+
+    def test_the_excess_is_reported_rather_than_recognised(self):
+        """Recognising it would create output tax on a supply nobody made."""
+        facts = order(
+            [standard_line(1, '115.0000')],
+            payments=(PaymentFact(7, MARCH, Decimal('150.0000')),),
+        )
+        recognition = order_recognition(facts, PAYMENTS)
+        self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+        self.assertEqual(recognition.unmatched_overpayment, Decimal('35.0000'))
+
+    def test_a_payment_against_a_fully_recognised_order_is_wholly_unmatched(self):
+        """The second payment has nothing left to be consideration for."""
+        facts = order(
+            [standard_line(1, '115.0000')],
+            payments=(
+                PaymentFact(7, MARCH, Decimal('115.0000')),
+                PaymentFact(8, MAY, Decimal('50.0000')),
+            ),
+        )
+        recognition = order_recognition(facts, PAYMENTS)
+        self.assertEqual(recognition.unmatched_overpayment, Decimal('50.0000'))
+
+
+class SameDayOrderingTests(SimpleTestCase):
+    """A deposit and a same-day delivery must split the same way every run."""
+
+    def test_the_payment_is_attributed_before_the_fulfillment(self):
+        """An attribution that changed between runs cannot be reconciled."""
+        facts = order(
+            [standard_line(1, '115.0000')],
+            payments=(PaymentFact(7, APRIL, Decimal('40.0000')),),
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+        )
+        recognition = order_recognition(facts, INVOICE)
+        by_source = {event.source_type: event.gross for event in recognition.supply_events}
+        self.assertEqual(by_source, {'payment': Decimal('40.0000'), 'fulfillment': Decimal('75.0000')})
+
+
+class AsAtTests(SimpleTestCase):
+    """Stopping the clock is what makes a basis-change adjustment computable."""
+
+    def facts(self):
+        """Delivered in April, paid in May."""
+        return order(
+            [standard_line(1, '115.0000')],
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+            payments=(PaymentFact(7, MAY, Decimal('115.0000')),),
+        )
+
+    def test_a_cutoff_excludes_later_triggers(self):
+        """At the end of April the invoice basis has recognised it; payments has not."""
+        cutoff = date(2026, 4, 30)
+        invoice = order_recognition(self.facts(), INVOICE, as_at=cutoff)
+        payments = order_recognition(self.facts(), PAYMENTS, as_at=cutoff)
+        self.assertEqual(invoice.recognised_gross, Decimal('115.0000'))
+        self.assertEqual(payments.recognised_gross, Decimal('0.0000'))
+
+    def test_the_difference_is_the_debtor_a_basis_change_adjusts_for(self):
+        """That gap is exactly what a payments-to-invoice transition brings in."""
+        cutoff = date(2026, 4, 30)
+        invoice = order_recognition(self.facts(), INVOICE, as_at=cutoff)
+        payments = order_recognition(self.facts(), PAYMENTS, as_at=cutoff)
+        self.assertEqual(
+            invoice.recognised_gross - payments.recognised_gross, Decimal('115.0000'),
+        )
+
+    def test_a_cutoff_excludes_a_later_refund(self):
+        """A credit dated after the change belongs to the new basis, not the old."""
+        facts = order(
+            [standard_line(1, '115.0000')],
+            fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+            refunds=(RefundFact(3, MAY, (RefundPortion(1, Decimal('115.0000'), Decimal('15.0000')),)),),
+        )
+        recognition = order_recognition(facts, INVOICE, as_at=date(2026, 4, 30))
+        self.assertEqual(recognition.credit_events, ())
+
+
+class RestatedConstantTests(SimpleTestCase):
+    """The strings restated here must not drift from the model's own choices.
+
+    `recognition` stays free of the model layer so it can be tested without a
+    database. That is worth a test rather than a comment: a fourth basis added
+    to the model and not here would silently recognise nothing.
+    """
+
+    def test_the_bases_match_the_registration_model(self):
+        """A basis the model offers and this module rejects would raise at report time."""
+        from .models import GstRegistration  # pylint: disable=import-outside-toplevel
+        self.assertEqual(set(BASES), set(GstRegistration.Basis.values))


### PR DESCRIPTION
This module is the whole of task 117's accounting judgement and it holds no database access at all. Facts in, recognition events out; the ORM read that gathers the facts comes later. The split is what makes the matrix the task's verification section asks for — six order shapes across three bases — eighteen fast unit tests instead of eighteen fixtures.

Payments recognises on money received, so an order delivered and unpaid produces nothing, which is the point of the basis. Invoice recognises on the earlier of an invoice issued and a payment received; there is no invoice document yet, so a fulfillment stands in for it. Every such event carries `proxy` and `time_of_supply_source`, so task 118 can find exactly the events it supersedes rather than re-deriving all of them. Hybrid is invoice for output tax, so it is identical here; the difference is on the purchase side.

A payment carries no line linkage and no tax split, so the split is derived: weight each line by its remaining tax-inclusive value and use the ledger's own largest-remainder distribution, which sums back exactly and does not churn when recomputed. Tax is taken out of the inclusive share and taxable is the residual, so every row balances by construction. The branch is on the tax code rather than the rate, so an exempt line carrying a stray rate cannot produce output tax.

A fulfillment recognises what it delivered capped by what the line still owes, so a deposit taken earlier is not counted twice. Cash beyond the order's value is not consideration for a supply — it is reported as an overpayment rather than inflating a return. A refund's credit is read straight off its RefundLine rows, which `proportional_refund` already split preserving each line's tax ratio, so it reconciles to the refund exactly instead of drifting by a rounding step. A return with no refund moves plants and not money, so it credits nothing; the outstanding credit note is reported instead of assumed away.

`as_at` stops the clock, which is what lets a basis-change adjustment be computed from these rules rather than from a second implementation.

## Summary by Sourcery

Implement GST recognition rules that determine when sales supplies and related credits fall due under each accounting basis.

New Features:
- Add pure GST recognition for sales supplies and refunds across payments, invoice, and hybrid accounting bases.
- Report tax-inclusive supply allocations, unmatched overpayments, unrecognised balances, excess credits, and unrefunded returns.

Enhancements:
- Support deterministic payment apportionment across order lines and tax-code-based GST calculation.
- Expose source metadata, invoice-date proxies, and cutoff-date evaluation for basis-change adjustments.

Tests:
- Add comprehensive unit coverage for GST timing, partial payments, refunds, mixed tax treatments, overpayments, ordering, cutoffs, and basis consistency.