### PR TITLE
feat(reporting): derive GST from receipt lines

### DIFF
--- a/reporting/filters.py
+++ b/reporting/filters.py
@@ -186,11 +186,15 @@ class GstEntryFilters(GstPeriodFilters):  # pylint: disable=abstract-method
 
     period = serializers.CharField(required=False)
     kind = serializers.ChoiceField(
-        required=False, choices=('supply', 'supply_credit', 'purchase'),
+        required=False,
+        choices=('supply', 'supply_credit', 'purchase', 'input_tax_adjustment'),
     )
     tax_code = serializers.ChoiceField(
         required=False,
-        choices=('standard', 'zero_rated', 'exempt', 'out_of_scope', 'unclassified'),
+        choices=(
+            'standard', 'zero_rated', 'exempt', 'out_of_scope',
+            'unclassified', 'unknown',
+        ),
     )
     exclusion = serializers.ChoiceField(
         required=False,

--- a/reporting/gst.py
+++ b/reporting/gst.py
@@ -26,7 +26,14 @@ from collections import defaultdict
 from datetime import date, datetime
 from decimal import Decimal
 
-from tax.entries import AWAITING_PAYMENT, PURCHASE, derive_entries
+from inventory.input_tax import receipt_tax_warnings
+from inventory.models import StockReceipt, StockReceiptLine
+from tax.entries import (
+    AWAITING_PAYMENT,
+    INPUT_TAX_ADJUSTMENT,
+    PURCHASE,
+    derive_entries,
+)
 from tax.periods import (
     enumerate_periods,
     local_date,
@@ -60,7 +67,8 @@ ENTRY_COLUMNS = (
     'period_label', 'kind', 'supply_date', 'basis', 'source_type', 'source_id',
     'document_id', 'line_id', 'tax_code', 'tax_rate',
     'taxable', 'tax', 'non_recoverable_tax', 'gross',
-    'currency_code', 'time_of_supply_source', 'proxy', 'exclusion',
+    'currency_code', 'time_of_supply_source', 'input_tax_source',
+    'adjustment_direction', 'proxy', 'exclusion',
 )
 
 RECONCILIATION = {
@@ -223,6 +231,9 @@ def _period_row(period, currency_code, entries, awaiting):  # pylint: disable=to
     supplies = [entry for entry in entries if entry.kind == SUPPLY]
     credits_ = [entry for entry in entries if entry.kind == SUPPLY_CREDIT]
     purchases = [entry for entry in entries if entry.kind == PURCHASE]
+    adjustments = [
+        entry for entry in entries if entry.kind == INPUT_TAX_ADJUSTMENT
+    ]
 
     taxable_supplies = _sum(entry.gross for entry in supplies if entry.tax_code == 'standard')
     zero_rated = _sum(entry.gross for entry in supplies if entry.tax_code == 'zero_rated')
@@ -232,14 +243,24 @@ def _period_row(period, currency_code, entries, awaiting):  # pylint: disable=to
 
     output_tax = _sum(entry.tax for entry in supplies) - _sum(entry.tax for entry in credits_)
     purchases_gross = _sum(entry.gross for entry in purchases)
-    input_tax = _sum(entry.tax for entry in purchases)
+    customs = [
+        entry for entry in purchases
+        if entry.input_tax_source == StockReceiptLine.InputTaxSource.CUSTOMS
+    ]
+    ordinary_purchases = [entry for entry in purchases if entry not in customs]
+    input_tax = _sum(entry.tax for entry in ordinary_purchases)
     non_recoverable = _sum(entry.non_recoverable_tax for entry in purchases)
 
-    # Debit and credit adjustments are the transition-adjustment slots task 117
-    # change 5 asks for. They stay zero until a basis change produces one, and
-    # they are named here so the return's arithmetic is complete either way.
-    debit_adjustments = ZERO
-    credit_adjustments = ZERO
+    # Customs GST and later changes in taxable use are return adjustments, not
+    # supplier tax folded into the ordinary purchases box.
+    debit_adjustments = _sum(
+        entry.tax for entry in adjustments
+        if entry.adjustment_direction == 'debit'
+    )
+    credit_adjustments = _sum(entry.tax for entry in customs) + _sum(
+        entry.tax for entry in adjustments
+        if entry.adjustment_direction == 'credit'
+    )
     total_output = output_tax + debit_adjustments
     total_input = input_tax + credit_adjustments
     net = total_output - total_input
@@ -376,6 +397,8 @@ def _entry_row(entry):
         'gross': decimal_string(entry.gross, MONEY_PLACES),
         'currency_code': entry.currency_code,
         'time_of_supply_source': entry.time_of_supply_source,
+        'input_tax_source': entry.input_tax_source,
+        'adjustment_direction': entry.adjustment_direction,
         'proxy': entry.proxy,
         'exclusion': entry.exclusion,
     }
@@ -394,7 +417,7 @@ def _entry_totals(entries):
     }
 
 
-def _data_quality(workspace, entries, rows, as_at):
+def _data_quality(workspace, entries, rows, as_at):  # pylint: disable=too-many-locals
     """Report every reason a figure is incomplete, with the rows behind it."""
     findings = []
     for exclusion, message in EXCLUSION_MESSAGES.items():
@@ -437,13 +460,22 @@ def _data_quality(workspace, entries, rows, as_at):
             kind=PURCHASE,
         ))
 
