### PR TITLE
feat(tax): recognise supply on the invoice date the document carries

### DIFF
--- a/billing/test_fixtures.py
+++ b/billing/test_fixtures.py
@@ -86,23 +86,35 @@ class DocumentScenarioMixin:
         values.update(overrides)
         return Customer.objects.create(workspace=self.workspace, **values)
 
-    def ready_plant(self, batch=None, cell_planting=None):
-        """Grow one plant as far as saleable."""
+    def ready_plant(self, batch=None, cell_planting=None, ready_at=None):
+        """Grow one plant as far as saleable.
+
+        `ready_at` back-dates the germination and the readiness, which a test
+        needs whenever it also wants to name the dispatch date: lifecycle
+        events must be recorded in the order they happened, so a plant that
+        became ready today cannot have been dispatched in June.
+        """
         values = {'workspace': self.workspace}
         if batch is not None:
             values['batch'] = batch
         if cell_planting is not None:
             values['cell_planting'] = cell_planting
+        if ready_at is not None:
+            values['germinated'] = ready_at
         plant = make_specific_plant(**values)
         record_germination_event(plant, self.user)
-        record_lifecycle_event(plant, self.user, OutcomeRequest(EventType.READY))
+        record_lifecycle_event(
+            plant, self.user, OutcomeRequest(EventType.READY, occurred_at=ready_at),
+        )
         return plant
 
-    def ready_plants(self, count):
+    def ready_plants(self, count, ready_at=None):
         """Grow a sibling group, so one order line can cover all of them."""
-        first = self.ready_plant()
+        first = self.ready_plant(ready_at=ready_at)
         rest = [
-            self.ready_plant(batch=first.batch, cell_planting=first.cell_planting)
+            self.ready_plant(
+                batch=first.batch, cell_planting=first.cell_planting, ready_at=ready_at,
+            )
             for _ in range(count - 1)
         ]
         return [first, *rest]

--- a/reporting/gst.py
+++ b/reporting/gst.py
@@ -83,8 +83,9 @@ RECONCILIATION = {
         'order belongs to.'
     ),
     'proxy_note': (
-        'A fulfillment stands in for the invoice date the invoice basis needs; '
-        'entries relying on it are marked proxy.'
+        'Where a taxable supply document was issued, the invoice basis '
+        'recognises on its date. Where none was, a fulfillment stands in for '
+        'the invoice date and the entry is marked proxy.'
     ),
 }
 
@@ -412,6 +413,19 @@ def _data_quality(workspace, entries, rows, as_at):
             'zero-rated, exempt, or outside GST, so they are reported in none '
             'of those boxes.',
             tax_code='unclassified',
+        ))
+
+    proxied = [
+        entry for entry in entries
+        if entry.proxy and not entry.exclusion and entry.source_type == 'fulfillment'
+    ]
+    if proxied:
+        findings.append(_finding(
+            'invoice_not_issued', len(proxied),
+            'Some supplies were brought to account on their dispatch date '
+            'because no taxable supply document was issued for them. The date '
+            'a return needs is the date a document was issued, so issuing one '
+            'is what settles which period they belong in.',
         ))
 
     non_recoverable = [entry for entry in entries if entry.non_recoverable_tax > 0]

--- a/reporting/test_gst.py
+++ b/reporting/test_gst.py
@@ -12,10 +12,12 @@ assertions in one test is the contract rather than a coincidence.
 
 # pylint: disable=duplicate-code
 
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from uuid import uuid4
 
+from billing.documents import issue_supply_document
+from billing.test_fixtures import DocumentScenarioMixin
 from inventory.ledger import post_receipt
 from inventory.models import InventoryItem, StockReceipt, StockReceiptLine
 from inventory.units import UnitCode
@@ -482,3 +484,64 @@ class InputTaxTests(GstReportTestCase):
         rows = [row for row in self.periods()['results'] if row['period_label'] == label]
         self.assertEqual(len(rows), 1, rows)
         return rows[0]
