### PR TITLE
feat(tax): watch taxable turnover against the GST thresholds

### DIFF
--- a/frontend/js/api/tax.ts
+++ b/frontend/js/api/tax.ts
@@ -1,4 +1,4 @@
-import { GstRegistration, GstRegistrationCreate, GstStatus } from '../types/tax'
+import { GstRegistration, GstRegistrationCreate, GstRegistrationCreated, GstStatus } from '../types/tax'
 import { csrfPost, fetchAsJson } from '../utils'
 
 const ROOT = '/tax/'
@@ -14,9 +14,9 @@ function getGstRegistrations(signal?: AbortSignal): Promise<GstRegistration[]> {
 // There is no update counterpart on purpose: the server refuses PATCH and PUT.
 // Correcting an arrangement means posting a new one with `supersedes` set, so
 // the mistake and the correction both stay readable.
-async function createGstRegistration(registration: Partial<GstRegistrationCreate>): Promise<GstRegistration> {
+async function createGstRegistration(registration: Partial<GstRegistrationCreate>): Promise<GstRegistrationCreated> {
   const response = await csrfPost(`${ROOT}gst/registrations/`, registration)
-  return response.json() as Promise<GstRegistration>
+  return response.json() as Promise<GstRegistrationCreated>
 }
 
 export { createGstRegistration, getGstRegistrations, getGstStatus }

--- a/frontend/js/tax/registration.tsx
+++ b/frontend/js/tax/registration.tsx
@@ -4,8 +4,8 @@ import { Alert, Badge, Button, Form, Spinner, Table } from 'react-bootstrap'
 
 import { createGstRegistration, getGstRegistrations, getGstStatus } from '../api/tax'
 import { queryKeys } from '../query'
-import { GstBasis, GstFrequency, GstRegistration, GstRegistrationCreate } from '../types/tax'
-import { errorsByField, formatDate } from '../utils'
+import { GstBasis, GstFrequency, GstRegistration, GstRegistrationCreate, GstStatus, GstWarning } from '../types/tax'
+import { errorsByField, formatDate, formatMoney } from '../utils'
 
 const BASIS_LABELS: Record<GstBasis, string> = {
   payments: 'Payments',
@@ -18,6 +18,11 @@ const FREQUENCY_LABELS: Record<GstFrequency, string> = {
   two_monthly: 'Two-monthly',
   six_monthly: 'Six-monthly'
 }
+
+// Compulsory registration and a basis a workspace has outgrown are different
+// kinds of finding, and the second must not be shouted at somebody who has
+// already done everything required of them.
+const URGENT_WARNING_CODES = ['threshold_exceeded', 'monthly_filing_required', 'payments_basis_ineligible', 'six_monthly_ineligible']
 
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
 
@@ -44,6 +49,42 @@ function describe(registration: GstRegistration): string {
   const basis = registration.basis ? BASIS_LABELS[registration.basis] : ''
   const frequency = registration.filing_frequency ? FREQUENCY_LABELS[registration.filing_frequency] : ''
   return `${basis} basis, ${frequency}`
+}
+
+function TurnoverBanner({ status }: { status: GstStatus }) {
+  const currencies = Object.keys(status.rolling_turnover.taxable)
+  if (currencies.length === 0) {
+    return null
+  }
+  return (
+    <p className="text-body-secondary">
+      Taxable supplies from {formatDate(status.rolling_turnover.start)} to {formatDate(status.rolling_turnover.end)}:{' '}
+      {currencies.map((code) => formatMoney(status.rolling_turnover.taxable[code], code)).join(', ')}. Registration becomes compulsory at{' '}
+      {formatMoney(status.registration_threshold, 'NZD')} in any twelve-month period.
+    </p>
+  )
+}
+
+function WarningList({ warnings }: { warnings: Array<GstWarning> }) {
+  if (warnings.length === 0) {
+    return null
+  }
+  return (
+    <>
+      {warnings.map((warning) => (
+        <Alert key={warning.code} variant={URGENT_WARNING_CODES.includes(warning.code) ? 'warning' : 'info'}>
+          {warning.message}
+          {warning.value && (
+            <>
+              {' '}
+              Measured: {formatMoney(warning.value, 'NZD')}
+              {warning.threshold && <> against {formatMoney(warning.threshold, 'NZD')}</>}.
+            </>
+          )}
+        </Alert>
+      ))}
+    </>
+  )
 }
 
 function GstRegistrationSettings() {
@@ -116,6 +157,9 @@ function GstRegistrationSettings() {
           )}
         </Alert>
       )}
+
+      {current && <TurnoverBanner status={current} />}
+      {current && <WarningList warnings={current.warnings} />}
 
       <h3 className="h5 mt-4">Record a change</h3>
       <Form onSubmit={submit}>
@@ -235,6 +279,7 @@ function GstRegistrationSettings() {
         </Button>
         {mutation.isSuccess && <span className="ms-3 text-success">Change recorded.</span>}
       </Form>
+      {mutation.isSuccess && mutation.data.warnings && <WarningList warnings={mutation.data.warnings} />}
 
       <h3 className="h5 mt-4">Recorded history</h3>
       {history.data && history.data.length === 0 && <p>No GST arrangement has been recorded yet.</p>}

--- a/frontend/js/types/tax.ts
+++ b/frontend/js/types/tax.ts
@@ -41,6 +41,28 @@ interface GstTaxablePeriod {
   registration: number
 }
 
+// A threshold or eligibility finding. Nothing is ever refused on account of
+// one: a workspace that has outgrown its accounting basis does not stop being
+// on it, and refusing to record the truth would leave its returns
+// unproducible.
+interface GstWarning {
+  code: string
+  message: string
+  // Money as a decimal string, or null when the finding is not about an amount.
+  value: string | null
+  threshold: string | null
+}
+
+interface GstTurnover {
+  start: string
+  end: string
+  // Kept per currency and never totalled: there is no exchange rate here.
+  taxable: Record<string, string>
+  // Zero-rated-looking supplies nobody has classified. Counted neither
+  // towards nor against the threshold.
+  unclassified: Record<string, string>
+}
+
 interface GstStatus {
   as_at: string
   registered: boolean
@@ -49,6 +71,16 @@ interface GstStatus {
   has_history: boolean
   registration: GstRegistration | null
   taxable_period: GstTaxablePeriod | null
+  rolling_turnover: GstTurnover
+  registration_threshold: string
+  warnings: Array<GstWarning>
+}
+
+// The create response repeats the arrangement with its consequences attached,
+// so the operator learns at the moment of choosing that a frequency is one
+// their turnover has outgrown.
+interface GstRegistrationCreated extends GstRegistration {
+  warnings: Array<GstWarning>
 }
 
 type GstRegistrationCreate = Pick<
@@ -56,4 +88,4 @@ type GstRegistrationCreate = Pick<
   'registered' | 'effective_from' | 'gst_number' | 'basis' | 'filing_frequency' | 'period_anchor_month' | 'taxable_activity_start' | 'reason' | 'notes' | 'supersedes'
 >
 
-export { GstBasis, GstFrequency, GstRegistration, GstRegistrationCreate, GstStatus, GstTaxablePeriod }
+export { GstBasis, GstFrequency, GstRegistration, GstRegistrationCreate, GstRegistrationCreated, GstStatus, GstTaxablePeriod, GstTurnover, GstWarning }

--- a/tax/facts.py
+++ b/tax/facts.py
@@ -1,0 +1,191 @@
+"""Read the commerce records the GST rules run on, and nothing more.
+
+`recognition` decides when a supply falls due and holds no database access;
+this module is the other half — one ORM read per order, shaped into the frozen
+facts those rules take. Splitting them is what keeps the accounting judgement
+testable without fixtures and the query work reviewable on its own.
+
+Only effective records are read. A reversal and the record it reverses both
+drop out, using the same pair of filters the commerce services already use, so
+a reversed fulfillment can never contribute to a return.
+"""
+
+from collections import defaultdict
+from decimal import Decimal
+
+from sales.models import (
+    Fulfillment,
+    FulfillmentLine,
+    Payment,
+    Refund,
+    RefundLine,
+    SalesOrder,
+    SalesReturn,
+)
+
+from .periods import local_date
+from .recognition import (
+    FulfillmentFact,
+    LineFact,
+    OrderFacts,
+    PaymentFact,
+    RefundFact,
+    RefundPortion,
+)
+
+
+ZERO = Decimal('0.0000')
+
+#: The house filter for a record that still counts: neither a reversal nor
+#: reversed. Restated here rather than imported out of `sales.commerce`, which
+#: is a write path this module has no business touching.
+EFFECTIVE = {'reversal_of__isnull': True, 'reversal__isnull': True}
+
+
+def effective(queryset):
+    """Narrow a commerce queryset to the records that still count."""
+    return queryset.filter(**EFFECTIVE)
+
+
+def orders_with_activity(workspace, start=None, end=None):
+    """Return orders whose GST could fall due in a date range.
+
+    An order contributes to a return only at one of its own triggers, so one
+    with no fulfillment, payment or refund inside the range contributes
+    nothing and does not need reading. The whole of a matching order is then
+    read, not just the part inside the range: under the invoice basis what a
+    fulfillment recognises depends on what earlier payments already brought to
+    account, so a window that cut the facts short would overstate it.
+    """
+    orders = SalesOrder.objects.filter(workspace=workspace)
+    if start is None and end is None:
+        return orders.order_by('pk')
+    bounds = {}
+    if start is not None:
+        bounds['gte'] = start
+    if end is not None:
+        bounds['lte'] = end
+    matched = set()
+    for model, field, path in (
+        (Fulfillment, 'fulfilled_at__date', 'order_id'),
+        (Payment, 'paid_on', 'order_id'),
+        (Refund, 'refunded_at__date', 'order_id'),
+    ):
+        lookup = {f'{field}__{suffix}': value for suffix, value in bounds.items()}
+        matched.update(
+            effective(model.objects.filter(workspace=workspace, **lookup))
+            .values_list(path, flat=True)
+        )
+    return orders.filter(pk__in=matched).order_by('pk')
+
+
+def order_facts(order):
+    """Return everything about one order that bears on when GST falls due."""
+    workspace = order.workspace
+    lines = tuple(
+        LineFact(
+            line_id=line.pk,
+            tax_rate=line.tax_rate,
+            tax_code=line.tax_treatment,
+            gross_incl_tax=line.total_incl_tax,
+        )
+        for line in order.lines.all().order_by('pk')
+    )
+    return OrderFacts(
+        order_id=order.pk,
+        currency_code=order.currency_code,
+        lines=lines,
+        fulfillments=_fulfillment_facts(workspace, order),
+        payments=_payment_facts(order),
+        refunds=_refund_facts(workspace, order),
+        unrefunded_return_ids=_unrefunded_return_ids(order),
+    )
+
+
+def workspace_order_facts(workspace, start=None, end=None):
+    """Return the facts for every order that could fall due in a range."""
+    orders = orders_with_activity(workspace, start, end).prefetch_related('lines')
+    return [order_facts(order) for order in orders]
+
+
+def _fulfillment_facts(workspace, order):
+    """Group each effective fulfillment's value by the order line it delivered."""
+    grouped = defaultdict(dict)
+    dates = {}
+    lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order,
+        fulfillment__reversal_of__isnull=True,
+        fulfillment__reversal__isnull=True,
+    ).select_related('allocation', 'fulfillment').order_by('pk')
+    for line in lines:
+        fulfillment = line.fulfillment
+        dates[fulfillment.pk] = local_date(workspace, fulfillment.fulfilled_at)
+        totals = grouped[fulfillment.pk]
+        line_id = line.allocation.line_id
+        totals[line_id] = totals.get(line_id, ZERO) + line.total_incl_tax
+    return tuple(
+        FulfillmentFact(
+            fulfillment_id=fulfillment_id,
+            supply_date=dates[fulfillment_id],
+            line_grosses=dict(totals),
+        )
+        for fulfillment_id, totals in sorted(grouped.items())
+    )
+
+
+def _payment_facts(order):
+    """Return every effective payment, oldest first.
+
+    `paid_on` is already a local business date, so unlike the timestamps on
+    the other documents it needs no conversion.
+    """
+    payments = effective(order.payments.all()).order_by('paid_on', 'pk')
+    return tuple(
+        PaymentFact(payment_id=payment.pk, paid_on=payment.paid_on, gross=payment.amount)
+        for payment in payments
+    )
+
+
+def _refund_facts(workspace, order):
+    """Return every effective refund, already classified against its order lines."""
+    grouped = defaultdict(list)
+    dates = {}
+    lines = RefundLine.objects.filter(
+        refund__order=order,
+        refund__reversal_of__isnull=True,
+        refund__reversal__isnull=True,
+    ).select_related('refund', 'fulfillment_line__allocation').order_by('pk')
+    for line in lines:
+        refund = line.refund
+        dates[refund.pk] = local_date(workspace, refund.refunded_at)
+        grouped[refund.pk].append(RefundPortion(
+            line_id=line.fulfillment_line.allocation.line_id,
+            gross=line.total_incl_tax,
+            tax=line.tax_total,
+        ))
+    return tuple(
+        RefundFact(
+            refund_id=refund_id,
+            refunded_on=dates[refund_id],
+            portions=tuple(portions),
+        )
+        for refund_id, portions in sorted(grouped.items())
+    )
+
+
+def _unrefunded_return_ids(order):
+    """Return effective returns carrying no effective refund.
+
+    A return moves plants, not money, so it changes no consideration and owes
+    no GST adjustment. It does owe a credit note, and reporting that as
+    outstanding work is more useful than reporting nothing.
+    """
+    refunded = set(
+        effective(Refund.objects.filter(order=order))
+        .exclude(sales_return__isnull=True)
+        .values_list('sales_return_id', flat=True)
+    )
+    returns = effective(SalesReturn.objects.filter(order=order)).order_by('pk')
+    return tuple(
+        sales_return.pk for sales_return in returns if sales_return.pk not in refunded
+    )

--- a/tax/rest.py
+++ b/tax/rest.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from inventory.ledger import quantize_money
 from workspaces.models import Workspace, get_current_workspace
 from workspaces.scoping import (
     CurrentWorkspaceSerializerMixin,
@@ -24,6 +25,7 @@ from workspaces.scoping import (
 from .models import GstRegistration
 from .periods import local_date, registration_history, taxable_period_for
 from .services import record_registration
+from .turnover import REGISTRATION_THRESHOLD, registration_warnings, rolling_turnover
 
 
 def _model_errors(error):
@@ -82,7 +84,30 @@ class GstRegistrationSerializer(CurrentWorkspaceSerializerMixin, serializers.Mod
         )
 
 
+class GstRegistrationCreateResponseMixin:  # pylint: disable=too-few-public-methods
+    """Return the eligibility consequences alongside the arrangement recorded.
+
+    Nothing is refused at the point of recording, so this is the moment the
+    operator finds out that the frequency they just chose is one their turnover
+    has outgrown. Saying it here rather than only on a later screen is the
+    difference between a warning and a discovery.
+    """
+
+    def create(self, request, *args, **kwargs):
+        """Create the arrangement, then answer with its warnings attached."""
+        response = super().create(request, *args, **kwargs)
+        workspace = get_current_workspace()
+        today = local_date(workspace, request_now())
+        registration = self.get_queryset().get(pk=response.data['pk'])
+        in_force = registration if registration.registered else None
+        response.data['warnings'] = registration_warnings(
+            workspace, today, registration=in_force,
+        )
+        return response
+
+
 class GstRegistrationViewSet(  # pylint: disable=too-many-ancestors
+    GstRegistrationCreateResponseMixin,
     RequireWorkspaceModeMixin,
     CurrentWorkspaceViewSetMixin,
     mixins.CreateModelMixin,
@@ -121,14 +146,19 @@ class GstStatusView(RequireWorkspaceModeMixin, APIView):
                 break
             registration = row
         period = taxable_period_for(workspace, today, history=history)
+        in_force = registration if registration and registration.registered else None
+        rolling = rolling_turnover(workspace, today)
         return Response({
             'as_at': today.isoformat(),
-            'registered': bool(registration and registration.registered),
+            'registered': bool(in_force),
             'has_history': bool(history),
             'registration': (
                 GstRegistrationSerializer(registration).data if registration else None
             ),
             'taxable_period': _period_payload(period),
+            'rolling_turnover': _turnover_payload(rolling),
+            'registration_threshold': str(quantize_money(REGISTRATION_THRESHOLD)),
+            'warnings': registration_warnings(workspace, today, registration=in_force),
         })
 
 
@@ -136,6 +166,22 @@ def request_now():
     """Return the current instant, isolated so a test can freeze it."""
     from django.utils import timezone  # pylint: disable=import-outside-toplevel
     return timezone.now()
+
+
+def _turnover_payload(rolling):
+    """Render turnover per currency, never totalled across them.
+
+    There is no exchange rate in this application — task 121 owns that — so
+    consolidating two currencies here would invent one.
+    """
+    return {
+        'start': rolling['start'].isoformat(),
+        'end': rolling['end'].isoformat(),
+        'taxable': {code: str(value) for code, value in rolling['taxable'].items()},
+        'unclassified': {
+            code: str(value) for code, value in rolling['unclassified'].items()
+        },
+    }
 
 
 def _period_payload(period):

--- a/tax/test_thresholds.py
+++ b/tax/test_thresholds.py
@@ -1,0 +1,316 @@
+"""Verification 2: the registration threshold across the rolling boundary.
+
+The whole point of a rolling twelve-month test is that it un-fires. A sale
+that pushes turnover over NZ$60,000 warns today and stops warning once it
+falls out of the window, and a test that only ever checks the firing half
+would pass against a system that never stopped warning at all.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import date
+from decimal import Decimal
+
+from inventory.models import InventoryItem
+from inventory.units import UnitCode
+from sales.models import SalesOrder, SalesOrderLine
+from sales.services import create_order
+from tests.api import RESTContractTestCase
+from tests.factories import make_inventory_item
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import GstRegistration
+from .services import record_registration
+from .turnover import (
+    MONTHLY_COMPULSORY_FLOOR,
+    PAYMENTS_BASIS_CEILING,
+    SIX_MONTHLY_CEILING,
+    months_before,
+    registration_warnings,
+    rolling_turnover,
+    turnover_projection,
+)
+
+
+def codes(warnings):
+    """Return just the finding codes, which is what the assertions are about."""
+    return {warning['code'] for warning in warnings}
+
+
+class MonthArithmeticTests(RESTContractTestCase):
+    """A day-count subtraction gets the boundary wrong exactly where it matters."""
+
+    def test_twelve_months_back_lands_on_the_same_day(self):
+        """The window has to be a calendar year, not 365 days."""
+        self.assertEqual(months_before(date(2027, 3, 15), 12), date(2026, 3, 15))
+
+    def test_a_leap_day_clamps_to_the_end_of_february(self):
+        """29 February has no counterpart in a common year."""
+        self.assertEqual(months_before(date(2028, 2, 29), 12), date(2027, 2, 28))
+
+    def test_three_months_back_crosses_a_year_end(self):
+        """The projection window must not wrap into the wrong year."""
+        self.assertEqual(months_before(date(2027, 2, 10), 3), date(2026, 11, 10))
+
+
+class TurnoverTestCase(RESTContractTestCase):
+    """A Nursery that can record sales at chosen dates and rates."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.currency_code = 'NZD'
+        self.workspace.timezone = 'Pacific/Auckland'
+        self.workspace.default_tax_rate = Decimal('15')
+        self.workspace.sales_prices_include_tax = False
+        self.workspace.save()
+        self.item = make_inventory_item(
+            workspace=self.workspace,
+            category=InventoryItem.Category.TRAY,
+            tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
+            base_unit=UnitCode.EACH,
+        )
+
+    def sell(self, paid_on, ex_tax, tax_rate='15', treatment=None):
+        """Record a supply of a given ex-GST value, paid on a date.
+
+        A payment is used rather than a fulfillment because it needs no plants,
+        no allocations and no stock, and the threshold is measured on supplies
+        made — which the invoice basis recognises at the earlier of the two.
+        """
+        from sales.models import Payment  # pylint: disable=import-outside-toplevel
+        from uuid import uuid4  # pylint: disable=import-outside-toplevel
+
+        order = create_order(self.workspace, self.user, status=SalesOrder.Status.DRAFT)
+        values = {
+            'order': order,
+            'line_type': SalesOrderLine.LineType.TRAY,
+            'tray_item': self.item,
+            'description': 'Trays',
+            'quantity': 1,
+            'unit_price': Decimal(ex_tax),
+            'tax_rate': Decimal(tax_rate),
+            'discount_type': SalesOrderLine.DiscountType.NONE,
+        }
+        if treatment is not None:
+            values['tax_treatment'] = treatment
+        line = SalesOrderLine.objects.create(**values)
+        SalesOrder.objects.filter(pk=order.pk).update(status=SalesOrder.Status.CONFIRMED)
+        order.refresh_from_db()
+        Payment.objects.create(
+            workspace=self.workspace, order=order, paid_on=paid_on,
+            amount=line.total_incl_tax, currency_code='NZD', method='cash',
+            operation_key=uuid4(), request_fingerprint='threshold-test',
+        )
+        return order
+
+
+class RollingThresholdTests(TurnoverTestCase):
+    """The window is what decides, and it moves."""
+
+    def test_turnover_is_measured_excluding_gst(self):
+        """The threshold is a value of supplies, not of money received."""
+        self.sell(date(2026, 6, 1), '1000')
+        rolling = rolling_turnover(self.workspace, date(2026, 7, 1))
+        self.assertEqual(rolling['taxable']['NZD'], Decimal('1000.0000'))
+
+    def test_turnover_just_over_the_threshold_warns(self):
+        """Registration becomes compulsory at NZ$60,000, not above it."""
+        self.sell(date(2026, 6, 1), '60000')
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertIn('threshold_exceeded', codes(warnings))
+
+    def test_turnover_just_under_the_threshold_does_not_warn(self):
+        """A warning that fires early is one an operator learns to ignore."""
+        self.sell(date(2026, 6, 1), '59999')
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertNotIn('threshold_exceeded', codes(warnings))
+
+    def test_the_warning_clears_once_the_sale_falls_out_of_the_window(self):
+        """This is the half a firing-only test would never catch."""
+        self.sell(date(2026, 6, 1), '60000')
+        inside = registration_warnings(self.workspace, date(2027, 6, 1))
+        outside = registration_warnings(self.workspace, date(2027, 6, 2))
+        self.assertIn('threshold_exceeded', codes(inside))
+        self.assertNotIn('threshold_exceeded', codes(outside))
+
+    def test_supplies_accumulate_across_the_window(self):
+        """The test is on the period's total, not on any single sale."""
+        self.sell(date(2026, 3, 1), '30000')
+        self.sell(date(2026, 9, 1), '30000')
+        self.assertIn(
+            'threshold_exceeded',
+            codes(registration_warnings(self.workspace, date(2026, 10, 1))),
+        )
+
+    def test_a_registered_workspace_is_never_told_to_register(self):
+        """It already did; repeating it would bury the findings that matter."""
+        record_registration(
+            self.workspace, self.user, registered=True,
+            effective_from=date(2026, 1, 1), gst_number='123456785',
+            basis=GstRegistration.Basis.INVOICE,
+            filing_frequency=GstRegistration.Frequency.TWO_MONTHLY,
+            period_anchor_month=3,
+        )
+        self.sell(date(2026, 6, 1), '60000')
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertNotIn('threshold_exceeded', codes(warnings))
+
+
+class TaxCodeTests(TurnoverTestCase):
+    """What counts as taxable turnover is the classification, not the rate."""
+
+    def test_zero_rated_supplies_count(self):
+        """A zero-rated export is taxable at zero, so it is still turnover."""
+        self.sell(date(2026, 6, 1), '60000', tax_rate='0', treatment='zero_rated')
+        self.assertIn(
+            'threshold_exceeded',
+            codes(registration_warnings(self.workspace, date(2026, 7, 1))),
+        )
+
+    def test_exempt_supplies_do_not_count(self):
+        """Counting them would force registration on an entity that needs none."""
+        self.sell(date(2026, 6, 1), '60000', tax_rate='0', treatment='exempt')
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertNotIn('threshold_exceeded', codes(warnings))
+
+    def test_unclassified_supplies_are_reported_rather_than_assumed(self):
+        """Assuming either way would move the answer across a line nobody chose."""
+        self.sell(date(2026, 6, 1), '60000', tax_rate='0')
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertIn('unclassified_turnover', codes(warnings))
+        self.assertNotIn('threshold_exceeded', codes(warnings))
+        rolling = rolling_turnover(self.workspace, date(2026, 7, 1))
+        self.assertEqual(rolling['unclassified']['NZD'], Decimal('60000.0000'))
+        self.assertEqual(rolling['taxable'].get('NZD', Decimal('0')), Decimal('0.0000'))
+
+
+class ProjectionTests(TurnoverTestCase):
+    """A projection is a prompt to think, and says so in its own payload."""
+
+    def test_recent_trading_is_annualised(self):
+        """20,000 in a quarter annualises to 80,000, which is over the line."""
+        self.sell(date(2026, 6, 1), '20000')
+        projection = turnover_projection(self.workspace, date(2026, 7, 1))
+        self.assertEqual(projection['taxable']['NZD'], Decimal('80000.0000'))
+        self.assertEqual(projection['method'], 'last_3_months_annualised')
+
+    def test_a_projection_over_the_threshold_warns(self):
+        """The legal test is expectation, so a trend is worth surfacing."""
+        self.sell(date(2026, 6, 1), '20000')
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertIn('threshold_projected', codes(warnings))
+
+    def test_the_measured_warning_replaces_the_projected_one(self):
+        """Two warnings about the same threshold is noise, not emphasis."""
+        self.sell(date(2026, 6, 1), '60000')
+        warnings = codes(registration_warnings(self.workspace, date(2026, 7, 1)))
+        self.assertIn('threshold_exceeded', warnings)
+        self.assertNotIn('threshold_projected', warnings)
+
+
+class EligibilityTests(TurnoverTestCase):
+    """A basis or frequency turnover has outgrown is a warning, never a refusal."""
+
+    def register(self, **overrides):
+        """Record an arrangement to test the eligibility of."""
+        values = {
+            'registered': True,
+            'effective_from': date(2026, 1, 1),
+            'gst_number': '123456785',
+            'basis': GstRegistration.Basis.PAYMENTS,
+            'filing_frequency': GstRegistration.Frequency.TWO_MONTHLY,
+            'period_anchor_month': 3,
+        }
+        values.update(overrides)
+        return record_registration(self.workspace, self.user, **values)
+
+    def test_the_payments_basis_ceiling_is_reported(self):
+        """Above NZ$2,000,000 the payments basis is no longer available."""
+        self.register()
+        self.sell(date(2026, 6, 1), str(PAYMENTS_BASIS_CEILING + 1))
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertIn('payments_basis_ineligible', codes(warnings))
+
+    def test_the_payments_basis_at_the_ceiling_is_not_reported(self):
+        """The ceiling is a limit, not a threshold; equal to it is still inside."""
+        self.register()
+        self.sell(date(2026, 6, 1), str(PAYMENTS_BASIS_CEILING))
+        warnings = registration_warnings(self.workspace, date(2026, 7, 1))
+        self.assertNotIn('payments_basis_ineligible', codes(warnings))
+
+    def test_the_six_monthly_ceiling_is_reported(self):
+        """Above NZ$500,000 six-monthly filing is no longer available."""
+        self.register(filing_frequency=GstRegistration.Frequency.SIX_MONTHLY)
+        self.sell(date(2026, 6, 1), str(SIX_MONTHLY_CEILING + 1))
+        self.assertIn(
+            'six_monthly_ineligible',
+            codes(registration_warnings(self.workspace, date(2026, 7, 1))),
+        )
+
+    def test_compulsory_monthly_filing_is_reported(self):
+        """Above NZ$24,000,000 nothing but monthly filing is permitted."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.sell(date(2026, 6, 1), str(MONTHLY_COMPULSORY_FLOOR + 1))
+        self.assertIn(
+            'monthly_filing_required',
+            codes(registration_warnings(self.workspace, date(2026, 7, 1))),
+        )
+
+    def test_an_unusual_six_monthly_cycle_is_reported(self):
+        """Inland Revenue offers three cycles; anything else is worth querying."""
+        self.register(
+            filing_frequency=GstRegistration.Frequency.SIX_MONTHLY,
+            period_anchor_month=1,
+        )
+        self.assertIn(
+            'six_monthly_cycle_unusual',
+            codes(registration_warnings(self.workspace, date(2026, 7, 1))),
+        )
+
+    def test_an_ineligible_arrangement_is_still_recorded(self):
+        """Refusing it would leave a workspace unable to produce its own returns."""
+        self.sell(date(2026, 6, 1), str(PAYMENTS_BASIS_CEILING + 1))
+        registration = self.register()
+        self.assertEqual(registration.basis, GstRegistration.Basis.PAYMENTS)
+
+
+class ConfigurationWarningTests(TurnoverTestCase):
+    """A workspace whose settings do not describe a New Zealand entity."""
+
+    def test_a_non_nzd_workspace_is_reported(self):
+        """A GST return is filed in New Zealand dollars, whatever is configured."""
+        self.workspace.currency_code = 'AUD'
+        self.workspace.save()
+        self.assertIn(
+            'workspace_currency_not_nzd',
+            codes(registration_warnings(self.workspace, date(2026, 7, 1))),
+        )
+
+
+class GstStatusWarningTests(TurnoverTestCase):
+    """The settings screen reads its banner from this payload."""
+
+    def test_the_status_route_reports_turnover_and_warnings(self):
+        """The operator has to see the threshold before it is a problem."""
+        self.sell(date(2026, 6, 1), '60000')
+        response = self.client.get('/tax/gst/status/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['registration_threshold'], '60000.0000')
+        self.assertIn('rolling_turnover', response.data)
+        self.assertIn('warnings', response.data)
+
+    def test_recording_an_arrangement_answers_with_its_consequences(self):
+        """This is the moment the choice was made, so this is where to say so."""
+        self.sell(date(2026, 6, 1), str(PAYMENTS_BASIS_CEILING + 1))
+        response = self.client.post('/tax/gst/registrations/', {
+            'registered': True,
+            'effective_from': '2026-01-01',
+            'gst_number': '123456785',
+            'basis': 'payments',
+            'filing_frequency': 'two_monthly',
+            'period_anchor_month': 3,
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertIn('payments_basis_ineligible', codes(response.data['warnings']))

--- a/tax/turnover.py
+++ b/tax/turnover.py
@@ -1,0 +1,252 @@
+"""Watch taxable turnover against the thresholds that force a change.
+
+Registration is compulsory once taxable turnover in any twelve-month period
+reaches NZ$60,000, and the accounting basis and filing frequency a workspace
+may use are capped by turnover as well. None of that is enforced here: a
+nursery that has outgrown the payments basis does not stop being on it the
+moment it crosses the line, and refusing to record what is actually true would
+leave its returns unproducible. Every finding is a warning.
+
+Turnover is derived from the commerce records directly rather than from any
+GST record, because the case this exists for is the workspace that is not
+registered yet and therefore has no arrangement, no basis, and no periods.
+Supplies are measured as made — the invoice basis — since that is what the
+threshold test asks about regardless of how the workspace accounts.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from inventory.ledger import quantize_money
+
+from .facts import workspace_order_facts
+from .periods import local_date, registration_history
+from .recognition import INVOICE, TURNOVER_CODES, order_recognition
+
+
+#: Compulsory registration once taxable turnover reaches this in any
+#: twelve-month period, past or expected.
+REGISTRATION_THRESHOLD = Decimal('60000')
+#: The payments basis is available only below this turnover.
+PAYMENTS_BASIS_CEILING = Decimal('2000000')
+#: Six-monthly filing is available only below this turnover.
+SIX_MONTHLY_CEILING = Decimal('500000')
+#: Above this, monthly filing is compulsory.
+MONTHLY_COMPULSORY_FLOOR = Decimal('24000000')
+
+#: How much recent trading the forward projection is annualised from.
+PROJECTION_MONTHS = 3
+#: The six-monthly cycles Inland Revenue offers, as the month a period ends in.
+SIX_MONTHLY_ANCHORS = (3, 4, 5, 9, 10, 11)
+
+ZERO = Decimal('0.0000')
+
+
+def months_before(day, months):
+    """Return the same day-of-month some months earlier, clamped for February.
+
+    A plain 365-day subtraction gets the leap-year boundary wrong, which for a
+    rolling twelve-month test means a supply drops out of the window a day
+    early or late — exactly at the point the answer changes.
+    """
+    index = day.year * 12 + day.month - 1 - months
+    year, month = index // 12, index % 12 + 1
+    for candidate in range(day.day, 0, -1):
+        try:
+            return date(year, month, candidate)
+        except ValueError:
+            continue
+    raise ValueError('No valid date in the target month.')
+
+
+def taxable_turnover(workspace, start, end):
+    """Return the value of taxable supplies made in a range, per currency.
+
+    Standard-rated and zero-rated supplies count; exempt and out-of-scope
+    supplies do not. An unclassified supply is neither counted nor ignored —
+    it is reported separately, because assuming either way would move the
+    answer across a threshold nobody decided to cross.
+    """
+    counted = {}
+    unclassified = {}
+    for facts in workspace_order_facts(workspace, start, end):
+        recognition = order_recognition(facts, INVOICE)
+        for event in recognition.events:
+            if not start <= event.supply_date <= end:
+                continue
+            bucket = counted if _counts_towards_turnover(event) else None
+            if bucket is None and _is_unclassified(event):
+                bucket = unclassified
+            if bucket is None:
+                continue
+            sign = -1 if event.kind != 'supply' else 1
+            current = bucket.get(facts.currency_code, ZERO)
+            bucket[facts.currency_code] = current + sign * event.taxable
+    return {
+        'start': start,
+        'end': end,
+        'taxable': {code: quantize_money(value) for code, value in counted.items()},
+        'unclassified': {code: quantize_money(value) for code, value in unclassified.items()},
+    }
+
+
+def _counts_towards_turnover(event):
+    """Whether one event's value belongs in the threshold measurement."""
+    return event.tax_code in TURNOVER_CODES or event.kind != 'supply'
+
+
+def _is_unclassified(event):
+    """Whether an event's value cannot yet be said to count or not."""
+    return event.tax_code == 'unclassified'
+
+
+def rolling_turnover(workspace, on_date):
+    """Return taxable turnover over the twelve months ending on a date."""
+    return taxable_turnover(workspace, months_before(on_date, 12), on_date)
+
+
+def turnover_projection(workspace, on_date):
+    """Annualise recent trading, labelled so it cannot pass for a measurement.
+
+    The legal test is whether turnover is *expected* to exceed the threshold,
+    and no system can know an expectation. Annualising the last quarter is a
+    prompt to think about it, not an answer, so the method travels with the
+    number.
+    """
+    recent = taxable_turnover(workspace, months_before(on_date, PROJECTION_MONTHS), on_date)
+    factor = Decimal(12) / Decimal(PROJECTION_MONTHS)
+    return {
+        'method': f'last_{PROJECTION_MONTHS}_months_annualised',
+        'start': recent['start'],
+        'end': recent['end'],
+        'taxable': {
+            code: quantize_money(value * factor)
+            for code, value in recent['taxable'].items()
+        },
+    }
+
+
+def registration_warnings(workspace, on_date=None, registration=None):
+    """Return every threshold or eligibility finding, worst case first.
+
+    Nothing here refuses anything. The findings reach the settings screen, the
+    period report, and the response to recording an arrangement, so the
+    consequence of a choice is visible at the moment it is made.
+    """
+    on_date = on_date or local_date(workspace, _now())
+    if registration is None:
+        registration = _registration_in_force(workspace, on_date)
+    rolling = rolling_turnover(workspace, on_date)
+    highest = max(rolling['taxable'].values(), default=ZERO)
+    warnings = []
+    if registration is None:
+        warnings.extend(_threshold_warnings(workspace, on_date, highest))
+    else:
+        warnings.extend(_eligibility_warnings(registration, highest))
+    warnings.extend(_configuration_warnings(workspace, rolling))
+    return warnings
+
+
+def _threshold_warnings(workspace, on_date, highest):
+    """Findings that apply only while the workspace is not registered."""
+    warnings = []
+    if highest >= REGISTRATION_THRESHOLD:
+        warnings.append(_warning(
+            'threshold_exceeded',
+            'Taxable turnover over the last twelve months has reached the '
+            'NZ$60,000 registration threshold. Registration is compulsory.',
+            highest,
+        ))
+    else:
+        projected = max(turnover_projection(workspace, on_date)['taxable'].values(), default=ZERO)
+        if projected >= REGISTRATION_THRESHOLD:
+            warnings.append(_warning(
+                'threshold_projected',
+                'Recent trading annualises above the NZ$60,000 threshold. '
+                'Registration is compulsory if you expect to exceed it.',
+                projected,
+            ))
+    return warnings
+
+
+def _eligibility_warnings(registration, highest):
+    """Findings about a basis or frequency turnover has outgrown."""
+    warnings = []
+    if registration.basis == 'payments' and highest > PAYMENTS_BASIS_CEILING:
+        warnings.append(_warning(
+            'payments_basis_ineligible',
+            'Turnover is above NZ$2,000,000, which is the ceiling for the '
+            'payments basis.',
+            highest,
+            PAYMENTS_BASIS_CEILING,
+        ))
+    if registration.filing_frequency == 'six_monthly' and highest > SIX_MONTHLY_CEILING:
+        warnings.append(_warning(
+            'six_monthly_ineligible',
+            'Turnover is above NZ$500,000, which is the ceiling for '
+            'six-monthly filing.',
+            highest,
+            SIX_MONTHLY_CEILING,
+        ))
+    if registration.filing_frequency != 'monthly' and highest > MONTHLY_COMPULSORY_FLOOR:
+        warnings.append(_warning(
+            'monthly_filing_required',
+            'Turnover is above NZ$24,000,000, so monthly filing is compulsory.',
+            highest,
+            MONTHLY_COMPULSORY_FLOOR,
+        ))
+    if registration.filing_frequency == 'six_monthly' and registration.period_anchor_month not in SIX_MONTHLY_ANCHORS:
+        warnings.append(_warning(
+            'six_monthly_cycle_unusual',
+            'Six-monthly periods normally end in March/September, '
+            'April/October, or May/November.',
+        ))
+    return warnings
+
+
+def _configuration_warnings(workspace, rolling):
+    """Findings about a workspace whose settings do not describe a NZ entity."""
+    warnings = []
+    if workspace.currency_code != 'NZD':
+        warnings.append(_warning(
+            'workspace_currency_not_nzd',
+            f'The workspace currency is {workspace.currency_code}. A GST '
+            'return is filed in New Zealand dollars.',
+        ))
+    if len(rolling['taxable']) > 1:
+        warnings.append(_warning(
+            'mixed_currency',
+            'Supplies were made in more than one currency, so turnover cannot '
+            'be totalled without an exchange rate.',
+        ))
+    if any(value > 0 for value in rolling['unclassified'].values()):
+        warnings.append(_warning(
+            'unclassified_turnover',
+            'Some supplies at a zero rate have not been classified as '
+            'zero-rated, exempt, or outside GST, so they are counted neither '
+            'towards nor against the threshold.',
+            max(rolling['unclassified'].values()),
+        ))
+    return warnings
+
+
+def _warning(code, message, value=None, threshold=None):
+    """Build one finding in the shape every surface renders."""
+    return {
+        'code': code,
+        'message': message,
+        'value': None if value is None else str(quantize_money(value)),
+        'threshold': None if threshold is None else str(quantize_money(threshold)),
+    }
+
+
+def _registration_in_force(workspace, on_date):
+    """Return the arrangement applying on a date, reusing one history read."""
+    from .periods import registration_in_force  # pylint: disable=import-outside-toplevel
+    return registration_in_force(workspace, on_date, history=registration_history(workspace))
+
+
+def _now():
+    """Return the current instant, isolated so a test can control the date."""
+    from django.utils import timezone  # pylint: disable=import-outside-toplevel
+    return timezone.now()


### PR DESCRIPTION
Registration is compulsory once taxable turnover reaches NZ$60,000 in any twelve-month period, and the basis and filing frequency a workspace may use are capped by turnover too. None of it is enforced: a nursery that has outgrown the payments basis does not stop being on it, and refusing to record what is true would leave it unable to produce its own returns. Every finding is a warning, shown on the settings screen and again in the response to recording an arrangement — which is the moment the operator finds out the frequency they just chose is one they have outgrown.

Turnover is derived from the commerce records rather than from any GST record, because the case this exists for is the workspace that is not registered yet and so has no arrangement, no basis, and no periods. Supplies are measured as made, which is what the threshold test asks regardless of how the workspace accounts for them.

The rolling window uses calendar-month arithmetic with a February clamp. A 365-day subtraction gets the leap-year boundary wrong by a day, which for a rolling test is precisely where the answer changes — so a test asserts not only that a $60,000 sale warns, but that the warning clears the day it falls out of the window.

Zero-rated supplies count towards turnover and exempt ones do not. A zero-rated-looking supply nobody has classified is counted neither way and reported as a gap, because assuming either would move the answer across a line nobody chose. The projection carries its own method in the payload: the legal test is expectation, which no system can know, and annualising a quarter is a prompt to think rather than an answer.

`facts` is the other half of `recognition` — one ORM read per order, shaped into the frozen facts the pure rules take. It reads only effective records, and it reads the whole of a matching order rather than the part inside the window, because under the invoice basis what a fulfillment recognises depends on what earlier payments already brought to account.

## Summary by Sourcery

Monitor GST turnover and surface non-blocking registration and arrangement eligibility warnings across the API and settings UI.

New Features:
- Add rolling taxable-turnover monitoring against GST registration, accounting-basis, and filing-frequency thresholds.
- Expose turnover measurements and warnings in GST status responses and display them in registration settings and creation responses.
- Derive turnover from effective commerce records, including zero-rated, exempt, unclassified, and multi-currency handling, with labelled recent-trading projections.

Bug Fixes:
- Use calendar-month rolling windows with leap-day clamping so threshold warnings clear on the correct date.

Enhancements:
- Separate commerce fact gathering from pure GST recognition and turnover rules while preserving complete order context for recognition.

Tests:
- Add coverage for rolling-boundary arithmetic, threshold crossings and clearing, tax treatment classification, projections, eligibility warnings, workspace configuration findings, and API payloads.