-    purchases = [entry for entry in entries if entry.kind == PURCHASE]
-    if purchases:
+    receipt_ids = {
+        entry.document_id for entry in entries
+        if entry.kind in {PURCHASE, INPUT_TAX_ADJUSTMENT} and entry.document_id
+    }
+    warning_groups = defaultdict(list)
+    receipts = StockReceipt.objects.filter(pk__in=receipt_ids).select_related(
+        'workspace',
+    ).prefetch_related('lines')
+    for receipt in receipts:
+        for warning in receipt_tax_warnings(receipt):
+            warning_groups[warning['code']].append(warning)
+    for code, warnings in sorted(warning_groups.items()):
         findings.append(_finding(
-            'receipt_level_tax_treatment', len(purchases),
-            'Tax treatment is recorded for a whole receipt rather than per '
-            'line, so a receipt mixing standard-rated and zero-rated purchases '
-            'cannot be represented.',
+            code,
+            len(warnings),
+            warnings[0]['message'],
             kind=PURCHASE,
         ))
 

--- a/reporting/test_gst.py
+++ b/reporting/test_gst.py
@@ -19,7 +19,12 @@ from uuid import uuid4
 from billing.documents import issue_supply_document
 from billing.test_fixtures import DocumentScenarioMixin
 from inventory.ledger import post_receipt
-from inventory.models import InventoryItem, StockReceipt, StockReceiptLine
+from inventory.models import (
+    InputTaxAdjustment,
+    InventoryItem,
+    StockReceipt,
+    StockReceiptLine,
+)
 from inventory.units import UnitCode
 from locations.models import Location
 from sales.models import Payment, SalesOrder, SalesOrderLine
@@ -426,8 +431,50 @@ class ExportTests(GstReportTestCase):
         self.assertIn('gst-entries', response.content.decode())
 
 
-class InputTaxTests(GstReportTestCase):
+class InputTaxTests(GstReportTestCase):  # pylint: disable=too-many-public-methods
     """Where input tax lands depends on the basis, and sometimes on nothing."""