+
+
+class InvoiceDateReportingTests(DocumentScenarioMixin, RESTContractTestCase):
+    """A period reports supplies on the date a document says, where one exists.
+
+    Task 117 shipped with a fulfillment standing in for the invoice date, and
+    every entry relying on it marked. These are the two halves of superseding
+    it: the report says how much still rests on the stand-in, and stops saying
+    so once a document has been issued.
+    """
+
+    dispatched_at = datetime(2026, 6, 10, 9, 0, tzinfo=timezone.utc)
+
+    def setUp(self):
+        """A registered nursery on the invoice basis, with one dispatched order."""
+        super().setUp()
+        self.register_for_gst(period_anchor_month=4)
+        plants = self.ready_plants(2, ready_at=datetime(2026, 3, 1, 9, 0, tzinfo=timezone.utc))
+        self.order, self.line, allocations = self.confirmed_order(
+            plants, order_date=date(2026, 3, 15),
+        )
+        self.fulfill(self.order, allocations, fulfilled_at=self.dispatched_at)
+
+    def periods(self):
+        """Fetch the period report over the whole year."""
+        response = self.client.get(
+            PERIODS_URL, {'date_from': '2026-01-01', 'date_to': '2026-12-31'},
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+    def row(self, label):
+        """Return the one period row carrying a label."""
+        rows = [item for item in self.periods()['results'] if item['period_label'] == label]
+        self.assertEqual(len(rows), 1, rows)
+        return rows[0]
+
+    def test_an_uninvoiced_supply_is_reported_as_resting_on_its_dispatch_date(self):
+        """A gap worth naming: the date a return needs is a date nobody chose."""
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+        self.assertIn('invoice_not_issued', codes)
+        self.assertEqual(self.row('2026-05-01..2026-06-30')['output_tax'], '3.0000')
+
+    def test_issuing_a_document_moves_the_supply_and_clears_the_finding(self):
+        """May's return carries it once May's invoice exists to say so."""
+        issue_supply_document(
+            self.order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': self.line, 'positions': [1, 2]}],
+            issued_on=date(2026, 4, 20),
+        )
+        codes = {finding['code'] for finding in self.periods()['data_quality']}
+
+        self.assertNotIn('invoice_not_issued', codes)
+        self.assertEqual(self.row('2026-03-01..2026-04-30')['output_tax'], '3.0000')
+        self.assertEqual(self.row('2026-05-01..2026-06-30')['output_tax'], '0.0000')
+
+    def test_the_reconciliation_note_describes_the_rule_now_in_force(self):
+        """The payload explains itself, so nobody infers the rule from a flag."""
+        note = self.periods()['reconciliation']['proxy_note']
+        self.assertIn('Where a taxable supply document was issued', note)

--- a/tax/entries.py
+++ b/tax/entries.py
@@ -2,11 +2,12 @@
 
 There is no GST ledger table. Every figure in a return is derived, at the
 moment it is read, from the commerce records that produced it — and those are
-already immutable: `Fulfillment`, `Payment`, `SalesReturn`, `Refund` and a
-posted `StockReceipt` all refuse to be edited or deleted. So "reconcile every
-period total to immutable source records" holds without a second copy of them,
-and a change of basis rewrites nothing because there is nothing to rewrite.
-Task 118 owns materialising this once it has real invoice documents to key on.
+already immutable: `Fulfillment`, `Payment`, `SalesReturn`, `Refund`, a posted
+`StockReceipt` and task 118's `SupplyDocument` all refuse to be edited or
+deleted. So "reconcile every period total to immutable source records" holds
+without a second copy of them, and a change of basis rewrites nothing because
+there is nothing to rewrite. Materialising the derivation would add a copy to
+keep in step with immutable rows that cannot drift, so it stays derived.
 
 The basis applied to a period is the basis in force during it. That is safe
 because a period is clipped whenever an arrangement changes, so no period ever

--- a/tax/facts.py
+++ b/tax/facts.py
@@ -8,11 +8,17 @@ testable without fixtures and the query work reviewable on its own.
 Only effective records are read. A reversal and the record it reverses both
 drop out, using the same pair of filters the commerce services already use, so
 a reversed fulfillment can never contribute to a return.
+
+Documents from `billing` are read here too. They are already immutable and have
+no reversal pair — an issued document is corrected, never withdrawn — so the
+effective filter does not apply to them; what a correction did to a document is
+its own dated event rather than a reason to stop reading the original.
 """
 
 from collections import defaultdict
 from decimal import Decimal
 
+from billing.models import SupplyCorrection, SupplyCorrectionLine, SupplyDocument, SupplyDocumentLine
 from sales.models import (
     Fulfillment,
     FulfillmentLine,
@@ -25,12 +31,14 @@ from sales.models import (
 
 from .periods import local_date
 from .recognition import (
+    CorrectionFact,
+    CreditPortion,
     FulfillmentFact,
+    InvoiceFact,
     LineFact,
     OrderFacts,
     PaymentFact,
     RefundFact,
-    RefundPortion,
 )
 
 
@@ -76,7 +84,30 @@ def orders_with_activity(workspace, start=None, end=None):
             effective(model.objects.filter(workspace=workspace, **lookup))
             .values_list(path, flat=True)
         )
+    matched.update(_document_order_ids(workspace, bounds))
     return orders.filter(pk__in=matched).order_by('pk')
+
+
+def _document_order_ids(workspace, bounds):
+    """Return the orders whose documents fall in a range.
+
+    Documents carry no reversal pair, so `effective` has nothing to filter
+    here. A correction reaches this the same way, through its own date: an
+    invoice issued in March and credited in May makes both periods worth
+    reading, and leaving the second out would hide the adjustment.
+    """
+    matched = set()
+    document_lookup = {f'issued_on__{suffix}': value for suffix, value in bounds.items()}
+    matched.update(
+        SupplyDocument.objects.filter(workspace=workspace, **document_lookup)
+        .values_list('order_id', flat=True)
+    )
+    correction_lookup = {f'corrected_on__{suffix}': value for suffix, value in bounds.items()}
+    matched.update(
+        SupplyCorrection.objects.filter(workspace=workspace, **correction_lookup)
+        .values_list('document__order_id', flat=True)
+    )
+    return matched
 
 
 def order_facts(order):
@@ -91,14 +122,17 @@ def order_facts(order):
         )
         for line in order.lines.all().order_by('pk')
     )
+    corrections = _correction_facts(order)
     return OrderFacts(
         order_id=order.pk,
         currency_code=order.currency_code,
         lines=lines,
         fulfillments=_fulfillment_facts(workspace, order),
+        invoices=_invoice_facts(order),
         payments=_payment_facts(order),
         refunds=_refund_facts(workspace, order),
-        unrefunded_return_ids=_unrefunded_return_ids(order),
+        corrections=corrections,
+        uncredited_return_ids=_uncredited_return_ids(order),
     )
 
 
@@ -158,34 +192,105 @@ def _refund_facts(workspace, order):
     for line in lines:
         refund = line.refund
         dates[refund.pk] = local_date(workspace, refund.refunded_at)
-        grouped[refund.pk].append(RefundPortion(
+        grouped[refund.pk].append(CreditPortion(
             line_id=line.fulfillment_line.allocation.line_id,
             gross=line.total_incl_tax,
             tax=line.tax_total,
         ))
+    credited = _refunds_carrying_a_credit_note(order)
     return tuple(
         RefundFact(
             refund_id=refund_id,
             refunded_on=dates[refund_id],
             portions=tuple(portions),
+            credited_by_document=refund_id in credited,
         )
         for refund_id, portions in sorted(grouped.items())
     )
 
 
-def _unrefunded_return_ids(order):
-    """Return effective returns carrying no effective refund.
+def _refunds_carrying_a_credit_note(order):
+    """Return the refunds a credit note already accounts for.
 
-    A return moves plants, not money, so it changes no consideration and owes
-    no GST adjustment. It does owe a credit note, and reporting that as
-    outstanding work is more useful than reporting nothing.
+    Under the invoice and hybrid bases the note is what alters the agreed
+    consideration, so the refund beside it is the same money reaching the
+    customer rather than a second adjustment.
+    """
+    return set(
+        SupplyCorrection.objects
+        .filter(document__order=order, refund__isnull=False)
+        .values_list('refund_id', flat=True)
+    )
+
+
+def _invoice_facts(order):
+    """Group each issued document's value by the order line it invoiced."""
+    grouped = defaultdict(dict)
+    dates = {}
+    lines = SupplyDocumentLine.objects.filter(
+        document__order=order,
+    ).select_related('document').order_by('pk')
+    for line in lines:
+        document = line.document
+        dates[document.pk] = document.issued_on
+        totals = grouped[document.pk]
+        totals[line.order_line_id] = totals.get(line.order_line_id, ZERO) + line.total_incl_tax
+    return tuple(
+        InvoiceFact(
+            document_id=document_id,
+            issued_on=dates[document_id],
+            line_grosses=dict(totals),
+        )
+        for document_id, totals in sorted(grouped.items())
+    )
+
+
+def _correction_facts(order):
+    """Group each correction's value by the order line it moves."""
+    grouped = defaultdict(list)
+    headers = {}
+    lines = SupplyCorrectionLine.objects.filter(
+        correction__document__order=order,
+    ).select_related('correction', 'document_line').order_by('pk')
+    for line in lines:
+        correction = line.correction
+        headers[correction.pk] = correction
+        grouped[correction.pk].append(CreditPortion(
+            line_id=line.document_line.order_line_id,
+            gross=line.total_incl_tax,
+            tax=line.tax_total,
+        ))
+    return tuple(
+        CorrectionFact(
+            correction_id=correction_id,
+            corrected_on=headers[correction_id].corrected_on,
+            kind=headers[correction_id].correction_type,
+            portions=tuple(portions),
+        )
+        for correction_id, portions in sorted(grouped.items())
+    )
+
+
+def _uncredited_return_ids(order):
+    """Return effective returns carrying neither a refund nor a credit note.
+
+    A return moves plants, not money, so on its own it changes no consideration
+    and owes no GST adjustment. What it owes is a correction document, and now
+    that one can be issued this reports only the returns where nobody has —
+    reaching zero when the paperwork is done, rather than nagging forever.
     """
     refunded = set(
         effective(Refund.objects.filter(order=order))
         .exclude(sales_return__isnull=True)
         .values_list('sales_return_id', flat=True)
     )
+    credited = set(
+        SupplyCorrection.objects
+        .filter(document__order=order, sales_return__isnull=False)
+        .values_list('sales_return_id', flat=True)
+    )
     returns = effective(SalesReturn.objects.filter(order=order)).order_by('pk')
+    settled = refunded | credited
     return tuple(
-        sales_return.pk for sales_return in returns if sales_return.pk not in refunded
+        sales_return.pk for sales_return in returns if sales_return.pk not in settled
     )

--- a/tax/recognition.py
+++ b/tax/recognition.py
@@ -12,13 +12,21 @@ The three bases, and what each one waits for:
 * **Payments** recognises on money received. An order invoiced and delivered
   but unpaid produces nothing at all, which is the point of the basis.
 * **Invoice** recognises on the earlier of an invoice issued and a payment
-  received. This repository has no invoice document yet — task 118 owns it — so
-  a fulfillment stands in for the invoice date. Every event says so through
-  `time_of_supply_source` and `proxy`, so task 118 can find exactly the events
-  it supersedes rather than re-deriving all of them.
+  received. Task 118 built the invoice, so where one has been issued the event
+  falls on its own date and says so. Where none has, a fulfillment still stands
+  in for it and the event is marked `proxy` — an order delivered and never
+  invoiced has still been supplied, and dropping it would understate a return.
+  The flag is therefore not a leftover: it is the difference between a date
+  somebody issued and a date this module chose.
 * **Hybrid** is invoice for output tax and payments for input tax. Only output
   tax is decided here, so hybrid and invoice behave identically in this module;
   the difference shows up on the purchase side.
+
+Credits work the same way round. Under the invoice and hybrid bases a credit
+note is what reduces the consideration, so a correction document is the credit
+event; a refund with no credit note against it still credits, marked `proxy`,
+because money that went back is not nothing. Under the payments basis only the
+refund matters, since no document moves cash.
 
 Recognition is capped at the order's own value. Cash beyond it is not
 consideration for a supply — it is an overpayment — and it is reported rather
@@ -58,12 +66,15 @@ UNCLASSIFIED = 'unclassified'
 #: assumed either way — it is reported as a gap.
 TURNOVER_CODES = (STANDARD, ZERO_RATED)
 
-#: Payments are ranked before fulfillments on the same day, so a deposit and a
-#: same-day delivery split deterministically. The totals are identical either
-#: way; only the attribution moves, and an arbitrary attribution that changed
-#: between runs would make a report impossible to reconcile.
+#: Triggers falling on one day are processed in this order, so a deposit, an
+#: invoice and a same-day delivery split deterministically. The totals are
+#: identical whatever the order; only the attribution moves, and an arbitrary
+#: attribution that changed between runs would make a report impossible to
+#: reconcile. An invoice ranks ahead of a fulfillment because where both exist
+#: the invoice is the real time of supply and the fulfillment is the stand-in.
 PAYMENT_RANK = 0
-FULFILLMENT_RANK = 1
+INVOICE_RANK = 1
+FULFILLMENT_RANK = 2
 
 
 @dataclass(frozen=True)
@@ -95,8 +106,28 @@ class PaymentFact:
 
 
 @dataclass(frozen=True)
-class RefundPortion:
-    """One refunded line's share, read straight off its RefundLine."""
+class InvoiceFact:
+    """One issued taxable supply document and the value it invoiced per line.
+
+    This is what supersedes the fulfillment stand-in. `issued_on` is already a
+    workspace-local business date, because a document is dated rather than
+    timestamped — an invoice is issued on a day, not at an instant.
+    """
+
+    document_id: int
+    issued_on: date
+    line_grosses: Mapping[int, Decimal]
+
+
+@dataclass(frozen=True)
+class CreditPortion:
+    """One credited line's share, read straight off the row that credits it.
+
+    Used by both a refund line and a correction line. The two are different
+    documents but the same three facts, and deriving the tax again here rather
+    than reading it would let a credit drift by a rounding step from the supply
+    it reverses.
+    """
 
     line_id: int
     gross: Decimal
@@ -105,27 +136,55 @@ class RefundPortion:
 
 @dataclass(frozen=True)
 class RefundFact:
-    """One effective refund, already classified against the lines it credits."""
+    """One effective refund, already classified against the lines it credits.
+
+    `credited_by_document` says a credit note covers this refund. Under the
+    invoice and hybrid bases the note is the credit event, so counting the
+    refund as well would credit the same money twice.
+    """
 
     refund_id: int
     refunded_on: date
-    portions: Tuple[RefundPortion, ...]
+    portions: Tuple[CreditPortion, ...]
+    credited_by_document: bool = False
 
 
 @dataclass(frozen=True)
-class OrderFacts:
+class CorrectionFact:
+    """One issued supply correction, classified against the lines it moves.
+
+    A credit note reduces the consideration for a supply and a debit note puts
+    part of a credit back. Both fall due on the correction's own date, which is
+    the whole point of the document: the adjustment belongs in the period it
+    was issued in, not retroactively in the period of the supply.
+    """
+
+    correction_id: int
+    corrected_on: date
+    kind: str
+    portions: Tuple[CreditPortion, ...]
+
+
+# An order's facts are one attribute per kind of record that can bear on its
+# GST, and there is no grouping of them that is not arbitrary — the same reason
+# `RecognitionEvent` below carries the disable.
+@dataclass(frozen=True)
+class OrderFacts:  # pylint: disable=too-many-instance-attributes
     """Everything about one order that bears on when GST falls due."""
 
     order_id: int
     currency_code: str
     lines: Tuple[LineFact, ...]
     fulfillments: Tuple[FulfillmentFact, ...] = ()
+    invoices: Tuple[InvoiceFact, ...] = ()
     payments: Tuple[PaymentFact, ...] = ()
     refunds: Tuple[RefundFact, ...] = ()
-    #: Returns with no refund against them. A return moves plants, not money,
-    #: so no GST adjustment is due — but the credit note is outstanding work
-    #: somebody has to do, and it is reported rather than assumed away.
-    unrefunded_return_ids: Tuple[int, ...] = ()
+    corrections: Tuple[CorrectionFact, ...] = ()
+    #: Returns with neither a refund nor a credit note against them. A return
+    #: moves plants, not money, so no GST adjustment is due on its own — but
+    #: the correction document is outstanding work somebody has to do, and it
+    #: is reported rather than assumed away.
+    uncredited_return_ids: Tuple[int, ...] = ()
 
 
 # A recognition event has to carry every fact a return column and its
@@ -155,6 +214,12 @@ class RecognitionEvent:  # pylint: disable=too-many-instance-attributes
 SUPPLY = 'supply'
 SUPPLY_CREDIT = 'supply_credit'
 
+#: Correction kinds, matching ``billing.SupplyCorrection.CorrectionType``.
+#: Restated as plain strings so this module stays free of the model layer, the
+#: way the bases and tax codes above are; a test keeps them in step.
+CREDIT_NOTE = 'credit'
+DEBIT_NOTE = 'debit'
+
 
 @dataclass(frozen=True)
 class Recognition:
@@ -172,7 +237,11 @@ class Recognition:
     #: zero — `post_refund` caps refunds — so a non-zero value is a defect
     #: worth reporting rather than absorbing.
     over_credited: Decimal = ZERO
-    unrefunded_return_ids: Tuple[int, ...] = field(default_factory=tuple)
+    uncredited_return_ids: Tuple[int, ...] = field(default_factory=tuple)
+    #: Supplies brought to account on a fulfillment because no document was
+    #: issued for them. Reported so a period can say how much of it rests on a
+    #: date nobody chose.
+    proxy_gross: Decimal = ZERO
 
     @property
     def supply_events(self):
@@ -224,11 +293,13 @@ def order_recognition(facts, basis, *, as_at=None):
         if isinstance(trigger, PaymentFact):
             recognised, unmatched = _recognise_payment(trigger, lines, remaining)
             overpaid += unmatched
+        elif isinstance(trigger, InvoiceFact):
+            recognised = _recognise_invoice(trigger, lines, remaining)
         else:
             recognised = _recognise_fulfillment(trigger, lines, remaining, basis)
         events.extend(recognised)
 
-    credit_events, over_credited = _recognise_refunds(facts, events, as_at)
+    credit_events, over_credited = _recognise_credits(facts, basis, events, as_at)
     events.extend(credit_events)
     events.sort(key=lambda event: (event.supply_date, event.source_type, event.source_id, event.line_id))
     return Recognition(
@@ -236,7 +307,10 @@ def order_recognition(facts, basis, *, as_at=None):
         unmatched_overpayment=quantize_money(overpaid),
         unrecognised_gross=quantize_money(sum(remaining.values(), ZERO)),
         over_credited=quantize_money(over_credited),
-        unrefunded_return_ids=tuple(facts.unrefunded_return_ids),
+        uncredited_return_ids=tuple(facts.uncredited_return_ids),
+        proxy_gross=quantize_money(sum(
+            (event.gross for event in events if event.proxy), ZERO,
+        )),
     )
 
 
@@ -247,6 +321,10 @@ def _ordered_triggers(facts, basis, as_at):
         for payment in facts.payments
     ]
     if basis in (INVOICE, HYBRID):
