### PR TITLE
feat(reporting): register and export every document issued

### DIFF
--- a/reporting/documents.py
+++ b/reporting/documents.py
@@ -1,0 +1,298 @@
+"""The register of every taxable supply document and correction issued.
+
+Task 118 change 6 asks for printable and exportable records with stable
+identifiers and audit history. The printable half lives in `billing.printing`,
+which shapes one document for a page; this is the other half — every document
+and every correction as one row, in the same envelope every other report uses,
+so it exports to CSV through the same renderer and is filtered the same way.
+
+Corrections are rows here rather than a column on the document they correct.
+A credit note is a document in its own right with its own number, its own date
+and its own place in a GST return, and folding it into a summary column on the
+invoice would make it unexportable as the record it is.
+"""
+
+# pylint: disable=duplicate-code
+
+from collections import defaultdict
+from datetime import date, datetime
+from decimal import Decimal
+
+from billing.documents import document_information, document_state
+from billing.models import SupplyCorrection, SupplyDocument
+from billing.thresholds import describe, missing_information
+from sales.models import Refund
+
+from .common import Report, decimal_string
+
+
+MONEY_PLACES = 4
+ZERO = Decimal('0.0000')
+
+SUPPLY_KIND = 'supply'
+
+COLUMNS = (
+    'document_number', 'document_kind', 'document_date', 'order', 'order_number',
+    'corrects', 'taxable_supply', 'tier',
+    'seller_legal_name', 'seller_trading_name', 'seller_gst_number',
+    'customer', 'buyer_name', 'buyer_identification',
+    'currency_code', 'subtotal_ex_tax', 'tax_total', 'total_incl_tax',
+    'credited_total', 'net_total_incl_tax',
+    'previously_invoiced', 'paid_to_date', 'balance_due', 'overpaid_at_issue',
+    'status', 'reason_code', 'reason', 'sales_return', 'refund',
+    'line_count', 'missing_information', 'issued_by', 'issued_at',
+)
+
+RECONCILIATION = {
+    'net_equation': 'net total = total including tax - credited total',
+    'correction_equation': (
+        'a correction row moves value on the document named in its corrects '
+        'column, and never rewrites it'
+    ),
+    'identifier_note': (
+        'Every row carries a document number that is unique within the '
+        'workspace and is never reissued, including for a document credited '
+        'away in full.'
+    ),
+    'audit_note': (
+        'issued_by and issued_at record who issued each document and when. '
+        'Both document kinds are immutable, so the row exported today is the '
+        'row that was handed over.'
+    ),
+    'balance_note': (
+        'previously invoiced, paid to date and balance due are what was true '
+        'on the document date, snapshotted at issue. They do not move when '
+        'later money arrives, which is why they can disagree with the order.'
+    ),
+}
+
+
+def supply_document_report(workspace, filters):
+    """Return one row per issued document and per correction against one."""
+    start, end = _date_bounds(filters)
+    documents = _documents(workspace, filters, start, end)
+    corrections = _corrections(workspace, filters, start, end)
+    rows = [_document_row(document) for document in documents]
+    rows.extend(_correction_row(correction) for correction in corrections)
+    rows.sort(key=lambda row: (row['document_date'], row['document_number']))
+    return Report(
+        name='supply-documents',
+        filters=dict(filters),
+        columns=COLUMNS,
+        rows=rows,
+        totals=_totals(rows),
+        reconciliation=dict(RECONCILIATION),
+        data_quality=_data_quality(workspace, documents, start, end),
+    )
+
+
+def _documents(workspace, filters, start, end):
+    """Return the documents in range, with everything a row needs prefetched."""
+    if filters.get('kind') not in (None, SUPPLY_KIND):
+        return []
+    queryset = SupplyDocument.objects.filter(
+        workspace=workspace, issued_on__gte=start, issued_on__lte=end,
+    ).select_related('order').prefetch_related('lines', 'corrections__lines')
+    return list(_narrowed(queryset, filters))
+
+
+def _corrections(workspace, filters, start, end):
+    """Return the corrections in range, keyed by their own date, not the supply's."""
+    kind = filters.get('kind')
+    if kind == SUPPLY_KIND:
+        return []
+    queryset = SupplyCorrection.objects.filter(
+        workspace=workspace, corrected_on__gte=start, corrected_on__lte=end,
+    ).select_related('document__order')
+    if kind:
+        queryset = queryset.filter(correction_type=kind)
+    if filters.get('order'):
+        queryset = queryset.filter(document__order_id=filters['order'])
+    if filters.get('customer'):
+        queryset = queryset.filter(customer_id=filters['customer'])
+    return list(queryset)
+
+
+def _narrowed(queryset, filters):
+    """Apply the filters a document and a correction share."""
+    if filters.get('order'):
+        queryset = queryset.filter(order_id=filters['order'])
+    if filters.get('customer'):
+        queryset = queryset.filter(customer_id=filters['customer'])
+    return queryset
+
+
+def _blank_row():
+    """Return a row with every column present, so the CSV never shifts."""
+    return {column: None for column in COLUMNS}
+
+
+def _document_row(document):
+    """Render one issued supply document."""
+    state = document_state(document)
+    missing = missing_information(document_information(document))
+    return {
+        **_blank_row(),
+        'document_number': document.document_number,
+        'document_kind': SUPPLY_KIND,
+        'document_date': document.issued_on.isoformat(),
+        'order': document.order_id,
+        'order_number': document.order.order_number,
+        'taxable_supply': document.taxable_supply,
+        'tier': document.tier,
+        'seller_legal_name': document.seller_legal_name,
+        'seller_trading_name': document.seller_trading_name,
+        'seller_gst_number': document.seller_gst_number,
+        'customer': document.customer_id,
+        'buyer_name': document.buyer_name,
+        'buyer_identification': document.buyer_identification,
+        'currency_code': document.currency_code,
+        'subtotal_ex_tax': decimal_string(document.subtotal_ex_tax, MONEY_PLACES),
+        'tax_total': decimal_string(document.tax_total, MONEY_PLACES),
+        'total_incl_tax': decimal_string(document.total_incl_tax, MONEY_PLACES),
+        'credited_total': decimal_string(state['credited_total'], MONEY_PLACES),
+        'net_total_incl_tax': decimal_string(state['net_total_incl_tax'], MONEY_PLACES),
+        'previously_invoiced': decimal_string(document.previously_invoiced, MONEY_PLACES),
+        'paid_to_date': decimal_string(document.paid_to_date, MONEY_PLACES),
+        'balance_due': decimal_string(document.balance_due, MONEY_PLACES),
+        'overpaid_at_issue': decimal_string(document.overpaid_at_issue, MONEY_PLACES),
+        'status': state['status'],
+        'line_count': document.lines.count(),
+        'missing_information': describe(missing) if missing else '',
+        'issued_by': document.created_by_id,
+        'issued_at': document.created.isoformat(),
+    }
+
+
+def _correction_row(correction):
+    """Render one credit or debit note as the document it is."""
+    return {
+        **_blank_row(),
+        'document_number': correction.document_number,
+        'document_kind': correction.correction_type,
+        'document_date': correction.corrected_on.isoformat(),
+        'order': correction.document.order_id,
+        'order_number': correction.document.order.order_number,
+        'corrects': correction.document.document_number,
+        'taxable_supply': correction.document.taxable_supply,
+        'seller_legal_name': correction.seller_legal_name,
+        'seller_trading_name': correction.seller_trading_name,
+        'seller_gst_number': correction.seller_gst_number,
+        'customer': correction.customer_id,
+        'buyer_name': correction.buyer_name,
+        'buyer_identification': correction.buyer_identification,
+        'currency_code': correction.currency_code,
+        'subtotal_ex_tax': decimal_string(correction.subtotal_ex_tax, MONEY_PLACES),
+        'tax_total': decimal_string(correction.tax_total, MONEY_PLACES),
+        'total_incl_tax': decimal_string(correction.total_incl_tax, MONEY_PLACES),
+        'status': 'issued',
+        'reason_code': correction.reason_code,
+        'reason': correction.reason,
+        'sales_return': correction.sales_return_id,
+        'refund': correction.refund_id,
+        'line_count': correction.lines.count(),
+        'missing_information': '',
+        'issued_by': correction.created_by_id,
+        'issued_at': correction.created.isoformat(),
+    }
+
+
+def _totals(rows):
+    """Total each currency separately, never across them.
+
+    There is no exchange rate in this application — task 121 owns that — so the
+    same rule the GST report follows applies here: two currencies are two
+    answers, and one consolidated figure would be an invented one.
+    """
+    summed = defaultdict(lambda: defaultdict(Decimal))
+    counts = defaultdict(lambda: defaultdict(int))
+    for row in rows:
+        currency = row['currency_code']
+        counts[currency][row['document_kind']] += 1
+        for field in ('subtotal_ex_tax', 'tax_total', 'total_incl_tax'):
+            summed[currency][field] += Decimal(row[field])
+    return {
+        'documents': len(rows),
+        'currencies': sorted(summed),
+        'by_currency': {
+            currency: {
+                **{
+                    field: decimal_string(summed[currency][field], MONEY_PLACES)
+                    for field in ('subtotal_ex_tax', 'tax_total', 'total_incl_tax')
+                },
+                'counts': dict(counts[currency]),
+            }
+            for currency in sorted(summed)
+        },
+    }
+
+
+def _data_quality(workspace, documents, start, end):
+    """Report the paperwork that is missing or defective, with what it is."""
+    findings = []
+    defective = [row for row in documents if missing_information(document_information(row))]
+    if defective:
+        findings.append({
+            'code': 'document_information_incomplete',
+            'count': len(defective),
+            'message': (
+                'Some documents no longer state everything their value band '
+                'requires. Issuing refuses an incomplete document, so this '
+                'means one was written by something other than the issuing '
+                'service.'
+            ),
+            'drill_down': '/reports/supply-documents/',
+        })
+    uncorrected = _refunds_without_a_correction(workspace, start, end)
+    if uncorrected:
+        findings.append({
+            'code': 'refund_without_a_correction',
+            'count': uncorrected,
+            'message': (
+                'Money was refunded without a credit note being issued for it. '
+                'The refund still adjusts a GST return, but the customer has '
+                'no supply correction information for the change.'
+            ),
+            'drill_down': '/reports/supply-documents/',
+        })
+    return findings
+
+
+def _refunds_without_a_correction(workspace, start, end):
+    """Count effective refunds in range that no correction document evidences."""
+    credited = set(
+        SupplyCorrection.objects.filter(workspace=workspace, refund__isnull=False)
+        .values_list('refund_id', flat=True)
+    )
+    refunds = Refund.objects.filter(
+        workspace=workspace,
+        refunded_at__date__gte=start,
+        refunded_at__date__lte=end,
+        reversal_of__isnull=True,
+        reversal__isnull=True,
+    ).values_list('pk', flat=True)
+    return sum(1 for refund in refunds if refund not in credited)
+
+
+def _date_bounds(filters):
+    """Return the inclusive range to report, defaulting to the current year."""
+    start = filters.get('date_from')
+    end = filters.get('date_to')
+    today = _today()
+    return (
+        _as_date(start) if start else date(today.year, 1, 1),
+        _as_date(end) if end else date(today.year, 12, 31),
+    )
+
+
+def _as_date(value):
+    """Accept a filter value as either an ISO string or an already-parsed date."""
+    if isinstance(value, date):
+        return value
+    return datetime.fromisoformat(value).date()
+
+
+def _today():
+    """Return today, isolated so a test can control the default range."""
+    from django.utils import timezone  # pylint: disable=import-outside-toplevel
+    return timezone.localdate()

