### PR TITLE
feat(inventory): capture tax evidence in purchase UI

### DIFF
--- a/frontend/js/api/inventory.ts
+++ b/frontend/js/api/inventory.ts
@@ -4,6 +4,8 @@ import {
   InventoryItemCreate,
   InventoryItemFilters,
   InventoryUnit,
+  InputTaxAdjustment,
+  InputTaxAdjustmentWrite,
   ItemUnitConversion,
   ItemUnitConversionCreate,
   StockReceipt,
@@ -17,6 +19,7 @@ import { csrfDelete, csrfPatch, csrfPost, fetchAsJson } from '../utils'
 const ITEMS_URL = '/inventory/items/'
 const CONVERSIONS_URL = '/inventory/conversions/'
 const RECEIPTS_URL = '/inventory/receipts/'
+const INPUT_TAX_ADJUSTMENTS_URL = '/inventory/input-tax-adjustments/'
 const STOCKTAKES_URL = '/inventory/stocktakes/'
 
 function getStocktakes(signal?: AbortSignal): Promise<Array<Stocktake>> {
@@ -100,6 +103,15 @@ function getStockReceipts(filters: StockReceiptFilters, signal?: AbortSignal): P
   return fetchAsJson<Array<StockReceipt>>(`${RECEIPTS_URL}${query}`, signal)
 }
 
+function getInputTaxAdjustments(receipt: number, signal?: AbortSignal): Promise<Array<InputTaxAdjustment>> {
+  return fetchAsJson<Array<InputTaxAdjustment>>(`${INPUT_TAX_ADJUSTMENTS_URL}?receipt=${receipt}`, signal)
+}
+
+async function createInputTaxAdjustment(adjustment: InputTaxAdjustmentWrite): Promise<InputTaxAdjustment> {
+  const response = await csrfPost(INPUT_TAX_ADJUSTMENTS_URL, adjustment)
+  return response.json() as Promise<InputTaxAdjustment>
+}
+
 async function createStockReceipt(receipt: StockReceiptWrite): Promise<StockReceipt> {
   const response = await csrfPost(RECEIPTS_URL, receipt)
   return response.json() as Promise<StockReceipt>
@@ -137,12 +149,14 @@ function deleteStockReceipt(pk: number): Promise<Response> {
 
 export {
   createInventoryItem,
+  createInputTaxAdjustment,
   createItemUnitConversion,
   createStockReceipt,
   deleteStockReceipt,
   getInventoryBalances,
   getInventoryItems,
   getInventoryUnits,
+  getInputTaxAdjustments,
   getItemUnitConversions,
   getStockReceipts,
   getStocktake,

--- a/frontend/js/inventory/receipt_editor.tsx
+++ b/frontend/js/inventory/receipt_editor.tsx
@@ -4,7 +4,18 @@ import { Alert, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
 
 import { createStockReceipt, getItemUnitConversions, updateStockReceipt } from '../api/inventory'
 import { ApiError, formatMeasure, formatQuantity } from '../utils'
-import { InventoryItem, InventoryUnit, QuantityCertainty, StockReceipt, StockReceiptLine, StockReceiptLineWrite, UnitCode } from '../types/inventory'
+import {
+  InputTaxSource,
+  InventoryItem,
+  InventoryUnit,
+  PurchaseTaxTreatment,
+  QuantityCertainty,
+  ReceiptDocumentType,
+  StockReceipt,
+  StockReceiptLine,
+  StockReceiptLineWrite,
+  UnitCode
+} from '../types/inventory'
 import { Location } from '../types/locations'
 import { Supplier } from '../types/suppliers'
 import { queryKeys } from '../query'
@@ -24,7 +35,14 @@ interface ReceiptLineDraft {
   unitChoice: UnitChoice
   supplierLotReference: string
   expiresOn: string
-  lineCostExTax: string
+  supplierCostInclTax: string
+  taxTreatment: PurchaseTaxTreatment
+  taxRate: string
+  inputTaxSource: InputTaxSource
+  inputTaxAmount: string
+  claimInputTax: boolean
+  claimablePercentage: string
+  apportionmentBasis: string
   destination: number | ''
   // The last quantity the server normalized. Null means nobody has checked
   // this line's arithmetic since it was last touched.
@@ -41,29 +59,21 @@ function blankLine(key: string): ReceiptLineDraft {
     unitChoice: '',
     supplierLotReference: '',
     expiresOn: '',
-    lineCostExTax: '',
+    supplierCostInclTax: '',
+    taxTreatment: 'unknown',
+    taxRate: '0',
+    inputTaxSource: 'none',
+    inputTaxAmount: '0',
+    claimInputTax: false,
+    claimablePercentage: '0',
+    apportionmentBasis: '',
     destination: '',
     baseQuantity: null,
     baseUnit: null
   }
 }
 
-function displayPrice(lineCostExTax: string, includesTax: boolean, taxRate: string): string {
-  if (!includesTax || taxRate.trim() === '') return lineCostExTax
-  const rate = Number(taxRate)
-  return Number.isFinite(rate) ? (Number(lineCostExTax) * (1 + rate / 100)).toFixed(4) : lineCostExTax
-}
-
-function convertEntryPrice(value: string, fromIncludesTax: boolean, toIncludesTax: boolean, taxRate: string): string {
-  if (value.trim() === '' || fromIncludesTax === toIncludesTax || taxRate.trim() === '') return value
-  const rate = Number(taxRate)
-  if (!Number.isFinite(rate)) return value
-  const factor = 1 + rate / 100
-  const converted = fromIncludesTax ? Number(value) / factor : Number(value) * factor
-  return Number.isFinite(converted) ? converted.toFixed(4) : value
-}
-
-function hydrateLine(line: StockReceiptLine, key: string, includesTax: boolean, taxRate: string): ReceiptLineDraft {
+function hydrateLine(line: StockReceiptLine, key: string): ReceiptLineDraft {
   return {
     key,
     item: line.item,
@@ -72,7 +82,14 @@ function hydrateLine(line: StockReceiptLine, key: string, includesTax: boolean, 
     unitChoice: line.unit_conversion !== null ? `conversion:${line.unit_conversion}` : line.unit_code !== null ? `unit:${line.unit_code}` : '',
     supplierLotReference: line.supplier_lot_reference,
     expiresOn: line.expires_on ?? '',
-    lineCostExTax: displayPrice(line.line_cost_ex_tax, includesTax, taxRate),
+    supplierCostInclTax: line.supplier_cost_incl_tax,
+    taxTreatment: line.tax_treatment,
+    taxRate: line.tax_rate,
+    inputTaxSource: line.input_tax_source,
+    inputTaxAmount: line.input_tax_amount,
+    claimInputTax: line.claim_input_tax,
+    claimablePercentage: line.claimable_percentage,
+    apportionmentBasis: line.apportionment_basis,
     destination: line.destination,
     baseQuantity: line.base_quantity,
     baseUnit: line.base_unit
@@ -92,7 +109,14 @@ function linePayload(line: ReceiptLineDraft): StockReceiptLineWrite {
     // omitting the unused one would leave a stale value behind on a PATCH.
     unit_code: kind === 'unit' ? (value as UnitCode) : null,
     unit_conversion: kind === 'conversion' ? Number(value) : null,
-    line_cost_ex_tax: line.lineCostExTax,
+    supplier_cost_incl_tax: line.supplierCostInclTax,
+    tax_treatment: line.taxTreatment,
+    tax_rate: line.taxRate,
+    input_tax_source: line.inputTaxSource,
+    input_tax_amount: line.inputTaxAmount,
+    claim_input_tax: line.claimInputTax,
+    claimable_percentage: line.claimablePercentage,
+    apportionment_basis: line.apportionmentBasis,
     destination: Number(line.destination)
   }
 }
@@ -218,16 +242,111 @@ function LineRow({ line, index, items, locations, units, errors, removable, onCh
         {errors.destination && <Form.Text className="text-danger">{errors.destination}</Form.Text>}
       </td>
       <td>
+        <Form.Label className="small mb-0">Supplier cost incl tax</Form.Label>
         <Form.Control
           size="sm"
           type="number"
           min="0"
           step="0.0001"
-          value={line.lineCostExTax}
-          isInvalid={errors.line_cost_ex_tax !== undefined}
-          onChange={(event) => onChange(line.key, { lineCostExTax: event.target.value })}
+          value={line.supplierCostInclTax}
+          isInvalid={errors.supplier_cost_incl_tax !== undefined}
+          onChange={(event) => onChange(line.key, { supplierCostInclTax: event.target.value })}
         />
-        {errors.line_cost_ex_tax && <Form.Text className="text-danger">{errors.line_cost_ex_tax}</Form.Text>}
+        <Form.Select
+          size="sm"
+          className="mt-1"
+          value={line.taxTreatment}
+          onChange={(event) => onChange(line.key, { taxTreatment: event.target.value as PurchaseTaxTreatment, taxRate: event.target.value === 'standard' ? line.taxRate : '0' })}
+        >
+          <option value="unknown">Tax treatment unknown</option>
+          <option value="standard">Standard-rated</option>
+          <option value="zero_rated">Zero-rated</option>
+          <option value="exempt">Exempt</option>
+          <option value="out_of_scope">Out of scope</option>
+        </Form.Select>
+        {line.taxTreatment === 'standard' && (
+          <Form.Control
+            size="sm"
+            className="mt-1"
+            type="number"
+            min="0"
+            step="0.0001"
+            value={line.taxRate}
+            placeholder="Tax rate %"
+            onChange={(event) => onChange(line.key, { taxRate: event.target.value })}
+          />
+        )}
+        <Form.Select
+          size="sm"
+          className="mt-1"
+          value={line.inputTaxSource}
+          onChange={(event) =>
+            onChange(line.key, { inputTaxSource: event.target.value as InputTaxSource, inputTaxAmount: event.target.value === 'none' ? '0' : line.inputTaxAmount })
+          }
+        >
+          <option value="none">No input tax</option>
+          <option value="supplier">Supplier GST</option>
+          <option value="customs">Customs GST</option>
+          <option value="second_hand">Second-hand deduction</option>
+        </Form.Select>
+        {line.inputTaxSource !== 'none' && (
+          <Form.Control
+            size="sm"
+            className="mt-1"
+            type="number"
+            min="0"
+            step="0.0001"
+            value={line.inputTaxAmount}
+            placeholder="Input tax amount"
+            onChange={(event) => onChange(line.key, { inputTaxAmount: event.target.value })}
+          />
+        )}
+        {line.inputTaxSource !== 'none' && (
+          <>
+            <Form.Check
+              className="mt-1"
+              type="checkbox"
+              label="Claim input tax"
+              checked={line.claimInputTax}
+              onChange={(event) =>
+                onChange(line.key, {
+                  claimInputTax: event.target.checked,
+                  claimablePercentage: event.target.checked ? (line.claimablePercentage === '0' ? '100' : line.claimablePercentage) : '0'
+                })
+              }
+            />
+            {line.claimInputTax && (
+              <Form.Control
+                size="sm"
+                type="number"
+                min="0"
+                max="100"
+                step="0.0001"
+                value={line.claimablePercentage}
+                placeholder="Claimable %"
+                onChange={(event) => onChange(line.key, { claimablePercentage: event.target.value })}
+              />
+            )}
+            {line.claimInputTax && line.claimablePercentage !== '100' && (
+              <Form.Control
+                size="sm"
+                className="mt-1"
+                value={line.apportionmentBasis}
+                placeholder="Apportionment basis"
+                onChange={(event) => onChange(line.key, { apportionmentBasis: event.target.value })}
+              />
+            )}
+          </>
+        )}
+        {Object.entries(errors)
+          .filter(([field]) =>
+            ['supplier_cost_incl_tax', 'tax_treatment', 'tax_rate', 'input_tax_source', 'input_tax_amount', 'claimable_percentage', 'apportionment_basis'].includes(field)
+          )
+          .map(([field, message]) => (
+            <Form.Text key={field} className="text-danger d-block">
+              {message}
+            </Form.Text>
+          ))}
       </td>
       <td>
         <Form.Control
@@ -272,17 +391,20 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
   const [supplier, setSupplier] = React.useState<number | ''>(receipt?.supplier ?? '')
   const [receivedDate, setReceivedDate] = React.useState(receipt?.received_date ?? new Date().toISOString().slice(0, 10))
   const [supplierReference, setSupplierReference] = React.useState(receipt?.supplier_reference ?? '')
+  const [invoiceDate, setInvoiceDate] = React.useState(receipt?.invoice_date ?? '')
+  const [sourceDocumentType, setSourceDocumentType] = React.useState<ReceiptDocumentType>(receipt?.source_document_type ?? 'none')
+  const [sourceDocumentNumber, setSourceDocumentNumber] = React.useState(receipt?.source_document_number ?? '')
+  const [evidenceReference, setEvidenceReference] = React.useState(receipt?.evidence_reference ?? '')
+  const [evidenceUrl, setEvidenceUrl] = React.useState(receipt?.evidence_url ?? '')
   const [currencyCode, setCurrencyCode] = React.useState(receipt?.currency_code ?? '')
-  const [taxRate, setTaxRate] = React.useState(receipt?.tax_rate ?? '')
-  const [priceIncludesTax, setPriceIncludesTax] = React.useState(receipt?.price_includes_tax ?? false)
-  const [taxRecoverable, setTaxRecoverable] = React.useState(receipt?.tax_recoverable ?? true)
   const [notes, setNotes] = React.useState(receipt?.notes ?? '')
   const [lines, setLines] = React.useState<Array<ReceiptLineDraft>>(() =>
-    receipt && receipt.lines.length > 0 ? receipt.lines.map((line) => hydrateLine(line, `saved-${line.pk}`, receipt.price_includes_tax, receipt.tax_rate)) : [blankLine(freshKey())]
+    receipt && receipt.lines.length > 0 ? receipt.lines.map((line) => hydrateLine(line, `saved-${line.pk}`)) : [blankLine(freshKey())]
   )
   const [error, setError] = React.useState<string>()
   const [lineErrors, setLineErrors] = React.useState<Array<Record<string, string>>>([])
   const [saved, setSaved] = React.useState(false)
+  const [taxWarnings, setTaxWarnings] = React.useState(receipt?.tax_warnings ?? [])
 
   const selectableItems = receivableItems(items)
   const selectableLocations = receivableLocations(locations)
@@ -322,13 +444,15 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
         supplier: Number(supplier),
         received_date: receivedDate,
         supplier_reference: supplierReference,
-        tax_recoverable: taxRecoverable,
-        price_includes_tax: priceIncludesTax,
+        invoice_date: invoiceDate || null,
+        source_document_type: sourceDocumentType,
+        source_document_number: sourceDocumentNumber,
+        evidence_reference: evidenceReference,
+        evidence_url: evidenceUrl,
         notes,
         // Blank means "whatever the workspace says", which the server fills in
         // and returns, so these inputs populate themselves after the first save.
         ...(currencyCode.trim() === '' ? {} : { currency_code: currencyCode }),
-        ...(taxRate.trim() === '' ? {} : { tax_rate: taxRate }),
         lines: lines.map(linePayload)
       }
       return receiptPk === null ? createStockReceipt(payload) : updateStockReceipt(receiptPk, payload)
@@ -336,12 +460,11 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
     onSuccess: async (response) => {
       setReceiptPk(response.pk)
       setCurrencyCode(response.currency_code)
-      setTaxRate(response.tax_rate)
-      setPriceIncludesTax(response.price_includes_tax)
       // A PATCH deletes and recreates every line, so the returned pks are all
       // new. Identity is carried positionally instead, which the server
       // guarantees by creating lines in the order they were submitted.
-      setLines((current) => response.lines.map((line, index) => hydrateLine(line, current[index]?.key ?? `saved-${line.pk}`, response.price_includes_tax, response.tax_rate)))
+      setLines((current) => response.lines.map((line, index) => hydrateLine(line, current[index]?.key ?? `saved-${line.pk}`)))
+      setTaxWarnings(response.tax_warnings)
       setError(undefined)
       setLineErrors([])
       setSaved(true)
@@ -350,7 +473,7 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
     onError: recordFailure
   })
 
-  const complete = lines.every((line) => line.item !== '' && line.destination !== '' && line.unitChoice !== '' && line.lineCostExTax.trim() !== '')
+  const complete = lines.every((line) => line.item !== '' && line.destination !== '' && line.unitChoice !== '' && line.supplierCostInclTax.trim() !== '')
   const quantified = lines.every((line) => line.quantityCertainty === 'unknown' || line.quantity.trim() !== '')
   const readyToSave = supplier !== '' && receivedDate !== '' && lines.length > 0 && complete && quantified
 
@@ -391,48 +514,52 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
             </Form.Group>
           </Col>
           <Col md={2}>
-            <Form.Group className="mb-3" controlId="receipt-tax-rate">
-              <Form.Label>Tax rate %</Form.Label>
-              <Form.Control value={taxRate} inputMode="decimal" placeholder="Workspace default" onChange={(event) => setTaxRate(event.target.value)} />
-            </Form.Group>
-          </Col>
-          <Col md={2}>
-            <Form.Group className="mb-3" controlId="receipt-price-basis">
-              <Form.Label>Prices</Form.Label>
-              <Form.Select
-                value={priceIncludesTax ? 'inclusive' : 'exclusive'}
-                onChange={(event) => {
-                  const nextIncludesTax = event.target.value === 'inclusive'
-                  setLines((current) =>
-                    current.map((line) => ({
-                      ...line,
-                      lineCostExTax: convertEntryPrice(line.lineCostExTax, priceIncludesTax, nextIncludesTax, taxRate)
-                    }))
-                  )
-                  setPriceIncludesTax(nextIncludesTax)
-                }}
-              >
-                <option value="exclusive">Ex GST</option>
-                <option value="inclusive">Inc GST</option>
-              </Form.Select>
+            <Form.Group className="mb-3" controlId="receipt-invoice-date">
+              <Form.Label>Invoice date</Form.Label>
+              <Form.Control type="date" value={invoiceDate} onChange={(event) => setInvoiceDate(event.target.value)} />
             </Form.Group>
           </Col>
         </Row>
         <Row className="g-2">
-          <Col md={9}>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="receipt-source-document-type">
+              <Form.Label>Source record</Form.Label>
+              <Form.Select value={sourceDocumentType} onChange={(event) => setSourceDocumentType(event.target.value as ReceiptDocumentType)}>
+                <option value="none">None recorded</option>
+                <option value="taxable_supply">Taxable supply information</option>
+                <option value="invoice">Invoice</option>
+                <option value="receipt">Receipt</option>
+                <option value="buyer_created">Buyer-created information</option>
+                <option value="customs_entry">Customs entry or statement</option>
+                <option value="contract">Contract or agreement</option>
+                <option value="bank_record">Bank record</option>
+                <option value="other">Other</option>
+              </Form.Select>
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="receipt-source-document-number">
+              <Form.Label>Document number</Form.Label>
+              <Form.Control value={sourceDocumentNumber} onChange={(event) => setSourceDocumentNumber(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="receipt-evidence-reference">
+              <Form.Label>Evidence reference</Form.Label>
+              <Form.Control value={evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={3}>
+            <Form.Group className="mb-3" controlId="receipt-evidence-url">
+              <Form.Label>Evidence URL</Form.Label>
+              <Form.Control type="url" value={evidenceUrl} onChange={(event) => setEvidenceUrl(event.target.value)} />
+            </Form.Group>
+          </Col>
+          <Col md={12}>
             <Form.Group className="mb-3" controlId="receipt-notes">
               <Form.Label>Notes</Form.Label>
               <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
             </Form.Group>
-          </Col>
-          <Col md={3} className="d-flex align-items-center">
-            <Form.Check
-              id="receipt-tax-recoverable"
-              type="checkbox"
-              label="Tax is recoverable"
-              checked={taxRecoverable}
-              onChange={(event) => setTaxRecoverable(event.target.checked)}
-            />
           </Col>
         </Row>
 
@@ -444,7 +571,7 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
               <th>Unit</th>
               <th>Normalizes to</th>
               <th>Destination</th>
-              <th>{priceIncludesTax ? 'Price inc GST' : 'Price ex GST'}</th>
+              <th>Cost and input tax</th>
               <th>Lot reference and expiry</th>
               <th />
             </tr>
@@ -471,6 +598,11 @@ function ReceiptEditor({ receipt, items, locations, suppliers, units, onClosed }
         </Button>
 
         {error && <Alert variant="danger">{error}</Alert>}
+        {taxWarnings.map((warning) => (
+          <Alert key={`${warning.code}-${warning.line_id ?? 'receipt'}`} variant="warning" className="py-2">
+            {warning.message}
+          </Alert>
+        ))}
         {saved && <Alert variant="info">Saved as a draft. Nothing has moved yet — check the normalized quantities, then post it from the list below.</Alert>}
 
         <div className="d-flex gap-2">

--- a/frontend/js/inventory/receipt_list.tsx
+++ b/frontend/js/inventory/receipt_list.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Alert, Badge, Button, Form, Table } from 'react-bootstrap'
 
-import { deleteStockReceipt, postStockReceipt, reverseStockReceipt } from '../api/inventory'
+import { createInputTaxAdjustment, deleteStockReceipt, getInputTaxAdjustments, postStockReceipt, reverseStockReceipt } from '../api/inventory'
 import { ReceiptSettlement } from './settlement'
 import { formatMeasure } from '../utils'
 import { InventoryItem, StockReceipt, StockReceiptLine } from '../types/inventory'
@@ -214,32 +214,132 @@ function ReceiptLinesTable({ receipt, items, locations }: ReceiptLinesTableProps
     return <span className="text-muted">No lines yet.</span>
   }
   return (
-    <Table size="sm" className="mb-0">
-      <thead>
-        <tr>
-          <th>Item</th>
-          <th>Quantity</th>
-          <th>Destination</th>
-          <th>Cost</th>
-          <th>Lot</th>
-        </tr>
-      </thead>
-      <tbody>
-        {receipt.lines.map((line) => (
-          <tr key={line.pk}>
-            <td>{items.find((item) => item.pk === line.item)?.name ?? `#${line.item}`}</td>
-            <td>
-              <LineQuantity line={line} />
-            </td>
-            <td>{locations.find((location) => location.pk === line.destination)?.name ?? `#${line.destination}`}</td>
-            <td>
-              {line.line_cost_ex_tax} {receipt.currency_code}
-            </td>
-            <td className="small">{line.lot !== null ? `#${line.lot}` : '—'}</td>
+    <>
+      {receipt.tax_warnings.map((warning) => (
+        <Alert key={`${warning.code}-${warning.line_id ?? 'receipt'}`} variant="warning" className="py-1 mb-1 small">
+          {warning.message}
+        </Alert>
+      ))}
+      <Table size="sm" className="mb-0">
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Quantity</th>
+            <th>Destination</th>
+            <th>Cost</th>
+            <th>Lot</th>
           </tr>
-        ))}
-      </tbody>
-    </Table>
+        </thead>
+        <tbody>
+          {receipt.lines.map((line) => (
+            <tr key={line.pk}>
+              <td>{items.find((item) => item.pk === line.item)?.name ?? `#${line.item}`}</td>
+              <td>
+                <LineQuantity line={line} />
+              </td>
+              <td>{locations.find((location) => location.pk === line.destination)?.name ?? `#${line.destination}`}</td>
+              <td>
+                <div>
+                  {line.supplier_cost_incl_tax} {receipt.currency_code} supplier cost
+                </div>
+                <div className="small">
+                  Input tax {line.input_tax_amount}; recoverable {line.recoverable_input_tax}; non-recoverable {line.non_recoverable_tax}
+                </div>
+                <div className="small">Inventory acquisition {line.acquisition_amount}</div>
+              </td>
+              <td className="small">{line.lot !== null ? `#${line.lot}` : '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </>
+  )
+}
+
+function InputTaxAdjustments({ receipt }: { receipt: StockReceipt }) {
+  const queryClient = useQueryClient()
+  const queryKey = ['input-tax-adjustments', receipt.pk]
+  const [show, setShow] = React.useState(false)
+  const [line, setLine] = React.useState(receipt.lines[0]?.pk ?? 0)
+  const [adjustmentDate, setAdjustmentDate] = React.useState(new Date().toISOString().slice(0, 10))
+  const [revisedPercentage, setRevisedPercentage] = React.useState('')
+  const [basis, setBasis] = React.useState('')
+  const [reason, setReason] = React.useState('')
+  const [evidenceReference, setEvidenceReference] = React.useState('')
+  const [error, setError] = React.useState<string>()
+  const { data: adjustments = [] } = useQuery({
+    queryKey,
+    queryFn: ({ signal }) => getInputTaxAdjustments(receipt.pk, signal),
+    enabled: show
+  })
+  const mutation = useMutation({
+    mutationFn: () =>
+      createInputTaxAdjustment({
+        receipt_line: line,
+        adjustment_date: adjustmentDate,
+        revised_claimable_percentage: revisedPercentage,
+        apportionment_basis: basis,
+        reason,
+        evidence_reference: evidenceReference
+      }),
+    onSuccess: async () => {
+      setError(undefined)
+      setRevisedPercentage('')
+      setBasis('')
+      setReason('')
+      setEvidenceReference('')
+      await queryClient.invalidateQueries({ queryKey })
+      await invalidateReceipts(queryClient)
+    },
+    onError: (caught) => setError(localErrorMessage(caught))
+  })
+
+  return (
+    <div className="mt-2">
+      <Button size="sm" variant="outline-secondary" onClick={() => setShow((current) => !current)}>
+        {show ? 'Hide tax adjustments' : 'Tax use changed'}
+      </Button>
+      {show && (
+        <div className="mt-2 small">
+          {adjustments.map((adjustment) => (
+            <div key={adjustment.pk}>
+              {adjustment.adjustment_date}: {adjustment.tax_adjustment} GST ({adjustment.previous_claimable_percentage}% → {adjustment.revised_claimable_percentage}%) —{' '}
+              {adjustment.reason}
+            </div>
+          ))}
+          <Form.Select size="sm" className="mt-1" value={line} onChange={(event) => setLine(Number(event.target.value))}>
+            {receipt.lines.map((entry) => (
+              <option key={entry.pk} value={entry.pk}>
+                Line #{entry.pk}
+              </option>
+            ))}
+          </Form.Select>
+          <Form.Control size="sm" className="mt-1" type="date" value={adjustmentDate} onChange={(event) => setAdjustmentDate(event.target.value)} />
+          <Form.Control
+            size="sm"
+            className="mt-1"
+            type="number"
+            min="0"
+            max="100"
+            step="0.0001"
+            value={revisedPercentage}
+            placeholder="Revised claimable %"
+            onChange={(event) => setRevisedPercentage(event.target.value)}
+          />
+          <Form.Control size="sm" className="mt-1" value={basis} placeholder="Revised apportionment basis" onChange={(event) => setBasis(event.target.value)} />
+          <Form.Control size="sm" className="mt-1" value={reason} placeholder="Reason use changed" onChange={(event) => setReason(event.target.value)} />
+          <Form.Control size="sm" className="mt-1" value={evidenceReference} placeholder="Evidence reference" onChange={(event) => setEvidenceReference(event.target.value)} />
+          {error && (
+            <Alert variant="danger" className="py-1 mt-1">
+              {error}
+            </Alert>
+          )}
+          <Button size="sm" className="mt-1" disabled={!line || !revisedPercentage || !basis || !reason || mutation.isPending} onClick={() => mutation.mutate()}>
+            Record adjustment
+          </Button>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -284,7 +384,12 @@ function ReceiptTable({ receipts, items, locations, suppliers, onEdit, onCancell
             </td>
             <td>
               {receipt.status === 'draft' && <DraftActions receipt={receipt} onEdit={onEdit} onCancelled={onCancelled} />}
-              {receipt.status === 'posted' && <ReverseReceiptButton receipt={receipt} />}
+              {receipt.status === 'posted' && (
+                <>
+                  <ReverseReceiptButton receipt={receipt} />
+                  <InputTaxAdjustments receipt={receipt} />
+                </>
+              )}
               {receipt.status === 'reversed' && <span className="text-muted">—</span>}
             </td>
           </tr>

--- a/frontend/js/seeds.tsx
+++ b/frontend/js/seeds.tsx
@@ -7,6 +7,7 @@ import Select from 'react-select'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { Supplier, SupplierCreate } from './types/suppliers'
+import { InputTaxSource, PurchaseTaxTreatment, ReceiptDocumentType } from './types/inventory'
 import { Seed, SeedCreate, SeedPacket, SeedPacketProvenance, SeedPacketReceiptCreate, SeedPacketReceiptDraft, SeedPacketReconciliation, SeedQuantityCertainty } from './types/seeds'
 import { Plant, PlantVariety } from './types/plants'
 import { SelectOption } from './types/others'
@@ -36,6 +37,9 @@ interface NewSeedSupplierRowProps {
 
 interface NewSeedSupplierRowState {
   name: string
+  address: string
+  gstStatus: 'registered' | 'unregistered' | 'unknown'
+  gstNumber: string
   website?: string
   notes?: string
 }
@@ -46,6 +50,9 @@ class NewSeedSupplierRow extends React.Component<NewSeedSupplierRowProps, NewSee
 
     this.state = {
       name: '',
+      address: '',
+      gstStatus: 'unknown',
+      gstNumber: '',
       website: undefined,
       notes: undefined
     }
@@ -78,6 +85,9 @@ class NewSeedSupplierRow extends React.Component<NewSeedSupplierRowProps, NewSee
   async add() {
     const data: SupplierCreate = {
       name: this.state.name,
+      address: this.state.address,
+      gst_status: this.state.gstStatus,
+      gst_number: this.state.gstStatus === 'registered' ? this.state.gstNumber : '',
       notes: this.state.notes
     }
     if (this.state.website && this.state.website !== '') {
@@ -95,6 +105,15 @@ class NewSeedSupplierRow extends React.Component<NewSeedSupplierRowProps, NewSee
         </td>
         <td>
           <input type="text" onChange={this.updateWebsite} />
+        </td>
+        <td>
+          <textarea placeholder="Address" onChange={(event) => this.setState({ address: event.target.value })} />
+          <select value={this.state.gstStatus} onChange={(event) => this.setState({ gstStatus: event.target.value as NewSeedSupplierRowState['gstStatus'] })}>
+            <option value="unknown">GST status unknown</option>
+            <option value="registered">GST registered</option>
+            <option value="unregistered">Not GST registered</option>
+          </select>
+          {this.state.gstStatus === 'registered' && <input type="text" placeholder="GST number" onChange={(event) => this.setState({ gstNumber: event.target.value })} />}
         </td>
         <td>
           <textarea onChange={this.updateNotes} />
@@ -126,6 +145,10 @@ class SeedSupplierRow extends React.Component<SeedSupplierRowProps> {
         </td>
         <td>
           <a href={this.props.supplier.website}>{this.props.supplier.website}</a>
+        </td>
+        <td>
+          <div>{this.props.supplier.address || '—'}</div>
+          <div>{this.props.supplier.gst_status === 'registered' ? `GST ${this.props.supplier.gst_number}` : this.props.supplier.gst_status}</div>
         </td>
         <td>{this.props.supplier.notes}</td>
       </tr>
@@ -167,6 +190,7 @@ function SeedSuppliersTable() {
             </Button>
           </td>
           <td>Website</td>
+          <td>Tax identity</td>
           <td>Notes</td>
         </tr>
       </thead>
@@ -421,14 +445,24 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
   const [seedPk, setSeedPk] = React.useState<number | undefined>(draft?.seeds)
   const [certainty, setCertainty] = React.useState<SeedQuantityCertainty>(draft?.quantity_certainty ?? 'unknown')
   const [quantity, setQuantity] = React.useState(draft?.quantity ? formatQuantity(draft.quantity) : '')
-  const [price, setPrice] = React.useState(draft?.line_price ?? (priceRequired ? '' : '0'))
+  const [price, setPrice] = React.useState(draft?.supplier_cost_incl_tax ?? draft?.line_price ?? (priceRequired ? '' : '0'))
   const [receivedDate, setReceivedDate] = React.useState(draft?.received_date ?? new Date().toISOString().slice(0, 10))
   const [sowBy, setSowBy] = React.useState(draft?.sow_by ?? '')
   const [supplierLot, setSupplierLot] = React.useState(draft?.supplier_lot_reference ?? '')
   const [vendorPk, setVendorPk] = React.useState<number | undefined>(draft?.supplier)
   const [supplierReference, setSupplierReference] = React.useState(draft?.supplier_reference ?? '')
+  const [invoiceDate, setInvoiceDate] = React.useState(draft?.invoice_date ?? '')
+  const [sourceDocumentType, setSourceDocumentType] = React.useState<ReceiptDocumentType>(draft?.source_document_type ?? 'none')
+  const [sourceDocumentNumber, setSourceDocumentNumber] = React.useState(draft?.source_document_number ?? '')
+  const [evidenceReference, setEvidenceReference] = React.useState(draft?.evidence_reference ?? '')
+  const [evidenceUrl, setEvidenceUrl] = React.useState(draft?.evidence_url ?? '')
   const [taxRate, setTaxRate] = React.useState(draft?.tax_rate ?? '')
-  const [taxRecoverable, setTaxRecoverable] = React.useState(draft?.tax_recoverable ?? false)
+  const [taxTreatment, setTaxTreatment] = React.useState<PurchaseTaxTreatment>(draft?.tax_treatment ?? 'unknown')
+  const [inputTaxSource, setInputTaxSource] = React.useState<InputTaxSource>(draft?.input_tax_source ?? 'none')
+  const [inputTaxAmount, setInputTaxAmount] = React.useState(draft?.input_tax_amount ?? '0')
+  const [claimInputTax, setClaimInputTax] = React.useState(draft?.claim_input_tax ?? false)
+  const [claimablePercentage, setClaimablePercentage] = React.useState(draft?.claimable_percentage ?? '0')
+  const [apportionmentBasis, setApportionmentBasis] = React.useState(draft?.apportionment_basis ?? '')
   const [notes, setNotes] = React.useState(draft?.notes ?? '')
   const [errors, setErrors] = React.useState<Record<string, string>>({})
   const editing = draft !== undefined
@@ -475,8 +509,19 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
     data.supplier_lot_reference = supplierLot
     if (vendor) data.supplier = vendor
     data.supplier_reference = supplierReference
-    if (taxRate) data.tax_rate = taxRate
-    data.tax_recoverable = taxRecoverable
+    data.invoice_date = invoiceDate || null
+    data.source_document_type = sourceDocumentType
+    data.source_document_number = sourceDocumentNumber
+    data.evidence_reference = evidenceReference
+    data.evidence_url = evidenceUrl
+    data.supplier_cost_incl_tax = price
+    data.tax_treatment = taxTreatment
+    data.tax_rate = taxTreatment === 'standard' ? taxRate : '0'
+    data.input_tax_source = inputTaxSource
+    data.input_tax_amount = inputTaxSource === 'none' ? '0' : inputTaxAmount
+    data.claim_input_tax = claimInputTax
+    data.claimable_percentage = claimInputTax ? claimablePercentage : '0'
+    data.apportionment_basis = apportionmentBasis
     data.notes = notes
     try {
       await onSave(data)
@@ -547,7 +592,7 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
             {fieldError('quantity')}
           </Form.Group>
           <Form.Group className="col-md-2">
-            <Form.Label>Line price</Form.Label>
+            <Form.Label>Supplier cost incl tax</Form.Label>
             <Form.Control required={priceRequired} type="number" min="0" step="0.0001" value={price} onChange={(event) => setPrice(event.target.value)} />
             {fieldError('line_price')}
           </Form.Group>
@@ -572,14 +617,84 @@ function PacketReceiptForm({ seeds, suppliers, plants, varieties, draft, onSave,
             {fieldError('supplier_reference')}
           </Form.Group>
           <Form.Group className="col-md-2">
-            <Form.Label>Tax rate</Form.Label>
-            <Form.Control type="number" min="0" step="0.0001" value={taxRate} onChange={(event) => setTaxRate(event.target.value)} />
-            {fieldError('tax_rate')}
+            <Form.Label>Invoice date</Form.Label>
+            <Form.Control type="date" value={invoiceDate} onChange={(event) => setInvoiceDate(event.target.value)} />
           </Form.Group>
           <Form.Group className="col-md-2">
-            <Form.Label>Tax</Form.Label>
-            <Form.Check type="checkbox" label="Recoverable" checked={taxRecoverable} onChange={(event) => setTaxRecoverable(event.target.checked)} />
-            {fieldError('tax_recoverable')}
+            <Form.Label>Tax treatment</Form.Label>
+            <Form.Select value={taxTreatment} onChange={(event) => setTaxTreatment(event.target.value as PurchaseTaxTreatment)}>
+              <option value="unknown">Unknown</option>
+              <option value="standard">Standard-rated</option>
+              <option value="zero_rated">Zero-rated</option>
+              <option value="exempt">Exempt</option>
+              <option value="out_of_scope">Out of scope</option>
+            </Form.Select>
+          </Form.Group>
+          {taxTreatment === 'standard' && (
+            <Form.Group className="col-md-2">
+              <Form.Label>Tax rate %</Form.Label>
+              <Form.Control type="number" min="0" step="0.0001" value={taxRate} onChange={(event) => setTaxRate(event.target.value)} />
+            </Form.Group>
+          )}
+          <Form.Group className="col-md-2">
+            <Form.Label>Input-tax source</Form.Label>
+            <Form.Select value={inputTaxSource} onChange={(event) => setInputTaxSource(event.target.value as InputTaxSource)}>
+              <option value="none">None</option>
+              <option value="supplier">Supplier</option>
+              <option value="customs">Customs</option>
+              <option value="second_hand">Second-hand</option>
+            </Form.Select>
+          </Form.Group>
+          {inputTaxSource !== 'none' && (
+            <Form.Group className="col-md-2">
+              <Form.Label>Input tax</Form.Label>
+              <Form.Control type="number" min="0" step="0.0001" value={inputTaxAmount} onChange={(event) => setInputTaxAmount(event.target.value)} />
+            </Form.Group>
+          )}
+          {inputTaxSource !== 'none' && (
+            <Form.Group className="col-md-2">
+              <Form.Check
+                type="checkbox"
+                label="Claim input tax"
+                checked={claimInputTax}
+                onChange={(event) => {
+                  setClaimInputTax(event.target.checked)
+                  setClaimablePercentage(event.target.checked ? '100' : '0')
+                }}
+              />
+              {claimInputTax && (
+                <Form.Control type="number" min="0" max="100" step="0.0001" value={claimablePercentage} onChange={(event) => setClaimablePercentage(event.target.value)} />
+              )}
+            </Form.Group>
+          )}
+          {claimInputTax && claimablePercentage !== '100' && (
+            <Form.Group className="col-md-3">
+              <Form.Label>Apportionment basis</Form.Label>
+              <Form.Control value={apportionmentBasis} onChange={(event) => setApportionmentBasis(event.target.value)} />
+            </Form.Group>
+          )}
+          <Form.Group className="col-md-3">
+            <Form.Label>Source record</Form.Label>
+            <Form.Select value={sourceDocumentType} onChange={(event) => setSourceDocumentType(event.target.value as ReceiptDocumentType)}>
+              <option value="none">None recorded</option>
+              <option value="taxable_supply">Taxable supply information</option>
+              <option value="invoice">Invoice</option>
+              <option value="receipt">Receipt</option>
+              <option value="customs_entry">Customs entry</option>
+              <option value="other">Other</option>
+            </Form.Select>
+          </Form.Group>
+          <Form.Group className="col-md-3">
+            <Form.Label>Document number</Form.Label>
+            <Form.Control value={sourceDocumentNumber} onChange={(event) => setSourceDocumentNumber(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-md-3">
+            <Form.Label>Evidence reference</Form.Label>
+            <Form.Control value={evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-md-3">
+            <Form.Label>Evidence URL</Form.Label>
+            <Form.Control type="url" value={evidenceUrl} onChange={(event) => setEvidenceUrl(event.target.value)} />
           </Form.Group>
           <Form.Group className="col-md-4">
             <Form.Label>Notes</Form.Label>

--- a/frontend/js/types/inventory.ts
+++ b/frontend/js/types/inventory.ts
@@ -134,6 +134,15 @@ interface InventoryBalance {
 
 type QuantityCertainty = 'exact' | 'estimated' | 'unknown'
 type StockReceiptStatus = 'draft' | 'posted' | 'reversed'
+type PurchaseTaxTreatment = 'standard' | 'zero_rated' | 'exempt' | 'out_of_scope' | 'unknown'
+type InputTaxSource = 'none' | 'supplier' | 'customs' | 'second_hand'
+type ReceiptDocumentType = 'none' | 'taxable_supply' | 'invoice' | 'receipt' | 'buyer_created' | 'customs_entry' | 'contract' | 'bank_record' | 'other'
+
+interface InputTaxWarning {
+  code: string
+  message: string
+  line_id: number | null
+}
 
 interface StockReceiptLine {
   pk: number
@@ -151,6 +160,18 @@ interface StockReceiptLine {
   base_quantity: string | null
   base_unit: UnitCode
   line_cost_ex_tax: string
+  supplier_cost_incl_tax: string
+  tax_treatment: PurchaseTaxTreatment
+  tax_rate: string
+  input_tax_source: InputTaxSource
+  input_tax_amount: string
+  claim_input_tax: boolean
+  claimable_percentage: string
+  apportionment_basis: string
+  recoverable_input_tax: string
+  non_recoverable_tax: string
+  acquisition_amount: string
+  legacy_tax_classification: boolean
   destination: number
   lot: number | null
   created: string
@@ -167,7 +188,14 @@ interface StockReceiptLineWrite {
   quantity_certainty: QuantityCertainty
   unit_code: UnitCode | null
   unit_conversion: number | null
-  line_cost_ex_tax: string
+  supplier_cost_incl_tax: string
+  tax_treatment: PurchaseTaxTreatment
+  tax_rate: string
+  input_tax_source: InputTaxSource
+  input_tax_amount: string
+  claim_input_tax: boolean
+  claimable_percentage: string
+  apportionment_basis: string
   destination: number
 }
 
@@ -177,10 +205,16 @@ interface StockReceipt {
   status: StockReceiptStatus
   received_date: string
   supplier_reference: string
+  invoice_date: string | null
+  source_document_type: ReceiptDocumentType
+  source_document_number: string
+  evidence_reference: string
+  evidence_url: string
+  supplier_name_snapshot: string
+  supplier_address_snapshot: string
+  supplier_gst_status: 'registered' | 'unregistered' | 'unknown'
+  supplier_gst_number: string
   currency_code: string
-  tax_rate: string
-  price_includes_tax: boolean
-  tax_recoverable: boolean
   notes: string
   created_by: number | null
   posted_at: string | null
@@ -193,19 +227,47 @@ interface StockReceipt {
   updated: string
   lines: Array<StockReceiptLine>
   movement_ids: Array<number>
+  tax_warnings: Array<InputTaxWarning>
 }
 
 interface StockReceiptWrite {
   supplier: number
   received_date: string
   supplier_reference?: string
-  // Omit these two and the server applies the workspace defaults.
+  invoice_date?: string | null
+  source_document_type?: ReceiptDocumentType
+  source_document_number?: string
+  evidence_reference?: string
+  evidence_url?: string
+  // Omit this and the server applies the workspace currency.
   currency_code?: string
-  tax_rate?: string
-  price_includes_tax?: boolean
-  tax_recoverable?: boolean
   notes?: string
   lines: Array<StockReceiptLineWrite>
+}
+
+interface InputTaxAdjustment {
+  pk: number
+  receipt_line: number
+  adjustment_date: string
+  previous_claimable_percentage: string
+  revised_claimable_percentage: string
+  tax_adjustment: string
+  apportionment_basis: string
+  reason: string
+  evidence_reference: string
+  evidence_url: string
+  created_by: number | null
+  created: string
+}
+
+interface InputTaxAdjustmentWrite {
+  receipt_line: number
+  adjustment_date: string
+  revised_claimable_percentage: string
+  apportionment_basis: string
+  reason: string
+  evidence_reference?: string
+  evidence_url?: string
 }
 
 interface StockReceiptFilters {
@@ -288,9 +350,15 @@ export {
   InventoryTrackingMode,
   InventoryUnit,
   InventoryUsageBasis,
+  InputTaxAdjustment,
+  InputTaxAdjustmentWrite,
+  InputTaxSource,
+  InputTaxWarning,
   ItemUnitConversion,
   ItemUnitConversionCreate,
   QuantityCertainty,
+  PurchaseTaxTreatment,
+  ReceiptDocumentType,
   SerializedInventoryUnit,
   SerializedPhysicalState,
   SerializedStockMovement,

--- a/frontend/js/types/seeds.ts
+++ b/frontend/js/types/seeds.ts
@@ -1,4 +1,4 @@
-import { UnitCode } from './inventory'
+import { InputTaxSource, PurchaseTaxTreatment, ReceiptDocumentType, UnitCode } from './inventory'
 
 type SeedQuantityCertainty = 'exact' | 'estimated' | 'unknown'
 
@@ -57,7 +57,12 @@ interface SeedPacketProvenance {
   line_cost_ex_tax: string | null
   currency_code: string | null
   tax_rate: string | null
-  tax_recoverable: boolean | null
+  claim_input_tax: boolean | null
+  supplier_cost_incl_tax: string | null
+  input_tax_amount: string | null
+  recoverable_input_tax: string | null
+  non_recoverable_tax: string | null
+  acquisition_amount: string | null
   settled_on: string | null
 }
 
@@ -84,8 +89,19 @@ interface SeedPacketReceiptCreate {
   // the server records the brand, which is right when it was bought direct.
   supplier?: number
   supplier_reference?: string
+  invoice_date?: string | null
+  source_document_type?: ReceiptDocumentType
+  source_document_number?: string
+  evidence_reference?: string
+  evidence_url?: string
   tax_rate?: string
-  tax_recoverable?: boolean
+  supplier_cost_incl_tax?: string
+  tax_treatment?: PurchaseTaxTreatment
+  input_tax_source?: InputTaxSource
+  input_tax_amount?: string
+  claim_input_tax?: boolean
+  claimable_percentage?: string
+  apportionment_basis?: string
   notes?: string
 }
 

--- a/frontend/js/types/seedtrays.ts
+++ b/frontend/js/types/seedtrays.ts
@@ -23,8 +23,6 @@ interface SeedTrayReceiptCreate {
   quantity: number
   line_cost_ex_tax?: string
   destination: number
-  tax_rate?: string
-  tax_recoverable?: boolean
   notes?: string
 }
 

--- a/frontend/js/types/suppliers.ts
+++ b/frontend/js/types/suppliers.ts
@@ -1,6 +1,9 @@
 interface Supplier {
   pk: number
   name: string
+  address: string
+  gst_status: 'registered' | 'unregistered' | 'unknown'
+  gst_number: string
   website: string
   notes: string
   is_system_default: boolean
@@ -8,6 +11,9 @@ interface Supplier {
 
 interface SupplierCreate {
   name: string
+  address?: string
+  gst_status?: 'registered' | 'unregistered' | 'unknown'
+  gst_number?: string
   website?: string
   notes?: string
 }

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=too-many-lines
 
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
@@ -217,9 +217,6 @@ class StockReceiptSerializer(
             'supplier_gst_status',
             'supplier_gst_number',
             'currency_code',
-            'tax_rate',
-            'price_includes_tax',
-            'tax_recoverable',
             'settled_on',
             'notes',
             'created_by',
@@ -247,7 +244,6 @@ class StockReceiptSerializer(
         extra_kwargs = {
             'supplier': {'required': False},
             'currency_code': {'required': False},
-            'tax_rate': {'required': False},
         }
 
     workspace_field_lookups = {'supplier': 'workspace'}
@@ -279,7 +275,6 @@ class StockReceiptSerializer(
         if self.instance is None:
             workspace = get_current_workspace()
             attrs.setdefault('currency_code', workspace.currency_code)
-            attrs.setdefault('tax_rate', workspace.default_tax_rate)
             attrs.setdefault('supplier', ensure_default_supplier(workspace))
         supplier = attrs.get('supplier') or getattr(self.instance, 'supplier', None)
         if supplier is not None:
@@ -293,7 +288,7 @@ class StockReceiptSerializer(
     def create(self, validated_data):
         """Create a draft and its normalized nested lines atomically."""
         lines = validated_data.pop('lines', [])
-        lines = self._canonical_lines(validated_data, lines)
+        lines = self._canonical_lines(lines)
         receipt = StockReceipt.objects.create(**validated_data)
         for line in lines:
             StockReceiptLine.objects.create(receipt=receipt, **line)
@@ -304,17 +299,7 @@ class StockReceiptSerializer(
         """Update a draft, replacing nested lines only when supplied."""
         lines = validated_data.pop('lines', None)
         if lines is not None:
-            lines = self._canonical_lines(
-                {
-                    **validated_data,
-                    'price_includes_tax': validated_data.get(
-                        'price_includes_tax',
-                        instance.price_includes_tax,
-                    ),
-                    'tax_rate': validated_data.get('tax_rate', instance.tax_rate),
-                },
-                lines,
-            )
+            lines = self._canonical_lines(lines)
         instance = super().update(instance, validated_data)
         if lines is not None:
             instance.lines.all().delete()
@@ -323,43 +308,10 @@ class StockReceiptSerializer(
         return instance
 
     @staticmethod
-    def _canonical_lines(receipt_data, lines):
-        """Translate only the deprecated receipt-wide tax inputs."""
-        rate = receipt_data.get('tax_rate', Decimal('0'))
-        recoverable = receipt_data.get('tax_recoverable', False)
+    def _canonical_lines(lines):
+        """Discard the temporary marker accepted from legacy ex-tax clients."""
         for line in lines:
-            legacy_receipt_tax = line.pop('_legacy_receipt_tax', False)
-            if not legacy_receipt_tax:
-                continue
-            if line.get(
-                'input_tax_source', StockReceiptLine.InputTaxSource.NONE,
-            ) != StockReceiptLine.InputTaxSource.NONE:
-                continue
-            entered = line['supplier_cost_incl_tax']
-            if rate <= 0:
-                continue
-            if receipt_data.get('price_includes_tax', False):
-                gross = entered
-                tax = (gross * rate / (Decimal('100') + rate)).quantize(
-                    Decimal('0.0001'), rounding=ROUND_HALF_UP,
-                )
-            else:
-                tax = (entered * rate / Decimal('100')).quantize(
-                    Decimal('0.0001'), rounding=ROUND_HALF_UP,
-                )
-                gross = entered + tax
-            if tax == 0:
-                line['supplier_cost_incl_tax'] = gross
-                continue
-            line.update({
-                'supplier_cost_incl_tax': gross,
-                'tax_treatment': StockReceiptLine.TaxTreatment.STANDARD,
-                'tax_rate': rate,
-                'input_tax_source': StockReceiptLine.InputTaxSource.SUPPLIER,
-                'input_tax_amount': tax,
-                'claim_input_tax': recoverable,
-                'claimable_percentage': Decimal('100') if recoverable else Decimal('0'),
-            })
+            line.pop('_legacy_receipt_tax', None)
         return lines
 
 

--- a/inventory/migrations/0014_remove_receipt_tax_defaults.py
+++ b/inventory/migrations/0014_remove_receipt_tax_defaults.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0013_evidenced_input_tax'),
+    ]
+
+    operations = [
+        migrations.RemoveField(model_name='stockreceipt', name='price_includes_tax'),
+        migrations.RemoveField(model_name='stockreceipt', name='tax_rate'),
+        migrations.RemoveField(model_name='stockreceipt', name='tax_recoverable'),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -479,20 +479,6 @@ class StockReceipt(WorkspaceOwnedModel):
             ),
         ],
     )
-    tax_rate = models.DecimalField(
-        max_digits=7,
-        decimal_places=4,
-        default=Decimal('0'),
-        validators=(
-            MinValueValidator(Decimal('0')),
-            MaxValueValidator(Decimal('100')),
-        ),
-    )
-    price_includes_tax = models.BooleanField(
-        default=False,
-        help_text='Whether entered receipt prices include the receipt tax rate.',
-    )
-    tax_recoverable = models.BooleanField(default=True)
     #: The date the supplier was paid. Under the payments and hybrid bases this
     #: is when input tax on the receipt falls due, so it has to be recordable
     #: after posting — a supplier is paid after the goods arrive, not before
@@ -755,34 +741,6 @@ class StockReceiptLine(models.Model):  # pylint: disable=too-many-instance-attri
         """Freeze the claim split and acquisition amount from explicit inputs."""
         quantum = Decimal('0.0001')
         tax = Decimal(self.input_tax_amount or 0).quantize(quantum)
-        legacy_receipt_tax = all((
-            self.input_tax_source == self.InputTaxSource.NONE,
-            self.tax_treatment == self.TaxTreatment.UNKNOWN,
-            tax == 0,
-            self.receipt_id,
-            Decimal(self.receipt.tax_rate or 0) > 0,
-        ))
-        if legacy_receipt_tax:
-            rate = Decimal(self.receipt.tax_rate)
-            entered = Decimal(self.line_cost_ex_tax or 0)
-            if self.receipt.price_includes_tax:
-                gross = entered
-                tax = (gross * rate / (Decimal('100') + rate)).quantize(quantum)
-            else:
-                tax = (entered * rate / Decimal('100')).quantize(quantum)
-                gross = entered + tax
-            if tax == 0:
-                self.supplier_cost_incl_tax = gross
-                return
-            self.supplier_cost_incl_tax = gross
-            self.tax_treatment = self.TaxTreatment.STANDARD
-            self.tax_rate = rate
-            self.input_tax_source = self.InputTaxSource.SUPPLIER
-            self.input_tax_amount = tax
-            self.claim_input_tax = self.receipt.tax_recoverable
-            self.claimable_percentage = (
-                Decimal('100') if self.claim_input_tax else Decimal('0')
-            )
         percentage = Decimal(self.claimable_percentage or 0)
         recoverable = Decimal('0')
         if self.claim_input_tax:

--- a/inventory/test_ledger.py
+++ b/inventory/test_ledger.py
@@ -77,7 +77,6 @@ class LedgerServiceTests(TestCase):
             'supplier': self.supplier,
             'received_date': date(2026, 8, 1),
             'currency_code': self.workspace.currency_code,
-            'tax_rate': self.workspace.default_tax_rate,
             'created_by': self.user,
         }
         values.update(overrides)
@@ -92,6 +91,11 @@ class LedgerServiceTests(TestCase):
             'unit_code': UnitCode.LITRE,
             'base_quantity': Decimal('2000'),
             'line_cost_ex_tax': Decimal('10'),
+            'supplier_cost_incl_tax': Decimal('11.5'),
+            'tax_treatment': StockReceiptLine.TaxTreatment.STANDARD,
+            'tax_rate': Decimal('15'),
+            'input_tax_source': StockReceiptLine.InputTaxSource.SUPPLIER,
+            'input_tax_amount': Decimal('1.5'),
             'destination': self.store,
         }
         values.update(overrides)
@@ -114,10 +118,7 @@ class LedgerServiceTests(TestCase):
 
     def test_post_receipt_creates_exact_lots_costs_and_balances(self):
         """Every line becomes one immutable valued lot and receipt movement."""
-        receipt = self.make_receipt(
-            supplier_reference='INV-100',
-            tax_recoverable=False,
-        )
+        receipt = self.make_receipt(supplier_reference='INV-100')
         first_line = self.add_receipt_line(receipt)
         second_item = InventoryItem.objects.create(
             workspace=self.workspace,
@@ -132,6 +133,8 @@ class LedgerServiceTests(TestCase):
             unit_code=UnitCode.EACH,
             base_quantity=Decimal('100'),
             line_cost_ex_tax=Decimal('20'),
+            supplier_cost_incl_tax=Decimal('23'),
+            input_tax_amount=Decimal('3'),
         )
 
         posted, lots = post_receipt(receipt, self.user)

--- a/inventory/test_ledger_rest.py
+++ b/inventory/test_ledger_rest.py
@@ -72,7 +72,6 @@ class LedgerRestFixture(APITestCase):
             'supplier': self.supplier.pk,
             'received_date': '2026-08-01',
             'supplier_reference': 'INV-API-1',
-            'tax_recoverable': False,
             'lines': [
                 {
                     'item': self.item.pk,
@@ -81,6 +80,13 @@ class LedgerRestFixture(APITestCase):
                     'quantity': '2.000000000',
                     'unit_code': UnitCode.LITRE,
                     'line_cost_ex_tax': '10.0000',
+                    'supplier_cost_incl_tax': '11.5000',
+                    'tax_treatment': 'standard',
+                    'tax_rate': '15.0000',
+                    'input_tax_source': 'supplier',
+                    'input_tax_amount': '1.5000',
+                    'claim_input_tax': False,
+                    'claimable_percentage': '0.0000',
                     'destination': self.store.pk,
                 },
             ],
@@ -151,7 +157,7 @@ class LedgerRestTests(LedgerRestFixture):
         created, posted, lot = self.create_and_post_receipt()
         self.assertEqual(created['status'], StockReceipt.Status.DRAFT)
         self.assertEqual(created['currency_code'], 'NZD')
-        self.assertEqual(created['tax_rate'], '15.0000')
+        self.assertEqual(created['lines'][0]['tax_rate'], '15.0000')
         self.assertEqual(created['lines'][0]['base_quantity'], '2000.000000000')
         self.assertIsNone(created['lines'][0]['lot'])
 
@@ -186,22 +192,23 @@ class LedgerRestTests(LedgerRestFixture):
             2,
         )
 
-    def test_inclusive_prices_are_stored_exclusive_and_keep_gross_cost(self):
-        """Inclusive supplier prices convert before canonical ledger storage."""
+    def test_explicit_supplier_tax_derives_exclusive_and_acquisition_costs(self):
+        """Line evidence derives the accounting values without receipt defaults."""
         response = self.client.post(
             self.receipt_url,
             self.receipt_payload(
-                price_includes_tax=True,
                 lines=[{
                     **self.receipt_payload()['lines'][0],
-                    'line_cost_ex_tax': '11.5000',
+                    'line_cost_ex_tax': '0.0000',
                 }],
             ),
             format='json',
         )
         self.assertEqual(response.status_code, 201, response.data)
-        self.assertTrue(response.data['price_includes_tax'])
         self.assertEqual(response.data['lines'][0]['line_cost_ex_tax'], '10.0000')
+        self.assertEqual(
+            response.data['lines'][0]['acquisition_amount'], '11.5000',
+        )
 
         posted = self.client.post(
             f"{self.receipt_url}{response.data['pk']}/post/",
@@ -496,7 +503,12 @@ class StockReceiptDraftTests(LedgerRestFixture):
     def test_a_line_with_no_price_defaults_to_zero(self):
         """A price is a real fact and zero is a legitimate one, not a stub."""
         payload = self.receipt_payload()
-        del payload['lines'][0]['line_cost_ex_tax']
+        for field in (
+            'line_cost_ex_tax', 'supplier_cost_incl_tax', 'tax_treatment',
+            'tax_rate', 'input_tax_source', 'input_tax_amount',
+            'claim_input_tax', 'claimable_percentage',
+        ):
+            del payload['lines'][0][field]
 
         created = self.create_draft(**payload)
 
@@ -857,7 +869,6 @@ class InputTaxEvidenceRestTests(LedgerRestFixture):
     def evidenced_payload(self):
         """Return one explicit supplier-GST claim without supporting evidence."""
         payload = self.receipt_payload()
-        payload.pop('tax_recoverable')
         payload['invoice_date'] = '2026-08-01'
         payload['lines'][0].pop('line_cost_ex_tax')
         payload['lines'][0].update({

--- a/reporting/test_gst.py
+++ b/reporting/test_gst.py
@@ -124,13 +124,29 @@ class GstReportTestCase(RESTContractTestCase):
         receipt = StockReceipt.objects.create(
             workspace=self.workspace, supplier=make_supplier(workspace=self.workspace),
             received_date=received_date, currency_code='NZD',
-            tax_rate=Decimal(tax_rate), tax_recoverable=recoverable,
             created_by=self.user,
         )
+        tax = (
+            Decimal(ex_tax) * Decimal(tax_rate) / Decimal('100')
+        ).quantize(Decimal('0.0001'))
         StockReceiptLine.objects.create(
             receipt=receipt, item=media, quantity=Decimal('2'),
             unit_code=UnitCode.LITRE, base_quantity=Decimal('2'),
-            line_cost_ex_tax=Decimal(ex_tax), destination=store,
+            line_cost_ex_tax=Decimal(ex_tax),
+            supplier_cost_incl_tax=Decimal(ex_tax) + tax,
+            tax_treatment=(
+                StockReceiptLine.TaxTreatment.STANDARD
+                if tax else StockReceiptLine.TaxTreatment.ZERO_RATED
+            ),
+            tax_rate=Decimal(tax_rate),
+            input_tax_source=(
+                StockReceiptLine.InputTaxSource.SUPPLIER
+                if tax else StockReceiptLine.InputTaxSource.NONE
+            ),
+            input_tax_amount=tax,
+            claim_input_tax=recoverable and tax > 0,
+            claimable_percentage=Decimal('100' if recoverable and tax > 0 else '0'),
+            destination=store,
         )
         receipt = post_receipt(receipt, self.user)[0]
         if settled_on is not None:
@@ -453,8 +469,6 @@ class InputTaxTests(GstReportTestCase):  # pylint: disable=too-many-public-metho
             ),
             source_document_number='EVIDENCE-1',
             currency_code='NZD',
-            tax_rate=Decimal('0'),
-            tax_recoverable=False,
             created_by=self.user,
         )
         line = StockReceiptLine.objects.create(

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -242,7 +242,6 @@ class PacketReceiptDraftSerializer(
         min_value=Decimal('0'),
         required=False,
     )
-    tax_recoverable = serializers.BooleanField(required=False)
     supplier_cost_incl_tax = serializers.DecimalField(
         max_digits=18, decimal_places=4, min_value=Decimal('0'), required=False,
     )
@@ -333,8 +332,7 @@ class PacketReceiptDraftSerializer(
             'source_document_number': draft.receipt.source_document_number,
             'evidence_reference': draft.receipt.evidence_reference,
             'evidence_url': draft.receipt.evidence_url,
-            'tax_rate': f'{draft.receipt.tax_rate:.4f}',
-            'tax_recoverable': draft.receipt.tax_recoverable,
+            'tax_rate': f'{line.tax_rate:.4f}',
             'supplier_cost_incl_tax': f'{line.supplier_cost_incl_tax:.4f}',
             'tax_treatment': line.tax_treatment,
             'input_tax_source': line.input_tax_source,

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -139,8 +139,6 @@ def create_packet_receipt_draft(workspace, user, values):
         supplier_gst_status=supplier.gst_status,
         supplier_gst_number=supplier.gst_number,
         currency_code=workspace.currency_code,
-        tax_rate=values.get('tax_rate', workspace.default_tax_rate),
-        tax_recoverable=values.get('tax_recoverable', False),
         notes=values.get('notes', ''),
         created_by=user,
     )
@@ -164,13 +162,12 @@ def create_packet_receipt_draft(workspace, user, values):
     for field in (
         'supplier_cost_incl_tax', 'tax_treatment', 'input_tax_source',
         'input_tax_amount', 'claim_input_tax', 'claimable_percentage',
-        'apportionment_basis',
+        'apportionment_basis', 'tax_rate',
     ):
         if field in values:
             line_values[field] = values[field]
     if 'supplier_cost_incl_tax' in values:
         line_values['line_cost_ex_tax'] = Decimal('0')
-        line_values['tax_rate'] = values.get('tax_rate', Decimal('0'))
     StockReceiptLine.objects.create(**line_values)
     return SeedPacketReceiptDraft.objects.create(
         workspace=workspace,
@@ -200,8 +197,6 @@ def update_packet_receipt_draft(draft, values):
         'source_document_number',
         'evidence_reference',
         'evidence_url',
-        'tax_rate',
-        'tax_recoverable',
         'notes',
     ):
         if field in values:
@@ -378,7 +373,7 @@ def packet_provenance(packet):
             'line_cost_ex_tax': None,
             'currency_code': lot.currency_code if lot else None,
             'tax_rate': None,
-            'tax_recoverable': None,
+            'claim_input_tax': None,
             'supplier_cost_incl_tax': None,
             'input_tax_amount': None,
             'recoverable_input_tax': None,
@@ -397,8 +392,8 @@ def packet_provenance(packet):
         'received_date': _isoformat(receipt.received_date),
         'line_cost_ex_tax': f'{line.line_cost_ex_tax:.4f}',
         'currency_code': receipt.currency_code,
-        'tax_rate': f'{receipt.tax_rate:.4f}',
-        'tax_recoverable': receipt.tax_recoverable,
+        'tax_rate': f'{line.tax_rate:.4f}',
+        'claim_input_tax': line.claim_input_tax,
         'supplier_cost_incl_tax': f'{line.supplier_cost_incl_tax:.4f}',
         'input_tax_amount': f'{line.input_tax_amount:.4f}',
         'recoverable_input_tax': f'{line.recoverable_input_tax:.4f}',

--- a/seeds/tests.py
+++ b/seeds/tests.py
@@ -598,7 +598,13 @@ class SeedPacketProvenanceTests(APITestCase):
             'quantity': '50',
             'line_price': '6.0000',
             'received_date': '2026-03-10',
+            'supplier_cost_incl_tax': '6.9000',
+            'tax_treatment': 'standard',
             'tax_rate': '15',
+            'input_tax_source': 'supplier',
+            'input_tax_amount': '0.9000',
+            'claim_input_tax': False,
+            'claimable_percentage': '0',
         }
         payload.update(overrides)
         draft = self.client.post('/seeds/packet-receipts/', payload, format='json')

--- a/seedtrays/rest.py
+++ b/seedtrays/rest.py
@@ -135,14 +135,6 @@ class SeedTrayReceiptSerializer(
     destination = serializers.PrimaryKeyRelatedField(
         queryset=Location.objects.all(),
     )
-    tax_rate = serializers.DecimalField(
-        max_digits=7,
-        decimal_places=4,
-        min_value=Decimal('0'),
-        max_value=Decimal('100'),
-        required=False,
-    )
-    tax_recoverable = serializers.BooleanField(required=False, default=True)
     notes = serializers.CharField(allow_blank=True, required=False, default='')
     workspace_field_lookups = {
         'supplier': 'workspace',
@@ -220,8 +212,6 @@ class SeedTrayModelsViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet)
             received_date=values['received_date'],
             supplier_reference=values['supplier_reference'],
             currency_code=workspace.currency_code,
-            tax_rate=values.get('tax_rate', workspace.default_tax_rate),
-            tax_recoverable=values['tax_recoverable'],
             notes=values['notes'],
             created_by=request.user,
         )
@@ -232,6 +222,7 @@ class SeedTrayModelsViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet)
             unit_code=UnitCode.EACH,
             base_quantity=Decimal(values['quantity']),
             line_cost_ex_tax=values['line_cost_ex_tax'],
+            supplier_cost_incl_tax=values['line_cost_ex_tax'],
             destination=values['destination'],
         )
         try:


### PR DESCRIPTION
Replace receipt-wide GST assumptions with explicit line evidence and expose supplier, document, warning, and change-of-use controls so operators can review the accounting facts before posting.

## Summary by Sourcery

Capture explicit purchase tax evidence and supporting records throughout inventory receipt workflows so accounting facts can be reviewed before posting and adjusted when use changes.

New Features:
- Capture tax treatment, input-tax source, claimability, apportionment, and supporting document evidence at the receipt-line level.
- Display calculated tax amounts, acquisition costs, supplier tax identity, and tax warnings for operator review.
- Record post-purchase changes to input-tax use with dated adjustments, reasons, and evidence references.

Enhancements:
- Replace receipt-wide tax defaults and price-basis controls with explicit line-level accounting facts.
- Extend seed packet receipt workflows and supplier records to use the same tax evidence model.

Tests:
- Update ledger, reporting, seed, and REST coverage for explicit line-level tax evidence and derived accounting amounts.

Chores:
- Remove obsolete receipt-level tax fields and related migration and compatibility handling.