### PR TITLE
feat(reporting): report GST periods and the rows behind every figure

### DIFF
--- a/frontend/js/main.tsx
+++ b/frontend/js/main.tsx
@@ -181,7 +181,7 @@ function FrontEndPage() {
             </WorkspaceModeRoute>
           }
         />
-        {(['inventory', 'production', 'orders', 'profitability', 'traceability'] as const).map((page) => (
+        {(['inventory', 'production', 'orders', 'profitability', 'traceability', 'gst'] as const).map((page) => (
           <Route
             key={page}
             path={`/reports/${page}`}

--- a/frontend/js/menu.tsx
+++ b/frontend/js/menu.tsx
@@ -75,6 +75,9 @@ function GPTopBar({ workspace }: GPTopBarProps) {
               <NavDropdown.Item as={NavLink} to="/reports/traceability">
                 Traceability
               </NavDropdown.Item>
+              <NavDropdown.Item as={NavLink} to="/reports/gst">
+                GST
+              </NavDropdown.Item>
             </NavDropdown>
           )}
           {workspace.mode === 'nursery' && (

--- a/frontend/js/reports.tsx
+++ b/frontend/js/reports.tsx
@@ -8,7 +8,15 @@ import { queryKeys } from './query'
 import { DashboardRow, ProfitabilityTotals, ReportEnvelope } from './types/reports'
 import { formatDateTime } from './utils'
 
-type ReportPage = 'dashboard' | 'inventory' | 'production' | 'orders' | 'profitability' | 'traceability'
+type ReportPage = 'dashboard' | 'inventory' | 'production' | 'orders' | 'profitability' | 'traceability' | 'gst'
+
+// The period totals and the rows every total is the sum of. They are two
+// reports rather than one because the second is the evidence for the first,
+// and every data-quality finding links straight into it.
+const GST_SECTIONS: Record<string, string> = {
+  periods: 'gst-periods',
+  entries: 'gst-entries'
+}
 
 const INVENTORY_SECTIONS: Record<string, string> = {
   balances: 'inventory-balances',
@@ -114,7 +122,8 @@ function ReportFilters({ page, params, setParams }: { page: ReportPage; params: 
     updated.delete('page')
     setParams(updated)
   }
-  const dated = ['dashboard', 'production', 'orders', 'profitability'].includes(page)
+  const dated = ['dashboard', 'production', 'orders', 'profitability', 'gst'].includes(page)
+  const gstEntries = page === 'gst' && params.get('section') === 'entries'
   return (
     <Card body className="mb-3">
       <Row className="g-2">
@@ -126,6 +135,10 @@ function ReportFilters({ page, params, setParams }: { page: ReportPage; params: 
         {page === 'profitability' && <FilterField label="Customer ID" name="customer" type="number" params={params} update={update} />}
         {page === 'inventory' && params.get('section') === 'balances' && <FilterField label="Item ID" name="item" type="number" params={params} update={update} />}
         {page === 'inventory' && params.get('section') === 'balances' && <FilterField label="Lot ID" name="lot" type="number" params={params} update={update} />}
+        {gstEntries && <FilterField label="Period" name="period" params={params} update={update} />}
+        {gstEntries && <FilterField label="Kind" name="kind" params={params} update={update} />}
+        {gstEntries && <FilterField label="Tax code" name="tax_code" params={params} update={update} />}
+        {gstEntries && <FilterField label="Excluded because" name="exclusion" params={params} update={update} />}
       </Row>
     </Card>
   )
@@ -213,6 +226,21 @@ function ProfitabilitySummary({ totals }: { totals: ProfitabilityTotals }) {
   )
 }
 
+// The two reports recognise on different dates on purpose, so the note the
+// server publishes is shown rather than left in the payload for somebody to
+// find after they have already queried why the figures differ.
+function GstRecognitionNote({ report }: { report: ReportEnvelope }) {
+  const note = report.reconciliation.recognition_note
+  if (typeof note !== 'string') {
+    return null
+  }
+  return (
+    <Alert variant="info">
+      <strong>Recognition:</strong> {note}
+    </Alert>
+  )
+}
+
 function ReportsView({ page }: { page: ReportPage }) {
   const [params, setParams] = useSearchParams()
   React.useEffect(() => {
@@ -221,20 +249,27 @@ function ReportsView({ page }: { page: ReportPage }) {
       updated.set('section', 'balances')
       setParams(updated, { replace: true })
     }
+    if (page === 'gst' && !params.get('section')) {
+      const updated = new URLSearchParams(params)
+      updated.set('section', 'periods')
+      setParams(updated, { replace: true })
+    }
   }, [page, params, setParams])
   const traceType = params.get('trace_type') ?? 'plant'
   const traceId = params.get('trace_id') ?? ''
   const section = params.get('section') ?? 'balances'
   const reportName =
-    page === 'inventory'
-      ? INVENTORY_SECTIONS[section]
-      : page === 'production'
-        ? 'production-batches'
-        : page === 'traceability'
-          ? traceId
-            ? `traceability/${traceType === 'lot' ? 'lots' : 'plants'}/${traceId}`
-            : ''
-          : page
+    page === 'gst'
+      ? GST_SECTIONS[params.get('section') ?? 'periods']
+      : page === 'inventory'
+        ? INVENTORY_SECTIONS[section]
+        : page === 'production'
+          ? 'production-batches'
+          : page === 'traceability'
+            ? traceId
+              ? `traceability/${traceType === 'lot' ? 'lots' : 'plants'}/${traceId}`
+              : ''
+            : page
   const apiParams = new URLSearchParams(params)
   ;['section', 'trace_type', 'trace_id'].forEach((key) => apiParams.delete(key))
   const query = useQuery({
@@ -252,7 +287,7 @@ function ReportsView({ page }: { page: ReportPage }) {
   return (
     <main className="container-fluid py-3">
       <div className="d-flex justify-content-between align-items-center mb-3">
-        <h1 className="mb-0">{page === 'dashboard' ? 'Nursery dashboard' : `Nursery ${page}`}</h1>
+        <h1 className="mb-0">{page === 'dashboard' ? 'Nursery dashboard' : page === 'gst' ? 'GST' : `Nursery ${page}`}</h1>
         {reportName && (
           <Button as="a" variant="outline-primary" href={reportExportUrl(reportName, apiParams)}>
             Export CSV
@@ -265,6 +300,12 @@ function ReportsView({ page }: { page: ReportPage }) {
           <option value="trays">Serialized trays</option>
           <option value="movements">Movement history</option>
           <option value="stocktakes">Stocktake variances</option>
+        </Form.Select>
+      )}
+      {page === 'gst' && (
+        <Form.Select className="mb-3" value={params.get('section') ?? 'periods'} onChange={(event) => setParams(new URLSearchParams({ section: event.target.value }))}>
+          <option value="periods">Period totals</option>
+          <option value="entries">Entries behind every total</option>
         </Form.Select>
       )}
       {page === 'traceability' && (
@@ -289,6 +330,7 @@ function ReportsView({ page }: { page: ReportPage }) {
       {!reportName && <Alert variant="info">Choose an exact plant or lot to trace.</Alert>}
       {query.data && (
         <>
+          {page === 'gst' && <GstRecognitionNote report={query.data} />}
           <QualityWarnings report={query.data} />
           {page === 'dashboard' ? <Dashboard report={query.data as unknown as ReportEnvelope<DashboardRow>} /> : null}
           {page === 'profitability' ? <ProfitabilitySummary totals={query.data.totals as unknown as ProfitabilityTotals} /> : null}

--- a/reporting/filters.py
+++ b/reporting/filters.py
@@ -131,3 +131,43 @@ class DashboardFilters(BaseReportFilters):  # pylint: disable=abstract-method
 
     date_from = serializers.DateField(required=False)
     date_to = serializers.DateField(required=False)
+
+
+class GstPeriodFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Filters for GST period totals.
+
+    The range is optional: with none given the report answers the question the
+    operator actually has, which is what the open period looks like. The
+    date_to/date_from check is a fourth copy of the same block in this file —
+    extracting a shared mixin would touch every existing filter class and
+    belongs in its own change.
+    """
+
+    date_from = serializers.DateField(required=False)
+    date_to = serializers.DateField(required=False)
+
+    def validate(self, attrs):
+        """Reject a range that ends before it starts."""
+        date_from, date_to = attrs.get('date_from'), attrs.get('date_to')
+        if date_from and date_to and date_to < date_from:
+            raise serializers.ValidationError({
+                'date_to': 'The range end must not be before its start.',
+            })
+        return attrs
+
+
+class GstEntryFilters(GstPeriodFilters):  # pylint: disable=abstract-method
+    """Filters for the entries behind a period total, as the drill-down links use."""
+
+    period = serializers.CharField(required=False)
+    kind = serializers.ChoiceField(
+        required=False, choices=('supply', 'supply_credit', 'purchase'),
+    )
+    tax_code = serializers.ChoiceField(
+        required=False,
+        choices=('standard', 'zero_rated', 'exempt', 'out_of_scope', 'unclassified'),
+    )
+    exclusion = serializers.ChoiceField(
+        required=False,
+        choices=('no_registration', 'deregistered_gap', 'input_tax_awaiting_payment'),
+    )

--- a/reporting/gst.py
+++ b/reporting/gst.py
@@ -1,0 +1,451 @@
+"""GST period totals and the immutable source rows behind every figure.
+
+Two reports. `gst_period_report` is one row per taxable period, with the boxes
+a New Zealand GST return is filed from. `gst_entry_report` is the drill-down:
+one row per derived entry, which is what every period total is the sum of and
+what makes the phrase "reconciles to immutable source records" checkable rather
+than asserted.
+
+This is deliberately not the same recognition as `reporting.commerce`. That
+report answers what a period earned, and recognises on fulfillment. This one
+answers what a period owes, and recognises on the basis in force at each time
+of supply. For one order paid in one period and delivered in the next, the two
+disagree — and they are supposed to. The `reconciliation` block says so in the
+payload rather than leaving somebody to discover it against a filed return.
+
+Nothing here is totalled across currencies. There is no exchange rate in this
+application (task 121 owns that), so a period trading in two currencies reports
+each separately and withholds the consolidated net figure, exactly as
+`profitability_report` withholds a margin it cannot state.
+"""
+
+# pylint: disable=duplicate-code
+
+from calendar import monthrange
+from collections import defaultdict
+from datetime import date, datetime
+from decimal import Decimal
+
+from tax.entries import AWAITING_PAYMENT, PURCHASE, derive_entries
+from tax.periods import (
+    enumerate_periods,
+    local_date,
+    registration_history,
+    taxable_period_for,
+)
+from tax.recognition import SUPPLY, SUPPLY_CREDIT
+from tax.turnover import registration_warnings
+
+from .common import Report, decimal_string
+
+
+MONEY_PLACES = 4
+ZERO = Decimal('0.0000')
+
+PERIOD_COLUMNS = (
+    'period_label', 'period_start', 'period_end', 'clipped',
+    'basis', 'filing_frequency', 'gst_number', 'registration',
+    'taxable_supplies_incl_tax', 'zero_rated_supplies', 'exempt_supplies',
+    'unclassified_supplies', 'supply_credits_incl_tax',
+    'output_tax', 'debit_adjustments', 'total_output_tax',
+    'purchases_incl_tax', 'input_tax', 'credit_adjustments', 'total_input_tax',
+    'non_recoverable_tax', 'input_tax_awaiting_payment',
+    'net_gst', 'net_gst_direction', 'entry_count', 'currency_code',
+)
+
+ENTRY_COLUMNS = (
+    'period_label', 'kind', 'supply_date', 'basis', 'source_type', 'source_id',
+    'document_id', 'line_id', 'tax_code', 'tax_rate',
+    'taxable', 'tax', 'non_recoverable_tax', 'gross',
+    'currency_code', 'time_of_supply_source', 'proxy', 'exclusion',
+)
+
+RECONCILIATION = {
+    'supplies_equation': (
+        'total supplies = taxable supplies + zero-rated supplies '
+        '- supply credits'
+    ),
+    'output_equation': 'total output tax = output tax + debit adjustments',
+    'input_equation': 'total input tax = input tax + credit adjustments',
+    'net_equation': 'net GST = total output tax - total input tax',
+    'entry_equation': (
+        'every period total is the sum of its entries in this report, and '
+        'every entry is derived from one immutable commerce record'
+    ),
+    'amount_equation': 'gross = taxable + claimable tax + non-claimable tax',
+    'recognition_note': (
+        'GST recognition uses the basis in force at each time of supply; '
+        'profitability recognition uses fulfillment dates and is calculated '
+        'separately. The two legitimately disagree about which period an '
+        'order belongs to.'
+    ),
+    'proxy_note': (
+        'A fulfillment stands in for the invoice date the invoice basis needs; '
+        'entries relying on it are marked proxy.'
+    ),
+}
+
+#: Explanations for the exclusion reasons an entry can carry, so a report says
+#: what a missing figure means rather than leaving a total looking complete.
+EXCLUSION_MESSAGES = {
+    'no_registration': (
+        'Commerce was recorded on dates before any GST registration. It '
+        'carried no GST obligation and belongs to no return period.'
+    ),
+    'deregistered_gap': (
+        'Commerce was recorded on dates after a cessation and before any later '
+        'registration, so it belongs to no return period.'
+    ),
+    AWAITING_PAYMENT: (
+        'Under the payments and hybrid bases input tax is claimed when the '
+        'supplier is paid, and no supplier payment date is recorded anywhere '
+        'yet. These purchases are held back rather than claimed on their '
+        'receipt date.'
+    ),
+}
+
+
+def gst_period_report(workspace, filters):
+    """Return one row per taxable period, in the shape a GST return is filed in."""
+    start, end = _date_bounds(workspace, filters)
+    entries = derive_entries(workspace, start, end)
+    periods = enumerate_periods(workspace, start, end, history=registration_history(workspace))
+    rows = []
+    for period in periods:
+        rows.extend(_period_rows(period, entries))
+    return Report(
+        name='gst-periods',
+        filters=dict(filters),
+        columns=PERIOD_COLUMNS,
+        rows=rows,
+        totals=_period_totals(rows),
+        reconciliation=dict(RECONCILIATION),
+        data_quality=_data_quality(workspace, entries, rows, end),
+    )
+
+
+def gst_entry_report(workspace, filters):
+    """Return every derived entry, which is what each period total is made of."""
+    start, end = _date_bounds(workspace, filters)
+    entries = _apply_entry_filters(derive_entries(workspace, start, end), filters)
+    return Report(
+        name='gst-entries',
+        filters=dict(filters),
+        columns=ENTRY_COLUMNS,
+        rows=[_entry_row(entry) for entry in entries],
+        totals=_entry_totals(entries),
+        reconciliation=dict(RECONCILIATION),
+        data_quality=[],
+    )
+
+
+def _apply_entry_filters(entries, filters):
+    """Narrow the drill-down to the slice a period total was queried about."""
+    period = filters.get('period')
+    kind = filters.get('kind')
+    tax_code = filters.get('tax_code')
+    exclusion = filters.get('exclusion')
+    selected = []
+    for entry in entries:
+        if period and entry.period_label != period:
+            continue
+        if kind and entry.kind != kind:
+            continue
+        if tax_code and entry.tax_code != tax_code:
+            continue
+        if exclusion and entry.exclusion != exclusion:
+            continue
+        selected.append(entry)
+    return selected
+
+
+def _period_rows(period, entries):
+    """Return one row per currency this period traded in, or one empty row.
+
+    A period with no trading still gets a row. A return was due for it, and a
+    report that simply omitted it would look the same as one where the period
+    had been forgotten.
+    """
+    matching = [
+        entry for entry in entries
+        if entry.period is not None and entry.period.label == period.label
+    ]
+    # Held-back input tax has no period, but it was incurred inside this one and
+    # the operator needs to see how much a return is not claiming.
+    awaiting = [
+        entry for entry in entries
+        if entry.exclusion == AWAITING_PAYMENT and period.contains(entry.supply_date)
+    ]
+    by_currency = defaultdict(lambda: ([], []))
+    for entry in matching:
+        by_currency[entry.currency_code][0].append(entry)
+    for entry in awaiting:
+        by_currency[entry.currency_code][1].append(entry)
+    if not by_currency:
+        return [_period_row(period, '', [], [])]
+    return [
+        _period_row(period, currency, included, held)
+        for currency, (included, held) in sorted(by_currency.items())
+    ]
+
+
+def _period_row(period, currency_code, entries, awaiting):  # pylint: disable=too-many-locals
+    """Sum one period's entries into the boxes a return is filed from."""
+    supplies = [entry for entry in entries if entry.kind == SUPPLY]
+    credits_ = [entry for entry in entries if entry.kind == SUPPLY_CREDIT]
+    purchases = [entry for entry in entries if entry.kind == PURCHASE]
+
+    taxable_supplies = _sum(entry.gross for entry in supplies if entry.tax_code == 'standard')
+    zero_rated = _sum(entry.gross for entry in supplies if entry.tax_code == 'zero_rated')
+    exempt = _sum(entry.gross for entry in supplies if entry.tax_code == 'exempt')
+    unclassified = _sum(entry.gross for entry in supplies if entry.tax_code == 'unclassified')
+    credit_gross = _sum(entry.gross for entry in credits_)
+
+    output_tax = _sum(entry.tax for entry in supplies) - _sum(entry.tax for entry in credits_)
+    purchases_gross = _sum(entry.gross for entry in purchases)
+    input_tax = _sum(entry.tax for entry in purchases)
+    non_recoverable = _sum(entry.non_recoverable_tax for entry in purchases)
+
+    # Debit and credit adjustments are the transition-adjustment slots task 117
+    # change 5 asks for. They stay zero until a basis change produces one, and
+    # they are named here so the return's arithmetic is complete either way.
+    debit_adjustments = ZERO
+    credit_adjustments = ZERO
+    total_output = output_tax + debit_adjustments
+    total_input = input_tax + credit_adjustments
+    net = total_output - total_input
+
+    return {
+        'period_label': period.label,
+        'period_start': period.start.isoformat(),
+        'period_end': period.end.isoformat(),
+        'clipped': period.clipped,
+        'basis': period.basis,
+        'filing_frequency': period.frequency,
+        'gst_number': _gst_number(period),
+        'registration': period.registration_id,
+        'taxable_supplies_incl_tax': decimal_string(taxable_supplies, MONEY_PLACES),
+        'zero_rated_supplies': decimal_string(zero_rated, MONEY_PLACES),
+        'exempt_supplies': decimal_string(exempt, MONEY_PLACES),
+        'unclassified_supplies': decimal_string(unclassified, MONEY_PLACES),
+        'supply_credits_incl_tax': decimal_string(credit_gross, MONEY_PLACES),
+        'output_tax': decimal_string(output_tax, MONEY_PLACES),
+        'debit_adjustments': decimal_string(debit_adjustments, MONEY_PLACES),
+        'total_output_tax': decimal_string(total_output, MONEY_PLACES),
+        'purchases_incl_tax': decimal_string(purchases_gross, MONEY_PLACES),
+        'input_tax': decimal_string(input_tax, MONEY_PLACES),
+        'credit_adjustments': decimal_string(credit_adjustments, MONEY_PLACES),
+        'total_input_tax': decimal_string(total_input, MONEY_PLACES),
+        'non_recoverable_tax': decimal_string(non_recoverable, MONEY_PLACES),
+        'input_tax_awaiting_payment': decimal_string(_sum(entry.tax for entry in awaiting), MONEY_PLACES),
+        'net_gst': decimal_string(net, MONEY_PLACES),
+        'net_gst_direction': _direction(net),
+        'entry_count': len(entries),
+        'currency_code': currency_code,
+    }
+
+
+def _direction(net):
+    """Name the direction so no consumer has to parse a minus sign."""
+    if net > 0:
+        return 'payable'
+    return 'refundable' if net < 0 else 'nil'
+
+
+def _gst_number(period):
+    """Return the number this period's return is filed under."""
+    from tax.models import GstRegistration  # pylint: disable=import-outside-toplevel
+    registration = GstRegistration.objects.filter(pk=period.registration_id).first()
+    return registration.gst_number if registration else ''
+
+
+def _period_totals(rows):
+    """Sum the periods, per currency, withholding what cannot be consolidated."""
+    summed = defaultdict(lambda: defaultdict(Decimal))
+    money_fields = [
+        column for column in PERIOD_COLUMNS
+        if column not in {
+            'period_label', 'period_start', 'period_end', 'clipped', 'basis',
+            'filing_frequency', 'gst_number', 'registration',
+            'net_gst_direction', 'entry_count', 'currency_code',
+        }
+    ]
+    for row in rows:
+        bucket = summed[row['currency_code']]
+        for field in money_fields:
+            bucket[field] += Decimal(row[field])
+        bucket['entry_count'] += row['entry_count']
+    currencies = sorted(code for code in summed if code)
+    per_currency = {
+        code: {
+            **{field: decimal_string(summed[code][field], MONEY_PLACES) for field in money_fields},
+            'net_gst_direction': _direction(summed[code]['net_gst']),
+            'entry_count': int(summed[code]['entry_count']),
+        }
+        for code in currencies
+    }
+    return {
+        'periods': len(rows),
+        'currencies': currencies,
+        'by_currency': per_currency,
+        # None means withheld, and must mean only that: consolidating two
+        # currencies would need an exchange rate this application does not
+        # hold. A range that simply saw no trading is nil, not unknown.
+        'net_gst': _consolidated_net(currencies, per_currency),
+    }
+
+
+def _consolidated_net(currencies, per_currency):
+    """Return the single-currency net, nil when nothing traded, None when mixed."""
+    if not currencies:
+        return decimal_string(ZERO, MONEY_PLACES)
+    if len(currencies) > 1:
+        return None
+    return per_currency[currencies[0]]['net_gst']
+
+
+def _entry_row(entry):
+    """Render one derived entry as the drill-down row behind a period total."""
+    return {
+        'period_label': entry.period_label,
+        'kind': entry.kind,
+        'supply_date': entry.supply_date.isoformat(),
+        'basis': entry.basis,
+        'source_type': entry.source_type,
+        'source_id': entry.source_id,
+        'document_id': entry.document_id,
+        'line_id': entry.line_id,
+        'tax_code': entry.tax_code,
+        'tax_rate': decimal_string(entry.tax_rate, MONEY_PLACES),
+        'taxable': decimal_string(entry.taxable, MONEY_PLACES),
+        'tax': decimal_string(entry.tax, MONEY_PLACES),
+        'non_recoverable_tax': decimal_string(entry.non_recoverable_tax, MONEY_PLACES),
+        'gross': decimal_string(entry.gross, MONEY_PLACES),
+        'currency_code': entry.currency_code,
+        'time_of_supply_source': entry.time_of_supply_source,
+        'proxy': entry.proxy,
+        'exclusion': entry.exclusion,
+    }
+
+
+def _entry_totals(entries):
+    """Total the drill-down so it can be checked against the period it explains."""
+    included = [entry for entry in entries if not entry.exclusion]
+    return {
+        'entries': len(entries),
+        'included': len(included),
+        'excluded': len(entries) - len(included),
+        'taxable': decimal_string(_sum(entry.taxable for entry in included), MONEY_PLACES),
+        'tax': decimal_string(_sum(entry.tax for entry in included), MONEY_PLACES),
+        'gross': decimal_string(_sum(entry.gross for entry in included), MONEY_PLACES),
+    }
+
+
+def _data_quality(workspace, entries, rows, as_at):
+    """Report every reason a figure is incomplete, with the rows behind it."""
+    findings = []
+    for exclusion, message in EXCLUSION_MESSAGES.items():
+        matching = [entry for entry in entries if entry.exclusion == exclusion]
+        if matching:
+            findings.append(_finding(exclusion, len(matching), message, exclusion=exclusion))
+
+    unclassified = [
+        entry for entry in entries
+        if not entry.exclusion and entry.tax_code == 'unclassified' and entry.kind == SUPPLY
+    ]
+    if unclassified:
+        findings.append(_finding(
+            'unclassified_tax_code', len(unclassified),
+            'Some supplies at a zero rate have not been classified as '
+            'zero-rated, exempt, or outside GST, so they are reported in none '
+            'of those boxes.',
+            tax_code='unclassified',
+        ))
+
+    non_recoverable = [entry for entry in entries if entry.non_recoverable_tax > 0]
+    if non_recoverable:
+        findings.append(_finding(
+            'non_recoverable_input_tax', len(non_recoverable),
+            'Tax on some purchases was not recoverable and is carried in the '
+            'cost of the stock instead of being claimed.',
+            kind=PURCHASE,
+        ))
+
+    purchases = [entry for entry in entries if entry.kind == PURCHASE]
+    if purchases:
+        findings.append(_finding(
+            'receipt_level_tax_treatment', len(purchases),
+            'Tax treatment is recorded for a whole receipt rather than per '
+            'line, so a receipt mixing standard-rated and zero-rated purchases '
+            'cannot be represented.',
+            kind=PURCHASE,
+        ))
+
+    currencies = {row['currency_code'] for row in rows if row['currency_code']}
+    if len(currencies) > 1:
+        findings.append(_finding(
+            'mixed_currency', len(currencies),
+            'Supplies were made in more than one currency. Each is reported '
+            'separately and the consolidated net GST is withheld, because no '
+            'exchange rate is recorded.',
+        ))
+
+    findings.extend(
+        _finding(warning['code'], 1, warning['message'])
+        for warning in registration_warnings(workspace, as_at)
+    )
+    return findings
+
+
+def _finding(code, count, message, **drill_down):
+    """Build one data-quality entry with a link to the rows behind it."""
+    query = '&'.join(f'{key}={value}' for key, value in sorted(drill_down.items()))
+    return {
+        'code': code,
+        'count': count,
+        'message': message,
+        'drill_down': f'/reports/gst-entries/?{query}' if query else '/reports/gst-entries/',
+    }
+
+
+def _sum(values):
+    """Total a series of money amounts, starting from an exact zero."""
+    return sum(values, ZERO)
+
+
+def _date_bounds(workspace, filters):
+    """Return the inclusive range to report, defaulting to the open period.
+
+    A GST report with no range asked for should answer the question the
+    operator actually has, which is what the return they are about to file
+    looks like. An unregistered workspace has no period, so it falls back to
+    the current calendar month — the same default the commerce reports use.
+    """
+    start = filters.get('date_from')
+    end = filters.get('date_to')
+    if start and end:
+        return _as_date(start), _as_date(end)
+    today = local_date(workspace, _now())
+    period = taxable_period_for(workspace, today)
+    if period is not None:
+        default_start, default_end = period.start, period.end
+    else:
+        default_start = date(today.year, today.month, 1)
+        default_end = date(today.year, today.month, monthrange(today.year, today.month)[1])
+    return (
+        _as_date(start) if start else default_start,
+        _as_date(end) if end else default_end,
+    )
+
+
+def _as_date(value):
+    """Accept a filter value as either an ISO string or an already-parsed date."""
+    if isinstance(value, date):
+        return value
+    return datetime.fromisoformat(value).date()
+
+
+def _now():
+    """Return the current instant, isolated so a test can control the default."""
+    from django.utils import timezone  # pylint: disable=import-outside-toplevel
+    return timezone.now()

--- a/reporting/rest.py
+++ b/reporting/rest.py
@@ -9,6 +9,8 @@ from .common import csv_response, normalized_filters, report_response
 from .filters import (
     CommerceFilters,
     DashboardFilters,
+    GstEntryFilters,
+    GstPeriodFilters,
     InventoryBalanceFilters,
     MovementFilters,
     OrderFilters,
@@ -18,6 +20,7 @@ from .filters import (
     TraceFilters,
 )
 from .commerce import dashboard_report, order_report, profitability_report
+from .gst import gst_entry_report, gst_period_report
 from .production import production_batches
 from .traceability import lot_trace, plant_trace
 from .inventory import (
@@ -137,4 +140,14 @@ ProfitabilityExportView = _view(
 )
 DashboardView = _view(
     'DashboardView', DashboardFilters, dashboard_report,
+)
+
+
+GstPeriodView = _view('GstPeriodView', GstPeriodFilters, gst_period_report)
+GstPeriodExportView = _view(
+    'GstPeriodExportView', GstPeriodFilters, gst_period_report, True,
+)
+GstEntryView = _view('GstEntryView', GstEntryFilters, gst_entry_report)
+GstEntryExportView = _view(
+    'GstEntryExportView', GstEntryFilters, gst_entry_report, True,
 )

--- a/reporting/test_gst.py
+++ b/reporting/test_gst.py
@@ -1,0 +1,484 @@
+"""Verification 3: every GST period total reconciles to its own source rows.
+
+The claim this feature makes is that a period figure is the sum of immutable
+commerce records and nothing else. That is only worth making if it is checked,
+so every box in a period row is asserted against a direct sum over the
+drill-down rows the report itself publishes.
+
+The separation tests are task 117 change 6: GST recognition and profitability
+recognition use different dates for the same order, on purpose, and the pair of
+assertions in one test is the contract rather than a coincidence.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+from inventory.ledger import post_receipt
+from inventory.models import InventoryItem, StockReceipt, StockReceiptLine
+from inventory.units import UnitCode
+from locations.models import Location
+from sales.models import Payment, SalesOrder, SalesOrderLine
+from sales.services import create_order
+from tax.models import GstRegistration
+from tax.services import record_registration
+from tests.api import RESTContractTestCase
+from tests.factories import make_inventory_item, make_supplier
+from workspaces.models import Workspace, get_current_workspace
+
+
+PERIODS_URL = '/reports/gst-periods/'
+ENTRIES_URL = '/reports/gst-entries/'
+
+MONEY_COLUMNS = (
+    'taxable_supplies_incl_tax', 'zero_rated_supplies', 'exempt_supplies',
+    'unclassified_supplies', 'supply_credits_incl_tax', 'output_tax',
+    'purchases_incl_tax', 'input_tax', 'non_recoverable_tax', 'net_gst',
+)
+
+
+class GstReportTestCase(RESTContractTestCase):
+    """A registered Nursery with sales that can be dated precisely."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.currency_code = 'NZD'
+        self.workspace.timezone = 'Pacific/Auckland'
+        self.workspace.default_tax_rate = Decimal('15')
+        self.workspace.sales_prices_include_tax = False
+        self.workspace.save()
+        self.item = make_inventory_item(
+            workspace=self.workspace,
+            category=InventoryItem.Category.TRAY,
+            tracking_mode=InventoryItem.TrackingMode.SERIALIZED,
+            base_unit=UnitCode.EACH,
+        )
+
+    def register(self, basis=GstRegistration.Basis.PAYMENTS, **overrides):
+        """Record an arrangement to report under."""
+        values = {
+            'registered': True,
+            'effective_from': date(2026, 1, 1),
+            'gst_number': '123456785',
+            'basis': basis,
+            'filing_frequency': GstRegistration.Frequency.TWO_MONTHLY,
+            # Periods ending in the even months, so a registration on 1 January
+            # starts a whole period and the year is exactly six of them.
+            'period_anchor_month': 4,
+        }
+        values.update(overrides)
+        return record_registration(self.workspace, self.user, **values)
+
+    def sell(self, paid_on, ex_tax='100', *, tax_rate='15', treatment=None, currency='NZD'):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        """Record a paid supply of a given ex-GST value."""
+        order = create_order(self.workspace, self.user, status=SalesOrder.Status.DRAFT)
+        if currency != order.currency_code:
+            SalesOrder.objects.filter(pk=order.pk).update(currency_code=currency)
+            order.refresh_from_db()
+        values = {
+            'order': order,
+            'line_type': SalesOrderLine.LineType.TRAY,
+            'tray_item': self.item,
+            'description': 'Trays',
+            'quantity': 1,
+            'unit_price': Decimal(ex_tax),
+            'tax_rate': Decimal(tax_rate),
+            'discount_type': SalesOrderLine.DiscountType.NONE,
+        }
+        if treatment is not None:
+            values['tax_treatment'] = treatment
+        line = SalesOrderLine.objects.create(**values)
+        SalesOrder.objects.filter(pk=order.pk).update(status=SalesOrder.Status.CONFIRMED)
+        Payment.objects.create(
+            workspace=self.workspace, order=order, paid_on=paid_on,
+            amount=line.total_incl_tax, currency_code=currency, method='cash',
+            operation_key=uuid4(), request_fingerprint='gst-report-test',
+        )
+        return order
+
+    def buy(self, received_date, ex_tax='200', tax_rate='15', recoverable=True):
+        """Post a supplier receipt, which is where input tax comes from."""
+        store = Location.objects.create(
+            workspace=self.workspace, name=f'Store {received_date}',
+            code=f'STORE-{received_date.isoformat()}',
+            location_type=Location.LocationType.STORAGE,
+        )
+        media = make_inventory_item(workspace=self.workspace)
+        receipt = StockReceipt.objects.create(
+            workspace=self.workspace, supplier=make_supplier(workspace=self.workspace),
+            received_date=received_date, currency_code='NZD',
+            tax_rate=Decimal(tax_rate), tax_recoverable=recoverable,
+            created_by=self.user,
+        )
+        StockReceiptLine.objects.create(
+            receipt=receipt, item=media, quantity=Decimal('2'),
+            unit_code=UnitCode.LITRE, base_quantity=Decimal('2'),
+            line_cost_ex_tax=Decimal(ex_tax), destination=store,
+        )
+        return post_receipt(receipt, self.user)[0]
+
+    def periods(self, **params):
+        """Fetch the period report over an explicit range."""
+        query = {'date_from': '2026-01-01', 'date_to': '2026-12-31'}
+        query.update(params)
+        response = self.client.get(PERIODS_URL, query)
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+    def entries(self, **params):
+        """Fetch the drill-down over the same range, unpaginated."""
+        query = {'date_from': '2026-01-01', 'date_to': '2026-12-31', 'page_size': '200'}
+        query.update(params)
+        response = self.client.get(ENTRIES_URL, query)
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+
+class GstPeriodContractTests(GstReportTestCase):
+    """The report's shape, and who is allowed to ask for it."""
+
+    def test_authentication_is_required(self):
+        """A GST return is not public information."""
+        self.assert_authentication_required([PERIODS_URL, ENTRIES_URL])
+
+    def test_garden_mode_is_refused(self):
+        """A bookmarked URL must be refused by the server, not only the menu."""
+        self.workspace.mode = Workspace.Mode.GARDEN
+        self.workspace.save()
+        for url in (PERIODS_URL, ENTRIES_URL):
+            with self.subTest(url=url):
+                self.assertEqual(self.client.get(url).status_code, 403)
+
+    def test_an_unknown_filter_is_rejected(self):
+        """A misspelled filter that was ignored would silently change scope."""
+        response = self.client.get(PERIODS_URL, {'date_form': '2026-01-01'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_reversed_range_is_rejected(self):
+        """An empty report is not the right answer to an impossible range."""
+        response = self.client.get(
+            PERIODS_URL, {'date_from': '2026-06-01', 'date_to': '2026-01-01'},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_the_periods_of_a_registered_year_are_all_reported(self):
+        """A period with no trading still had a return due, so it must appear."""
+        self.register()
+        data = self.periods()
+        self.assertEqual(len(data['results']), 6)
+        self.assertEqual(data['results'][0]['period_start'], '2026-01-01')
+        self.assertEqual(data['results'][0]['period_end'], '2026-02-28')
+
+    def test_an_unregistered_workspace_reports_no_periods(self):
+        """Inventing periods would be the first step to filing a wrong return."""
+        data = self.periods()
+        self.assertEqual(data['results'], [])
+
+    def test_the_recognition_difference_is_published(self):
+        """Somebody comparing this against profitability must be told why they differ."""
+        self.register()
+        data = self.periods()
+        self.assertIn('recognition_note', data['reconciliation'])
+        self.assertIn('profitability', data['reconciliation']['recognition_note'])
+
+
+class ReconciliationTests(GstReportTestCase):
+    """Every period figure is the sum of the rows the report itself publishes."""
+
+    def test_output_tax_is_the_sum_of_its_entries(self):
+        """115.00 paid at 15% carries 15.00 of GST, in the period it was paid."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['taxable_supplies_incl_tax'], '115.0000')
+        self.assertEqual(row['output_tax'], '15.0000')
+
+    def test_every_money_column_equals_a_direct_sum_over_the_drill_down(self):
+        """This is the claim the whole feature rests on, checked column by column."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        self.sell(date(2026, 4, 2), '200', tax_rate='0', treatment='zero_rated')
+        row = self._period('2026-03-01..2026-04-30')
+        rows = self.entries(period='2026-03-01..2026-04-30')['results']
+        supplies = [entry for entry in rows if entry['kind'] == 'supply']
+        self.assertEqual(
+            row['taxable_supplies_incl_tax'],
+            self._total(entry['gross'] for entry in supplies if entry['tax_code'] == 'standard'),
+        )
+        self.assertEqual(
+            row['zero_rated_supplies'],
+            self._total(entry['gross'] for entry in supplies if entry['tax_code'] == 'zero_rated'),
+        )
+        self.assertEqual(row['output_tax'], self._total(entry['tax'] for entry in supplies))
+        self.assertEqual(row['entry_count'], len(rows))
+
+    def test_net_gst_equals_output_less_input(self):
+        """The return's bottom line has to follow from the boxes above it."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        row = self._period('2026-03-01..2026-04-30')
+        expected = Decimal(row['total_output_tax']) - Decimal(row['total_input_tax'])
+        self.assertEqual(Decimal(row['net_gst']), expected)
+        self.assertEqual(row['net_gst_direction'], 'payable')
+
+    def test_a_period_with_no_trading_is_reported_as_nil(self):
+        """Nil and forgotten must not look the same in a list of returns."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        row = self._period('2026-01-01..2026-02-28')
+        for column in MONEY_COLUMNS:
+            with self.subTest(column=column):
+                self.assertEqual(row[column], '0.0000')
+        self.assertEqual(row['net_gst_direction'], 'nil')
+
+    def test_every_entry_balances(self):
+        """gross = taxable + claimable tax + non-claimable tax, on every row."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        for entry in self.entries()['results']:
+            with self.subTest(entry=entry['source_id']):
+                parts = (
+                    Decimal(entry['taxable']),
+                    Decimal(entry['tax']),
+                    Decimal(entry['non_recoverable_tax']),
+                )
+                self.assertEqual(Decimal(entry['gross']), sum(parts, Decimal('0')))
+
+    def _period(self, label):
+        """Return the one period row carrying a label."""
+        rows = [row for row in self.periods()['results'] if row['period_label'] == label]
+        self.assertEqual(len(rows), 1, rows)
+        return rows[0]
+
+    def _total(self, values):
+        """Sum drill-down strings the same way the report renders its own."""
+        return f'{sum((Decimal(value) for value in values), Decimal("0")):.4f}'
+
+
+class BasisTests(GstReportTestCase):
+    """A change of basis moves which period an order lands in, never its value."""
+
+    def test_the_payments_basis_reports_in_the_payment_period(self):
+        """Money received in March belongs to March's return."""
+        self.register(basis=GstRegistration.Basis.PAYMENTS)
+        self.sell(date(2026, 3, 10), '100')
+        labels = {
+            row['period_label'] for row in self.periods()['results']
+            if row['output_tax'] != '0.0000'
+        }
+        self.assertEqual(labels, {'2026-03-01..2026-04-30'})
+
+    def test_each_period_reports_the_basis_it_was_filed_under(self):
+        """A return that cannot say which basis produced it cannot be checked."""
+        self.register(basis=GstRegistration.Basis.PAYMENTS)
+        record_registration(
+            self.workspace, self.user, registered=True,
+            effective_from=date(2026, 7, 1), gst_number='123456785',
+            basis=GstRegistration.Basis.INVOICE,
+            filing_frequency=GstRegistration.Frequency.TWO_MONTHLY,
+            period_anchor_month=4,
+        )
+        bases = {row['period_start']: row['basis'] for row in self.periods()['results']}
+        self.assertEqual(bases['2026-01-01'], 'payments')
+        self.assertEqual(bases['2026-07-01'], 'invoice')
+
+    def test_a_basis_change_closes_the_period_it_lands_in(self):
+        """No single return may be filed on two different bases."""
+        self.register(basis=GstRegistration.Basis.PAYMENTS)
+        record_registration(
+            self.workspace, self.user, registered=True,
+            effective_from=date(2026, 6, 10), gst_number='123456785',
+            basis=GstRegistration.Basis.INVOICE,
+            filing_frequency=GstRegistration.Frequency.TWO_MONTHLY,
+            period_anchor_month=4,
+        )
+        rows = {row['period_start']: row for row in self.periods()['results']}
+        self.assertEqual(rows['2026-05-01']['period_end'], '2026-06-09')
+        self.assertTrue(rows['2026-05-01']['clipped'])
+        self.assertEqual(rows['2026-06-10']['period_end'], '2026-06-30')
+
+
+class ExclusionTests(GstReportTestCase):
+    """Nothing is silently dropped, and no gap is reported as a zero."""
+
+    def test_supplies_before_registration_are_reported_as_excluded(self):
+        """A report that skipped a year of trading would look complete."""
+        self.register(effective_from=date(2026, 7, 1))
+        self.sell(date(2026, 3, 10), '100')
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('no_registration', codes)
+        excluded = self.entries(exclusion='no_registration')['results']
+        self.assertTrue(excluded)
+        self.assertTrue(all(entry['period_label'] is None for entry in excluded))
+
+    def test_supplies_in_a_deregistered_gap_are_told_apart_from_never_registered(self):
+        """They are different situations and a report must not conflate them."""
+        self.register()
+        record_registration(
+            self.workspace, self.user, registered=False, effective_from=date(2026, 7, 1),
+        )
+        self.sell(date(2026, 9, 10), '100')
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('deregistered_gap', codes)
+        self.assertNotIn('no_registration', codes)
+
+    def test_unclassified_supplies_are_reported_in_their_own_column(self):
+        """Counting them as zero-rated would put them in a box nobody chose."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100', tax_rate='0')
+        row = [
+            row for row in self.periods()['results']
+            if row['period_label'] == '2026-03-01..2026-04-30'
+        ][0]
+        self.assertEqual(row['unclassified_supplies'], '100.0000')
+        self.assertEqual(row['zero_rated_supplies'], '0.0000')
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('unclassified_tax_code', codes)
+
+    def test_a_data_quality_finding_links_to_the_rows_behind_it(self):
+        """A count nobody can drill into is an assertion, not evidence."""
+        self.register(effective_from=date(2026, 7, 1))
+        self.sell(date(2026, 3, 10), '100')
+        finding = [
+            item for item in self.periods()['data_quality']
+            if item['code'] == 'no_registration'
+        ][0]
+        self.assertIn('/reports/gst-entries/', finding['drill_down'])
+
+
+class MixedCurrencyTests(GstReportTestCase):
+    """There is no exchange rate here, so nothing is consolidated across one."""
+
+    def test_each_currency_is_reported_separately(self):
+        """Adding NZD and AUD would invent a rate this application does not hold."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        self.sell(date(2026, 3, 11), '100', currency='AUD')
+        rows = [
+            row for row in self.periods()['results']
+            if row['period_label'] == '2026-03-01..2026-04-30'
+        ]
+        self.assertEqual({row['currency_code'] for row in rows}, {'NZD', 'AUD'})
+
+    def test_the_consolidated_net_is_withheld(self):
+        """A withheld figure is honest; a wrong one gets filed."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        self.sell(date(2026, 3, 11), '100', currency='AUD')
+        data = self.periods()
+        self.assertIsNone(data['totals']['net_gst'])
+        self.assertEqual(data['totals']['currencies'], ['AUD', 'NZD'])
+        codes = {finding['code'] for finding in data['data_quality']}
+        self.assertIn('mixed_currency', codes)
+
+    def test_a_single_currency_still_reports_a_consolidated_net(self):
+        """Withholding must mean something, so the ordinary case must not."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        self.assertEqual(self.periods()['totals']['net_gst'], '15.0000')
+
+    def test_a_range_with_no_trading_is_nil_rather_than_withheld(self):
+        """None has to mean "cannot be stated", not "nothing happened"."""
+        self.register()
+        self.assertEqual(self.periods()['totals']['net_gst'], '0.0000')
+
+
+class ExportTests(GstReportTestCase):
+    """Every report in this app has a CSV twin carrying the same figures."""
+
+    def test_the_period_export_carries_the_version_and_the_same_totals(self):
+        """An export that disagreed with the screen would be filed from anyway."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        response = self.client.get(
+            f'{PERIODS_URL}export/', {'date_from': '2026-01-01', 'date_to': '2026-12-31'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('X-Report-Version', response.headers)
+        body = response.content.decode()
+        self.assertIn('gst-periods', body)
+        self.assertIn('115.0000', body)
+
+    def test_the_entry_export_is_available_too(self):
+        """The drill-down is the evidence, so it has to leave the screen as well."""
+        self.register()
+        self.sell(date(2026, 3, 10), '100')
+        response = self.client.get(
+            f'{ENTRIES_URL}export/', {'date_from': '2026-01-01', 'date_to': '2026-12-31'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('gst-entries', response.content.decode())
+
+
+class InputTaxTests(GstReportTestCase):
+    """Where input tax lands depends on the basis, and sometimes on nothing."""
+
+    def test_the_invoice_basis_claims_input_tax_on_the_receipt_date(self):
+        """The receipt date stands in for the supplier invoice task 119 will add."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.buy(date(2026, 3, 10), '200')
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['purchases_incl_tax'], '230.0000')
+        self.assertEqual(row['input_tax'], '30.0000')
+        self.assertEqual(row['net_gst_direction'], 'refundable')
+
+    def test_the_payments_basis_holds_input_tax_back(self):
+        """It is claimed when the supplier is paid, and no payment date exists."""
+        self.register(basis=GstRegistration.Basis.PAYMENTS)
+        self.buy(date(2026, 3, 10), '200')
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['input_tax'], '0.0000')
+        self.assertEqual(row['input_tax_awaiting_payment'], '30.0000')
+
+    def test_the_held_back_claim_is_reported_as_a_finding(self):
+        """A return quietly claiming nothing would look like a return claiming nothing."""
+        self.register(basis=GstRegistration.Basis.PAYMENTS)
+        self.buy(date(2026, 3, 10), '200')
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('input_tax_awaiting_payment', codes)
+
+    def test_the_hybrid_basis_holds_input_tax_back_too(self):
+        """Hybrid is invoice for output tax and payments for input tax."""
+        self.register(basis=GstRegistration.Basis.HYBRID)
+        self.buy(date(2026, 3, 10), '200')
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['input_tax'], '0.0000')
+        self.assertEqual(row['input_tax_awaiting_payment'], '30.0000')
+
+    def test_non_recoverable_tax_is_reported_as_a_memo_not_a_claim(self):
+        """It is already inside the stock cost, so claiming it would double-count."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.buy(date(2026, 3, 10), '200', recoverable=False)
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['input_tax'], '0.0000')
+        self.assertEqual(row['non_recoverable_tax'], '30.0000')
+        self.assertEqual(row['purchases_incl_tax'], '230.0000')
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('non_recoverable_input_tax', codes)
+
+    def test_net_gst_nets_output_against_input(self):
+        """Both sides of the return have to meet in the one figure that is filed."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.sell(date(2026, 3, 10), '400')
+        self.buy(date(2026, 3, 11), '200')
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['output_tax'], '60.0000')
+        self.assertEqual(row['input_tax'], '30.0000')
+        self.assertEqual(row['net_gst'], '30.0000')
+
+    def test_the_receipt_level_limitation_is_reported(self):
+        """Task 119 owns per-line treatment; until then the gap is stated."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.buy(date(2026, 3, 10), '200')
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('receipt_level_tax_treatment', codes)
+
+    def _period(self, label):
+        """Return the one period row carrying a label."""
+        rows = [row for row in self.periods()['results'] if row['period_label'] == label]
+        self.assertEqual(len(rows), 1, rows)
+        return rows[0]

--- a/reporting/urls.py
+++ b/reporting/urls.py
@@ -4,6 +4,10 @@ from django.urls import path
 
 from .rest import (
     DashboardView,
+    GstEntryExportView,
+    GstEntryView,
+    GstPeriodExportView,
+    GstPeriodView,
     InventoryBalanceExportView,
     InventoryBalanceView,
     MovementExportView,
@@ -41,6 +45,10 @@ urlpatterns = [
     path('orders/export/', OrderExportView.as_view()),
     path('profitability/', ProfitabilityView.as_view()),
     path('profitability/export/', ProfitabilityExportView.as_view()),
+    path('gst-periods/', GstPeriodView.as_view()),
+    path('gst-periods/export/', GstPeriodExportView.as_view()),
+    path('gst-entries/', GstEntryView.as_view()),
+    path('gst-entries/export/', GstEntryExportView.as_view()),
     path('traceability/plants/<int:identity>/', PlantTraceView.as_view()),
     path(
         'traceability/plants/<int:identity>/export/',

--- a/tax/entries.py
+++ b/tax/entries.py
@@ -1,0 +1,289 @@
+"""Derive the GST entries a period report is built from, and reconciles to.
+
+There is no GST ledger table. Every figure in a return is derived, at the
+moment it is read, from the commerce records that produced it — and those are
+already immutable: `Fulfillment`, `Payment`, `SalesReturn`, `Refund` and a
+posted `StockReceipt` all refuse to be edited or deleted. So "reconcile every
+period total to immutable source records" holds without a second copy of them,
+and a change of basis rewrites nothing because there is nothing to rewrite.
+Task 118 owns materialising this once it has real invoice documents to key on.
+
+The basis applied to a period is the basis in force during it. That is safe
+because a period is clipped whenever an arrangement changes, so no period ever
+spans two bases. Where an order straddles a change, the two periods can
+legitimately disagree about how much of it has been brought to account — and
+the size of that disagreement is the transition adjustment, which `transition`
+computes rather than hides.
+
+Anything falling outside a registration produces an entry with no period and an
+exclusion reason. Nothing is silently dropped and nothing becomes a zero.
+"""
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from inventory.ledger import quantize_money
+from inventory.models import StockReceipt, StockReceiptLine
+
+from .facts import workspace_order_facts
+from .periods import (
+    TaxablePeriod,
+    enumerate_periods,
+    registration_history,
+    registration_in_force,
+)
+from .recognition import INVOICE, SUPPLY, SUPPLY_CREDIT, order_recognition
+
+
+ZERO = Decimal('0.0000')
+PERCENT_DIVISOR = Decimal('100')
+
+SUPPLY_KINDS = (SUPPLY, SUPPLY_CREDIT)
+PURCHASE = 'purchase'
+
+#: Why an entry belongs to no taxable period. Each becomes a data-quality code
+#: on the report, with the rows behind it reachable through the drill-down.
+NO_REGISTRATION = 'no_registration'
+DEREGISTERED_GAP = 'deregistered_gap'
+AWAITING_PAYMENT = 'input_tax_awaiting_payment'
+
+
+@dataclass(frozen=True)
+class GstEntry:  # pylint: disable=too-many-instance-attributes
+    """One line's worth of supply, credit, or purchase, placed in a period."""
+
+    kind: str
+    supply_date: date
+    period: Optional[TaxablePeriod]
+    basis: str
+    source_type: str
+    source_id: int
+    document_id: Optional[int]
+    line_id: Optional[int]
+    tax_code: str
+    tax_rate: Decimal
+    taxable: Decimal
+    tax: Decimal
+    non_recoverable_tax: Decimal
+    currency_code: str
+    time_of_supply_source: str
+    proxy: bool = False
+    exclusion: str = ''
+
+    @property
+    def gross(self):
+        """Value including every kind of tax, claimable or not."""
+        return quantize_money(self.taxable + self.tax + self.non_recoverable_tax)
+
+    @property
+    def period_label(self):
+        """The period this entry is reported in, or None when it is in none."""
+        return self.period.label if self.period else None
+
+
+def derive_entries(workspace, start, end):
+    """Return every GST entry falling in a date range, in supply-date order."""
+    history = registration_history(workspace)
+    periods = enumerate_periods(workspace, start, end, history=history)
+    order_facts = workspace_order_facts(workspace, start, end)
+    entries = []
+    for period in periods:
+        entries.extend(_period_supply_entries(order_facts, period))
+        entries.extend(_period_purchase_entries(workspace, period))
+    context = _Uncovered(workspace, history, (start, end), _covered_days(periods))
+    entries.extend(_unregistered_supply_entries(order_facts, context))
+    entries.extend(_unregistered_purchase_entries(context))
+    entries.sort(key=lambda entry: (entry.supply_date, entry.kind, entry.source_id, entry.line_id or 0))
+    return entries
+
+
+def _period_supply_entries(order_facts, period):
+    """Bring every order to account under the basis this period was filed on."""
+    entries = []
+    for facts in order_facts:
+        recognition = order_recognition(facts, period.basis)
+        for event in recognition.events:
+            if not period.contains(event.supply_date):
+                continue
+            entries.append(_supply_entry(facts, event, period))
+    return entries
+
+
+def _supply_entry(facts, event, period):
+    """Place one recognition event in the period that reports it.
+
+    A period of None means the supply fell outside every registration, so
+    there is no basis it was accounted on either.
+    """
+    return GstEntry(
+        kind=event.kind,
+        supply_date=event.supply_date,
+        period=period,
+        basis=period.basis if period else '',
+        source_type=event.source_type,
+        source_id=event.source_id,
+        document_id=facts.order_id,
+        line_id=event.line_id,
+        tax_code=event.tax_code,
+        tax_rate=event.tax_rate,
+        taxable=event.taxable,
+        tax=event.tax,
+        non_recoverable_tax=ZERO,
+        currency_code=facts.currency_code,
+        time_of_supply_source=event.time_of_supply_source,
+        proxy=event.proxy,
+    )
+
+
+def _unregistered_supply_entries(order_facts, context):
+    """Report supplies made while unregistered instead of dropping them.
+
+    Commerce before a registration, or inside a gap after a cessation, carried
+    no GST obligation. Leaving it out entirely would make a report look
+    complete when it had quietly skipped a year of trading, so it appears with
+    no period and the reason it has none.
+    """
+    start, end = context.window
+    entries = []
+    for facts in order_facts:
+        recognition = order_recognition(facts, INVOICE)
+        for event in recognition.events:
+            if not start <= event.supply_date <= end or event.supply_date in context.covered:
+                continue
+            entry = _supply_entry(facts, event, None)
+            entries.append(_with(entry, exclusion=context.exclusion_for(event.supply_date)))
+    return entries
+
+
+def _period_purchase_entries(workspace, period):
+    """Return the input tax a period may claim.
+
+    Only the invoice basis can claim on the receipt date. Under the payments
+    and hybrid bases input tax is claimed when the supplier is paid, and this
+    application records no supplier payment anywhere — task 80 owns purchasing
+    and accounts payable. So those purchases are reported as awaiting payment
+    evidence rather than being claimed on a date that is not the right one.
+    """
+    if period.basis != INVOICE:
+        return _awaiting_payment_entries(workspace, period.start, period.end, period.basis)
+    return [
+        _purchase_entry(line, period, period.basis)
+        for line in _posted_receipt_lines(workspace, period.start, period.end)
+    ]
+
+
+def _unregistered_purchase_entries(context):
+    """Report purchases made while unregistered, with the reason they claim nothing."""
+    start, end = context.window
+    entries = []
+    for line in _posted_receipt_lines(context.workspace, start, end):
+        received = line.receipt.received_date
+        if received in context.covered:
+            continue
+        entry = _purchase_entry(line, None, '')
+        entries.append(_with(entry, exclusion=context.exclusion_for(received)))
+    return entries
+
+
+def _awaiting_payment_entries(workspace, start, end, basis):
+    """Return purchases held back for want of a supplier payment date."""
+    return [
+        _with(_purchase_entry(line, None, basis), exclusion=AWAITING_PAYMENT)
+        for line in _posted_receipt_lines(workspace, start, end)
+    ]
+
+
+def _purchase_entry(line, period, basis):
+    """Split one receipt line into its recoverable and non-recoverable tax.
+
+    The claimable amount is recomputed rather than read: `_receipt_acquisition_cost`
+    calculates it to decide what to capitalise into stock and then discards it,
+    so it exists nowhere in the database. Where the tax is not recoverable it is
+    already inside the lot's cost, and it is reported as a memo here so a period
+    states the whole of what was paid rather than only the claimable part.
+
+    Tax treatment is a property of the whole receipt, not of its lines; task 119
+    owns moving it down to the line, and the report says so.
+    """
+    receipt = line.receipt
+    taxable = quantize_money(line.line_cost_ex_tax)
+    full_tax = quantize_money(taxable * Decimal(receipt.tax_rate) / PERCENT_DIVISOR)
+    recoverable = receipt.tax_recoverable
+    return GstEntry(
+        kind=PURCHASE,
+        supply_date=receipt.received_date,
+        period=period,
+        basis=basis,
+        source_type='stock_receipt',
+        source_id=receipt.pk,
+        document_id=receipt.pk,
+        line_id=line.pk,
+        tax_code='standard' if full_tax > 0 else 'unclassified',
+        tax_rate=Decimal(receipt.tax_rate),
+        taxable=taxable,
+        tax=full_tax if recoverable else ZERO,
+        non_recoverable_tax=ZERO if recoverable else full_tax,
+        currency_code=receipt.currency_code,
+        time_of_supply_source='receipt_date_proxy',
+        proxy=True,
+    )
+
+
+def _posted_receipt_lines(workspace, start, end):
+    """Return the lines of every posted receipt received in a range.
+
+    A reversed receipt leaves POSTED, so filtering on status is what excludes
+    it; there is no reversal pair to filter here as there is on the sales side.
+    """
+    return StockReceiptLine.objects.filter(
+        receipt__workspace=workspace,
+        receipt__status=StockReceipt.Status.POSTED,
+        receipt__received_date__gte=start,
+        receipt__received_date__lte=end,
+    ).select_related('receipt').order_by('receipt__received_date', 'pk')
+
+
+class _Uncovered:  # pylint: disable=too-few-public-methods
+    """The days in a report range that no taxable period accounts for.
+
+    Bundled rather than passed around loose because every caller needs the
+    same four things, and a six-argument helper reads worse than the thing it
+    is helping.
+    """
+
+    def __init__(self, workspace, history, window, covered):
+        self.workspace = workspace
+        self.history = history
+        self.window = window
+        self.covered = covered
+
+    def exclusion_for(self, day):
+        """Say why a day belongs to no period: never registered, or no longer.
+
+        The two are told apart by whether anything was recorded on or before
+        the day itself, not by whether the workspace has any history at all —
+        a workspace that registers in July has no registration in March, and
+        calling that a cessation gap would misdescribe it.
+        """
+        if registration_in_force(self.workspace, day, history=self.history) is not None:
+            return ''
+        applying = [row for row in self.history if row.effective_from <= day]
+        return DEREGISTERED_GAP if applying else NO_REGISTRATION
+
+
+def _covered_days(periods):
+    """Return every day a taxable period accounts for."""
+    covered = set()
+    for period in periods:
+        for ordinal in range(period.start.toordinal(), period.end.toordinal() + 1):
+            covered.add(date.fromordinal(ordinal))
+    return covered
+
+
+def _with(entry, **changes):
+    """Return a copy of an entry with fields replaced."""
+    values = dict(entry.__dict__)
+    values.update(changes)
+    return GstEntry(**values)

--- a/tax/test_separation.py
+++ b/tax/test_separation.py
@@ -1,0 +1,143 @@
+"""Task 117 change 6: GST and profitability recognition stay visibly separate.
+
+They answer different questions. Profitability asks what a period earned and
+recognises on fulfillment; GST asks what a period owes and recognises on the
+basis in force at each time of supply. For one order paid in one period and
+delivered in the next, the two disagree — and the disagreement is the contract,
+not a defect. Asserting both halves in one test is what stops somebody
+"fixing" one to match the other.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import date, datetime, timezone as utc_timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from reporting.commerce import profitability_report
+from reporting.gst import gst_period_report
+from sales.models import (
+    Fulfillment,
+    FulfillmentLine,
+    Payment,
+    SalesOrder,
+    SalesOrderAllocation,
+    SalesOrderLine,
+)
+from sales.services import create_order
+from tests.api import RESTContractTestCase
+from tests.factories import make_specific_plant
+from workspaces.models import Workspace, get_current_workspace
+
+from .models import GstRegistration
+from .services import record_registration
+
+
+class RecognitionSeparationTests(RESTContractTestCase):
+    """One order, paid in March and delivered in April, seen from both sides."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.currency_code = 'NZD'
+        self.workspace.timezone = 'Pacific/Auckland'
+        self.workspace.default_tax_rate = Decimal('15')
+        self.workspace.sales_prices_include_tax = False
+        self.workspace.save()
+        record_registration(
+            self.workspace, self.user, registered=True,
+            effective_from=date(2026, 1, 1), gst_number='123456785',
+            basis=GstRegistration.Basis.PAYMENTS,
+            filing_frequency=GstRegistration.Frequency.MONTHLY,
+            period_anchor_month=1,
+        )
+        self.order = self._paid_in_march_delivered_in_april()
+
+    def _paid_in_march_delivered_in_april(self):
+        """Build the one order both reports are asked about."""
+        order = create_order(self.workspace, self.user, status=SalesOrder.Status.DRAFT)
+        plant = make_specific_plant(workspace=self.workspace)
+        line = SalesOrderLine.objects.create(
+            order=order,
+            line_type=SalesOrderLine.LineType.SEEDLING,
+            variety=plant.batch.variety,
+            description='Seedlings',
+            quantity=1,
+            unit_price=Decimal('100'),
+            tax_rate=Decimal('15'),
+            discount_type=SalesOrderLine.DiscountType.NONE,
+        )
+        SalesOrder.objects.filter(pk=order.pk).update(status=SalesOrder.Status.CONFIRMED)
+        order.refresh_from_db()
+        Payment.objects.create(
+            workspace=self.workspace, order=order, paid_on=date(2026, 3, 10),
+            amount=line.total_incl_tax, currency_code='NZD', method='cash',
+            operation_key=uuid4(), request_fingerprint='separation-test',
+        )
+        allocation = SalesOrderAllocation.objects.create(line=line, plant=plant)
+        fulfillment = Fulfillment.objects.create(
+            workspace=self.workspace, order=order, fulfillment_number='FUL-000001',
+            fulfilled_at=datetime(2026, 4, 20, 2, 0, tzinfo=utc_timezone.utc),
+            operation_key=uuid4(), request_fingerprint='separation-test',
+        )
+        FulfillmentLine.objects.create(
+            fulfillment=fulfillment, allocation=allocation, commercial_position=1,
+            gross_ex_tax=line.gross_ex_tax, discount_ex_tax=line.discount_ex_tax,
+            subtotal_ex_tax=line.subtotal_ex_tax, tax_total=line.tax_total,
+            total_incl_tax=line.total_incl_tax, tax_treatment=line.tax_treatment,
+            currency_code='NZD',
+        )
+        return order
+
+    def _gst_output_tax(self, month):
+        """Return the output tax the GST report puts in one calendar month."""
+        report = gst_period_report(self.workspace, {
+            'date_from': f'2026-{month:02d}-01', 'date_to': f'2026-{month:02d}-28',
+        })
+        return sum(Decimal(row['output_tax']) for row in report.rows)
+
+    def _profit_net_sales(self, month):
+        """Return the net sales the profitability report puts in one calendar month."""
+        report = profitability_report(self.workspace, {
+            'date_from': f'2026-{month:02d}-01', 'date_to': f'2026-{month:02d}-28',
+        })
+        return sum(
+            (Decimal(summary['net_sales']) for summary in report.totals['currencies']),
+            Decimal('0'),
+        )
+
+    def test_gst_recognises_the_payment_month(self):
+        """On the payments basis, March is when the money arrived."""
+        self.assertEqual(self._gst_output_tax(3), Decimal('15.0000'))
+        self.assertEqual(self._gst_output_tax(4), Decimal('0.0000'))
+
+    def test_profitability_recognises_the_fulfillment_month(self):
+        """Revenue follows the delivery, a whole period later. Both are right."""
+        self.assertEqual(self._profit_net_sales(3), Decimal('0'))
+        self.assertEqual(self._profit_net_sales(4), Decimal('100.0000'))
+
+    def test_the_two_reports_disagree_on_purpose(self):
+        """Asserted together so neither can be quietly changed to match the other."""
+        self.assertGreater(self._gst_output_tax(3), Decimal('0'))
+        self.assertEqual(self._profit_net_sales(3), Decimal('0'))
+        self.assertEqual(self._gst_output_tax(4), Decimal('0'))
+        self.assertGreater(self._profit_net_sales(4), Decimal('0'))
+
+    def test_profitability_reports_ex_tax_amounts_and_carries_no_gst_column(self):
+        """Keeping GST out of the margin is what makes the separation legible."""
+        report = profitability_report(self.workspace, {
+            'date_from': '2026-04-01', 'date_to': '2026-04-30',
+        })
+        self.assertNotIn('output_tax', report.columns)
+        self.assertNotIn('tax', report.columns)
+        self.assertEqual(self._profit_net_sales(4), Decimal('100.0000'))
+
+    def test_the_gst_report_says_the_two_differ(self):
+        """A reader comparing them against a filed return has to be told why."""
+        report = gst_period_report(self.workspace, {
+            'date_from': '2026-01-01', 'date_to': '2026-12-31',
+        })
+        note = report.reconciliation['recognition_note']
+        self.assertIn('basis in force', note)
+        self.assertIn('fulfillment dates', note)

--- a/workspaces/test_route_authorization.py
+++ b/workspaces/test_route_authorization.py
@@ -24,6 +24,8 @@ NURSERY_ONLY_URLS = (
     '/plantings/planning-assumptions/',
     '/plantings/cohorts/',
     '/plantings/register/',
+    '/tax/gst/registrations/',
+    '/tax/gst/status/',
 )
 
 


### PR DESCRIPTION
Two reports. gst-periods is one row per taxable period, per currency, in the shape a New Zealand return is filed in. gst-entries is the drill-down, and every data-quality finding links into it — a count nobody can open is an assertion, not evidence. A test asserts each box against a direct sum over those rows, because the claim this feature makes is only worth making if it is checked.

There is no GST ledger table. Fulfillment, Payment, SalesReturn, Refund and a posted StockReceipt already refuse every edit and delete, so "reconciles to immutable source records" holds without a second copy of them — and a change of basis rewrites nothing because there is nothing to rewrite. Task 118 owns materialising this once it has real invoice documents to key on rather than the fulfillment-date proxy.

The basis applied to a period is the basis in force during it, which is safe because a period is clipped at every arrangement change, so no return spans two bases. Where an order straddles one the two periods can disagree about how much of it is brought to account; that difference is the transition adjustment, and the columns for it exist and read zero rather than being absent.

Nothing is dropped and no gap is a zero. Commerce recorded before a registration, or in a gap after a cessation, appears with no period and the reason it has none — and the two are told apart by what was recorded on or before the day itself, since a workspace that registers in July has no registration in March and calling that a cessation gap would misdescribe it. A period that saw no trading still gets a row, because nil and forgotten must not look the same in a list of returns.

Under the payments and hybrid bases input tax is claimed when the supplier is paid and no supplier payment date exists anywhere, so those purchases are held back under input_tax_awaiting_payment rather than claimed on a receipt date that is not the right one. Tax that was not recoverable is reported as a memo: it is already inside the stock cost, so claiming it would double-count.

Nothing is totalled across currencies. A period trading in two reports each separately and withholds the consolidated net, exactly as the profitability report withholds a margin it cannot state — and a range that simply saw no trading is nil rather than withheld, so None keeps meaning "cannot be stated".

## Summary by Sourcery

Add auditable GST period and entry reporting that reconciles every return figure to its underlying immutable commerce records.

New Features:
- Add GST period reports with New Zealand return-style totals for each taxable period and currency.
- Add GST entry drill-down reports exposing the source rows behind period figures and data-quality findings.
- Expose GST reports in the reporting UI with filtering, recognition notes, CSV exports, and navigation.

Enhancements:
- Derive GST figures from immutable commerce records without introducing a separate GST ledger.
- Represent registration gaps, unclassified tax, held-back input tax, non-recoverable tax, and mixed currencies explicitly instead of silently omitting or consolidating them.
- Apply the GST basis in force for each clipped taxable period and document its intentional recognition difference from profitability reporting.

Tests:
- Add comprehensive contract, reconciliation, basis, exclusion, currency, export, input-tax, and recognition-separation coverage for GST reporting.