### PR TITLE
feat(inventory): apply evidenced tax to receipts

### DIFF
--- a/inventory/input_tax.py
+++ b/inventory/input_tax.py
@@ -1,0 +1,98 @@
+"""Input-tax evidence warnings that never silently alter an operator's claim."""
+
+from tax.periods import registration_in_force
+
+from .models import StockReceiptLine
+
+
+def receipt_tax_warnings(receipt):
+    """Return actionable warnings for explicit claims on one receipt."""
+    lines = list(receipt.lines.all())
+    claimed = [line for line in lines if line.recoverable_input_tax > 0]
+    warnings = []
+    if not claimed:
+        return warnings
+
+    claim_date = receipt.invoice_date or receipt.received_date
+    if registration_in_force(receipt.workspace, claim_date) is None:
+        warnings.append(_warning(
+            'workspace_not_registered',
+            'Input tax is claimed on a date when the workspace has no GST registration.',
+        ))
+    if not _has_evidence(receipt):
+        warnings.append(_warning(
+            'purchase_evidence_missing',
+            'Input tax is claimed without a source document number, evidence reference, or evidence URL.',
+        ))
+    if receipt.invoice_date is None:
+        warnings.append(_warning(
+            'invoice_date_missing',
+            'No supplier invoice date is recorded, so the received date remains a proxy.',
+        ))
+
+    for line in claimed:
+        warnings.extend(_line_warnings(receipt, line))
+    return warnings
+
+
+def _line_warnings(receipt, line):
+    """Return evidence warnings specific to one claimed line."""
+    warnings = []
+    if line.legacy_tax_classification:
+        warnings.append(_warning(
+            'legacy_unverified_claim',
+            'This claim was migrated from the former receipt-wide recoverability flag.',
+            line.pk,
+        ))
+    if line.tax_treatment == StockReceiptLine.TaxTreatment.UNKNOWN:
+        warnings.append(_warning(
+            'unknown_purchase_tax_treatment',
+            'A claimed line still has unknown GST treatment.',
+            line.pk,
+        ))
+    if line.input_tax_source == StockReceiptLine.InputTaxSource.SUPPLIER:
+        if receipt.supplier_gst_status != 'registered':
+            warnings.append(_warning(
+                'supplier_registration_unsupported',
+                'Supplier-charged GST is claimed without recorded supplier registration.',
+                line.pk,
+            ))
+        if not receipt.supplier_gst_number:
+            warnings.append(_warning(
+                'supplier_gst_number_missing',
+                'Supplier-charged GST is claimed without the supplier GST number.',
+                line.pk,
+            ))
+    if line.input_tax_source == StockReceiptLine.InputTaxSource.CUSTOMS:
+        if receipt.source_document_type != receipt.SourceDocumentType.CUSTOMS_ENTRY:
+            warnings.append(_warning(
+                'customs_evidence_missing',
+                'Customs GST is claimed without a Customs entry or statement as the source record.',
+                line.pk,
+            ))
+    if line.input_tax_source == StockReceiptLine.InputTaxSource.SECOND_HAND:
+        if receipt.supplier_gst_status != 'unregistered':
+            warnings.append(_warning(
+                'second_hand_supplier_status_missing',
+                'A second-hand-goods deduction needs the seller recorded as unregistered.',
+                line.pk,
+            ))
+        if not receipt.supplier_name_snapshot or not receipt.supplier_address_snapshot:
+            warnings.append(_warning(
+                'second_hand_seller_details_missing',
+                'A second-hand-goods deduction needs the seller name and address.',
+                line.pk,
+            ))
+    return warnings
+
+
+def _has_evidence(receipt):
+    return any((
+        receipt.source_document_number.strip(),
+        receipt.evidence_reference.strip(),
+        receipt.evidence_url.strip(),
+    ))
+
+
+def _warning(code, message, line_id=None):
+    return {'code': code, 'message': message, 'line_id': line_id}

--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -459,19 +459,12 @@ def post_opening_balance(workspace, user, request):
     return lot, movement
 
 