--- a/reporting/filters.py
+++ b/reporting/filters.py
@@ -156,6 +156,31 @@ class GstPeriodFilters(BaseReportFilters):  # pylint: disable=abstract-method
         return attrs
 
 
+class SupplyDocumentFilters(BaseReportFilters):  # pylint: disable=abstract-method
+    """Filters for the register of issued documents and corrections.
+
+    The date range is matched against each row's own date — a document by when
+    it was issued, a correction by when it was made — because a credit note
+    belongs to the period it was issued in rather than to the period of the
+    supply it corrects.
+    """
+
+    date_from = serializers.DateField(required=False)
+    date_to = serializers.DateField(required=False)
+    order = serializers.IntegerField(required=False, min_value=1)
+    customer = serializers.IntegerField(required=False, min_value=1)
+    kind = serializers.ChoiceField(required=False, choices=('supply', 'credit', 'debit'))
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        if attrs.get('date_from') and attrs.get('date_to'):
+            if attrs['date_to'] < attrs['date_from']:
+                raise serializers.ValidationError({
+                    'date_to': 'The end must not be before the start.',
+                })
+        return attrs
+
+
 class GstEntryFilters(GstPeriodFilters):  # pylint: disable=abstract-method
     """Filters for the entries behind a period total, as the drill-down links use."""
 

