### PR TITLE
fix(tax): count only supply in the proxied-value figure

### DIFF
--- a/tax/recognition.py
+++ b/tax/recognition.py
@@ -238,9 +238,12 @@ class Recognition:
     #: worth reporting rather than absorbing.
     over_credited: Decimal = ZERO
     uncredited_return_ids: Tuple[int, ...] = field(default_factory=tuple)
-    #: Supplies brought to account on a fulfillment because no document was
-    #: issued for them. Reported so a period can say how much of it rests on a
-    #: date nobody chose.
+    #: Supply brought to account on a fulfillment because no document was
+    #: issued for it. Reported so a period can say how much of it rests on a
+    #: date nobody chose. Credits are excluded deliberately: a refund with no
+    #: credit note is also a stand-in, but netting it off here would produce
+    #: one figure meaning two things, and the register reports that gap
+    #: separately as `refund_without_a_correction`.
     proxy_gross: Decimal = ZERO
 
     @property
@@ -309,7 +312,8 @@ def order_recognition(facts, basis, *, as_at=None):
         over_credited=quantize_money(over_credited),
         uncredited_return_ids=tuple(facts.uncredited_return_ids),
         proxy_gross=quantize_money(sum(
-            (event.gross for event in events if event.proxy), ZERO,
+            (event.gross for event in events if event.proxy and event.kind == SUPPLY),
+            ZERO,
         )),
     )
 

--- a/tax/test_recognition.py
+++ b/tax/test_recognition.py
@@ -562,6 +562,21 @@ class CorrectionDocumentTests(SimpleTestCase):
         self.assertEqual(credit.source_type, 'refund')
         self.assertTrue(credit.proxy)
 
+    def test_a_proxied_credit_does_not_net_off_the_proxied_supply_figure(self):
+        """One figure meaning two things would be worse than not reporting it.
+
+        The supply here rests on a real invoice date, so nothing about it is a
+        stand-in; the refund beside it is one. Summing both would report
+        negative proxied supply, which describes nothing.
+        """
+        facts = self.facts(corrections=(), refunds=(RefundFact(
+            refund_id=3,
+            refunded_on=MAY,
+            portions=(CreditPortion(1, Decimal('115.0000'), Decimal('15.0000')),),
+        ),))
+        recognition = order_recognition(facts, INVOICE)
+        self.assertEqual(recognition.proxy_gross, Decimal('0.0000'))
+
     def test_the_payments_basis_ignores_a_credit_note(self):
         """A note moves no cash, so it is not an event on the payments basis."""
         facts = self.facts(payments=(PaymentFact(7, MARCH, Decimal('115.0000')),))


### PR DESCRIPTION
`proxy_gross` says how much of a period rests on a date this module chose rather than one somebody issued. Credits are now proxied too — a refund with no credit note behind it — and summing them in made one figure mean two things, reporting negative proxied supply for an order invoiced on a real date and refunded without paperwork.

The gap on the credit side is still reported, in the place it belongs: the document register's `refund_without_a_correction`, which counts money that went back with no supply correction information for the customer.

## Summary by Sourcery

Ensure the proxied-value figure represents only supply amounts while reporting unsupported refunds separately.

Bug Fixes:
- Restrict the proxied-value figure to proxied supply, preventing proxied refunds from producing misleading net values.

Enhancements:
- Keep refund-without-correction gaps reported separately through the document register.

Tests:
- Add coverage ensuring proxied credits do not reduce the proxied supply figure.