-def _receipt_acquisition_cost(receipt, line):
-    """Return acquisition total excluding only recoverable tax."""
-    line_cost = line.line_cost_ex_tax.quantize(
+def _receipt_acquisition_cost(line):
+    """Return the explicit frozen acquisition amount on a receipt line."""
+    return line.acquisition_amount.quantize(
         MONEY_QUANTUM,
         rounding=ROUND_HALF_UP,
     )
-    if receipt.tax_recoverable:
-        return line_cost
-    tax = (line_cost * receipt.tax_rate / Decimal('100')).quantize(
-        MONEY_QUANTUM,
-        rounding=ROUND_HALF_UP,
-    )
-    return line_cost + tax
 
 
 def _serialized_unit_costs(total, quantity):
@@ -543,7 +536,7 @@ def post_receipt(receipt, user):  # pylint: disable=too-many-branches
     posted_at = timezone.now()
     lots = []
     for line in lines:
-        acquisition_total = _receipt_acquisition_cost(receipt, line)
+        acquisition_total = _receipt_acquisition_cost(line)
         unit_cost = None
         if line.base_quantity is not None:
             unit_cost = (acquisition_total / line.base_quantity).quantize(

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -34,6 +34,7 @@ from .ledger import (
     settle_receipt,
 )
 from .models import (
+    InputTaxAdjustment,
     InventoryItem,
     ItemUnitConversion,
     QuantityCertainty,
@@ -44,6 +45,7 @@ from .models import (
     Stocktake,
     StocktakeLine,
 )
+from .input_tax import receipt_tax_warnings
 from .rest_query import (
     parse_boolean as _parse_boolean,
     parse_date as _parse_date,
@@ -96,16 +98,32 @@ class StockReceiptLineSerializer(
             'base_quantity',
             'base_unit',
             'line_cost_ex_tax',
+            'supplier_cost_incl_tax',
+            'tax_treatment',
+            'tax_rate',
+            'input_tax_source',
+            'input_tax_amount',
+            'claim_input_tax',
+            'claimable_percentage',
+            'apportionment_basis',
+            'recoverable_input_tax',
+            'non_recoverable_tax',
+            'acquisition_amount',
+            'legacy_tax_classification',
             'destination',
             'lot',
             'created',
             'updated',
         ]
-        read_only_fields = ['lot', 'created', 'updated']
+        read_only_fields = [
+            'recoverable_input_tax', 'non_recoverable_tax', 'acquisition_amount',
+            'legacy_tax_classification', 'lot', 'created', 'updated',
+        ]
         extra_kwargs = {
             # A Basic Garden gift or swap has no price; zero is a legitimate
             # cost, not a placeholder for one that was never entered.
             'line_cost_ex_tax': {'required': False},
+            'supplier_cost_incl_tax': {'required': False},
         }
 
     workspace_field_lookups = {
@@ -142,6 +160,10 @@ class StockReceiptLineSerializer(
             )
         if destination and not destination.active:
             raise ValidationError({'destination': 'The location is inactive.'})
+        if 'supplier_cost_incl_tax' not in attrs and 'line_cost_ex_tax' in attrs:
+            attrs['supplier_cost_incl_tax'] = attrs['line_cost_ex_tax']
+            attrs['_legacy_receipt_tax'] = True
+        attrs.setdefault('supplier_cost_incl_tax', Decimal('0'))
         attrs.setdefault('line_cost_ex_tax', Decimal('0'))
         certainty = attrs.get(
             'quantity_certainty',
@@ -175,6 +197,7 @@ class StockReceiptSerializer(
     lines = StockReceiptLineSerializer(many=True, required=False)
     movement_ids = serializers.SerializerMethodField()
     is_seed_packet_draft = serializers.SerializerMethodField()
+    tax_warnings = serializers.SerializerMethodField()
 
     class Meta:
         model = StockReceipt
@@ -184,6 +207,15 @@ class StockReceiptSerializer(
             'status',
             'received_date',
             'supplier_reference',
+            'invoice_date',
+            'source_document_type',
+            'source_document_number',
+            'evidence_reference',
+            'evidence_url',
+            'supplier_name_snapshot',
+            'supplier_address_snapshot',
+            'supplier_gst_status',
+            'supplier_gst_number',
             'currency_code',
             'tax_rate',
             'price_includes_tax',
@@ -198,6 +230,7 @@ class StockReceiptSerializer(
             'updated',
             'lines',
             'movement_ids',
+            'tax_warnings',
         ]
         read_only_fields = [
             'status',
@@ -209,6 +242,7 @@ class StockReceiptSerializer(
             'created',
             'updated',
             'movement_ids',
+            'tax_warnings',
         ]
         extra_kwargs = {
             'supplier': {'required': False},
@@ -230,6 +264,10 @@ class StockReceiptSerializer(
         """Name the drafts the seed workflow owns its own editor for."""
         return hasattr(receipt, 'seed_packet_draft')
 
+    def get_tax_warnings(self, receipt):
+        """Expose unsupported claims without silently changing them."""
+        return receipt_tax_warnings(receipt)
+
     def validate(self, attrs):
         """Apply workspace financial defaults to new draft documents."""
         if self.instance and hasattr(self.instance, 'seed_packet_draft'):
@@ -243,6 +281,12 @@ class StockReceiptSerializer(
             attrs.setdefault('currency_code', workspace.currency_code)
             attrs.setdefault('tax_rate', workspace.default_tax_rate)
             attrs.setdefault('supplier', ensure_default_supplier(workspace))
+        supplier = attrs.get('supplier') or getattr(self.instance, 'supplier', None)
+        if supplier is not None:
+            attrs.setdefault('supplier_name_snapshot', supplier.name)
+            attrs.setdefault('supplier_address_snapshot', supplier.address)
+            attrs.setdefault('supplier_gst_status', supplier.gst_status)
+            attrs.setdefault('supplier_gst_number', supplier.gst_number)
         return attrs
 
     @transaction.atomic
@@ -280,16 +324,116 @@ class StockReceiptSerializer(
 
     @staticmethod
     def _canonical_lines(receipt_data, lines):
-        """Store line costs ex tax regardless of how the supplier quoted them."""
-        if not receipt_data.get('price_includes_tax', False):
-            return lines
+        """Translate only the deprecated receipt-wide tax inputs."""
         rate = receipt_data.get('tax_rate', Decimal('0'))
-        divisor = Decimal('1') + rate / Decimal('100')
+        recoverable = receipt_data.get('tax_recoverable', False)
         for line in lines:
-            line['line_cost_ex_tax'] = (
-                line['line_cost_ex_tax'] / divisor
-            ).quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)
+            legacy_receipt_tax = line.pop('_legacy_receipt_tax', False)
+            if not legacy_receipt_tax:
+                continue
+            if line.get(
+                'input_tax_source', StockReceiptLine.InputTaxSource.NONE,
+            ) != StockReceiptLine.InputTaxSource.NONE:
+                continue
+            entered = line['supplier_cost_incl_tax']
+            if rate <= 0:
+                continue
+            if receipt_data.get('price_includes_tax', False):
+                gross = entered
+                tax = (gross * rate / (Decimal('100') + rate)).quantize(
+                    Decimal('0.0001'), rounding=ROUND_HALF_UP,
+                )
+            else:
+                tax = (entered * rate / Decimal('100')).quantize(
+                    Decimal('0.0001'), rounding=ROUND_HALF_UP,
+                )
+                gross = entered + tax
+            if tax == 0:
+                line['supplier_cost_incl_tax'] = gross
+                continue
+            line.update({
+                'supplier_cost_incl_tax': gross,
+                'tax_treatment': StockReceiptLine.TaxTreatment.STANDARD,
+                'tax_rate': rate,
+                'input_tax_source': StockReceiptLine.InputTaxSource.SUPPLIER,
+                'input_tax_amount': tax,
+                'claim_input_tax': recoverable,
+                'claimable_percentage': Decimal('100') if recoverable else Decimal('0'),
+            })
         return lines
+
+
+class InputTaxAdjustmentSerializer(
+    CurrentWorkspaceSerializerMixin,
+    serializers.ModelSerializer,
+):
+    """Create and read append-only changes in taxable use."""
+
+    class Meta:
+        model = InputTaxAdjustment
+        fields = [
+            'pk', 'receipt_line', 'adjustment_date',
+            'previous_claimable_percentage', 'revised_claimable_percentage',
+            'tax_adjustment', 'apportionment_basis', 'reason',
+            'evidence_reference', 'evidence_url', 'created_by', 'created',
+        ]
+        read_only_fields = [
+            'previous_claimable_percentage', 'tax_adjustment',
+            'created_by', 'created',
+        ]
+
+    workspace_field_lookups = {'receipt_line': 'receipt__workspace'}
+
+    def create(self, validated_data):
+        """Calculate the delta from the latest recorded claim percentage."""
+        line = validated_data['receipt_line']
+        latest = line.input_tax_adjustments.order_by(
+            '-adjustment_date', '-pk',
+        ).first()
+        previous = (
+            latest.revised_claimable_percentage
+            if latest else line.claimable_percentage
+        )
+        revised = validated_data['revised_claimable_percentage']
+        tax_delta = Decimal(line.input_tax_amount) * (revised - previous)
+        return InputTaxAdjustment.objects.create(
+            previous_claimable_percentage=previous,
+            tax_adjustment=(tax_delta / Decimal('100')).quantize(Decimal('0.0001')),
+            **validated_data,
+        )
+
+
+class InputTaxAdjustmentViewSet(
+    CurrentWorkspaceViewSetMixin,
+    viewsets.ModelViewSet,
+):  # pylint: disable=too-many-ancestors
+    """List and append input-tax adjustments; never edit or delete them."""
+
+    queryset = InputTaxAdjustment.objects.select_related('receipt_line__receipt')
+    serializer_class = InputTaxAdjustmentSerializer
+    http_method_names = ['get', 'post', 'head', 'options']
+
+    def perform_create(self, serializer):
+        serializer.save(
+            workspace=self.get_current_workspace(),
+            created_by=self.request.user,
+        )
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        receipt_line = _parse_integer(
+            self.request.query_params.get('receipt_line'),
+            'receipt_line',
+        )
+        if receipt_line is not None:
+            queryset = queryset.filter(receipt_line_id=receipt_line)
+        receipt = _parse_integer(
+            self.request.query_params.get('receipt'),
+            'receipt',
+        )
+        if receipt is not None:
+            queryset = queryset.filter(receipt_line__receipt_id=receipt)
+        return queryset
 
 
 class StockLotSerializer(serializers.ModelSerializer):
@@ -1024,6 +1168,7 @@ def register_ledger_routes(router):
     from .stocktake_rest import NurseryStocktakeViewSet  # pylint: disable=import-outside-toplevel
 
     router.register(r'receipts', StockReceiptViewSet)
+    router.register(r'input-tax-adjustments', InputTaxAdjustmentViewSet)
     router.register(r'lots', StockLotViewSet)
     router.register(r'serialized-units', InventoryUnitViewSet)
     router.register(r'movements', StockMovementViewSet)

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -541,7 +541,7 @@ class StockReceipt(WorkspaceOwnedModel):
         return super().delete(*args, **kwargs)
 
 
-class StockReceiptLine(models.Model):
+class StockReceiptLine(models.Model):  # pylint: disable=too-many-instance-attributes
     """A draft purchase line normalized into its item's base unit."""
 
     class TaxTreatment(models.TextChoices):
@@ -755,6 +755,34 @@ class StockReceiptLine(models.Model):
         """Freeze the claim split and acquisition amount from explicit inputs."""
         quantum = Decimal('0.0001')
         tax = Decimal(self.input_tax_amount or 0).quantize(quantum)
+        legacy_receipt_tax = all((
+            self.input_tax_source == self.InputTaxSource.NONE,
+            self.tax_treatment == self.TaxTreatment.UNKNOWN,
+            tax == 0,
+            self.receipt_id,
+            Decimal(self.receipt.tax_rate or 0) > 0,
+        ))
+        if legacy_receipt_tax:
+            rate = Decimal(self.receipt.tax_rate)
+            entered = Decimal(self.line_cost_ex_tax or 0)
+            if self.receipt.price_includes_tax:
+                gross = entered
+                tax = (gross * rate / (Decimal('100') + rate)).quantize(quantum)
+            else:
+                tax = (entered * rate / Decimal('100')).quantize(quantum)
+                gross = entered + tax
+            if tax == 0:
+                self.supplier_cost_incl_tax = gross
+                return
+            self.supplier_cost_incl_tax = gross
+            self.tax_treatment = self.TaxTreatment.STANDARD
+            self.tax_rate = rate
+            self.input_tax_source = self.InputTaxSource.SUPPLIER
+            self.input_tax_amount = tax
+            self.claim_input_tax = self.receipt.tax_recoverable
+            self.claimable_percentage = (
+                Decimal('100') if self.claim_input_tax else Decimal('0')
+            )
         percentage = Decimal(self.claimable_percentage or 0)
         recoverable = Decimal('0')
         if self.claim_input_tax:
@@ -762,10 +790,19 @@ class StockReceiptLine(models.Model):
         self.recoverable_input_tax = recoverable
         self.non_recoverable_tax = tax - recoverable
         gross = Decimal(self.supplier_cost_incl_tax or 0).quantize(quantum)
+        if gross == 0 and tax == 0 and Decimal(self.line_cost_ex_tax or 0) > 0:
+            gross = Decimal(self.line_cost_ex_tax).quantize(quantum)
+            self.supplier_cost_incl_tax = gross
         if self.input_tax_source == self.InputTaxSource.CUSTOMS:
             self.acquisition_amount = gross + self.non_recoverable_tax
+            self.line_cost_ex_tax = gross
         else:
             self.acquisition_amount = gross - recoverable
+            supplier_tax = tax if self.input_tax_source in {
+                self.InputTaxSource.SUPPLIER,
+                self.InputTaxSource.SECOND_HAND,
+            } else Decimal('0')
+            self.line_cost_ex_tax = gross - supplier_tax
 
     def normalized_quantity(self):
         """Calculate the display quantity in the item's canonical unit."""

--- a/inventory/test_ledger_rest.py
+++ b/inventory/test_ledger_rest.py
@@ -847,3 +847,75 @@ class StockReceiptSettlementTests(LedgerRestFixture):
         self.assertEqual(created.status_code, 201, created.data)
         self.assertIsNone(created.data['settled_on'])
         self.assertIsNone(StockReceipt.objects.get(pk=created.data['pk']).settled_on)
+
+
+class InputTaxEvidenceRestTests(LedgerRestFixture):
+    """Line claims stay explicit and unsupported claims remain visible."""
+
+    adjustment_url = '/inventory/input-tax-adjustments/'
+
+    def evidenced_payload(self):
+        """Return one explicit supplier-GST claim without supporting evidence."""
+        payload = self.receipt_payload()
+        payload.pop('tax_recoverable')
+        payload['invoice_date'] = '2026-08-01'
+        payload['lines'][0].pop('line_cost_ex_tax')
+        payload['lines'][0].update({
+            'supplier_cost_incl_tax': '115.0000',
+            'tax_treatment': 'standard',
+            'tax_rate': '15.0000',
+            'input_tax_source': 'supplier',
+            'input_tax_amount': '15.0000',
+            'claim_input_tax': True,
+            'claimable_percentage': '100.0000',
+            'apportionment_basis': '',
+        })
+        return payload
+
+    def test_unsupported_claim_warns_but_posts(self):
+        """The selected warn-only policy never rewrites or blocks a claim."""
+        created = self.client.post(
+            self.receipt_url, self.evidenced_payload(), format='json',
+        )
+        self.assertEqual(created.status_code, 201, created.data)
+        codes = {warning['code'] for warning in created.data['tax_warnings']}
+        self.assertIn('workspace_not_registered', codes)
+        self.assertIn('purchase_evidence_missing', codes)
+        self.assertIn('supplier_registration_unsupported', codes)
+
+        posted = self.client.post(
+            f"{self.receipt_url}{created.data['pk']}/post/", {}, format='json',
+        )
+        self.assertEqual(posted.status_code, 200, posted.data)
+        line = posted.data['lines'][0]
+        self.assertEqual(line['recoverable_input_tax'], '15.0000')
+        self.assertEqual(line['non_recoverable_tax'], '0.0000')
+        self.assertEqual(line['acquisition_amount'], '100.0000')
+
+    def test_change_of_use_adjustment_is_derived_and_append_only(self):
+        """The API derives the signed adjustment from the latest percentage."""
+        created = self.client.post(
+            self.receipt_url, self.evidenced_payload(), format='json',
+        )
+        posted = self.client.post(
+            f"{self.receipt_url}{created.data['pk']}/post/", {}, format='json',
+        )
+        line_id = posted.data['lines'][0]['pk']
+        response = self.client.post(self.adjustment_url, {
+            'receipt_line': line_id,
+            'adjustment_date': '2026-08-20',
+            'revised_claimable_percentage': '60.0000',
+            'apportionment_basis': 'Observed taxable use',
+            'reason': 'Private use increased',
+            'evidence_reference': 'USE-LOG-1',
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['previous_claimable_percentage'], '100.0000')
+        self.assertEqual(response.data['tax_adjustment'], '-6.0000')
+        self.assertEqual(
+            self.client.patch(
+                f"{self.adjustment_url}{response.data['pk']}/",
+                {'reason': 'rewrite'}, format='json',
+            ).status_code,
+            405,
+        )

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.response import Response
 
-from inventory.models import QuantityCertainty
+from inventory.models import QuantityCertainty, StockReceipt, StockReceiptLine
 from inventory.units import UnitCode
 from workspaces.scoping import (
     CurrentWorkspaceSerializerMixin,
@@ -228,6 +228,14 @@ class PacketReceiptDraftSerializer(
         allow_blank=True,
         required=False,
     )
+    invoice_date = serializers.DateField(allow_null=True, required=False)
+    source_document_type = serializers.ChoiceField(
+        choices=StockReceipt.SourceDocumentType.choices,
+        required=False,
+    )
+    source_document_number = serializers.CharField(allow_blank=True, required=False)
+    evidence_reference = serializers.CharField(allow_blank=True, required=False)
+    evidence_url = serializers.URLField(allow_blank=True, required=False)
     tax_rate = serializers.DecimalField(
         max_digits=7,
         decimal_places=4,
@@ -235,6 +243,24 @@ class PacketReceiptDraftSerializer(
         required=False,
     )
     tax_recoverable = serializers.BooleanField(required=False)
+    supplier_cost_incl_tax = serializers.DecimalField(
+        max_digits=18, decimal_places=4, min_value=Decimal('0'), required=False,
+    )
+    tax_treatment = serializers.ChoiceField(
+        choices=StockReceiptLine.TaxTreatment.choices, required=False,
+    )
+    input_tax_source = serializers.ChoiceField(
+        choices=StockReceiptLine.InputTaxSource.choices, required=False,
+    )
+    input_tax_amount = serializers.DecimalField(
+        max_digits=18, decimal_places=4, min_value=Decimal('0'), required=False,
+    )
+    claim_input_tax = serializers.BooleanField(required=False)
+    claimable_percentage = serializers.DecimalField(
+        max_digits=7, decimal_places=4, min_value=Decimal('0'),
+        max_value=Decimal('100'), required=False,
+    )
+    apportionment_basis = serializers.CharField(allow_blank=True, required=False)
     notes = serializers.CharField(allow_blank=True, required=False)
     packet = serializers.PrimaryKeyRelatedField(read_only=True)
 
@@ -302,8 +328,20 @@ class PacketReceiptDraftSerializer(
             'sow_by': line.expires_on,
             'supplier': draft.receipt.supplier_id,
             'supplier_reference': draft.receipt.supplier_reference,
+            'invoice_date': draft.receipt.invoice_date,
+            'source_document_type': draft.receipt.source_document_type,
+            'source_document_number': draft.receipt.source_document_number,
+            'evidence_reference': draft.receipt.evidence_reference,
+            'evidence_url': draft.receipt.evidence_url,
             'tax_rate': f'{draft.receipt.tax_rate:.4f}',
             'tax_recoverable': draft.receipt.tax_recoverable,
+            'supplier_cost_incl_tax': f'{line.supplier_cost_incl_tax:.4f}',
+            'tax_treatment': line.tax_treatment,
+            'input_tax_source': line.input_tax_source,
+            'input_tax_amount': f'{line.input_tax_amount:.4f}',
+            'claim_input_tax': line.claim_input_tax,
+            'claimable_percentage': f'{line.claimable_percentage:.4f}',
+            'apportionment_basis': line.apportionment_basis,
             'notes': draft.notes,
             'packet': draft.packet_id,
         }

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -1,5 +1,8 @@
 """Transactional seed catalog, packet receiving, and counting services."""
 
+# Receipt evidence is intentionally mirrored by the one-line seed workflow.
+# pylint: disable=duplicate-code
+
 from decimal import Decimal
 from uuid import uuid4
 
@@ -118,11 +121,23 @@ def create_packet_receipt_draft(workspace, user, values):
     # was sold by the shop, and the receipt has to say so — it is the purchase
     # record a GST return and a supplier payment are read from. Defaulting to
     # the brand keeps buying direct a single choice rather than two.
+    supplier = values.get('supplier') or seeds.supplier
     receipt = StockReceipt.objects.create(
         workspace=workspace,
-        supplier=values.get('supplier') or seeds.supplier,
+        supplier=supplier,
         received_date=values['received_date'],
         supplier_reference=values.get('supplier_reference', ''),
+        invoice_date=values.get('invoice_date'),
+        source_document_type=values.get(
+            'source_document_type', StockReceipt.SourceDocumentType.NONE,
+        ),
+        source_document_number=values.get('source_document_number', ''),
+        evidence_reference=values.get('evidence_reference', ''),
+        evidence_url=values.get('evidence_url', ''),
+        supplier_name_snapshot=supplier.name,
+        supplier_address_snapshot=supplier.address,
+        supplier_gst_status=supplier.gst_status,
+        supplier_gst_number=supplier.gst_number,
         currency_code=workspace.currency_code,
         tax_rate=values.get('tax_rate', workspace.default_tax_rate),
         tax_recoverable=values.get('tax_recoverable', False),
@@ -134,18 +149,29 @@ def create_packet_receipt_draft(workspace, user, values):
     base_quantity = None
     if certainty != QuantityCertainty.UNKNOWN:
         base_quantity = quantize_quantity(quantity)
-    StockReceiptLine.objects.create(
-        receipt=receipt,
-        item=seeds.inventory_item,
-        supplier_lot_reference=values.get('supplier_lot_reference', ''),
-        expires_on=values.get('sow_by'),
-        quantity=quantity,
-        quantity_certainty=certainty,
-        unit_code=seeds.inventory_item.base_unit,
-        base_quantity=base_quantity,
-        line_cost_ex_tax=values['line_price'],
-        destination=location,
-    )
+    line_values = {
+        'receipt': receipt,
+        'item': seeds.inventory_item,
+        'supplier_lot_reference': values.get('supplier_lot_reference', ''),
+        'expires_on': values.get('sow_by'),
+        'quantity': quantity,
+        'quantity_certainty': certainty,
+        'unit_code': seeds.inventory_item.base_unit,
+        'base_quantity': base_quantity,
+        'line_cost_ex_tax': values['line_price'],
+        'destination': location,
+    }
+    for field in (
+        'supplier_cost_incl_tax', 'tax_treatment', 'input_tax_source',
+        'input_tax_amount', 'claim_input_tax', 'claimable_percentage',
+        'apportionment_basis',
+    ):
+        if field in values:
+            line_values[field] = values[field]
+    if 'supplier_cost_incl_tax' in values:
+        line_values['line_cost_ex_tax'] = Decimal('0')
+        line_values['tax_rate'] = values.get('tax_rate', Decimal('0'))
+    StockReceiptLine.objects.create(**line_values)
     return SeedPacketReceiptDraft.objects.create(
         workspace=workspace,
         seeds=seeds,
@@ -169,18 +195,36 @@ def update_packet_receipt_draft(draft, values):
         'received_date',
         'supplier',
         'supplier_reference',
+        'invoice_date',
+        'source_document_type',
+        'source_document_number',
+        'evidence_reference',
+        'evidence_url',
         'tax_rate',
         'tax_recoverable',
         'notes',
     ):
         if field in values:
             setattr(receipt, field, values[field])
+    if 'supplier' in values:
+        supplier = values['supplier']
+        receipt.supplier_name_snapshot = supplier.name
+        receipt.supplier_address_snapshot = supplier.address
+        receipt.supplier_gst_status = supplier.gst_status
+        receipt.supplier_gst_number = supplier.gst_number
     receipt.save()
     line = receipt.lines.select_for_update().get()
     for field in ('supplier_lot_reference', 'expires_on', 'line_cost_ex_tax'):
         source = 'sow_by' if field == 'expires_on' else 'line_price' if field == 'line_cost_ex_tax' else field
         if source in values:
             setattr(line, field, values[source])
+    for field in (
+        'supplier_cost_incl_tax', 'tax_treatment', 'input_tax_source',
+        'input_tax_amount', 'claim_input_tax', 'claimable_percentage',
+        'apportionment_basis', 'tax_rate',
+    ):
+        if field in values:
+            setattr(line, field, values[field])
     if 'quantity_certainty' in values or 'quantity' in values:
         certainty = values.get('quantity_certainty', line.quantity_certainty)
         quantity = values.get('quantity', line.quantity)
@@ -335,6 +379,11 @@ def packet_provenance(packet):
             'currency_code': lot.currency_code if lot else None,
             'tax_rate': None,
             'tax_recoverable': None,
+            'supplier_cost_incl_tax': None,
+            'input_tax_amount': None,
+            'recoverable_input_tax': None,
+            'non_recoverable_tax': None,
+            'acquisition_amount': None,
             'settled_on': None,
         }
     receipt = line.receipt
@@ -350,6 +399,11 @@ def packet_provenance(packet):
         'currency_code': receipt.currency_code,
         'tax_rate': f'{receipt.tax_rate:.4f}',
         'tax_recoverable': receipt.tax_recoverable,
+        'supplier_cost_incl_tax': f'{line.supplier_cost_incl_tax:.4f}',
+        'input_tax_amount': f'{line.input_tax_amount:.4f}',
+        'recoverable_input_tax': f'{line.recoverable_input_tax:.4f}',
+        'non_recoverable_tax': f'{line.non_recoverable_tax:.4f}',
+        'acquisition_amount': f'{line.acquisition_amount:.4f}',
         'settled_on': _isoformat(receipt.settled_on),
     }
 

--- a/supplies/rest.py
+++ b/supplies/rest.py
@@ -1,8 +1,8 @@
-"""
-Rest related classes for supplies
-"""
+"""REST resources for suppliers."""
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import routers, serializers, viewsets
 
+from tax.ird import normalize_ird_number, validate_ird_number
 from workspaces.scoping import CurrentWorkspaceViewSetMixin
 
 from .models import Supplier
@@ -14,8 +14,37 @@ class SupplierSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = Supplier
-        fields = ['pk', 'name', 'website', 'notes', 'is_system_default']
+        fields = [
+            'pk', 'name', 'address', 'gst_status', 'gst_number',
+            'website', 'notes', 'is_system_default',
+        ]
         read_only_fields = ['is_system_default']
+
+    def validate(self, attrs):
+        """Return GST identity contradictions as ordinary API field errors."""
+        status = attrs.get(
+            'gst_status', getattr(self.instance, 'gst_status', Supplier.GstStatus.UNKNOWN),
+        )
+        number = attrs.get(
+            'gst_number', getattr(self.instance, 'gst_number', ''),
+        )
+        if status != Supplier.GstStatus.REGISTERED:
+            if number:
+                raise serializers.ValidationError({
+                    'gst_number': 'Only a GST-registered supplier has a GST number.',
+                })
+            return attrs
+        if not number:
+            raise serializers.ValidationError({
+                'gst_number': 'A GST-registered supplier needs its GST number.',
+            })
+        try:
+            number = normalize_ird_number(number)
+            validate_ird_number(number)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError({'gst_number': exc.messages}) from exc
+        attrs['gst_number'] = number
+        return attrs
 
 
 class SupplierViewSet(

--- a/supplies/tests.py
+++ b/supplies/tests.py
@@ -1,6 +1,7 @@
 """
 Tests for supplies
 """
+from supplies.models import Supplier
 from tests.api import RESTContractTestCase
 
 
@@ -27,3 +28,28 @@ class SupplierAPITests(RESTContractTestCase):
                 'notes': 'Open-pollinated varieties',
             },
         )
+
+    def test_registered_supplier_number_is_normalized(self):
+        """Supplier evidence uses the same validated GST identity as tax."""
+        response = self.client.post('/supplies/supplier/', {
+            'name': 'Registered Seed Company',
+            'address': '1 Seed Lane',
+            'gst_status': 'registered',
+            'gst_number': '49-091-850',
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data['gst_number'], '049091850')
+        self.assertEqual(
+            Supplier.objects.get(pk=response.data['pk']).gst_number,
+            '049091850',
+        )
+
+    def test_unregistered_supplier_cannot_carry_a_gst_number(self):
+        """Contradictory supplier evidence is rejected as a field error."""
+        response = self.client.post('/supplies/supplier/', {
+            'name': 'Private seller',
+            'gst_status': 'unregistered',
+            'gst_number': '049091850',
+        }, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('gst_number', response.data)


### PR DESCRIPTION
Posting must use the claim and acquisition amounts frozen on each line, while unsupported claims remain visible under the chosen warn-only policy. Expose evidence, warnings, adjustments, and matching seed receipt behavior through the API.

## Summary by Sourcery

Apply evidenced, line-level input-tax treatment to inventory receipts while preserving claims, warning on unsupported evidence, and exposing tax adjustments through the APIs.

New Features:
- Expose receipt tax evidence and line-level tax claim details through the inventory and seed APIs.
- Add an append-only API for recording input-tax change-of-use adjustments.
- Expose and validate supplier GST identity information in the supplier API.

Bug Fixes:
- Ensure ledger posting uses each receipt line’s frozen acquisition amount rather than recalculating costs from receipt-wide tax settings.
- Preserve unsupported input-tax claims while surfacing actionable warnings instead of silently altering or blocking them.

Enhancements:
- Extend seed packet receipt workflows and provenance responses to carry evidenced tax claims, recoverability, and acquisition amounts.
- Maintain compatibility with deprecated receipt-wide tax inputs while translating them into explicit line-level tax data.

Tests:
- Add API coverage for warn-only tax claims, frozen posting amounts, derived tax adjustments, append-only adjustment behavior, and supplier GST validation.