### PR TITLE
feat(billing): expose documents and corrections over REST

### DIFF
--- a/billing/documents.py
+++ b/billing/documents.py
@@ -306,6 +306,30 @@ def _previously_invoiced(order):
     return money(total)
 
 
+def document_information(document):
+    """Return what an already-issued document states, for the threshold rules.
+
+    The same question `_refuse_incomplete` asks before issuing, asked of a row
+    that exists. A printed document has to be able to show a reader that each
+    element its value band requires is present, and re-deriving the answer from
+    the stored document is the only way that claim stays true rather than being
+    asserted once at issue and never checked again.
+    """
+    lines = list(document.lines.all())
+    return DocumentInformation(
+        total_incl_tax=document.total_incl_tax,
+        taxable_supply=document.taxable_supply,
+        seller_name=document.seller_legal_name,
+        seller_gst_number=document.seller_gst_number,
+        document_date=document.issued_on,
+        gst_stated=document.taxable_supply,
+        line_descriptions=tuple(line.description for line in lines),
+        supply_quantities=tuple(line.quantity for line in lines),
+        buyer_name=document.buyer_name,
+        buyer_identification=document.buyer_identification,
+    )
+
+
 def _refuse_incomplete(document_values, line_values):
     """Refuse to issue a document its own value band would make defective."""
     information = DocumentInformation(

--- a/billing/printing.py
+++ b/billing/printing.py
@@ -1,0 +1,142 @@
+"""One document shaped for the page it is printed on.
+
+A serializer answers what a record holds; this answers what a customer is
+handed. The difference is small but real — the parties become two blocks, the
+value band becomes a checklist a reader can see is satisfied, and the running
+balance becomes the four lines that explain why the amount due is what it is.
+
+Keeping it out of `rest` means the shaping is testable without a request, and
+keeping it out of `documents` means the write path carries no presentation.
+"""
+
+from .documents import document_information, document_state, net_credited
+from .thresholds import ELEMENT_LABELS, TIER_LABELS, missing_information, required_elements
+
+
+def _money(value):
+    """Render an amount the way every other money field on the API is rendered."""
+    return f'{value:f}'
+
+
+def _party_blocks(document):
+    """Return the two identity blocks a printed document leads with."""
+    return {
+        'seller': {
+            'legal_name': document.seller_legal_name,
+            'trading_name': document.seller_trading_name,
+            'address': document.seller_address,
+            'gst_number': document.seller_gst_number,
+        },
+        'buyer': {
+            'name': document.buyer_name,
+            'address': document.buyer_address,
+            'identifier': document.buyer_identifier,
+        },
+    }
+
+
+def _requirement_checklist(document):
+    """Say, element by element, whether this document carries what it must.
+
+    Every element is listed rather than only the absent ones. A document that
+    quietly showed nothing would look identical whether it was complete or
+    whether nobody had checked, and the point of change 5 is that somebody can
+    see which.
+    """
+    information = document_information(document)
+    missing = set(missing_information(information))
+    return [
+        {
+            'code': code,
+            'label': ELEMENT_LABELS[code],
+            'satisfied': code not in missing,
+        }
+        for code in required_elements(
+            document.tier, taxable_supply=document.taxable_supply,
+        )
+    ]
+
+
+def _line_rows(document):
+    """Return the supply lines, each with the items it covers."""
+    rows = []
+    for line in document.lines.all():
+        coverage = list(line.coverage.all())
+        rows.append({
+            'pk': line.pk,
+            'order_line': line.order_line_id,
+            'description': line.description,
+            'quantity': line.quantity,
+            'unit_price': _money(line.unit_price),
+            'tax_rate': _money(line.tax_rate),
+            'tax_treatment': line.tax_treatment,
+            'subtotal_ex_tax': _money(line.subtotal_ex_tax),
+            'tax_total': _money(line.tax_total),
+            'total_incl_tax': _money(line.total_incl_tax),
+            'credited_total': _money(net_credited(line)),
+            'positions': [row.commercial_position for row in coverage],
+            'dispatched_positions': [
+                row.commercial_position for row in coverage
+                if row.fulfillment_line_id is not None
+            ],
+        })
+    return rows
+
+
+def _correction_rows(document):
+    """Return every correction issued against this document, oldest first."""
+    return [
+        {
+            'pk': correction.pk,
+            'document_number': correction.document_number,
+            'correction_type': correction.correction_type,
+            'reason_code': correction.reason_code,
+            'reason': correction.reason,
+            'corrected_on': correction.corrected_on.isoformat(),
+            'sales_return': correction.sales_return_id,
+            'refund': correction.refund_id,
+            'subtotal_ex_tax': _money(correction.subtotal_ex_tax),
+            'tax_total': _money(correction.tax_total),
+            'total_incl_tax': _money(correction.total_incl_tax),
+        }
+        for correction in document.corrections.all()
+    ]
+
+
+def printable_document(document):
+    """Return everything one printed taxable supply document shows."""
+    state = document_state(document)
+    return {
+        'pk': document.pk,
+        'document_number': document.document_number,
+        # The heading is what tells a reader which kind of document this is.
+        # A receipt from an unregistered seller is not taxable supply
+        # information, and calling it a tax invoice would be a false record.
+        'title': 'Tax invoice' if document.taxable_supply else 'Sales receipt',
+        'taxable_supply': document.taxable_supply,
+        'issued_on': document.issued_on.isoformat(),
+        'order': document.order_id,
+        'order_number': document.order.order_number,
+        'currency_code': document.currency_code,
+        'tier': document.tier,
+        'tier_label': TIER_LABELS[document.tier],
+        'required_information': _requirement_checklist(document),
+        'notes': document.notes,
+        'lines': _line_rows(document),
+        'corrections': _correction_rows(document),
+        'totals': {
+            'subtotal_ex_tax': _money(document.subtotal_ex_tax),
+            'tax_total': _money(document.tax_total),
+            'total_incl_tax': _money(document.total_incl_tax),
+            'previously_invoiced': _money(document.previously_invoiced),
+            'paid_to_date': _money(document.paid_to_date),
+            'balance_due': _money(document.balance_due),
+            'overpaid_at_issue': _money(document.overpaid_at_issue),
+            'credited_total': _money(state['credited_total']),
+            'net_total_incl_tax': _money(state['net_total_incl_tax']),
+        },
+        'status': state['status'],
+        'issued_by': document.created_by_id,
+        'issued_at': document.created.isoformat(),
+        **_party_blocks(document),
+    }

--- a/billing/rest.py
+++ b/billing/rest.py
@@ -1,0 +1,346 @@
+"""Read and issue taxable supply documents and their corrections.
+
+Documents are immutable, so this surface offers list, retrieve and create and
+nothing else — the same shape `tax` uses for arrangements, and for the same
+reason: correcting one is a different act from editing one and reads as one in
+the audit trail.
+
+There is deliberately no action on `SalesOrderViewSet` for this. `billing`
+already depends on `sales`, and hanging the endpoint off the order would make
+the dependency run both ways for the sake of a URL. The order is a field on the
+request instead.
+"""
+
+# pylint: disable=duplicate-code,too-many-ancestors
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import mixins, routers, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from sales.models import Refund, SalesOrder, SalesOrderLine, SalesReturn
+from workspaces.models import Workspace
+from workspaces.scoping import (
+    CurrentWorkspaceSerializerMixin,
+    CurrentWorkspaceViewSetMixin,
+    RequireWorkspaceModeMixin,
+)
+
+from .documents import document_state, full_credit, invoiceable, issue_correction, issue_supply_document
+from .models import SupplyCorrection, SupplyDocument, SupplyDocumentLine
+from .printing import printable_document
+
+
+def _model_errors(error):
+    """Translate a Django validation error into DRF's field-error shape."""
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _run(function, *args, **kwargs):
+    """Run one domain command with REST-native validation errors."""
+    try:
+        return function(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise ValidationError(_model_errors(exc)) from exc
+
+
+class ActionSerializer(serializers.Serializer):
+    """Validation-only serializer base for explicit commands."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class SupplyDocumentCoverageSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Which item of an order line a document line covers, and whether it shipped."""
+
+    commercial_position = serializers.IntegerField(read_only=True)
+    fulfillment_line = serializers.IntegerField(source='fulfillment_line_id', read_only=True)
+
+
+class SupplyDocumentLineSerializer(serializers.ModelSerializer):
+    """One order line's worth of supply, with the items behind it."""
+
+    coverage = SupplyDocumentCoverageSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SupplyDocumentLine
+        fields = [
+            'pk', 'order_line', 'description', 'quantity', 'unit_price',
+            'tax_rate', 'tax_treatment', 'gross_ex_tax', 'discount_ex_tax',
+            'subtotal_ex_tax', 'tax_total', 'total_incl_tax', 'coverage',
+        ]
+        read_only_fields = fields
+
+
+class SupplyCorrectionLineSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """How much of one document line a correction moves."""
+
+    pk = serializers.IntegerField(read_only=True)
+    document_line = serializers.IntegerField(source='document_line_id', read_only=True)
+    quantity = serializers.IntegerField(read_only=True, allow_null=True)
+    tax_rate = serializers.DecimalField(max_digits=7, decimal_places=4, read_only=True)
+    tax_treatment = serializers.CharField(read_only=True)
+    subtotal_ex_tax = serializers.DecimalField(max_digits=18, decimal_places=4, read_only=True)
+    tax_total = serializers.DecimalField(max_digits=18, decimal_places=4, read_only=True)
+    total_incl_tax = serializers.DecimalField(max_digits=18, decimal_places=4, read_only=True)
+
+
+class SupplyCorrectionSerializer(serializers.ModelSerializer):
+    """One credit or debit note, exactly as it was issued."""
+
+    lines = SupplyCorrectionLineSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SupplyCorrection
+        fields = [
+            'pk', 'document', 'document_number', 'correction_type',
+            'reason_code', 'reason', 'corrected_on', 'sales_return', 'refund',
+            'currency_code', 'subtotal_ex_tax', 'tax_total', 'total_incl_tax',
+            'notes', 'created_by', 'created', 'lines',
+        ]
+        read_only_fields = fields
+
+
+class SupplyDocumentSerializer(serializers.ModelSerializer):
+    """One issued document, its lines, and what corrections have left of it."""
+
+    lines = SupplyDocumentLineSerializer(many=True, read_only=True)
+    corrections = SupplyCorrectionSerializer(many=True, read_only=True)
+    order_number = serializers.CharField(source='order.order_number', read_only=True)
+    state = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SupplyDocument
+        fields = [
+            'pk', 'document_number', 'order', 'order_number', 'issued_on',
+            'taxable_supply', 'tier', 'currency_code',
+            'seller_legal_name', 'seller_trading_name', 'seller_address',
+            'seller_gst_number', 'seller_registration',
+            'customer', 'buyer_name', 'buyer_address', 'buyer_identifier',
+            'subtotal_ex_tax', 'tax_total', 'total_incl_tax',
+            'previously_invoiced', 'paid_to_date', 'balance_due',
+            'overpaid_at_issue', 'notes', 'created_by', 'created',
+            'lines', 'corrections', 'state',
+        ]
+        read_only_fields = fields
+
+    def get_state(self, document):
+        """Expose what the corrections have left of the document."""
+        state = document_state(document)
+        return {
+            'status': state['status'],
+            'credited_total': f"{state['credited_total']:f}",
+            'net_total_incl_tax': f"{state['net_total_incl_tax']:f}",
+        }
+
+
+class BuyerSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """A one-off recipient named on a document without a customer record."""
+
+    buyer_name = serializers.CharField(required=False, allow_blank=True)
+    buyer_address = serializers.CharField(required=False, allow_blank=True)
+    buyer_identifier = serializers.CharField(required=False, allow_blank=True)
+
+
+class DocumentLineWriteSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """One order line and the items of it being invoiced."""
+
+    order_line = serializers.PrimaryKeyRelatedField(queryset=SalesOrderLine.objects.all())
+    positions = serializers.ListField(
+        child=serializers.IntegerField(min_value=1), allow_empty=False,
+    )
+
+
+class SupplyDocumentWriteSerializer(CurrentWorkspaceSerializerMixin, ActionSerializer):  # pylint: disable=abstract-method
+    """Everything needed to issue one document."""
+
+    workspace_field_lookups = {'order': 'workspace'}
+
+    operation_key = serializers.UUIDField()
+    order = serializers.PrimaryKeyRelatedField(queryset=SalesOrder.objects.all())
+    lines = DocumentLineWriteSerializer(many=True, allow_empty=False)
+    issued_on = serializers.DateField(required=False, allow_null=True)
+    buyer = BuyerSerializer(required=False, allow_null=True)
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+
+class CorrectionLineWriteSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """One document line and how much of it a correction moves."""
+
+    document_line = serializers.PrimaryKeyRelatedField(queryset=SupplyDocumentLine.objects.all())
+    amount = serializers.DecimalField(max_digits=18, decimal_places=4, min_value=0)
+    quantity = serializers.IntegerField(required=False, allow_null=True, min_value=1)
+
+
+class SupplyCorrectionWriteSerializer(ActionSerializer):  # pylint: disable=abstract-method
+    """Everything needed to issue one correction.
+
+    `full` is the cancellation and wrong-treatment path: it credits every line
+    that has anything left, which is what frees the items to be invoiced again
+    on a corrected document.
+    """
+
+    operation_key = serializers.UUIDField()
+    correction_type = serializers.ChoiceField(choices=SupplyCorrection.CorrectionType.choices)
+    reason_code = serializers.ChoiceField(choices=SupplyCorrection.Reason.choices)
+    reason = serializers.CharField(allow_blank=False)
+    full = serializers.BooleanField(required=False, default=False)
+    lines = CorrectionLineWriteSerializer(many=True, required=False, default=list)
+    corrected_on = serializers.DateField(required=False, allow_null=True)
+    sales_return = serializers.PrimaryKeyRelatedField(
+        queryset=SalesReturn.objects.all(), required=False, allow_null=True,
+    )
+    refund = serializers.PrimaryKeyRelatedField(
+        queryset=Refund.objects.all(), required=False, allow_null=True,
+    )
+    notes = serializers.CharField(required=False, allow_blank=True, default='')
+
+    def validate(self, attrs):
+        """Require either a full credit or an explicit set of lines, never both."""
+        if attrs['full'] == bool(attrs['lines']):
+            raise ValidationError('Credit the whole document or name the lines to correct.')
+        if attrs['full'] and attrs['correction_type'] != SupplyCorrection.CorrectionType.CREDIT:
+            raise ValidationError({'full': 'Only a credit can cover a whole document.'})
+        return attrs
+
+
+class SupplyDocumentViewSet(
+    RequireWorkspaceModeMixin,
+    CurrentWorkspaceViewSetMixin,
+    mixins.CreateModelMixin,
+    viewsets.ReadOnlyModelViewSet,
+):
+    """Issue and read the documents this workspace has handed to customers."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    queryset = SupplyDocument.objects.select_related('order', 'customer').prefetch_related(
+        'lines__coverage', 'corrections__lines',
+    ).order_by('-issued_on', '-pk')
+    serializer_class = SupplyDocumentSerializer
+    bind_workspace_on_create = False
+    http_method_names = ['get', 'post', 'head', 'options']
+
+    def get_queryset(self):
+        """Narrow the register by order, customer, or document date."""
+        queryset = super().get_queryset()
+        for parameter, lookup in (
+                ('order', 'order_id'),
+                ('customer', 'customer_id'),
+                ('issued_from', 'issued_on__gte'),
+                ('issued_to', 'issued_on__lte'),
+        ):
+            value = self.request.query_params.get(parameter)
+            if value:
+                queryset = queryset.filter(**{lookup: value})
+        return queryset
+
+    def create(self, request, *args, **kwargs):
+        """Issue one document against the order and items named."""
+        values = SupplyDocumentWriteSerializer(data=request.data, context=self.get_serializer_context())
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        buyer = data.get('buyer')
+        document = _run(
+            issue_supply_document,
+            data['order'],
+            request.user,
+            operation_key=data['operation_key'],
+            lines=[
+                {'order_line': item['order_line'], 'positions': item['positions']}
+                for item in data['lines']
+            ],
+            issued_on=data.get('issued_on'),
+            buyer=dict(buyer) if buyer else None,
+            notes=data['notes'],
+        )
+        return Response(self.get_serializer(document).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get'])
+    def print(self, request, pk=None):  # pylint: disable=unused-argument
+        """Return everything the printed form of this document shows."""
+        return Response(printable_document(self.get_object()))
+
+    @action(detail=True, methods=['get', 'post'])
+    def corrections(self, request, pk=None):  # pylint: disable=unused-argument
+        """List the corrections against one document, or issue another."""
+        document = self.get_object()
+        if request.method == 'GET':
+            return Response(SupplyCorrectionSerializer(
+                document.corrections.prefetch_related('lines'), many=True,
+            ).data)
+        values = SupplyCorrectionWriteSerializer(data=request.data)
+        values.is_valid(raise_exception=True)
+        data = values.validated_data
+        shared = {
+            'operation_key': data['operation_key'],
+            'reason_code': data['reason_code'],
+            'reason': data['reason'],
+            'corrected_on': data.get('corrected_on'),
+            'sales_return': data.get('sales_return'),
+            'refund': data.get('refund'),
+            'notes': data['notes'],
+        }
+        if data['full']:
+            correction = _run(full_credit, document, request.user, **shared)
+        else:
+            correction = _run(
+                issue_correction, document, request.user,
+                correction_type=data['correction_type'],
+                lines=[
+                    {
+                        'document_line': item['document_line'],
+                        'amount': item['amount'],
+                        'quantity': item.get('quantity'),
+                    }
+                    for item in data['lines']
+                ],
+                **shared,
+            )
+        return Response(
+            SupplyCorrectionSerializer(correction).data, status=status.HTTP_201_CREATED,
+        )
+
+
+class InvoiceableView(RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin, viewsets.GenericViewSet):
+    """What of one order has not been invoiced yet."""
+
+    required_workspace_modes = (Workspace.Mode.NURSERY,)
+    queryset = SalesOrder.objects.prefetch_related('lines')
+    serializer_class = SupplyDocumentSerializer
+
+    def retrieve(self, request, pk=None):  # pylint: disable=unused-argument
+        """Return each order line's remaining items, priced as they will invoice."""
+        order = self.get_object()
+        return Response({
+            'order': order.pk,
+            'order_number': order.order_number,
+            'currency_code': order.currency_code,
+            'lines': [
+                {
+                    'order_line': row['order_line'].pk,
+                    'description': row['description'],
+                    'quantity': row['order_line'].quantity,
+                    'invoiced_positions': row['invoiced_positions'],
+                    'returned_positions': row['returned_positions'],
+                    'positions': [
+                        {
+                            'position': item['position'],
+                            'dispatched': item['fulfillment_line'] is not None,
+                            'total_incl_tax': f"{item['total_incl_tax']:f}",
+                        }
+                        for item in row['positions']
+                    ],
+                }
+                for row in invoiceable(order)
+            ],
+        })
+
+
+router = routers.SimpleRouter()
+router.register(r'supply-documents', SupplyDocumentViewSet, basename='supplydocument')
+router.register(r'invoiceable', InvoiceableView, basename='invoiceable')

--- a/billing/test_rest.py
+++ b/billing/test_rest.py
@@ -1,0 +1,300 @@
+"""The REST contract for issuing, reading and printing documents.
+
+The frontend has no test runner of its own, so what the screens rely on is
+pinned here: the payload the printable view renders, the shape the issue form
+posts, and the refusals it has to show against a field.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+from django.test import TestCase
+
+from tests.api import RESTContractTestCase
+from workspaces.models import Workspace
+
+from .documents import issue_supply_document
+from .models import SupplyCorrection
+from .test_fixtures import DocumentScenarioMixin
+
+
+DOCUMENTS_URL = '/billing/supply-documents/'
+
+
+class DocumentRESTTests(DocumentScenarioMixin, RESTContractTestCase):
+    """Issuing and reading documents over the API."""
+
+    def setUp(self):
+        """Register, confirm a two-plant order, and dispatch it."""
+        super().setUp()
+        self.register_for_gst()
+        self.plants = self.ready_plants(2)
+        self.customer = self.make_customer()
+        self.order, self.line, self.allocations = self.confirmed_order(
+            self.plants, customer=self.customer,
+        )
+
+    def issue(self, positions=(1, 2), **overrides):
+        """Post one document and return the response."""
+        payload = {
+            'operation_key': str(uuid4()),
+            'order': self.order.pk,
+            'lines': [{'order_line': self.line.pk, 'positions': list(positions)}],
+            'issued_on': '2026-05-04',
+        }
+        payload.update(overrides)
+        return self.client.post(DOCUMENTS_URL, payload, format='json')
+
+    def test_authentication_is_required(self):
+        """An anonymous caller reads nobody's invoices."""
+        self.assert_authentication_required([DOCUMENTS_URL])
+
+    def test_issuing_and_reading_one_document(self):
+        """The register lists what was issued, and the detail carries its lines."""
+        response = self.issue()
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['document_number'], 'INV-000001')
+        self.assertEqual(response.data['total_incl_tax'], '23.0000')
+        self.assertEqual(response.data['state']['status'], 'issued')
+
+        detail = self.client.get(f"{DOCUMENTS_URL}{response.data['pk']}/")
+        self.assertEqual(detail.status_code, 200)
+        self.assertEqual(detail.data['order_number'], self.order.order_number)
+        self.assertEqual(len(detail.data['lines']), 1)
+        self.assertEqual(
+            [row['commercial_position'] for row in detail.data['lines'][0]['coverage']],
+            [1, 2],
+        )
+
+        listed = self.client.get(DOCUMENTS_URL)
+        self.assertEqual(listed.status_code, 200)
+        self.assertEqual([row['pk'] for row in listed.data], [response.data['pk']])
+
+    def test_the_register_can_be_narrowed_to_one_order(self):
+        """An order screen asks for its own documents and gets only those."""
+        self.issue(positions=(1,))
+        matching = self.client.get(f'{DOCUMENTS_URL}?order={self.order.pk}')
+        self.assertEqual(len(matching.data), 1)
+        other = self.client.get(f'{DOCUMENTS_URL}?order={self.order.pk + 1000}')
+        self.assertEqual(other.data, [])
+
+    def test_a_document_cannot_be_edited_or_deleted_over_the_api(self):
+        """The surface offers no way to rewrite evidence."""
+        created = self.issue()
+        url = f"{DOCUMENTS_URL}{created.data['pk']}/"
+        for method in (self.client.patch, self.client.put):
+            with self.subTest(method=method.__name__):
+                self.assertEqual(method(url, {'notes': 'no'}, format='json').status_code, 405)
+        self.assertEqual(self.client.delete(url).status_code, 405)
+
+    def test_a_defective_document_is_refused_against_its_own_fields(self):
+        """A form can show the message beside the control it belongs to."""
+        big_plants = self.ready_plants(2)
+        order, line, _allocations = self.confirmed_order(big_plants, unit_price='900.0000')
+        response = self.client.post(DOCUMENTS_URL, {
+            'operation_key': str(uuid4()),
+            'order': order.pk,
+            'lines': [{'order_line': line.pk, 'positions': [1, 2]}],
+            'issued_on': '2026-05-04',
+        }, format='json')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(set(response.data), {'buyer_name', 'buyer_identification'})
+
+    def test_a_one_off_buyer_can_be_supplied_with_the_request(self):
+        """Invoicing a wholesale load should not require inventing a customer."""
+        big_plants = self.ready_plants(2)
+        order, line, _allocations = self.confirmed_order(big_plants, unit_price='900.0000')
+        response = self.client.post(DOCUMENTS_URL, {
+            'operation_key': str(uuid4()),
+            'order': order.pk,
+            'lines': [{'order_line': line.pk, 'positions': [1, 2]}],
+            'issued_on': '2026-05-04',
+            'buyer': {'buyer_name': 'Te Awa Plantings', 'buyer_identifier': '9429041234567'},
+        }, format='json')
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['buyer_name'], 'Te Awa Plantings')
+        self.assertEqual(response.data['tier'], 'full')
+
+    def test_the_invoiceable_route_says_what_is_left_and_what_shipped(self):
+        """The issue form is built from this, so its shape is a contract."""
+        self.fulfill(self.order, self.allocations[:1])
+        self.issue(positions=(2,))
+
+        response = self.client.get(f'/billing/invoiceable/{self.order.pk}/')
+        self.assertEqual(response.status_code, 200)
+        line = response.data['lines'][0]
+        self.assertEqual(line['invoiced_positions'], [2])
+        self.assertEqual(line['positions'], [
+            {'position': 1, 'dispatched': True, 'total_incl_tax': '11.5000'},
+        ])
+
+    def test_the_printable_payload_carries_both_parties_and_the_checklist(self):
+        """Change 5 has to be visible to a reader, not only enforced at issue."""
+        created = self.issue()
+        response = self.client.get(f"{DOCUMENTS_URL}{created.data['pk']}/print/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['title'], 'Tax invoice')
+        self.assertEqual(response.data['seller']['gst_number'], '049091850')
+        self.assertEqual(response.data['seller']['legal_name'], 'Kowhai Growers Limited')
+        self.assertEqual(response.data['buyer']['name'], 'Riverbend Landscapes')
+        self.assertEqual(response.data['tier_label'], '$200 or less')
+        self.assertTrue(response.data['required_information'])
+        self.assertTrue(all(row['satisfied'] for row in response.data['required_information']))
+        self.assertEqual(response.data['totals']['balance_due'], '23.0000')
+
+
+class UnregisteredSellerRESTTests(DocumentScenarioMixin, RESTContractTestCase):
+    """A workspace below the threshold issues receipts, and they say so."""
+
+    def test_the_printed_document_is_a_receipt_not_a_tax_invoice(self):
+        """Calling a receipt a tax invoice would be a false record."""
+        plants = self.ready_plants(1)
+        order, line, _allocations = self.confirmed_order(plants, tax_rate='0')
+        document = issue_supply_document(
+            order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': line, 'positions': [1]}],
+            issued_on=date(2026, 5, 4),
+        )
+        response = self.client.get(f'{DOCUMENTS_URL}{document.pk}/print/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['title'], 'Sales receipt')
+        self.assertFalse(response.data['taxable_supply'])
+        self.assertEqual(response.data['seller']['gst_number'], '')
+        codes = {row['code'] for row in response.data['required_information']}
+        self.assertNotIn('seller_gst_number', codes)
+        self.assertIn('seller_name', codes)
+
+
+class CorrectionRESTTests(DocumentScenarioMixin, RESTContractTestCase):
+    """Issuing corrections over the API."""
+
+    def setUp(self):
+        """Issue one document to correct."""
+        super().setUp()
+        self.register_for_gst()
+        self.plants = self.ready_plants(2)
+        self.order, self.line, self.allocations = self.confirmed_order(self.plants)
+        self.document = issue_supply_document(
+            self.order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': self.line, 'positions': [1, 2]}],
+            issued_on=date(2026, 5, 4),
+        )
+        self.url = f'{DOCUMENTS_URL}{self.document.pk}/corrections/'
+
+    def test_a_partial_credit_is_issued_and_listed(self):
+        """One record, readable straight back from the document it corrects."""
+        response = self.client.post(self.url, {
+            'operation_key': str(uuid4()),
+            'correction_type': 'credit',
+            'reason_code': 'discount',
+            'reason': 'Agreed price adjustment',
+            'lines': [{'document_line': self.document.lines.get().pk, 'amount': '5.0000'}],
+            'corrected_on': '2026-05-06',
+        }, format='json')
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['document_number'], 'CRN-000001')
+        self.assertEqual(response.data['total_incl_tax'], '5.0000')
+
+        listed = self.client.get(self.url)
+        self.assertEqual([row['pk'] for row in listed.data], [response.data['pk']])
+        detail = self.client.get(f'{DOCUMENTS_URL}{self.document.pk}/')
+        self.assertEqual(detail.data['state']['status'], 'part_credited')
+        self.assertEqual(detail.data['state']['net_total_incl_tax'], '18.0000')
+
+    def test_a_full_credit_needs_no_line_selection(self):
+        """Cancelling is one button, and it credits whatever is left."""
+        response = self.client.post(self.url, {
+            'operation_key': str(uuid4()),
+            'correction_type': 'credit',
+            'reason_code': 'cancellation',
+            'reason': 'Order cancelled',
+            'full': True,
+        }, format='json')
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['total_incl_tax'], '23.0000')
+        self.assertEqual(SupplyCorrection.objects.count(), 1)
+
+    def test_naming_lines_and_asking_for_a_full_credit_is_refused(self):
+        """Two answers to one question is a mistake worth failing on."""
+        response = self.client.post(self.url, {
+            'operation_key': str(uuid4()),
+            'correction_type': 'credit',
+            'reason_code': 'cancellation',
+            'reason': 'Order cancelled',
+            'full': True,
+            'lines': [{'document_line': self.document.lines.get().pk, 'amount': '5.0000'}],
+        }, format='json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_full_debit_is_refused(self):
+        """A debit reverses a credit; there is no whole document to debit."""
+        response = self.client.post(self.url, {
+            'operation_key': str(uuid4()),
+            'correction_type': 'debit',
+            'reason_code': 'other',
+            'reason': 'Nope',
+            'full': True,
+        }, format='json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_an_over_credit_is_refused_with_a_field_error(self):
+        """The screen can put the message against the amount that caused it."""
+        response = self.client.post(self.url, {
+            'operation_key': str(uuid4()),
+            'correction_type': 'credit',
+            'reason_code': 'discount',
+            'reason': 'Too much',
+            'lines': [{'document_line': self.document.lines.get().pk, 'amount': '99.0000'}],
+        }, format='json')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('lines', response.data)
+
+
+class GardenProfileTests(DocumentScenarioMixin, RESTContractTestCase):
+    """A Garden workspace has no nursery to invoice for."""
+
+    def setUp(self):
+        """Present the workspace as a Garden."""
+        super().setUp()
+        self.workspace.mode = Workspace.Mode.GARDEN
+        self.workspace.save()
+
+    def test_the_document_routes_are_refused_in_the_garden_profile(self):
+        """Enforced on the server, so a bookmarked URL stays honest."""
+        response = self.client.get(DOCUMENTS_URL)
+        self.assertEqual(response.status_code, 403)
+
+
+class MoneyPrecisionTests(DocumentScenarioMixin, TestCase):
+    """A document's own arithmetic has to close, not nearly close."""
+
+    def test_three_items_at_an_awkward_price_still_total_the_order(self):
+        """Positions are split exactly, so a document never drifts from its order."""
+        self.register_for_gst()
+        plants = self.ready_plants(3)
+        order, line, _allocations = self.confirmed_order(plants, unit_price='10.0100')
+        document = issue_supply_document(
+            order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': line, 'positions': [1, 2, 3]}],
+            issued_on=date(2026, 5, 4),
+        )
+
+        self.assertEqual(document.total_incl_tax, order.total_incl_tax)
+        self.assertEqual(
+            document.subtotal_ex_tax + document.tax_total,
+            document.total_incl_tax,
+        )
+        self.assertEqual(document.total_incl_tax, Decimal('34.5345'))

--- a/billing/urls.py
+++ b/billing/urls.py
@@ -1,0 +1,8 @@
+"""URL routing for taxable supply and correction documents."""
+
+from django.urls import include, path
+
+from .rest import router
+
+
+urlpatterns = [path('', include(router.urls))]

--- a/gp/urls.py
+++ b/gp/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path("applications/", include('applications.urls')),
     path("costing/", include('costing.urls')),
     path("sales/", include('sales.urls')),
+    path("billing/", include('billing.urls')),
     path("labels/", include('labels.urls')),
     path("work/", include('work.urls')),
     path("health/", include('health.urls')),


### PR DESCRIPTION
List, retrieve and create, and nothing else — the same surface `tax` gives its arrangements, because correcting a document is a different act from editing one and has to read as one in the audit trail. PATCH, PUT and DELETE all answer 405 rather than being quietly ignored.

Three routes carry the work. `/billing/invoiceable/<order>/` says which items of an order have not been invoiced and which of those have shipped, which is what the issue form is built from. `/billing/supply-documents/` issues and lists. `/print/` returns the document shaped for the page it goes on: two party blocks, the lines with the items behind each, the running balance, and a checklist of every element the value band requires with whether it is satisfied — because change 5 has to be visible to a reader, not only enforced once at issue.

The routes hang off `billing` rather than off `SalesOrderViewSet`. `billing` already depends on `sales`, and putting the action on the order would make the dependency run both ways for the sake of a URL.

## Summary by Sourcery

Expose an immutable billing document API that supports issuance, correction, invoiceability lookup, and print-ready document data.

New Features:
- Expose invoiceable order items, issued supply documents, printable document views, and document corrections through billing REST endpoints.

Bug Fixes:
- Prevent document totals from drifting when invoicing multiple items at precise or awkward prices.

Enhancements:
- Keep issued documents immutable through the API while supporting explicit correction records and workspace/profile enforcement.
- Expose document status, balances, covered and dispatched items, party details, and value-band requirement checklists for consumers and printable views.

Tests:
- Add REST contract coverage for document issuance, retrieval, filtering, immutability, printing, corrections, validation, workspace restrictions, and monetary precision.