+
+    def explicit_purchase(self, *, source='supplier', treatment='standard'):
+        """Post one fully line-classified purchase for task 119 scenarios."""
+        store = Location.objects.create(
+            workspace=self.workspace,
+            name=f'Explicit {source}',
+            code=f'EXPLICIT-{source}',
+            location_type=Location.LocationType.STORAGE,
+        )
+        receipt = StockReceipt.objects.create(
+            workspace=self.workspace,
+            supplier=make_supplier(workspace=self.workspace),
+            received_date=date(2026, 3, 10),
+            invoice_date=date(2026, 3, 5),
+            source_document_type=(
+                StockReceipt.SourceDocumentType.CUSTOMS_ENTRY
+                if source == 'customs' else StockReceipt.SourceDocumentType.INVOICE
+            ),
+            source_document_number='EVIDENCE-1',
+            currency_code='NZD',
+            tax_rate=Decimal('0'),
+            tax_recoverable=False,
+            created_by=self.user,
+        )
+        line = StockReceiptLine.objects.create(
+            receipt=receipt,
+            item=make_inventory_item(workspace=self.workspace),
+            quantity=Decimal('2'),
+            unit_code=UnitCode.LITRE,
+            base_quantity=Decimal('2'),
+            line_cost_ex_tax=Decimal('0'),
+            supplier_cost_incl_tax=Decimal('100' if source == 'customs' else '115'),
+            tax_treatment=treatment,
+            tax_rate=Decimal('15' if treatment == 'standard' else '0'),
+            input_tax_source=source,
+            input_tax_amount=Decimal('15'),
+            claim_input_tax=True,
+            claimable_percentage=Decimal('100'),
+            destination=store,
+        )
+        receipt = post_receipt(receipt, self.user)[0]
+        return receipt, line
 
     def test_the_invoice_basis_claims_input_tax_on_the_receipt_date(self):
         """The receipt date stands in for the supplier invoice task 119 will add."""
@@ -482,12 +529,57 @@ class InputTaxTests(GstReportTestCase):
         self.assertEqual(row['input_tax'], '30.0000')
         self.assertEqual(row['net_gst'], '30.0000')
 
-    def test_the_receipt_level_limitation_is_reported(self):
-        """Task 119 owns per-line treatment; until then the gap is stated."""
+    def test_purchase_evidence_gaps_replace_the_receipt_level_limitation(self):
+        """The report now identifies the actual missing evidence on each claim."""
         self.register(basis=GstRegistration.Basis.INVOICE)
         self.buy(date(2026, 3, 10), '200')
         codes = {finding['code'] for finding in self.periods()['data_quality']}
-        self.assertIn('receipt_level_tax_treatment', codes)
+        self.assertNotIn('receipt_level_tax_treatment', codes)
+        self.assertIn('purchase_evidence_missing', codes)
+
+    def test_invoice_date_replaces_the_receipt_date_proxy(self):
+        """Invoice-basis input tax lands on the recorded supplier invoice date."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.explicit_purchase()
+        row = next(
+            row for row in self.entries()['results'] if row['kind'] == 'purchase'
+        )
+        self.assertEqual(row['supply_date'], '2026-03-05')
+        self.assertEqual(row['time_of_supply_source'], 'supplier_invoice')
+        self.assertFalse(row['proxy'])
+
+    def test_customs_gst_is_a_credit_adjustment_not_ordinary_input_tax(self):
+        """Customs GST stays outside the supplier purchases tax box."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        self.explicit_purchase(source='customs', treatment='out_of_scope')
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['purchases_incl_tax'], '100.0000')
+        self.assertEqual(row['input_tax'], '0.0000')
+        self.assertEqual(row['credit_adjustments'], '15.0000')
+        self.assertEqual(row['total_input_tax'], '15.0000')
+
+    def test_change_of_use_reduction_is_a_debit_adjustment(self):
+        """A later fall in taxable use increases net GST without revaluing stock."""
+        self.register(basis=GstRegistration.Basis.INVOICE)
+        receipt, line = self.explicit_purchase()
+        lot_cost = line.stock_lot.acquisition_total
+        InputTaxAdjustment.objects.create(
+            workspace=self.workspace,
+            receipt_line=line,
+            adjustment_date=date(2026, 4, 1),
+            previous_claimable_percentage=Decimal('100'),
+            revised_claimable_percentage=Decimal('60'),
+            tax_adjustment=Decimal('-6'),
+            apportionment_basis='Observed taxable use',
+            reason='Private use increased',
+            created_by=self.user,
+        )
+        row = self._period('2026-03-01..2026-04-30')
+        self.assertEqual(row['debit_adjustments'], '6.0000')
+        self.assertEqual(row['net_gst'], '-9.0000')
+        line.refresh_from_db()
+        self.assertEqual(line.stock_lot.acquisition_total, lot_cost)
+        self.assertEqual(receipt.status, StockReceipt.Status.POSTED)
 
     def test_the_payments_basis_claims_a_paid_receipt_in_the_payment_period(self):
         """The whole point of the settlement date: goods in March, paid in May."""

