### PR TITLE
feat(seeds): record who sold a packet, not just whose name is on it

### DIFF
--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -424,6 +424,7 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
   const [receivedDate, setReceivedDate] = React.useState(draft?.received_date ?? new Date().toISOString().slice(0, 10))
   const [sowBy, setSowBy] = React.useState(draft?.sow_by ?? '')
   const [supplierLot, setSupplierLot] = React.useState(draft?.supplier_lot_reference ?? '')
+  const [vendorPk, setVendorPk] = React.useState<number | undefined>(draft?.supplier)
   const [supplierReference, setSupplierReference] = React.useState(draft?.supplier_reference ?? '')
   const [taxRate, setTaxRate] = React.useState(draft?.tax_rate ?? '')
   const [taxRecoverable, setTaxRecoverable] = React.useState(draft?.tax_recoverable ?? false)
@@ -433,6 +434,10 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
 
   function fieldError(field: string) {
     return errors[field] && <Form.Text className="text-danger">{errors[field]}</Form.Text>
+  }
+
+  function brandOf(pk: number | undefined) {
+    return seeds.find((seed) => seed.pk === pk)?.supplier
   }
 
   function showServerErrors(caught: unknown) {
@@ -454,6 +459,9 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
     event.preventDefault()
     const selectedSeed = seedPk ?? seeds[0]?.pk
     if (!selectedSeed) return
+    // An untouched vendor follows the brand rather than staying blank, so the
+    // receipt records what the form was showing when it was submitted.
+    const vendor = vendorPk ?? brandOf(selectedSeed)
     setErrors({})
     const data: SeedPacketReceiptCreate = {
       seeds: selectedSeed,
@@ -464,6 +472,7 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
     data.quantity = certainty === 'unknown' ? null : quantity
     data.sow_by = sowBy || null
     data.supplier_lot_reference = supplierLot
+    if (vendor) data.supplier = vendor
     data.supplier_reference = supplierReference
     if (taxRate) data.tax_rate = taxRate
     data.tax_recoverable = taxRecoverable
@@ -494,6 +503,19 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
                 </option>
               ))}
             </Form.Select>
+          </Form.Group>
+          <Form.Group className="col-md-3">
+            <Form.Label>Bought from</Form.Label>
+            <Form.Select value={vendorPk ?? brandOf(seedPk ?? seeds[0]?.pk) ?? ''} onChange={(event) => setVendorPk(event.target.value ? Number(event.target.value) : undefined)}>
+              <option value="">Select…</option>
+              {suppliers.map((supplier) => (
+                <option key={supplier.pk} value={supplier.pk}>
+                  {supplier.name}
+                </option>
+              ))}
+            </Form.Select>
+            <Form.Text className="text-muted">The shop or site that sold it. Defaults to the seed&apos;s brand.</Form.Text>
+            {fieldError('supplier')}
           </Form.Group>
           <Form.Group className="col-md-2">
             <Form.Label>Quantity certainty</Form.Label>