+        triggers.extend(
+            (item.issued_on, INVOICE_RANK, item.document_id, item)
+            for item in facts.invoices
+        )
         triggers.extend(
             (item.supply_date, FULFILLMENT_RANK, item.fulfillment_id, item)
             for item in facts.fulfillments
@@ -282,70 +360,166 @@ def _recognise_payment(payment, lines, remaining):
     return events, quantize_money(gross - applied)
 
 
-def _recognise_fulfillment(fulfillment, lines, remaining, basis):
-    """Bring the value one fulfillment delivered to account, less anything prepaid.
+def _recognise_document(line_grosses, lines, remaining, event):
+    """Bring the value one document or dispatch names to account, once.
 
-    Under the invoice and hybrid bases a fulfillment stands in for the invoice
-    task 118 will issue. It recognises what it delivered, capped by what that
-    line still owes: a deposit taken earlier has already brought part of it to
-    account, and recognising the delivery in full would double-count it.
+    Every share is capped by what its line still owes. That single cap is what
+    makes a deposit, an invoice and a delivery of the same goods add up to the
+    order rather than to three times it: whichever comes first consumes the
+    value, and the rest find nothing left to recognise.
+
+    ``event`` carries the date, the source and whether the date was chosen by
+    this module rather than by somebody issuing a document.
     """
+    supply_date, source_type, source_id, proxy = event
     events = []
-    for line_id, delivered in fulfillment.line_grosses.items():
+    for line_id, named in line_grosses.items():
         outstanding = remaining.get(line_id, ZERO)
-        share = min(quantize_money(delivered), outstanding)
+        share = min(quantize_money(named), outstanding)
         if share <= 0:
             continue
         remaining[line_id] = quantize_money(outstanding - share)
         events.append(_supply_event(
-            lines[line_id],
-            share,
-            fulfillment.supply_date,
-            'fulfillment',
-            fulfillment.fulfillment_id,
-            proxy=basis in (INVOICE, HYBRID),
+            lines[line_id], share, supply_date, source_type, source_id, proxy=proxy,
         ))
     return events
 
 
-def _recognise_refunds(facts, supply_events, as_at):
-    """Credit refunded value at the refund date, capped by what was supplied.
+def _recognise_invoice(invoice, lines, remaining):
+    """Bring an issued document to account on the date it was issued.
 
-    The amounts are read straight off the refund's own lines rather than
-    re-derived. `proportional_refund` already split the refund preserving each
-    source line's tax ratio, so reading it back reconciles to the refund row
-    exactly and cannot drift by a rounding step.
+    This is the invoice basis doing what it actually says, rather than through
+    the fulfillment stand-in. Nothing is marked `proxy`, because the date came
+    off a document somebody handed a customer.
+    """
+    return _recognise_document(
+        invoice.line_grosses, lines, remaining,
+        (invoice.issued_on, 'supply_document', invoice.document_id, False),
+    )
+
+
+def _recognise_fulfillment(fulfillment, lines, remaining, basis):
+    """Bring the value one fulfillment delivered to account, less anything prepaid.
+
+    Under the invoice and hybrid bases this is the stand-in for a document that
+    was never issued. Where one was, the invoice ran first and consumed the
+    line's value, so this finds nothing left and produces no event at all —
+    which is exactly how the proxy gets superseded rather than switched off.
+    """
+    return _recognise_document(
+        fulfillment.line_grosses, lines, remaining,
+        (
+            fulfillment.supply_date,
+            'fulfillment',
+            fulfillment.fulfillment_id,
+            basis in (INVOICE, HYBRID),
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class _CreditSource:
+    """One dated adjustment to consideration already brought to account."""
+
+    adjusted_on: date
+    source_type: str
+    source_id: int
+    kind: str
+    portions: Tuple[CreditPortion, ...]
+    proxy: bool
+
+    @property
+    def order_key(self):
+        """Sort adjustments deterministically, so a report reconciles run to run."""
+        return (self.adjusted_on, self.source_type, self.source_id)
+
+
+def _credit_sources(facts, basis, as_at):
+    """Return what reduces or restores consideration, in a stable order.
+
+    Under the invoice and hybrid bases a credit note is what alters the agreed
+    consideration, so it is the event; a refund carrying a credit note is that
+    same money and is skipped, while a refund carrying none still credits as a
+    stand-in and says so. Under the payments basis only cash matters, so the
+    correction documents are not events at all — they change no money.
+    """
+    documented = basis in (INVOICE, HYBRID)
+    sources = [
+        _CreditSource(
+            adjusted_on=refund.refunded_on,
+            source_type='refund',
+            source_id=refund.refund_id,
+            kind=SUPPLY_CREDIT,
+            portions=refund.portions,
+            proxy=documented,
+        )
+        for refund in facts.refunds
+        if not (documented and refund.credited_by_document)
+    ]
+    if documented:
+        sources.extend(
+            _CreditSource(
+                adjusted_on=correction.corrected_on,
+                source_type='supply_correction',
+                source_id=correction.correction_id,
+                kind=SUPPLY_CREDIT if correction.kind == CREDIT_NOTE else SUPPLY,
+                portions=correction.portions,
+                proxy=False,
+            )
+            for correction in facts.corrections
+        )
+    if as_at is not None:
+        sources = [source for source in sources if source.adjusted_on <= as_at]
+    return sorted(sources, key=lambda source: source.order_key)
+
+
+def _recognise_credits(facts, basis, supply_events, as_at):
+    """Adjust already-recognised supply at the date the adjustment was made.
+
+    The amounts are read straight off the row that credits them rather than
+    re-derived. `proportional_refund` and `billing.documents` each split their
+    lines preserving the source line's tax ratio, so reading them back
+    reconciles exactly and cannot drift by a rounding step.
+
+    A credit is capped by what has actually been brought to account for that
+    line; anything beyond it is reported as `over_credited` rather than
+    absorbed, because a credit larger than its supply is a defect somewhere
+    else. A debit note is not capped here — `billing` already bounds it by the
+    credit it reverses — and it puts supply back.
     """
     supplied = {}
     for event in supply_events:
         supplied[event.line_id] = supplied.get(event.line_id, ZERO) + event.gross
     events = []
     over_credited = ZERO
-    for refund in facts.refunds:
-        if as_at is not None and refund.refunded_on > as_at:
-            continue
-        for portion in refund.portions:
-            available = supplied.get(portion.line_id, ZERO)
+    for source in _credit_sources(facts, basis, as_at):
+        for portion in source.portions:
             gross = quantize_money(portion.gross)
-            credited = min(gross, available)
-            over_credited += gross - credited
-            if credited <= 0:
-                continue
-            supplied[portion.line_id] = quantize_money(available - credited)
             tax = quantize_money(portion.tax)
-            if credited < gross:
-                tax = quantize_money(tax * credited / gross)
+            if source.kind == SUPPLY:
+                supplied[portion.line_id] = quantize_money(supplied.get(portion.line_id, ZERO) + gross)
+            else:
+                available = supplied.get(portion.line_id, ZERO)
+                credited = min(gross, available)
+                over_credited += gross - credited
+                if credited <= 0:
+                    continue
+                supplied[portion.line_id] = quantize_money(available - credited)
+                if credited < gross:
+                    tax = quantize_money(tax * credited / gross)
+                gross = credited
             events.append(RecognitionEvent(
-                kind=SUPPLY_CREDIT,
-                supply_date=refund.refunded_on,
-                source_type='refund',
-                source_id=refund.refund_id,
+                kind=source.kind,
+                supply_date=source.adjusted_on,
+                source_type=source.source_type,
+                source_id=source.source_id,
                 line_id=portion.line_id,
                 tax_code='',
                 tax_rate=ZERO,
-                gross=credited,
+                gross=gross,
                 tax=tax,
-                time_of_supply_source='refund',
+                time_of_supply_source=source.source_type,
+                proxy=source.proxy,
             ))
     return events, over_credited
 

--- a/tax/test_invoice_recognition.py
+++ b/tax/test_invoice_recognition.py
@@ -1,0 +1,157 @@
+"""The GST period ledger against real documents rather than the stand-in.
+
+`test_recognition` proves the rules; this proves the reading. An invoice, a
+credit note and a return with no money attached all have to reach the period
+report through `facts`, and the fulfillment-date proxy has to stop being used
+the moment a document exists to supersede it.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from django.test import TestCase
+
+from billing.documents import full_credit, issue_correction, issue_supply_document
+from billing.models import SupplyCorrection
+from billing.test_fixtures import DocumentScenarioMixin
+from sales.commerce import post_return
+
+from .entries import derive_entries
+from .facts import order_facts
+from .recognition import INVOICE, SUPPLY, SUPPLY_CREDIT, order_recognition
+
+
+class InvoiceDrivenRecognitionTests(DocumentScenarioMixin, TestCase):
+    """What a period owes, once a document says when the supply happened."""
+
+    #: A dispatch instant in June, so it is unambiguously a different month
+    #: from the May invoice date and the July correction date.
+    dispatched_at = datetime(2026, 6, 10, 9, 0, tzinfo=timezone.utc)
+
+    def setUp(self):
+        """Register, confirm a two-plant order, and dispatch it in June."""
+        super().setUp()
+        self.register_for_gst()
+        self.plants = self.ready_plants(2, ready_at=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc))
+        self.order, self.line, self.allocations = self.confirmed_order(self.plants)
+        self.fulfillment = self.fulfill(
+            self.order, self.allocations, fulfilled_at=self.dispatched_at,
+        )
+
+    def invoice(self, issued_on=date(2026, 5, 4), positions=(1, 2)):
+        """Issue one document over the positions given."""
+        return issue_supply_document(
+            self.order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': self.line, 'positions': list(positions)}],
+            issued_on=issued_on,
+        )
+
+    def recognition(self):
+        """Recognise this order under the invoice basis, straight from the database."""
+        return order_recognition(order_facts(self.order), INVOICE)
+
+    def test_without_a_document_the_dispatch_date_still_stands_in(self):
+        """The behaviour task 117 shipped, and the baseline this supersedes."""
+        recognition = self.recognition()
+        event = recognition.supply_events[0]
+
+        self.assertEqual(event.supply_date, date(2026, 6, 10))
+        self.assertTrue(event.proxy)
+        self.assertEqual(recognition.proxy_gross, Decimal('23.0000'))
+
+    def test_issuing_a_document_moves_the_supply_to_its_own_date(self):
+        """May's return carries it now, and nothing is marked proxy."""
+        self.invoice()
+        recognition = self.recognition()
+
+        self.assertEqual({event.supply_date for event in recognition.supply_events}, {date(2026, 5, 4)})
+        self.assertEqual(recognition.proxy_gross, Decimal('0.0000'))
+        self.assertEqual(recognition.recognised_gross, Decimal('23.0000'))
+
+    def test_a_partly_invoiced_order_mixes_a_real_date_with_the_stand_in(self):
+        """Half documented is half documented; the report says which half."""
+        self.invoice(positions=(1,))
+        recognition = self.recognition()
+        by_source = {event.source_type: event for event in recognition.supply_events}
+
+        self.assertEqual(by_source['supply_document'].supply_date, date(2026, 5, 4))
+        self.assertFalse(by_source['supply_document'].proxy)
+        self.assertEqual(by_source['fulfillment'].supply_date, date(2026, 6, 10))
+        self.assertTrue(by_source['fulfillment'].proxy)
+        self.assertEqual(recognition.recognised_gross, Decimal('23.0000'))
+
+    def test_a_credit_note_credits_in_the_period_it_was_issued(self):
+        """The adjustment belongs to July, not back in May."""
+        document = self.invoice()
+        full_credit(
+            document, self.user,
+            operation_key=uuid4(),
+            reason_code=SupplyCorrection.Reason.CANCELLATION,
+            reason='Order cancelled after invoicing',
+            corrected_on=date(2026, 7, 1),
+        )
+        recognition = self.recognition()
+
+        self.assertEqual({event.supply_date for event in recognition.credit_events}, {date(2026, 7, 1)})
+        self.assertEqual(recognition.recognised_gross, Decimal('0.0000'))
+
+    def test_a_return_with_no_money_is_settled_by_its_credit_note(self):
+        """Task 117 could only report this as outstanding work; now it is accounted for."""
+        document = self.invoice()
+        returned = post_return(
+            self.order, self.user,
+            operation_key=uuid4(),
+            items=[{
+                'fulfillment_line': self.fulfillment.lines.order_by('pk').first(),
+                'outcome': 'available',
+                'destination': self.store,
+            }],
+            reason='Root rot found on arrival',
+        )
+        self.assertEqual(self.recognition().uncredited_return_ids, (returned.pk,))
+
+        issue_correction(
+            document, self.user,
+            operation_key=uuid4(),
+            correction_type=SupplyCorrection.CorrectionType.CREDIT,
+            reason_code=SupplyCorrection.Reason.RETURN,
+            reason='Credit for the plant returned',
+            lines=[{'document_line': document.lines.get(), 'amount': Decimal('11.5000'), 'quantity': 1}],
+            corrected_on=date(2026, 7, 1),
+            sales_return=returned,
+        )
+        recognition = self.recognition()
+
+        self.assertEqual(recognition.uncredited_return_ids, ())
+        self.assertEqual(recognition.recognised_gross, Decimal('11.5000'))
+
+    def test_the_period_entries_report_the_document_as_the_source(self):
+        """The drill-down names the invoice, which is what makes it reconcilable."""
+        document = self.invoice()
+        entries = derive_entries(self.workspace, date(2026, 5, 1), date(2026, 6, 30))
+        supplies = [entry for entry in entries if entry.kind == SUPPLY]
+
+        self.assertEqual({entry.source_type for entry in supplies}, {'supply_document'})
+        self.assertEqual({entry.source_id for entry in supplies}, {document.pk})
+        self.assertEqual({entry.period_label for entry in supplies}, {'2026-05-01..2026-06-30'})
+        self.assertFalse(any(entry.proxy for entry in supplies))
+
+    def test_a_credit_note_appears_in_the_period_it_falls_in(self):
+        """A May invoice and a July credit are two periods, as they should be."""
+        document = self.invoice()
+        full_credit(
+            document, self.user,
+            operation_key=uuid4(),
+            reason_code=SupplyCorrection.Reason.CANCELLATION,
+            reason='Cancelled',
+            corrected_on=date(2026, 7, 1),
+        )
+        entries = derive_entries(self.workspace, date(2026, 5, 1), date(2026, 8, 31))
+        credits_ = [entry for entry in entries if entry.kind == SUPPLY_CREDIT]
+
+        self.assertEqual([entry.period_label for entry in credits_], ['2026-07-01..2026-08-31'])
+        self.assertEqual(sum(entry.tax for entry in credits_), Decimal('3.0000'))

--- a/tax/test_recognition.py
+++ b/tax/test_recognition.py
@@ -23,12 +23,16 @@ from .recognition import (
     SUPPLY,
     SUPPLY_CREDIT,
     ZERO_RATED,
+    CREDIT_NOTE,
+    DEBIT_NOTE,
+    CorrectionFact,
+    CreditPortion,
     FulfillmentFact,
+    InvoiceFact,
     LineFact,
     OrderFacts,
     PaymentFact,
     RefundFact,
-    RefundPortion,
     line_tax,
     order_recognition,
 )
@@ -242,7 +246,7 @@ class ReturnedWithoutRefundTests(SimpleTestCase):
             [standard_line(1, '115.0000')],
             fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
             payments=(PaymentFact(7, APRIL, Decimal('115.0000')),),
-            unrefunded_return_ids=(4,),
+            uncredited_return_ids=(4,),
         )
 
     def test_no_basis_credits_anything(self):
@@ -258,7 +262,7 @@ class ReturnedWithoutRefundTests(SimpleTestCase):
         for basis in BASES:
             with self.subTest(basis=basis):
                 recognition = order_recognition(self.facts(), basis)
-                self.assertEqual(recognition.unrefunded_return_ids, (4,))
+                self.assertEqual(recognition.uncredited_return_ids, (4,))
 
 
 class RefundedOrderTests(SimpleTestCase):
@@ -273,7 +277,7 @@ class RefundedOrderTests(SimpleTestCase):
             refunds=(RefundFact(
                 refund_id=3,
                 refunded_on=MAY,
-                portions=(RefundPortion(1, Decimal(refund_gross), Decimal(refund_tax)),),
+                portions=(CreditPortion(1, Decimal(refund_gross), Decimal(refund_tax)),),
             ),),
         )
 
@@ -429,10 +433,162 @@ class AsAtTests(SimpleTestCase):
         facts = order(
             [standard_line(1, '115.0000')],
             fulfillments=(FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
-            refunds=(RefundFact(3, MAY, (RefundPortion(1, Decimal('115.0000'), Decimal('15.0000')),)),),
+            refunds=(RefundFact(3, MAY, (CreditPortion(1, Decimal('115.0000'), Decimal('15.0000')),)),),
         )
         recognition = order_recognition(facts, INVOICE, as_at=date(2026, 4, 30))
         self.assertEqual(recognition.credit_events, ())
+
+
+class IssuedInvoiceTests(SimpleTestCase):
+    """An issued document is the time of supply the invoice basis actually wants."""
+
+    def facts(self, **overrides):
+        """Invoiced in March, delivered in April."""
+        values = {
+            'invoices': (InvoiceFact(11, MARCH, {1: Decimal('115.0000')}),),
+            'fulfillments': (FulfillmentFact(9, APRIL, {1: Decimal('115.0000')}),),
+        }
+        values.update(overrides)
+        return order([standard_line(1, '115.0000')], **values)
+
+    def test_the_invoice_date_supersedes_the_dispatch_date(self):
+        """March's return carries it, because March is when the document was issued."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertEqual(dates_of(recognition, SUPPLY), {MARCH})
+        self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+
+    def test_nothing_recognised_on_a_document_is_marked_proxy(self):
+        """The flag means "this module chose the date", and here it did not."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertTrue(all(not event.proxy for event in recognition.supply_events))
+        self.assertEqual(recognition.proxy_gross, Decimal('0.0000'))
+        self.assertEqual(
+            {event.time_of_supply_source for event in recognition.supply_events},
+            {'supply_document'},
+        )
+
+    def test_the_dispatch_still_stands_in_where_no_document_was_issued(self):
+        """An order delivered and never invoiced has still been supplied."""
+        recognition = order_recognition(self.facts(invoices=()), INVOICE)
+        self.assertEqual(dates_of(recognition, SUPPLY), {APRIL})
+        self.assertTrue(all(event.proxy for event in recognition.supply_events))
+        self.assertEqual(recognition.proxy_gross, Decimal('115.0000'))
+
+    def test_a_delivery_after_its_invoice_adds_nothing(self):
+        """The invoice consumed the line, so the dispatch finds nothing left."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        self.assertEqual(len(recognition.supply_events), 1)
+        self.assertEqual(recognition.unrecognised_gross, Decimal('0.0000'))
+
+    def test_a_deposit_before_an_invoice_is_not_counted_twice(self):
+        """Payment, invoice and delivery of one order total the order once."""
+        facts = self.facts(payments=(PaymentFact(7, date(2026, 3, 1), Decimal('50.0000')),))
+        recognition = order_recognition(facts, INVOICE)
+
+        self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+        self.assertEqual(
+            {(event.source_type, event.gross) for event in recognition.supply_events},
+            {('payment', Decimal('50.0000')), ('supply_document', Decimal('65.0000'))},
+        )
+
+    def test_the_payments_basis_ignores_the_document_entirely(self):
+        """Nothing is due until cash arrives, whatever paperwork exists."""
+        recognition = order_recognition(self.facts(), PAYMENTS)
+        self.assertEqual(recognition.supply_events, ())
+        self.assertEqual(recognition.unrecognised_gross, Decimal('115.0000'))
+
+    def test_hybrid_recognises_output_tax_on_the_document_like_invoice(self):
+        """Hybrid is the invoice basis for output tax, and this is output tax."""
+        recognition = order_recognition(self.facts(), HYBRID)
+        self.assertEqual(dates_of(recognition, SUPPLY), {MARCH})
+
+
+class CorrectionDocumentTests(SimpleTestCase):
+    """A credit note is what alters the consideration on the invoice basis."""
+
+    def facts(self, **overrides):
+        """Invoiced in March, credited in May."""
+        values = {
+            'invoices': (InvoiceFact(11, MARCH, {1: Decimal('115.0000')}),),
+            'corrections': (CorrectionFact(
+                correction_id=21,
+                corrected_on=MAY,
+                kind=CREDIT_NOTE,
+                portions=(CreditPortion(1, Decimal('115.0000'), Decimal('15.0000')),),
+            ),),
+        }
+        values.update(overrides)
+        return order([standard_line(1, '115.0000')], **values)
+
+    def test_a_credit_note_credits_in_the_period_it_was_issued(self):
+        """March's return stands; May's carries the adjustment."""
+        recognition = order_recognition(self.facts(), INVOICE)
+
+        self.assertEqual(dates_of(recognition, SUPPLY), {MARCH})
+        self.assertEqual(dates_of(recognition, SUPPLY_CREDIT), {MAY})
+        self.assertEqual(totals(recognition), (Decimal('0.0000'), Decimal('0.0000')))
+
+    def test_a_credit_note_settles_a_return_that_moved_no_money(self):
+        """Task 117 could only report this as outstanding; now it is accounted for."""
+        recognition = order_recognition(self.facts(), INVOICE)
+        credit = recognition.credit_events[0]
+        self.assertEqual(credit.source_type, 'supply_correction')
+        self.assertFalse(credit.proxy)
+
+    def test_a_refund_beside_its_credit_note_is_not_credited_twice(self):
+        """One reduction in consideration, evidenced two ways."""
+        facts = self.facts(refunds=(RefundFact(
+            refund_id=3,
+            refunded_on=MAY,
+            portions=(CreditPortion(1, Decimal('115.0000'), Decimal('15.0000')),),
+            credited_by_document=True,
+        ),))
+        recognition = order_recognition(facts, INVOICE)
+
+        self.assertEqual(len(recognition.credit_events), 1)
+        self.assertEqual(totals(recognition), (Decimal('0.0000'), Decimal('0.0000')))
+        self.assertEqual(recognition.over_credited, Decimal('0.0000'))
+
+    def test_a_refund_with_no_credit_note_still_credits_as_a_stand_in(self):
+        """Money that went back is not nothing, and the entry says it is a proxy."""
+        facts = self.facts(corrections=(), refunds=(RefundFact(
+            refund_id=3,
+            refunded_on=MAY,
+            portions=(CreditPortion(1, Decimal('115.0000'), Decimal('15.0000')),),
+        ),))
+        recognition = order_recognition(facts, INVOICE)
+        credit = recognition.credit_events[0]
+
+        self.assertEqual(credit.source_type, 'refund')
+        self.assertTrue(credit.proxy)
+
+    def test_the_payments_basis_ignores_a_credit_note(self):
+        """A note moves no cash, so it is not an event on the payments basis."""
+        facts = self.facts(payments=(PaymentFact(7, MARCH, Decimal('115.0000')),))
+        recognition = order_recognition(facts, PAYMENTS)
+
+        self.assertEqual(recognition.credit_events, ())
+        self.assertEqual(totals(recognition), (Decimal('115.0000'), Decimal('15.0000')))
+
+    def test_a_debit_note_puts_supply_back_on_its_own_date(self):
+        """Reversing part of a credit is a debit adjustment in its own period."""
+        facts = self.facts(corrections=(
+            CorrectionFact(21, APRIL, CREDIT_NOTE, (CreditPortion(1, Decimal('115.0000'), Decimal('15.0000')),)),
+            CorrectionFact(22, MAY, DEBIT_NOTE, (CreditPortion(1, Decimal('46.0000'), Decimal('6.0000')),)),
+        ))
+        recognition = order_recognition(facts, INVOICE)
+
+        self.assertEqual(totals(recognition), (Decimal('46.0000'), Decimal('6.0000')))
+        debit = [event for event in recognition.supply_events if event.source_type == 'supply_correction']
+        self.assertEqual([event.supply_date for event in debit], [MAY])
+
+    def test_a_credit_beyond_the_supply_is_reported_rather_than_absorbed(self):
+        """A credit larger than its supply is a defect somewhere else."""
+        facts = self.facts(
+            invoices=(InvoiceFact(11, MARCH, {1: Decimal('50.0000')}),),
+        )
+        recognition = order_recognition(facts, INVOICE)
+        self.assertEqual(recognition.over_credited, Decimal('65.0000'))
 
 
 class RestatedConstantTests(SimpleTestCase):
@@ -447,3 +603,11 @@ class RestatedConstantTests(SimpleTestCase):
         """A basis the model offers and this module rejects would raise at report time."""
         from .models import GstRegistration  # pylint: disable=import-outside-toplevel
         self.assertEqual(set(BASES), set(GstRegistration.Basis.values))
+
+    def test_the_correction_kinds_match_the_document_model(self):
+        """A third kind added to `billing` and not here would adjust nothing."""
+        from billing.models import SupplyCorrection  # pylint: disable=import-outside-toplevel
+        self.assertEqual(
+            {CREDIT_NOTE, DEBIT_NOTE},
+            set(SupplyCorrection.CorrectionType.values),
+        )


### PR DESCRIPTION
Task 117 shipped the invoice basis with a fulfillment standing in for the invoice date, because no invoice existed. Every entry relying on it was marked `proxy` with its `time_of_supply_source` so this change could find exactly the ones to supersede. Now it does: where a document has been issued, the supply falls due on the date somebody issued it.

The stand-in is not removed, and that matters. An order delivered and never invoiced has still been supplied, so dropping it would understate a return — it keeps recognising on the dispatch date and keeps saying it chose that date. The flag now means something sharper than it did: not "this feature is unbuilt" but "no document exists for this supply yet". The GST period report reports it as `invoice_not_issued` with the count behind it, and the finding clears when the invoice is issued.

Superseding needs no special case. `_recognise_document` caps every share by what its line still owes, so an invoice consumes the line and the later fulfillment finds nothing left. That is the same cap that already stopped a deposit and a delivery double-counting, applied to a third trigger.

Credits move the same way round. On the invoice and hybrid bases a credit note is what alters the agreed consideration, so a correction document is the credit event on its own date; a refund carrying a credit note is that same money and is not counted twice; a refund carrying none still credits as a marked stand-in. On the payments basis only cash moves, so correction documents are not events there at all.

This closes task 117's fourth recorded deviation. A return that moved no money produced no adjustment and could only be reported as outstanding work; a credit note against it is now a real credit, and `uncredited_return_ids` reaches zero when the paperwork is done instead of nagging forever.

The ledger stays derived. `SupplyDocument` is immutable like every record already behind these figures, so materialising them would add a second copy of rows that cannot drift.

## Summary by Sourcery

Use issued supply documents as the invoice-basis time of supply while preserving and reporting fulfillment-based proxies for supplies that remain uninvoiced.

New Features:
- Recognise invoice-basis supplies on the issued supply document date when available, while retaining fulfillment dates as explicit proxies for uninvoiced supplies.
- Recognise invoice and hybrid credit/debit corrections on their document dates and reconcile related refunds and returns without double-counting.

Bug Fixes:
- Correct GST period allocation when an invoice supersedes a fulfillment-based supply date.
- Resolve outstanding return-credit reporting once a corresponding credit document is issued.

Enhancements:
- Add invoice and correction facts to derived tax recognition and expose proxy supply amounts for data-quality reporting.
- Report uninvoiced supplies with an invoice_not_issued finding and update reconciliation guidance.
- Keep the tax ledger derived from immutable commerce and billing records.

Tests:
- Add coverage for invoice-date supersession, partial invoicing, correction timing, debit notes, refund de-duplication, payments-basis behavior, and GST period reporting.