--- a/tax/entries.py
+++ b/tax/entries.py
@@ -25,8 +25,10 @@ from datetime import date
 from decimal import Decimal
 from typing import Optional
 
+from django.db import models
+
 from inventory.ledger import quantize_money
-from inventory.models import StockReceipt, StockReceiptLine
+from inventory.models import InputTaxAdjustment, StockReceipt, StockReceiptLine
 
 from .facts import workspace_order_facts
 from .periods import (
@@ -46,10 +48,9 @@ from .recognition import (
 
 
 ZERO = Decimal('0.0000')
-PERCENT_DIVISOR = Decimal('100')
-
 SUPPLY_KINDS = (SUPPLY, SUPPLY_CREDIT)
 PURCHASE = 'purchase'
+INPUT_TAX_ADJUSTMENT = 'input_tax_adjustment'
 
 #: The bases that claim input tax when the supplier is paid rather than when
 #: the goods were received. Hybrid follows the payments rule on the input side
@@ -62,6 +63,8 @@ PAYMENT_BASED = (PAYMENTS, HYBRID)
 #: which stands in for a supplier invoice date the application does not hold.
 SUPPLIER_PAYMENT = 'supplier_payment'
 RECEIPT_PROXY = 'receipt_date_proxy'
+SUPPLIER_INVOICE = 'supplier_invoice'
+CHANGE_OF_USE = 'change_of_use_adjustment'
 
 #: Why an entry belongs to no taxable period. Each becomes a data-quality code
 #: on the report, with the rows behind it reachable through the drill-down.
@@ -89,12 +92,18 @@ class GstEntry:  # pylint: disable=too-many-instance-attributes
     non_recoverable_tax: Decimal
     currency_code: str
     time_of_supply_source: str
+    input_tax_source: str = ''
+    adjustment_direction: str = ''
     proxy: bool = False
     exclusion: str = ''
 
     @property
     def gross(self):
         """Value including every kind of tax, claimable or not."""
+        if self.kind == INPUT_TAX_ADJUSTMENT:
+            return ZERO
+        if self.input_tax_source == StockReceiptLine.InputTaxSource.CUSTOMS:
+            return quantize_money(self.taxable + self.non_recoverable_tax)
         return quantize_money(self.taxable + self.tax + self.non_recoverable_tax)
 
     @property
@@ -120,6 +129,7 @@ def derive_entries(workspace, start, end):
     for period in periods:
         entries.extend(_period_supply_entries(order_facts, period))
         purchases.extend(_period_purchase_entries(workspace, period, claimed))
+        entries.extend(_period_adjustment_entries(workspace, period))
     entries.extend(purchases)
     context = _Uncovered(workspace, history, (start, end), _covered_days(periods))
     entries.extend(_unregistered_supply_entries(order_facts, context))
@@ -127,6 +137,7 @@ def derive_entries(workspace, start, end):
         context,
         {entry.line_id for entry in purchases},
     ))
+    entries.extend(_unregistered_adjustment_entries(context))
     entries.sort(key=lambda entry: (entry.supply_date, entry.kind, entry.source_id, entry.line_id or 0))
     return entries
 