--- a/reporting/rest.py
+++ b/reporting/rest.py
@@ -17,9 +17,11 @@ from .filters import (
     ProductionFilters,
     SerializedTrayFilters,
     StocktakeVarianceFilters,
+    SupplyDocumentFilters,
     TraceFilters,
 )
 from .commerce import dashboard_report, order_report, profitability_report
+from .documents import supply_document_report
 from .gst import gst_entry_report, gst_period_report
 from .production import production_batches
 from .traceability import lot_trace, plant_trace
@@ -97,6 +99,12 @@ ProductionView = _view(
 )
 ProductionExportView = _view(
     'ProductionExportView', ProductionFilters, production_batches, True,
+)
+SupplyDocumentView = _view(
+    'SupplyDocumentView', SupplyDocumentFilters, supply_document_report,
+)
+SupplyDocumentExportView = _view(
+    'SupplyDocumentExportView', SupplyDocumentFilters, supply_document_report, True,
 )
 
 

--- a/reporting/test_documents.py
+++ b/reporting/test_documents.py
@@ -1,0 +1,187 @@
+"""The register of issued documents, and the export of it.
+
+Change 6 asks for exportable records with stable identifiers and audit
+history. What that means in practice is checked here: a correction is a row of
+its own with its own number and date, the audit columns say who issued what,
+and the CSV carries every column whether or not a given row fills it in.
+"""
+
+# pylint: disable=duplicate-code
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from billing.documents import full_credit, issue_correction, issue_supply_document
+from billing.models import SupplyCorrection
+from billing.test_fixtures import DocumentScenarioMixin
+from sales.commerce import post_refund
+from tests.api import RESTContractTestCase
+
+
+REGISTER_URL = '/reports/supply-documents/'
+EXPORT_URL = '/reports/supply-documents/export/'
+
+
+class SupplyDocumentRegisterTests(DocumentScenarioMixin, RESTContractTestCase):
+    """One row per document and per correction, filtered and exported."""
+
+    def setUp(self):
+        """Register, invoice a dispatched two-plant order, and credit part of it."""
+        super().setUp()
+        self.register_for_gst()
+        plants = self.ready_plants(2, ready_at=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc))
+        self.order, self.line, self.allocations = self.confirmed_order(plants)
+        self.document = issue_supply_document(
+            self.order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': self.line, 'positions': [1, 2]}],
+            issued_on=date(2026, 5, 4),
+        )
+
+    def register(self, **params):
+        """Fetch the register over a range covering the whole scenario."""
+        query = {'date_from': '2026-01-01', 'date_to': '2026-12-31'}
+        query.update(params)
+        response = self.client.get(REGISTER_URL, query)
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data
+
+    def credit(self, amount, **overrides):
+        """Issue one credit note against the document."""
+        values = {
+            'operation_key': uuid4(),
+            'correction_type': SupplyCorrection.CorrectionType.CREDIT,
+            'reason_code': SupplyCorrection.Reason.DISCOUNT,
+            'reason': 'Agreed price adjustment',
+            'lines': [{'document_line': self.document.lines.get(), 'amount': Decimal(amount)}],
+            'corrected_on': date(2026, 6, 2),
+        }
+        values.update(overrides)
+        return issue_correction(self.document, self.user, **values)
+
+    def test_authentication_is_required(self):
+        """A customer register is not public information."""
+        self.assert_authentication_required([REGISTER_URL])
+
+    def test_a_document_carries_its_identity_parties_and_audit_columns(self):
+        """The stable identifier and the audit history change 6 asks for."""
+        row = self.register()['results'][0]
+
+        self.assertEqual(row['document_number'], 'INV-000001')
+        self.assertEqual(row['document_kind'], 'supply')
+        self.assertEqual(row['document_date'], '2026-05-04')
+        self.assertEqual(row['order_number'], self.order.order_number)
+        self.assertEqual(row['seller_gst_number'], '049091850')
+        self.assertEqual(row['total_incl_tax'], '23.0000')
+        self.assertEqual(row['status'], 'issued')
+        self.assertEqual(row['missing_information'], '')
+        self.assertEqual(row['issued_by'], self.user.pk)
+        self.assertIsNotNone(row['issued_at'])
+
+    def test_a_correction_is_a_row_of_its_own_naming_what_it_corrects(self):
+        """A credit note is a document, not a column on the invoice."""
+        self.credit('5.0000')
+        rows = {row['document_number']: row for row in self.register()['results']}
+
+        self.assertEqual(set(rows), {'INV-000001', 'CRN-000001'})
+        credit = rows['CRN-000001']
+        self.assertEqual(credit['document_kind'], 'credit')
+        self.assertEqual(credit['corrects'], 'INV-000001')
+        self.assertEqual(credit['document_date'], '2026-06-02')
+        self.assertEqual(credit['reason_code'], 'discount')
+        self.assertEqual(credit['total_incl_tax'], '5.0000')
+        self.assertEqual(rows['INV-000001']['net_total_incl_tax'], '18.0000')
+
+    def test_rows_are_dated_by_their_own_document_not_by_the_supply(self):
+        """A range covering only June sees the credit note and not the invoice."""
+        self.credit('5.0000')
+        numbers = [
+            row['document_number'] for row in
+            self.register(date_from='2026-06-01', date_to='2026-06-30')['results']
+        ]
+        self.assertEqual(numbers, ['CRN-000001'])
+
+    def test_the_register_can_be_narrowed_to_one_kind(self):
+        """An accountant asking for the credit notes gets only those."""
+        self.credit('5.0000')
+        numbers = [row['document_number'] for row in self.register(kind='credit')['results']]
+        self.assertEqual(numbers, ['CRN-000001'])
+
+    def test_a_credited_document_keeps_its_number_and_says_it_is_credited(self):
+        """Identifiers are never reissued, including for a document credited away."""
+        full_credit(
+            self.document, self.user,
+            operation_key=uuid4(),
+            reason_code=SupplyCorrection.Reason.CANCELLATION,
+            reason='Order cancelled',
+            corrected_on=date(2026, 6, 2),
+        )
+        replacement = issue_supply_document(
+            self.order, self.user,
+            operation_key=uuid4(),
+            lines=[{'order_line': self.line, 'positions': [1, 2]}],
+            issued_on=date(2026, 6, 3),
+        )
+        rows = {row['document_number']: row for row in self.register()['results']}
+
+        self.assertEqual(rows['INV-000001']['status'], 'credited')
+        self.assertEqual(rows['INV-000001']['net_total_incl_tax'], '0.0000')
+        self.assertEqual(replacement.document_number, 'INV-000002')
+        self.assertIn('INV-000002', rows)
+
+    def test_the_totals_stay_inside_one_currency(self):
+        """No exchange rate exists, so nothing is consolidated across currencies."""
+        self.credit('5.0000')
+        totals = self.register()['totals']
+
+        self.assertEqual(totals['documents'], 2)
+        self.assertEqual(totals['currencies'], ['NZD'])
+        self.assertEqual(totals['by_currency']['NZD']['counts'], {'supply': 1, 'credit': 1})
+        self.assertEqual(totals['by_currency']['NZD']['total_incl_tax'], '28.0000')
+
+    def test_a_refund_with_no_credit_note_is_reported_as_outstanding_paperwork(self):
+        """The GST adjustment happens either way; the customer's evidence does not."""
+        fulfillment = self.fulfill(self.order, self.allocations)
+        payment = self.pay(self.order, '23.0000', date(2026, 5, 5))
+        post_refund(
+            self.order, self.user,
+            operation_key=uuid4(),
+            payment=payment,
+            fulfillment_lines=list(fulfillment.lines.all()),
+            amount=Decimal('5.0000'),
+            reason='Damaged in transit',
+        )
+        codes = {finding['code'] for finding in self.register()['data_quality']}
+        self.assertIn('refund_without_a_correction', codes)
+
+    def test_issuing_the_credit_note_clears_the_finding(self):
+        """The report stops nagging once the paperwork exists."""
+        fulfillment = self.fulfill(self.order, self.allocations)
+        payment = self.pay(self.order, '23.0000', date(2026, 5, 5))
+        refund = post_refund(
+            self.order, self.user,
+            operation_key=uuid4(),
+            payment=payment,
+            fulfillment_lines=list(fulfillment.lines.all()),
+            amount=Decimal('5.0000'),
+            reason='Damaged in transit',
+        )
+        self.credit('5.0000', reason_code=SupplyCorrection.Reason.RETURN, refund=refund)
+        codes = {finding['code'] for finding in self.register()['data_quality']}
+        self.assertNotIn('refund_without_a_correction', codes)
+
+    def test_the_export_carries_every_column_for_every_row(self):
+        """A correction fills in fewer columns, and the CSV shape must not shift."""
+        self.credit('5.0000')
+        response = self.client.get(EXPORT_URL, {'date_from': '2026-01-01', 'date_to': '2026-12-31'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/csv; charset=utf-8')
+        lines = response.content.decode().splitlines()
+        header = lines[3].split(',')
+        self.assertIn('document_number', header)
+        self.assertIn('corrects', header)
+        self.assertEqual(len(lines), 6)
+        for row in lines[4:]:
+            self.assertEqual(len(row.split(',')), len(header))

--- a/reporting/urls.py
+++ b/reporting/urls.py
@@ -26,6 +26,8 @@ from .rest import (
     SerializedTrayView,
     StocktakeVarianceExportView,
     StocktakeVarianceView,
+    SupplyDocumentExportView,
+    SupplyDocumentView,
 )
 
 
@@ -45,6 +47,8 @@ urlpatterns = [
     path('orders/export/', OrderExportView.as_view()),
     path('profitability/', ProfitabilityView.as_view()),
     path('profitability/export/', ProfitabilityExportView.as_view()),
+    path('supply-documents/', SupplyDocumentView.as_view()),
+    path('supply-documents/export/', SupplyDocumentExportView.as_view()),
     path('gst-periods/', GstPeriodView.as_view()),
     path('gst-periods/export/', GstPeriodExportView.as_view()),
     path('gst-entries/', GstEntryView.as_view()),


### PR DESCRIPTION
Change 6 asks for exportable records with stable identifiers and audit history. `billing.printing` shapes one document for a page; this is the register — every document and every correction as a row, in the same envelope every other report uses, so it filters and exports to CSV the same way.

A correction is a row rather than a column on the invoice it corrects. A credit note has its own number, its own date and its own place in a GST return, and folding it into a summary column would make it unexportable as the record it actually is. Rows are therefore dated by their own document, so a June range shows June's credit note and not May's invoice.

Two data-quality findings. `document_information_incomplete` re-derives each document's requirement checklist rather than trusting the tier stored at issue, so a row written by something other than the issuing service cannot sit in the register looking valid. `refund_without_a_correction` counts money that went back with no credit note behind it: the GST adjustment happens either way, but the customer has no supply correction information for it.

## Summary by Sourcery

Add an exportable supply-document register covering issued documents and corrections with stable identifiers, audit history, filtering, and data-quality checks.

New Features:
- Add a supply-document register that reports every issued supply document and correction as an individually identifiable, auditable row.
- Provide filtered report and CSV export endpoints for supply documents and corrections.
- Expose document, correction, currency, reconciliation, and data-quality information through the reporting API.

Bug Fixes:
- Identify incomplete document information by rechecking each document's requirements at report time.
- Flag effective refunds that lack an associated correction document.

Enhancements:
- Date and filter documents and corrections according to each record's own issue date while preserving stable identifiers and document history.

Tests:
- Add coverage for register contents, correction handling, date and kind filtering, stable numbering, currency totals, data-quality findings, authentication, and CSV shape.