### PR TITLE
feat(inventory): record explicit input tax evidence

### DIFF
--- a/inventory/migrations/0013_evidenced_input_tax.py
+++ b/inventory/migrations/0013_evidenced_input_tax.py
@@ -1,0 +1,205 @@
+from decimal import Decimal, ROUND_HALF_UP
+
+import django.core.validators
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import workspaces.models
+
+
+MONEY = Decimal('0.0001')
+
+
+def preserve_receipt_tax(apps, schema_editor):
+    StockReceiptLine = apps.get_model('inventory', 'StockReceiptLine')
+    for line in StockReceiptLine.objects.select_related('receipt__supplier').iterator():
+        receipt = line.receipt
+        ex_tax = Decimal(line.line_cost_ex_tax).quantize(MONEY)
+        tax = (
+            ex_tax * Decimal(receipt.tax_rate) / Decimal('100')
+        ).quantize(MONEY, rounding=ROUND_HALF_UP)
+        recoverable = tax if receipt.tax_recoverable else Decimal('0.0000')
+        line.supplier_cost_incl_tax = ex_tax + tax
+        line.tax_treatment = 'standard' if tax > 0 else 'unknown'
+        line.tax_rate = receipt.tax_rate if tax > 0 else Decimal('0')
+        line.input_tax_source = 'supplier' if tax > 0 else 'none'
+        line.input_tax_amount = tax
+        line.claim_input_tax = recoverable > 0
+        line.claimable_percentage = Decimal('100') if recoverable > 0 else Decimal('0')
+        line.recoverable_input_tax = recoverable
+        line.non_recoverable_tax = tax - recoverable
+        line.acquisition_amount = ex_tax + tax - recoverable
+        line.legacy_tax_classification = True
+        line.save(update_fields=[
+            'supplier_cost_incl_tax', 'tax_treatment', 'tax_rate',
+            'input_tax_source', 'input_tax_amount', 'claim_input_tax',
+            'claimable_percentage', 'recoverable_input_tax',
+            'non_recoverable_tax', 'acquisition_amount',
+            'legacy_tax_classification',
+        ])
+        type(receipt).objects.filter(pk=receipt.pk).update(
+            source_document_number=receipt.supplier_reference,
+            supplier_name_snapshot=receipt.supplier.name,
+            supplier_address_snapshot=receipt.supplier.address,
+            supplier_gst_status=receipt.supplier.gst_status,
+            supplier_gst_number=receipt.supplier.gst_number,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('supplies', '0004_supplier_tax_identity'),
+        ('inventory', '0012_stockreceipt_settled_on'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='evidence_reference',
+            field=models.CharField(blank=True, default='', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='evidence_url',
+            field=models.URLField(blank=True, default='', max_length=2048),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='invoice_date',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='source_document_number',
+            field=models.CharField(blank=True, default='', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='source_document_type',
+            field=models.CharField(
+                choices=[
+                    ('none', 'No source document recorded'),
+                    ('taxable_supply', 'Taxable supply information'),
+                    ('invoice', 'Invoice'),
+                    ('receipt', 'Receipt'),
+                    ('buyer_created', 'Buyer-created taxable supply information'),
+                    ('customs_entry', 'Customs entry or statement'),
+                    ('contract', 'Contract or supplier agreement'),
+                    ('bank_record', 'Bank or payment record'),
+                    ('other', 'Other record'),
+                ],
+                default='none',
+                max_length=24,
+            ),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='supplier_address_snapshot',
+            field=models.TextField(blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='supplier_gst_number',
+            field=models.CharField(blank=True, default='', max_length=16),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='supplier_gst_status',
+            field=models.CharField(
+                choices=[
+                    ('registered', 'GST registered'),
+                    ('unregistered', 'Not GST registered'),
+                    ('unknown', 'Unknown'),
+                ],
+                default='unknown',
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name='stockreceipt',
+            name='supplier_name_snapshot',
+            field=models.CharField(blank=True, default='', max_length=1024),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='acquisition_amount',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), editable=False, max_digits=18, validators=[django.core.validators.MinValueValidator(Decimal('0'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='apportionment_basis',
+            field=models.TextField(blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='claim_input_tax',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='claimable_percentage',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), max_digits=7, validators=[django.core.validators.MinValueValidator(Decimal('0')), django.core.validators.MaxValueValidator(Decimal('100'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='input_tax_amount',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), max_digits=18, validators=[django.core.validators.MinValueValidator(Decimal('0'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='input_tax_source',
+            field=models.CharField(choices=[('none', 'No input tax'), ('supplier', 'GST charged by supplier'), ('customs', 'GST levied by Customs'), ('second_hand', 'Second-hand-goods deduction')], default='none', max_length=16),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='legacy_tax_classification',
+            field=models.BooleanField(default=False, editable=False),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='non_recoverable_tax',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), editable=False, max_digits=18, validators=[django.core.validators.MinValueValidator(Decimal('0'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='recoverable_input_tax',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), editable=False, max_digits=18, validators=[django.core.validators.MinValueValidator(Decimal('0'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='supplier_cost_incl_tax',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), max_digits=18, validators=[django.core.validators.MinValueValidator(Decimal('0'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='tax_rate',
+            field=models.DecimalField(decimal_places=4, default=Decimal('0'), max_digits=7, validators=[django.core.validators.MinValueValidator(Decimal('0')), django.core.validators.MaxValueValidator(Decimal('100'))]),
+        ),
+        migrations.AddField(
+            model_name='stockreceiptline',
+            name='tax_treatment',
+            field=models.CharField(choices=[('standard', 'Standard-rated'), ('zero_rated', 'Zero-rated'), ('exempt', 'Exempt'), ('out_of_scope', 'Outside the scope of GST'), ('unknown', 'Unknown')], default='unknown', max_length=16),
+        ),
+        migrations.CreateModel(
+            name='InputTaxAdjustment',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('adjustment_date', models.DateField()),
+                ('previous_claimable_percentage', models.DecimalField(decimal_places=4, max_digits=7, validators=[django.core.validators.MinValueValidator(Decimal('0')), django.core.validators.MaxValueValidator(Decimal('100'))])),
+                ('revised_claimable_percentage', models.DecimalField(decimal_places=4, max_digits=7, validators=[django.core.validators.MinValueValidator(Decimal('0')), django.core.validators.MaxValueValidator(Decimal('100'))])),
+                ('tax_adjustment', models.DecimalField(decimal_places=4, help_text='Positive increases the deduction; negative reduces it.', max_digits=18)),
+                ('apportionment_basis', models.TextField()),
+                ('reason', models.TextField()),
+                ('evidence_reference', models.CharField(blank=True, default='', max_length=255)),
+                ('evidence_url', models.URLField(blank=True, default='', max_length=2048)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('created_by', models.ForeignKey(editable=False, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('receipt_line', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='input_tax_adjustments', to='inventory.stockreceiptline')),
+                ('workspace', models.ForeignKey(default=workspaces.models.get_default_workspace_id, editable=False, on_delete=django.db.models.deletion.PROTECT, related_name='+', to='workspaces.workspace')),
+            ],
+            options={'ordering': ['adjustment_date', 'pk']},
+        ),
+        migrations.RunPython(preserve_receipt_tax, migrations.RunPython.noop),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -423,6 +423,19 @@ class StockReceipt(WorkspaceOwnedModel):
         POSTED = 'posted', 'Posted'
         REVERSED = 'reversed', 'Reversed'
 
+    class SourceDocumentType(models.TextChoices):
+        """The principal record supporting the supplier purchase."""
+
+        NONE = 'none', 'No source document recorded'
+        TAXABLE_SUPPLY = 'taxable_supply', 'Taxable supply information'
+        INVOICE = 'invoice', 'Invoice'
+        RECEIPT = 'receipt', 'Receipt'
+        BUYER_CREATED = 'buyer_created', 'Buyer-created taxable supply information'
+        CUSTOMS_ENTRY = 'customs_entry', 'Customs entry or statement'
+        CONTRACT = 'contract', 'Contract or supplier agreement'
+        BANK_RECORD = 'bank_record', 'Bank or payment record'
+        OTHER = 'other', 'Other record'
+
     supplier = models.ForeignKey(
         'supplies.Supplier',
         on_delete=models.PROTECT,
@@ -436,6 +449,27 @@ class StockReceipt(WorkspaceOwnedModel):
     )
     received_date = models.DateField()
     supplier_reference = models.CharField(max_length=255, blank=True, default='')
+    invoice_date = models.DateField(null=True, blank=True)
+    source_document_type = models.CharField(
+        max_length=24,
+        choices=SourceDocumentType.choices,
+        default=SourceDocumentType.NONE,
+    )
+    source_document_number = models.CharField(max_length=255, blank=True, default='')
+    evidence_reference = models.CharField(max_length=255, blank=True, default='')
+    evidence_url = models.URLField(max_length=2048, blank=True, default='')
+    supplier_name_snapshot = models.CharField(max_length=1024, blank=True, default='')
+    supplier_address_snapshot = models.TextField(blank=True, default='')
+    supplier_gst_status = models.CharField(
+        max_length=16,
+        choices=(
+            ('registered', 'GST registered'),
+            ('unregistered', 'Not GST registered'),
+            ('unknown', 'Unknown'),
+        ),
+        default='unknown',
+    )
+    supplier_gst_number = models.CharField(max_length=16, blank=True, default='')
     currency_code = models.CharField(
         max_length=3,
         validators=[
@@ -510,6 +544,23 @@ class StockReceipt(WorkspaceOwnedModel):
 class StockReceiptLine(models.Model):
     """A draft purchase line normalized into its item's base unit."""
 
+    class TaxTreatment(models.TextChoices):
+        """How the purchased supply is treated for GST."""
+
+        STANDARD = 'standard', 'Standard-rated'
+        ZERO_RATED = 'zero_rated', 'Zero-rated'
+        EXEMPT = 'exempt', 'Exempt'
+        OUT_OF_SCOPE = 'out_of_scope', 'Outside the scope of GST'
+        UNKNOWN = 'unknown', 'Unknown'
+
+    class InputTaxSource(models.TextChoices):
+        """Where an input-tax amount comes from."""
+
+        NONE = 'none', 'No input tax'
+        SUPPLIER = 'supplier', 'GST charged by supplier'
+        CUSTOMS = 'customs', 'GST levied by Customs'
+        SECOND_HAND = 'second_hand', 'Second-hand-goods deduction'
+
     receipt = models.ForeignKey(
         StockReceipt,
         on_delete=models.CASCADE,
@@ -563,6 +614,70 @@ class StockReceiptLine(models.Model):
         decimal_places=MONEY_DECIMAL_PLACES,
         validators=[MinValueValidator(Decimal('0'))],
     )
+    supplier_cost_incl_tax = models.DecimalField(
+        max_digits=MONEY_MAX_DIGITS,
+        decimal_places=MONEY_DECIMAL_PLACES,
+        default=Decimal('0'),
+        validators=[MinValueValidator(Decimal('0'))],
+    )
+    tax_treatment = models.CharField(
+        max_length=16,
+        choices=TaxTreatment.choices,
+        default=TaxTreatment.UNKNOWN,
+    )
+    tax_rate = models.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        default=Decimal('0'),
+        validators=(
+            MinValueValidator(Decimal('0')),
+            MaxValueValidator(Decimal('100')),
+        ),
+    )
+    input_tax_source = models.CharField(
+        max_length=16,
+        choices=InputTaxSource.choices,
+        default=InputTaxSource.NONE,
+    )
+    input_tax_amount = models.DecimalField(
+        max_digits=MONEY_MAX_DIGITS,
+        decimal_places=MONEY_DECIMAL_PLACES,
+        default=Decimal('0'),
+        validators=[MinValueValidator(Decimal('0'))],
+    )
+    claim_input_tax = models.BooleanField(default=False)
+    claimable_percentage = models.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        default=Decimal('0'),
+        validators=(
+            MinValueValidator(Decimal('0')),
+            MaxValueValidator(Decimal('100')),
+        ),
+    )
+    apportionment_basis = models.TextField(blank=True, default='')
+    recoverable_input_tax = models.DecimalField(
+        max_digits=MONEY_MAX_DIGITS,
+        decimal_places=MONEY_DECIMAL_PLACES,
+        default=Decimal('0'),
+        editable=False,
+        validators=[MinValueValidator(Decimal('0'))],
+    )
+    non_recoverable_tax = models.DecimalField(
+        max_digits=MONEY_MAX_DIGITS,
+        decimal_places=MONEY_DECIMAL_PLACES,
+        default=Decimal('0'),
+        editable=False,
+        validators=[MinValueValidator(Decimal('0'))],
+    )
+    acquisition_amount = models.DecimalField(
+        max_digits=MONEY_MAX_DIGITS,
+        decimal_places=MONEY_DECIMAL_PLACES,
+        default=Decimal('0'),
+        editable=False,
+        validators=[MinValueValidator(Decimal('0'))],
+    )
+    legacy_tax_classification = models.BooleanField(default=False, editable=False)
     destination = models.ForeignKey(
         Location,
         on_delete=models.PROTECT,
@@ -610,8 +725,47 @@ class StockReceiptLine(models.Model):
             errors['quantity'] = 'Exact and estimated quantities require a number.'
         if not errors and self.quantity is not None and self.base_quantity != self.normalized_quantity():
             errors['base_quantity'] = 'The normalized quantity is incorrect.'
+        errors.update(self._tax_errors())
         if errors:
             raise ValidationError(errors)
+
+    def _tax_errors(self):
+        """Return structural tax errors without deciding legal eligibility."""
+        errors = {}
+        rate = Decimal(self.tax_rate or 0)
+        tax = Decimal(self.input_tax_amount or 0)
+        percentage = Decimal(self.claimable_percentage or 0)
+        if self.tax_treatment == self.TaxTreatment.STANDARD and rate <= 0:
+            errors['tax_rate'] = 'A standard-rated line needs a positive tax rate.'
+        if self.tax_treatment != self.TaxTreatment.STANDARD and rate > 0:
+            errors['tax_rate'] = 'Only a standard-rated line carries a tax rate.'
+        if self.input_tax_source == self.InputTaxSource.NONE and tax != 0:
+            errors['input_tax_amount'] = 'Select where this input tax came from.'
+        if self.input_tax_source != self.InputTaxSource.NONE and tax <= 0:
+            errors['input_tax_amount'] = 'This input-tax source needs a positive amount.'
+        if self.claim_input_tax and percentage <= 0:
+            errors['claimable_percentage'] = 'A claim needs a positive percentage.'
+        if not self.claim_input_tax and percentage != 0:
+            errors['claimable_percentage'] = 'An unclaimed line must use zero percent.'
+        if 0 < percentage < 100 and not self.apportionment_basis.strip():
+            errors['apportionment_basis'] = 'Explain how a partial claim was apportioned.'
+        return errors
+
+    def _set_tax_amounts(self):
+        """Freeze the claim split and acquisition amount from explicit inputs."""
+        quantum = Decimal('0.0001')
+        tax = Decimal(self.input_tax_amount or 0).quantize(quantum)
+        percentage = Decimal(self.claimable_percentage or 0)
+        recoverable = Decimal('0')
+        if self.claim_input_tax:
+            recoverable = (tax * percentage / Decimal('100')).quantize(quantum)
+        self.recoverable_input_tax = recoverable
+        self.non_recoverable_tax = tax - recoverable
+        gross = Decimal(self.supplier_cost_incl_tax or 0).quantize(quantum)
+        if self.input_tax_source == self.InputTaxSource.CUSTOMS:
+            self.acquisition_amount = gross + self.non_recoverable_tax
+        else:
+            self.acquisition_amount = gross - recoverable
 
     def normalized_quantity(self):
         """Calculate the display quantity in the item's canonical unit."""
@@ -626,6 +780,7 @@ class StockReceiptLine(models.Model):
     def save(self, *args, **kwargs):
         if self.receipt_id and self.receipt.status != StockReceipt.Status.DRAFT:
             raise ValidationError('Posted receipt lines are immutable.')
+        self._set_tax_amounts()
         self.full_clean()
         super().save(*args, **kwargs)
 
@@ -633,6 +788,83 @@ class StockReceiptLine(models.Model):
         if self.receipt.status != StockReceipt.Status.DRAFT:
             raise ValidationError('Posted receipt lines are immutable.')
         return super().delete(*args, **kwargs)
+
+
+class InputTaxAdjustment(WorkspaceOwnedModel):
+    """An immutable later change to the input tax claimed for a receipt line."""
+
+    receipt_line = models.ForeignKey(
+        StockReceiptLine,
+        on_delete=models.PROTECT,
+        related_name='input_tax_adjustments',
+    )
+    adjustment_date = models.DateField()
+    previous_claimable_percentage = models.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        validators=(MinValueValidator(Decimal('0')), MaxValueValidator(Decimal('100'))),
+    )
+    revised_claimable_percentage = models.DecimalField(
+        max_digits=7,
+        decimal_places=4,
+        validators=(MinValueValidator(Decimal('0')), MaxValueValidator(Decimal('100'))),
+    )
+    tax_adjustment = models.DecimalField(
+        max_digits=MONEY_MAX_DIGITS,
+        decimal_places=MONEY_DECIMAL_PLACES,
+        help_text='Positive increases the deduction; negative reduces it.',
+    )
+    apportionment_basis = models.TextField()
+    reason = models.TextField()
+    evidence_reference = models.CharField(max_length=255, blank=True, default='')
+    evidence_url = models.URLField(max_length=2048, blank=True, default='')
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        editable=False,
+        related_name='+',
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['adjustment_date', 'pk']
+
+    def clean(self):
+        """Require a posted same-workspace line and exact percentage delta."""
+        super().clean()
+        errors = {}
+        if self.receipt_line_id:
+            receipt = StockReceipt.objects.only('workspace_id', 'status').get(
+                pk=self.receipt_line.receipt_id,
+            )
+            if receipt.workspace_id != self.workspace_id:
+                errors['receipt_line'] = 'The receipt line belongs to another workspace.'
+            if receipt.status != StockReceipt.Status.POSTED:
+                errors['receipt_line'] = 'Adjust input tax only on a posted receipt.'
+            revised = Decimal(self.revised_claimable_percentage)
+            previous = Decimal(self.previous_claimable_percentage)
+            percentage_delta = revised - previous
+            tax_delta = Decimal(self.receipt_line.input_tax_amount) * percentage_delta
+            expected = (tax_delta / Decimal('100')).quantize(Decimal('0.0001'))
+            if Decimal(self.tax_adjustment) != expected:
+                errors['tax_adjustment'] = f'The percentage change produces {expected:.4f}.'
+        if not self.reason.strip():
+            errors['reason'] = 'Explain why the taxable use changed.'
+        if not self.apportionment_basis.strip():
+            errors['apportionment_basis'] = 'Record the revised apportionment basis.'
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        """Create once; later corrections append another adjustment."""
+        if self.pk:
+            raise ValidationError('Input-tax adjustments are immutable.')
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        raise ValidationError('Input-tax adjustments are immutable.')
 
 
 class StockLot(WorkspaceOwnedModel):

--- a/inventory/test_ledger_models.py
+++ b/inventory/test_ledger_models.py
@@ -14,6 +14,7 @@ from supplies.models import Supplier
 from workspaces.models import Workspace, get_current_workspace
 
 from .models import (
+    InputTaxAdjustment,
     InventoryItem,
     InventoryUnit,
     QuantityCertainty,
@@ -140,6 +141,108 @@ class LedgerModelTests(TestCase):
         with self.assertRaises(ValidationError) as context:
             line.save()
         self.assertIn('destination', context.exception.message_dict)
+
+    def test_receipt_line_freezes_apportioned_tax_and_acquisition_amounts(self):
+        """Explicit claim inputs produce all four auditable cost amounts."""
+        receipt = StockReceipt.objects.create(
+            workspace=self.workspace,
+            supplier=self.supplier,
+            received_date=date(2026, 8, 1),
+            currency_code='NZD',
+            created_by=self.user,
+        )
+        line = StockReceiptLine.objects.create(
+            receipt=receipt,
+            item=self.item,
+            quantity=Decimal('2'),
+            unit_code=UnitCode.LITRE,
+            base_quantity=Decimal('2000'),
+            line_cost_ex_tax=Decimal('100'),
+            supplier_cost_incl_tax=Decimal('115'),
+            tax_treatment=StockReceiptLine.TaxTreatment.STANDARD,
+            tax_rate=Decimal('15'),
+            input_tax_source=StockReceiptLine.InputTaxSource.SUPPLIER,
+            input_tax_amount=Decimal('15'),
+            claim_input_tax=True,
+            claimable_percentage=Decimal('60'),
+            apportionment_basis='Estimated taxable nursery use',
+            destination=self.location,
+        )
+
+        self.assertEqual(line.recoverable_input_tax, Decimal('9.0000'))
+        self.assertEqual(line.non_recoverable_tax, Decimal('6.0000'))
+        self.assertEqual(line.acquisition_amount, Decimal('106.0000'))
+
+    def test_customs_tax_not_recovered_is_added_to_supplier_cost(self):
+        """Border GST is outside the overseas supplier consideration."""
+        receipt = StockReceipt.objects.create(
+            workspace=self.workspace,
+            supplier=self.supplier,
+            received_date=date(2026, 8, 1),
+            currency_code='NZD',
+            created_by=self.user,
+        )
+        line = StockReceiptLine.objects.create(
+            receipt=receipt,
+            item=self.item,
+            quantity=Decimal('1'),
+            unit_code=UnitCode.LITRE,
+            base_quantity=Decimal('1000'),
+            line_cost_ex_tax=Decimal('100'),
+            supplier_cost_incl_tax=Decimal('100'),
+            tax_treatment=StockReceiptLine.TaxTreatment.OUT_OF_SCOPE,
+            input_tax_source=StockReceiptLine.InputTaxSource.CUSTOMS,
+            input_tax_amount=Decimal('18'),
+            destination=self.location,
+        )
+
+        self.assertEqual(line.recoverable_input_tax, Decimal('0.0000'))
+        self.assertEqual(line.non_recoverable_tax, Decimal('18.0000'))
+        self.assertEqual(line.acquisition_amount, Decimal('118.0000'))
+
+    def test_change_of_use_adjustment_is_exact_and_immutable(self):
+        """Later use changes append a tax fact without rewriting line cost."""
+        receipt = StockReceipt.objects.create(
+            workspace=self.workspace,
+            supplier=self.supplier,
+            received_date=date(2026, 8, 1),
+            currency_code='NZD',
+            created_by=self.user,
+        )
+        line = StockReceiptLine.objects.create(
+            receipt=receipt,
+            item=self.item,
+            quantity=Decimal('1'),
+            unit_code=UnitCode.LITRE,
+            base_quantity=Decimal('1000'),
+            line_cost_ex_tax=Decimal('100'),
+            supplier_cost_incl_tax=Decimal('115'),
+            tax_treatment=StockReceiptLine.TaxTreatment.STANDARD,
+            tax_rate=Decimal('15'),
+            input_tax_source=StockReceiptLine.InputTaxSource.SUPPLIER,
+            input_tax_amount=Decimal('15'),
+            claim_input_tax=True,
+            claimable_percentage=Decimal('100'),
+            destination=self.location,
+        )
+        StockReceipt.objects.filter(pk=receipt.pk).update(
+            status=StockReceipt.Status.POSTED,
+        )
+        adjustment = InputTaxAdjustment.objects.create(
+            workspace=self.workspace,
+            receipt_line=line,
+            adjustment_date=date(2026, 8, 20),
+            previous_claimable_percentage=Decimal('100'),
+            revised_claimable_percentage=Decimal('60'),
+            tax_adjustment=Decimal('-6'),
+            apportionment_basis='Observed business use',
+            reason='Use changed',
+            created_by=self.user,
+        )
+
+        self.assertEqual(line.acquisition_amount, Decimal('100.0000'))
+        with self.assertRaises(ValidationError):
+            adjustment.save()
 
     def test_unknown_seed_receipt_omits_quantity_without_claiming_zero(self):
         """An uncounted packet keeps its quantity genuinely nullable."""

--- a/supplies/migrations/0004_supplier_tax_identity.py
+++ b/supplies/migrations/0004_supplier_tax_identity.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('supplies', '0003_supplier_is_system_default_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='supplier',
+            name='address',
+            field=models.TextField(blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='supplier',
+            name='gst_number',
+            field=models.CharField(blank=True, default='', max_length=16),
+        ),
+        migrations.AddField(
+            model_name='supplier',
+            name='gst_status',
+            field=models.CharField(
+                choices=[
+                    ('registered', 'GST registered'),
+                    ('unregistered', 'Not GST registered'),
+                    ('unknown', 'Unknown'),
+                ],
+                default='unknown',
+                max_length=16,
+            ),
+        ),
+    ]

--- a/supplies/models.py
+++ b/supplies/models.py
@@ -1,6 +1,8 @@
 """Database models for garden supplies."""
+from django.core.exceptions import ValidationError
 from django.db import models
 
+from tax.ird import normalize_ird_number, validate_ird_number
 from workspaces.models import WorkspaceOwnedModel
 
 
@@ -8,7 +10,21 @@ class Supplier(WorkspaceOwnedModel):
     """
     A seed supplier
     """
+    class GstStatus(models.TextChoices):
+        """What the operator knows about this supplier's NZ GST status."""
+
+        REGISTERED = 'registered', 'GST registered'
+        UNREGISTERED = 'unregistered', 'Not GST registered'
+        UNKNOWN = 'unknown', 'Unknown'
+
     name = models.CharField(max_length=1024)
+    address = models.TextField(blank=True, default='')
+    gst_status = models.CharField(
+        max_length=16,
+        choices=GstStatus.choices,
+        default=GstStatus.UNKNOWN,
+    )
+    gst_number = models.CharField(max_length=16, blank=True, default='')
     website = models.CharField(max_length=1024, blank=True, null=True)
     notes = models.TextField(blank=True, null=True)
     is_system_default = models.BooleanField(
@@ -31,3 +47,27 @@ class Supplier(WorkspaceOwnedModel):
 
     def __str__(self):
         return self.name
+
+    def clean(self):
+        """Keep the GST number consistent with the stated registration."""
+        super().clean()
+        if self.gst_status != self.GstStatus.REGISTERED:
+            if self.gst_number:
+                raise ValidationError({
+                    'gst_number': 'Only a GST-registered supplier has a GST number.',
+                })
+            return
+        if not self.gst_number:
+            raise ValidationError({
+                'gst_number': 'A GST-registered supplier needs its GST number.',
+            })
+        try:
+            self.gst_number = normalize_ird_number(self.gst_number)
+            validate_ird_number(self.gst_number)
+        except ValidationError as exc:
+            raise ValidationError({'gst_number': exc.messages}) from exc
+
+    def save(self, *args, **kwargs):
+        """Validate direct ORM writes as well as REST writes."""
+        self.full_clean()
+        super().save(*args, **kwargs)


### PR DESCRIPTION
Receipt-wide defaults cannot support mixed tax treatment or prove a claim. Add supplier tax identity, receipt evidence snapshots, line-level claim amounts, and immutable change-of-use adjustments while preserving legacy valuations.

## Summary by Sourcery

Record auditable supplier tax evidence and line-level input-tax claims while preserving legacy inventory valuations.

New Features:
- Add supplier GST identity validation and receipt-level source-document and evidence snapshots.
- Record tax treatment, tax source, claim percentages, recoverable amounts, and acquisition costs per receipt line.
- Support immutable, evidence-backed input-tax adjustments for later changes in taxable use.

Bug Fixes:
- Preserve existing receipt valuations and tax classifications during migration to the new evidence model.

Enhancements:
- Enforce structural consistency for tax rates, claim amounts, apportionment details, and acquisition-cost calculations.

Tests:
- Add coverage for apportioned supplier tax, non-recoverable customs tax, and immutable change-of-use adjustments.