--- a/frontend/js/types/seeds.ts
+++ b/frontend/js/types/seeds.ts
@@ -60,6 +60,9 @@ interface SeedPacketReceiptCreate {
   supplier_lot_reference?: string
   received_date: string
   sow_by?: string | null
+  // Who sold the packet, as opposed to the brand on Seed.supplier. Omit and
+  // the server records the brand, which is right when it was bought direct.
+  supplier?: number
   supplier_reference?: string
   tax_rate?: string
   tax_recoverable?: boolean

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -18,6 +18,7 @@ from workspaces.scoping import (
 )
 
 from supplies.defaults import ensure_default_supplier
+from supplies.models import Supplier
 
 from .models import SeedPacket, SeedPacketReceiptDraft, Seeds
 from .services import (
@@ -208,6 +209,13 @@ class PacketReceiptDraftSerializer(
     )
     received_date = serializers.DateField()
     sow_by = serializers.DateField(allow_null=True, required=False)
+    #: Who sold the packet, which is not who put their name on it. Omitted, the
+    #: seed catalog's brand stands in, because buying direct is the common case
+    #: and should not need saying twice.
+    supplier = serializers.PrimaryKeyRelatedField(
+        queryset=Supplier.objects.all(),
+        required=False,
+    )
     supplier_reference = serializers.CharField(
         allow_blank=True,
         required=False,
@@ -222,7 +230,7 @@ class PacketReceiptDraftSerializer(
     notes = serializers.CharField(allow_blank=True, required=False)
     packet = serializers.PrimaryKeyRelatedField(read_only=True)
 
-    workspace_field_lookups = {'seeds': 'workspace'}
+    workspace_field_lookups = {'seeds': 'workspace', 'supplier': 'workspace'}
 
     def validate(self, attrs):
         existing_line = self.instance.receipt.lines.get() if self.instance else None
@@ -284,6 +292,7 @@ class PacketReceiptDraftSerializer(
             'supplier_lot_reference': line.supplier_lot_reference,
             'received_date': draft.receipt.received_date,
             'sow_by': line.expires_on,
+            'supplier': draft.receipt.supplier_id,
             'supplier_reference': draft.receipt.supplier_reference,
             'tax_rate': f'{draft.receipt.tax_rate:.4f}',
             'tax_recoverable': draft.receipt.tax_recoverable,

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -113,9 +113,14 @@ def create_packet_receipt_draft(workspace, user, values):
     if not seeds.inventory_item_id:
         raise ValidationError({'seeds': 'The seed catalog has no inventory item.'})
     location = _packet_location(workspace)
+    # `Seeds.supplier` is the brand whose catalog the packet came out of, which
+    # is only the vendor when it was bought direct. A packet off a retail shelf
+    # was sold by the shop, and the receipt has to say so — it is the purchase
+    # record a GST return and a supplier payment are read from. Defaulting to
+    # the brand keeps buying direct a single choice rather than two.
     receipt = StockReceipt.objects.create(
         workspace=workspace,
-        supplier=seeds.supplier,
+        supplier=values.get('supplier') or seeds.supplier,
         received_date=values['received_date'],
         supplier_reference=values.get('supplier_reference', ''),
         currency_code=workspace.currency_code,
@@ -162,6 +167,7 @@ def update_packet_receipt_draft(draft, values):
     receipt = draft.receipt
     for field in (
         'received_date',
+        'supplier',
         'supplier_reference',
         'tax_rate',
         'tax_recoverable',

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
 from inventory.models import QuantityCertainty, StockMovement, StockReceipt
-from seeds.models import SeedPacketQuantityReconciliation
+from seeds.models import SeedPacketQuantityReconciliation, Seeds
 from seeds.services import packet_inventory_snapshot, reverse_packet_reconciliation
 from supplies.models import Supplier
 from plantings.models import (
@@ -28,6 +28,7 @@ from tests.factories import (
     make_seed_tray_cell,
     make_supplier,
 )
+from workspaces.models import Workspace, get_current_workspace
 
 
 class SeedRESTContractTests(RESTContractTestCase):
@@ -469,3 +470,91 @@ class SeedPacketInventoryWorkflowTests(APITestCase):
             self.client.post(f'{detail}post/', {}, format='json').status_code,
             400,
         )
+
+
+class SeedVendorSeparationTests(APITestCase):
+    """The brand on a seed catalog is not the shop the packet was bought from."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.user = get_user_model().objects.create_user(username='vendor-split')
+        self.client.force_authenticate(self.user)
+        self.brand = make_supplier(workspace=self.workspace, name='Kings Seeds')
+        self.shop = make_supplier(workspace=self.workspace, name='Mitre 10')
+        variety = make_plant_variety()
+        created = self.client.post(
+            '/seeds/seeds/',
+            {
+                'supplier': self.brand.pk,
+                'plant_variety': variety.pk,
+                'supplier_code': 'BEET-1',
+                'base_unit': 'seed',
+            },
+            format='json',
+        )
+        self.assertEqual(created.status_code, 201, created.data)
+        self.seeds_pk = created.data['pk']
+
+    def create_draft(self, **overrides):
+        """Create one packet receipt draft through the seed workflow."""
+        payload = {
+            'seeds': self.seeds_pk,
+            'quantity_certainty': QuantityCertainty.EXACT,
+            'quantity': '50',
+            'line_price': '6.0000',
+            'received_date': '2026-03-10',
+        }
+        payload.update(overrides)
+        response = self.client.post('/seeds/packet-receipts/', payload, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def receipt_for(self, draft_pk):
+        """Return the stock receipt behind one draft."""
+        return StockReceipt.objects.get(seed_packet_draft__pk=draft_pk)
+
+    def test_a_packet_bought_retail_records_the_shop_not_the_brand(self):
+        """This is the whole point: Kings Seeds off a Mitre 10 shelf was sold by Mitre 10."""
+        draft = self.create_draft(supplier=self.shop.pk)
+        self.assertEqual(draft['supplier'], self.shop.pk)
+        self.assertEqual(self.receipt_for(draft['pk']).supplier_id, self.shop.pk)
+        seeds = Seeds.objects.get(pk=self.seeds_pk)
+        self.assertEqual(seeds.supplier_id, self.brand.pk)
+
+    def test_an_omitted_vendor_falls_back_to_the_brand(self):
+        """Buying direct is the common case and should not need saying twice."""
+        draft = self.create_draft()
+        self.assertEqual(draft['supplier'], self.brand.pk)
+        self.assertEqual(self.receipt_for(draft['pk']).supplier_id, self.brand.pk)
+
+    def test_the_vendor_can_be_corrected_on_a_draft(self):
+        """Realising at the till that it came from the shop must not mean starting again."""
+        draft = self.create_draft()
+        updated = self.client.patch(
+            f"/seeds/packet-receipts/{draft['pk']}/",
+            {'supplier': self.shop.pk},
+            format='json',
+        )
+        self.assertEqual(updated.status_code, 200, updated.data)
+        self.assertEqual(updated.data['supplier'], self.shop.pk)
+        self.assertEqual(self.receipt_for(draft['pk']).supplier_id, self.shop.pk)
+
+    def test_a_vendor_from_another_workspace_is_refused(self):
+        """A supplier picker is not a way to reach across the isolation boundary."""
+        other = Workspace.objects.create(name='Other vendor workspace')
+        outsider = make_supplier(workspace=other, name='Elsewhere')
+        response = self.client.post(
+            '/seeds/packet-receipts/',
+            {
+                'seeds': self.seeds_pk,
+                'quantity_certainty': QuantityCertainty.EXACT,
+                'quantity': '50',
+                'line_price': '6.0000',
+                'received_date': '2026-03-10',
+                'supplier': outsider.pk,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn('supplier', response.data)


### PR DESCRIPTION
`Seeds.supplier` is the brand whose catalog a packet came out of, which is only the vendor when it was bought direct. A Kings Seeds packet off a Mitre 10 shelf was sold by Mitre 10, and the receipt has to say so — it is the purchase record a GST return and a supplier payment are read from, and it was previously copied from the brand with no way to correct it.

The packet receipt draft now takes its own supplier, on create and on update. Omitted, it still falls back to the brand, because buying direct is the common case and should not need saying twice; the form pre-selects the brand so the receipt records what was on screen when it was submitted.

Nothing is renamed and no data moves. Existing receipts keep the supplier they were recorded with, which is correct where the packet was bought direct and unknowable where it was not, so it stays as recorded rather than being guessed at. `reporting.traceability` already carried both a `seed_supplier_id` off the catalog and a `supplier_id` off the receipt; until now they could not differ.

## Summary by Sourcery

Record the actual seller on seed packet receipts while retaining the seed brand as the default supplier.

New Features:
- Allow seed packet receipts to record the business that sold the packet independently from the seed brand, with a form field for selection.

Bug Fixes:
- Preserve accurate supplier information for retail seed purchases instead of always attributing receipts to the catalog brand.

Enhancements:
- Default omitted receipt suppliers to the seed brand while retaining existing receipt supplier values and supporting corrections during draft updates.

Tests:
- Add coverage for retail vendor recording, brand fallback, vendor correction, and cross-workspace supplier validation.