@@ -208,7 +219,7 @@ def _period_purchase_entries(workspace, period, claimed):
     here. See `derive_entries` for why a period has to be told.
     """
     if period.basis == INVOICE:
-        lines = _posted_receipt_lines(workspace, period.start, period.end)
+        lines = _invoiced_receipt_lines(workspace, period.start, period.end)
         return [
             _purchase_entry(line, period, period.basis)
             for line in _take(lines, claimed)
@@ -252,7 +263,7 @@ def _unregistered_purchase_entries(context, accounted_line_ids):
     """
     start, end = context.window
     entries = []
-    for line in _posted_receipt_lines(context.workspace, start, end):
+    for line in _invoiced_receipt_lines(context.workspace, start, end):
         if line.pk in accounted_line_ids:
             continue
         day = _unaccounted_day(line, context)
@@ -281,9 +292,9 @@ def _unaccounted_day(line, context):
     not cover. That line is accounted for elsewhere, and saying nothing about it
     here is what makes a narrow range honest rather than lossy.
     """
-    received = line.receipt.received_date
-    if received not in context.covered:
-        return received
+    invoice_day = line.receipt.invoice_date or line.receipt.received_date
+    if invoice_day not in context.covered:
+        return invoice_day
     start, end = context.window
     settled = line.receipt.settled_on
     if settled is not None and start <= settled <= end:
@@ -305,30 +316,89 @@ def _purchase_entry(line, period, basis):
     """
     receipt = line.receipt
     taxable = quantize_money(line.line_cost_ex_tax)
-    full_tax = quantize_money(taxable * Decimal(receipt.tax_rate) / PERCENT_DIVISOR)
-    recoverable = receipt.tax_recoverable
+    recoverable = quantize_money(line.recoverable_input_tax)
+    non_recoverable = quantize_money(line.non_recoverable_tax)
     # A settlement date is a date somebody paid a supplier on, so under a basis
     # that claims on payment it is the real time of supply and not a stand-in.
     # Every other purchase is still dated by the receipt standing in for the
     # supplier invoice date this application does not hold, and stays a proxy.
     paid = basis in PAYMENT_BASED and receipt.settled_on is not None
+    invoice_day = receipt.invoice_date or receipt.received_date
     return GstEntry(
         kind=PURCHASE,
-        supply_date=receipt.settled_on if paid else receipt.received_date,
+        supply_date=receipt.settled_on if paid else invoice_day,
         period=period,
         basis=basis,
         source_type='stock_receipt',
         source_id=receipt.pk,
         document_id=receipt.pk,
         line_id=line.pk,
-        tax_code='standard' if full_tax > 0 else 'unclassified',
-        tax_rate=Decimal(receipt.tax_rate),
+        tax_code=line.tax_treatment,
+        tax_rate=Decimal(line.tax_rate),
         taxable=taxable,
-        tax=full_tax if recoverable else ZERO,
-        non_recoverable_tax=ZERO if recoverable else full_tax,
+        tax=recoverable,
+        non_recoverable_tax=non_recoverable,
         currency_code=receipt.currency_code,
-        time_of_supply_source=SUPPLIER_PAYMENT if paid else RECEIPT_PROXY,
-        proxy=not paid,
+        time_of_supply_source=(
+            SUPPLIER_PAYMENT if paid
+            else SUPPLIER_INVOICE if receipt.invoice_date
+            else RECEIPT_PROXY
+        ),
+        input_tax_source=line.input_tax_source,
+        proxy=not paid and receipt.invoice_date is None,
+    )
+
+
+def _period_adjustment_entries(workspace, period):
+    """Return change-of-use adjustments made inside one taxable period."""
+    adjustments = InputTaxAdjustment.objects.filter(
+        workspace=workspace,
+        adjustment_date__gte=period.start,
+        adjustment_date__lte=period.end,
+    ).select_related('receipt_line__receipt').order_by('adjustment_date', 'pk')
+    return [_adjustment_entry(adjustment, period) for adjustment in adjustments]
+
+
+def _unregistered_adjustment_entries(context):
+    """Keep adjustments outside registration visible and unclaimed."""
+    start, end = context.window
+    adjustments = InputTaxAdjustment.objects.filter(
+        workspace=context.workspace,
+        adjustment_date__gte=start,
+        adjustment_date__lte=end,
+    ).select_related('receipt_line__receipt').order_by('adjustment_date', 'pk')
+    entries = []
+    for adjustment in adjustments:
+        if adjustment.adjustment_date in context.covered:
+            continue
+        entry = _adjustment_entry(adjustment, None)
+        entries.append(_with(
+            entry,
+            exclusion=context.exclusion_for(adjustment.adjustment_date),
+        ))
+    return entries
+
+
+def _adjustment_entry(adjustment, period):
+    amount = quantize_money(abs(adjustment.tax_adjustment))
+    return GstEntry(
+        kind=INPUT_TAX_ADJUSTMENT,
+        supply_date=adjustment.adjustment_date,
+        period=period,
+        basis=period.basis if period else '',
+        source_type='input_tax_adjustment',
+        source_id=adjustment.pk,
+        document_id=adjustment.receipt_line.receipt_id,
+        line_id=adjustment.receipt_line_id,
+        tax_code=adjustment.receipt_line.tax_treatment,
+        tax_rate=adjustment.receipt_line.tax_rate,
+        taxable=ZERO,
+        tax=amount,
+        non_recoverable_tax=ZERO,
+        currency_code=adjustment.receipt_line.receipt.currency_code,
+        time_of_supply_source=CHANGE_OF_USE,
+        input_tax_source=CHANGE_OF_USE,
+        adjustment_direction='credit' if adjustment.tax_adjustment > 0 else 'debit',
     )
 
 
@@ -346,11 +416,17 @@ def _receipt_lines(workspace):
     ).select_related('receipt')
 
 
-def _posted_receipt_lines(workspace, start, end):
-    """Return the lines of every posted receipt received in a range."""
+def _invoiced_receipt_lines(workspace, start, end):
+    """Return lines whose invoice date, or receipt proxy, is in a range."""
     return _receipt_lines(workspace).filter(
-        receipt__received_date__gte=start,
-        receipt__received_date__lte=end,
+        models.Q(
+            receipt__invoice_date__gte=start,
+            receipt__invoice_date__lte=end,
+        ) | models.Q(
+            receipt__invoice_date__isnull=True,
+            receipt__received_date__gte=start,
+            receipt__received_date__lte=end,
+        ),
     ).order_by('receipt__received_date', 'pk')
 
 
@@ -364,11 +440,9 @@ def _settled_receipt_lines(workspace, start, end):
 
 def _unsettled_receipt_lines(workspace, start, end):
     """Return the lines of posted receipts received in a range and not yet paid."""
-    return _receipt_lines(workspace).filter(
+    return _invoiced_receipt_lines(workspace, start, end).filter(
         receipt__settled_on__isnull=True,
-        receipt__received_date__gte=start,
-        receipt__received_date__lte=end,
-    ).order_by('receipt__received_date', 'pk')
+    )
 
 
 class _Uncovered:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
GST periods must reconcile to the explicit tax facts frozen on each purchase line. Recognize supplier invoice dates, classify Customs GST as a credit adjustment, and bring immutable change-of-use adjustments into the return arithmetic.

## Summary by Sourcery

Derive GST reporting from explicit receipt-line tax facts and include Customs and change-of-use adjustments in return calculations.

New Features:
- Derive GST purchase entries from receipt-line tax facts, including supplier invoice dates, line tax treatments, recoverable tax, and source classification.
- Report Customs GST and change-of-use input-tax adjustments as separate credit or debit adjustments in GST returns.

Bug Fixes:
- Replace receipt-date proxies with recorded supplier invoice dates when determining invoice-basis purchase periods.
- Replace receipt-level tax evidence warnings with warnings for the specific missing purchase evidence.

Enhancements:
- Expose input-tax sources and adjustment directions in GST entry exports and support filtering by input-tax adjustment and unknown tax code.

Tests:
- Add coverage for supplier invoice dating, Customs GST credit adjustments, change-of-use debit adjustments, and line-level purchase evidence warnings.