### PR TITLE
feat(attachments): capture photos in record workflows

### DIFF
--- a/attachments/test_attachments.py
+++ b/attachments/test_attachments.py
@@ -13,8 +13,10 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from PIL import Image
 
+from health.models import HealthObservation, HealthObservationType
+from plantings.models import NurseryObservation
 from tests.api import RESTContractTestCase
-from tests.factories import make_specific_plant
+from tests.factories import make_harvest, make_specific_plant
 from workspaces.models import Workspace, get_current_workspace
 
 from .models import ImageAttachment
@@ -195,3 +197,35 @@ class AttachmentContractTests(AttachmentTestCase):
             attachment.save()
         with self.assertRaisesMessage(ValidationError, 'cannot be deleted'):
             attachment.delete()
+
+    def test_record_serializers_embed_protected_attachment_metadata(self):
+        self.workspace.mode = Workspace.Mode.NURSERY
+        self.workspace.save()
+        nursery = NurseryObservation.objects.create(
+            workspace=self.workspace, notes='Healthy new growth.',
+        )
+        health = HealthObservation.objects.create(
+            workspace=self.workspace,
+            observation_type=HealthObservationType.objects.get(
+                workspace=self.workspace, code='pest-signs',
+            ),
+            severity=HealthObservation.Severity.LOW,
+        )
+        harvest = make_harvest(workspace=self.workspace)
+        targets = (
+            ('plant', self.plant, f'/plantings/specificplants/{self.plant.pk}/'),
+            ('nursery_observation', nursery, '/plantings/nursery-observations/'),
+            ('health_observation', health, '/health/observations/'),
+            ('harvest', harvest, f'/plantings/harvests/{harvest.pk}/'),
+        )
+        for target_type, target, url in targets:
+            create_attachment(
+                self.workspace, self.user, target_type, target, image_upload(),
+            )
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200, response.data)
+            payload = response.data
+            if isinstance(payload, list):
+                payload = next(row for row in payload if row['pk'] == target.pk)
+            with self.subTest(target_type=target_type):
+                self.assertEqual(payload['attachments'][0]['target_type'], target_type)

--- a/frontend/js/api/attachments.ts
+++ b/frontend/js/api/attachments.ts
@@ -1,0 +1,27 @@
+import { AttachmentTargetType, AttachmentUploadResult, ImageAttachment } from '../types/attachments'
+import { csrfPostForm, fetchAsJson } from '../utils'
+
+function getAttachments(targetType: AttachmentTargetType, targetId: number, signal?: AbortSignal): Promise<Array<ImageAttachment>> {
+  const query = new URLSearchParams({ target_type: targetType, target_id: String(targetId) })
+  return fetchAsJson<Array<ImageAttachment>>('/attachments/?' + query.toString(), signal)
+}
+
+async function uploadAttachments(targetType: AttachmentTargetType, targetId: number, files: Array<File>): Promise<AttachmentUploadResult> {
+  const uploaded: Array<ImageAttachment> = []
+  const failures: AttachmentUploadResult['failures'] = []
+  for (const file of files) {
+    const form = new FormData()
+    form.set('target_type', targetType)
+    form.set('target_id', String(targetId))
+    form.set('image', file)
+    try {
+      const response = await csrfPostForm('/attachments/', form)
+      uploaded.push((await response.json()) as ImageAttachment)
+    } catch (error) {
+      failures.push({ file, message: error instanceof Error ? error.message : String(error) })
+    }
+  }
+  return { uploaded, failures }
+}
+
+export { getAttachments, uploadAttachments }

--- a/frontend/js/attachments.tsx
+++ b/frontend/js/attachments.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { Alert, Button, Form } from 'react-bootstrap'
+
+import { uploadAttachments } from './api/attachments'
+import { AttachmentTargetType, ImageAttachment } from './types/attachments'
+
+interface PhotoInputProps {
+  id: string
+  files: Array<File>
+  onChange: (files: Array<File>) => void
+  label?: string
+}
+
+function FilePreview({ file }: { file: File }) {
+  const url = React.useMemo(() => URL.createObjectURL(file), [file])
+  React.useEffect(() => () => URL.revokeObjectURL(url), [url])
+  return <img src={url} alt="" className="rounded border" style={{ width: 72, height: 72, objectFit: 'cover' }} />
+}
+
+function PhotoInput({ id, files, onChange, label = 'Photos (optional)' }: PhotoInputProps) {
+  return (
+    <Form.Group controlId={id}>
+      <Form.Label>{label}</Form.Label>
+      <Form.Control
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        capture="environment"
+        multiple
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => onChange(Array.from(event.target.files ?? []))}
+      />
+      <Form.Text>JPEG, PNG, or WebP; up to 15 MiB each. Location and camera metadata are removed.</Form.Text>
+      {files.length > 0 && (
+        <div className="d-flex flex-wrap gap-2 mt-2" aria-live="polite">
+          {files.map((file, index) => (
+            <div key={[file.name, file.lastModified, index].join(':')} className="text-center small" style={{ maxWidth: 88 }}>
+              <FilePreview file={file} />
+              <div className="text-truncate" title={file.name}>
+                {file.name}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Form.Group>
+  )
+}
+
+function AttachmentGallery({ attachments }: { attachments: Array<ImageAttachment> }) {
+  if (attachments.length === 0) return null
+  return (
+    <div className="d-flex flex-wrap gap-2 mt-2">
+      {attachments.map((attachment) => (
+        <a key={attachment.id} href={attachment.content_url} target="_blank" rel="noreferrer" title={attachment.original_filename}>
+          <img src={attachment.thumbnail_url} alt={attachment.original_filename} className="rounded border" loading="lazy" style={{ width: 88, height: 88, objectFit: 'cover' }} />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+interface AttachmentUploaderProps {
+  targetType: AttachmentTargetType
+  targetId: number
+  onUploaded?: (attachments: Array<ImageAttachment>) => void
+  id: string
+}
+
+function AttachmentUploader({ targetType, targetId, onUploaded, id }: AttachmentUploaderProps) {
+  const [files, setFiles] = React.useState<Array<File>>([])
+  const [uploading, setUploading] = React.useState(false)
+  const [error, setError] = React.useState('')
+
+  async function upload() {
+    setUploading(true)
+    setError('')
+    const result = await uploadAttachments(targetType, targetId, files)
+    setFiles(result.failures.map((failure) => failure.file))
+    if (result.failures.length > 0) {
+      const noun = result.failures.length === 1 ? 'photo' : 'photos'
+      setError(String(result.failures.length) + ' ' + noun + ' could not be uploaded. The failed selection is ready to retry.')
+    }
+    if (result.uploaded.length > 0) onUploaded?.(result.uploaded)
+    setUploading(false)
+  }
+
+  return (
+    <div>
+      <PhotoInput id={id} files={files} onChange={setFiles} label="Add photos" />
+      <Button className="mt-2" size="sm" variant="outline-primary" disabled={files.length === 0 || uploading} onClick={() => void upload()}>
+        {uploading ? 'Uploading…' : 'Upload selected photos'}
+      </Button>
+      {error && (
+        <Alert className="mt-2 mb-0 py-2" variant="warning">
+          {error}
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+export { AttachmentGallery, AttachmentUploader, PhotoInput }

--- a/frontend/js/health.tsx
+++ b/frontend/js/health.tsx
@@ -3,6 +3,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Alert, Badge, Button, Card, Col, Form, Row, Table } from 'react-bootstrap'
 import { useSearchParams } from 'react-router'
 
+import { AttachmentGallery, PhotoInput } from './attachments'
+import { uploadAttachments } from './api/attachments'
 import {
   actOnQuarantine,
   correctHealthObservation,
@@ -57,6 +59,9 @@ function ObservationComposer({ initialScopes = [] }: { initialScopes?: Array<Hea
   const [notes, setNotes] = React.useState('')
   const [evidenceUrl, setEvidenceUrl] = React.useState('')
   const [followUp, setFollowUp] = React.useState('')
+  const [photos, setPhotos] = React.useState<Array<File>>([])
+  const [photoWarning, setPhotoWarning] = React.useState('')
+  const [photoTarget, setPhotoTarget] = React.useState<number | null>(null)
 
   React.useEffect(() => {
     if (observationType === '' && types.length > 0) setObservationType(types[0].pk)
@@ -67,8 +72,8 @@ function ObservationComposer({ initialScopes = [] }: { initialScopes?: Array<Hea
     onSuccess: setPreview
   })
   const createMutation = useMutation({
-    mutationFn: () =>
-      createHealthObservation({
+    mutationFn: async () => {
+      const observation = await createHealthObservation({
         scopes,
         reviewed_digest: preview?.digest ?? '',
         observation_type: observationType as number,
@@ -77,13 +82,18 @@ function ObservationComposer({ initialScopes = [] }: { initialScopes?: Array<Hea
         evidence: evidenceUrl ? [{ url: evidenceUrl, label: 'Observation evidence' }] : [],
         follow_up_due_at: followUp ? new Date(followUp).toISOString() : null,
         notes
-      }),
-    onSuccess: () => {
+      })
+      return { observation, photoResult: await uploadAttachments('health_observation', observation.pk, photos) }
+    },
+    onSuccess: ({ observation, photoResult }) => {
       setScopes([])
       setPreview(undefined)
       setNotes('')
       setEvidenceUrl('')
       setFollowUp('')
+      setPhotos(photoResult.failures.map((failure) => failure.file))
+      setPhotoWarning(photoResult.failures.length === 0 ? '' : 'The observation was recorded, but some photos failed. The failed selection is ready to retry.')
+      setPhotoTarget(photoResult.failures.length === 0 ? null : observation.pk)
       void invalidateHealth(cache)
     }
   })
@@ -203,10 +213,37 @@ function ObservationComposer({ initialScopes = [] }: { initialScopes?: Array<Hea
           <Form.Label>Notes</Form.Label>
           <Form.Control as="textarea" value={notes} onChange={(event) => setNotes(event.target.value)} />
         </Col>
+        <Col xs={12}>
+          <PhotoInput id="health-observation-photos" files={photos} onChange={setPhotos} />
+        </Col>
       </Row>
       <Button className="mt-3" disabled={!preview || observationType === '' || createMutation.isPending} onClick={() => createMutation.mutate()}>
         Record reviewed observation
       </Button>
+      {photoWarning && (
+        <Alert className="mt-3" variant="warning">
+          {photoWarning}
+          {photoTarget !== null && (
+            <div>
+              <Button
+                className="mt-2"
+                size="sm"
+                variant="outline-dark"
+                onClick={() => {
+                  void uploadAttachments('health_observation', photoTarget, photos).then((result) => {
+                    setPhotos(result.failures.map((failure) => failure.file))
+                    setPhotoWarning(result.failures.length === 0 ? '' : photoWarning)
+                    if (result.failures.length === 0) setPhotoTarget(null)
+                    void invalidateHealth(cache)
+                  })
+                }}
+              >
+                Retry failed photos
+              </Button>
+            </div>
+          )}
+        </Alert>
+      )}
     </Card>
   )
 }
@@ -222,6 +259,9 @@ function ObservationActions({ observation }: { observation: HealthObservation })
   const [correctionReason, setCorrectionReason] = React.useState('')
   const [correctedSeverity, setCorrectedSeverity] = React.useState<HealthSeverity>(observation.severity)
   const [correctedNotes, setCorrectedNotes] = React.useState(observation.notes)
+  const [correctionPhotos, setCorrectionPhotos] = React.useState<Array<File>>([])
+  const [photoWarning, setPhotoWarning] = React.useState('')
+  const [photoTarget, setPhotoTarget] = React.useState<number | null>(null)
   const quarantineMutation = useMutation({
     mutationFn: () =>
       quarantineHealthObservation(observation.pk, {
@@ -250,8 +290,8 @@ function ObservationActions({ observation }: { observation: HealthObservation })
     }
   })
   const correctionMutation = useMutation({
-    mutationFn: () =>
-      correctHealthObservation(observation.pk, {
+    mutationFn: async () => {
+      const replacement = await correctHealthObservation(observation.pk, {
         observation_type: observation.observation_type,
         severity: correctedSeverity,
         diagnoses: observation.diagnoses.map((row) => ({ diagnosis: row.diagnosis, certainty: row.certainty })),
@@ -260,9 +300,14 @@ function ObservationActions({ observation }: { observation: HealthObservation })
         follow_up_due_at: observation.follow_up_due_at,
         notes: correctedNotes,
         correction_reason: correctionReason
-      }),
-    onSuccess: () => {
+      })
+      return { replacement, photoResult: await uploadAttachments('health_observation', replacement.pk, correctionPhotos) }
+    },
+    onSuccess: ({ replacement, photoResult }) => {
       setCorrectionReason('')
+      setCorrectionPhotos(photoResult.failures.map((failure) => failure.file))
+      setPhotoWarning(photoResult.failures.length === 0 ? '' : 'The correction was recorded, but some photos failed. Retry them on the replacement observation.')
+      setPhotoTarget(photoResult.failures.length === 0 ? null : replacement.pk)
       void invalidateHealth(cache)
     }
   })
@@ -340,11 +385,38 @@ function ObservationActions({ observation }: { observation: HealthObservation })
           <Form.Label>Correction reason</Form.Label>
           <Form.Control value={correctionReason} onChange={(event) => setCorrectionReason(event.target.value)} />
         </Col>
+        <Col md={8}>
+          <PhotoInput id={`health-correction-photos-${observation.pk}`} files={correctionPhotos} onChange={setCorrectionPhotos} label="Correction photos (optional)" />
+        </Col>
         <Col md={4}>
           <Button variant="outline-secondary" disabled={!correctionReason || correctionMutation.isPending} onClick={() => correctionMutation.mutate()}>
             Append correction
           </Button>
         </Col>
+        {photoWarning && (
+          <Col xs={12}>
+            <Alert className="mb-0" variant="warning">
+              {photoWarning}
+              {photoTarget !== null && (
+                <Button
+                  className="ms-2"
+                  size="sm"
+                  variant="outline-dark"
+                  onClick={() => {
+                    void uploadAttachments('health_observation', photoTarget, correctionPhotos).then((result) => {
+                      setCorrectionPhotos(result.failures.map((failure) => failure.file))
+                      setPhotoWarning(result.failures.length === 0 ? '' : photoWarning)
+                      if (result.failures.length === 0) setPhotoTarget(null)
+                      void invalidateHealth(cache)
+                    })
+                  }}
+                >
+                  Retry failed photos
+                </Button>
+              )}
+            </Alert>
+          </Col>
+        )}
       </Row>
     </details>
   )
@@ -481,6 +553,7 @@ function HealthView() {
                 </a>
               </div>
             ))}
+            <AttachmentGallery attachments={observation.attachments} />
             <ObservationActions observation={observation} />
           </Card>
         ))

--- a/frontend/js/plantings/harvest_form.tsx
+++ b/frontend/js/plantings/harvest_form.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Alert, Button, Col, Form, Row } from 'react-bootstrap'
 
+import { PhotoInput } from '../attachments'
+import { uploadAttachments } from '../api/attachments'
 import { addHarvest } from '../api/plantings'
 import { queryKeys } from '../query'
 import { localDatetimeInputValue, parseLocalDatetimeInput } from '../utils'
@@ -72,6 +74,9 @@ function HarvestForm({ batches, plants = [], gardenSquare, gardenRow, onRecorded
   const [selected, setSelected] = React.useState<Array<number>>([])
   const [finishPlants, setFinishPlants] = React.useState(false)
   const [error, setError] = React.useState<string>()
+  const [photos, setPhotos] = React.useState<Array<File>>([])
+  const [photoWarning, setPhotoWarning] = React.useState('')
+  const [photoTarget, setPhotoTarget] = React.useState<number | null>(null)
 
   React.useEffect(() => {
     if (batches.length === 1) {
@@ -87,13 +92,19 @@ function HarvestForm({ batches, plants = [], gardenSquare, gardenRow, onRecorded
   const predatesAPlant = chosen.some((plant) => plant.since !== null && harvestedDate !== null && harvestedDate < new Date(plant.since))
 
   const mutation = useMutation({
-    mutationFn: addHarvest,
-    onSuccess: (harvest) => {
+    mutationFn: async (data: Parameters<typeof addHarvest>[0]) => {
+      const harvest = await addHarvest(data)
+      return { harvest, photoResult: await uploadAttachments('harvest', harvest.pk, photos) }
+    },
+    onSuccess: ({ harvest, photoResult }) => {
       setQuantity('')
       setNotes('')
       setSelected([])
       setFinishPlants(false)
       setError(undefined)
+      setPhotos(photoResult.failures.map((failure) => failure.file))
+      setPhotoWarning(photoResult.failures.length === 0 ? '' : 'The harvest was recorded, but some photos failed. The failed selection is ready to retry.')
+      setPhotoTarget(photoResult.failures.length === 0 ? null : harvest.pk)
       return invalidateHarvests(queryClient, harvest.batch, harvest.finished_plants.length > 0).then(() => onRecorded?.())
     },
     onError: (caught: unknown) => setError(caught instanceof Error ? caught.message : String(caught))
@@ -203,6 +214,9 @@ function HarvestForm({ batches, plants = [], gardenSquare, gardenRow, onRecorded
             <Form.Control value={notes} onChange={(event) => setNotes(event.target.value)} />
           </Form.Group>
         </Col>
+        <Col md={12}>
+          <PhotoInput id="harvest-photos" files={photos} onChange={setPhotos} />
+        </Col>
       </Row>
       {batchPlants.length > 0 && (
         <fieldset className="mt-3">
@@ -238,6 +252,30 @@ function HarvestForm({ batches, plants = [], gardenSquare, gardenRow, onRecorded
       {error && (
         <Alert className="mt-3" variant="danger">
           {error}
+        </Alert>
+      )}
+      {photoWarning && (
+        <Alert className="mt-3" variant="warning">
+          {photoWarning}
+          {photoTarget !== null && (
+            <div>
+              <Button
+                className="mt-2"
+                size="sm"
+                variant="outline-dark"
+                onClick={() => {
+                  void uploadAttachments('harvest', photoTarget, photos).then((result) => {
+                    setPhotos(result.failures.map((failure) => failure.file))
+                    setPhotoWarning(result.failures.length === 0 ? '' : photoWarning)
+                    if (result.failures.length === 0) setPhotoTarget(null)
+                    void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.harvestsAll })
+                  })
+                }}
+              >
+                Retry failed photos
+              </Button>
+            </div>
+          )}
         </Alert>
       )}
     </Form>

--- a/frontend/js/plantings/harvest_list.tsx
+++ b/frontend/js/plantings/harvest_list.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Alert, Button, Form, Table } from 'react-bootstrap'
 
+import { AttachmentGallery, AttachmentUploader } from '../attachments'
 import { reverseHarvest } from '../api/plantings'
+import { queryKeys } from '../query'
 import { formatDateTime, formatMeasure } from '../utils'
 import { HARVEST_UNIT_LABELS, Harvest, HarvestFamilyTotal, HarvestGrade } from '../types/plantings'
 import { invalidateHarvests } from './harvest_form'
@@ -86,6 +88,7 @@ interface HarvestTableProps {
 }
 
 function HarvestTable({ harvests, showCrop = true, showLocation = true }: HarvestTableProps) {
+  const queryClient = useQueryClient()
   if (harvests.length === 0) {
     return <p className="text-muted mb-0">No harvests recorded yet.</p>
   }
@@ -129,6 +132,16 @@ function HarvestTable({ harvests, showCrop = true, showLocation = true }: Harves
               <td>
                 {harvest.notes || '—'}
                 {reversed && harvest.reverse_reason && <div>Reversed: {harvest.reverse_reason}</div>}
+                <AttachmentGallery attachments={harvest.attachments} />
+                <details className="mt-2">
+                  <summary>Add photos</summary>
+                  <AttachmentUploader
+                    id={`harvest-photos-${harvest.pk}`}
+                    targetType="harvest"
+                    targetId={harvest.pk}
+                    onUploaded={() => void queryClient.invalidateQueries({ queryKey: queryKeys.plantings.harvestsAll })}
+                  />
+                </details>
               </td>
               <td className="text-nowrap">
                 <ReverseHarvestButton harvest={harvest} />

--- a/frontend/js/plantings/plant_detail.tsx
+++ b/frontend/js/plantings/plant_detail.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Card, Col, Row, Table } from 'react-bootstrap'
 import { NavLink } from 'react-router'
 
+import { AttachmentGallery, AttachmentUploader } from '../attachments'
 import { getPlantCostBreakdown } from '../api/costing'
 import { getSpecificPlant, getSpecificPlantLifecycleEvents } from '../api/plantings'
 import { queryKeys } from '../query'
@@ -92,6 +93,7 @@ interface PlantDetailViewProps {
 }
 
 function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
+  const queryClient = useQueryClient()
   const { data: plant, isPending } = useQuery({
     queryKey: queryKeys.plantings.specificPlantDetail(plantPk),
     queryFn: ({ signal }) => getSpecificPlant(plantPk, signal)
@@ -114,6 +116,8 @@ function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
   if (plant === undefined) {
     return <main className="container py-3">Plant not found.</main>
   }
+
+  const refreshPlant = () => queryClient.invalidateQueries({ queryKey: queryKeys.plantings.specificPlantDetail(plantPk) })
 
   return (
     <main className="container py-3">
@@ -171,6 +175,16 @@ function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
                                 </a>
                               </div>
                             )}
+                            <AttachmentGallery attachments={entry.attachments} />
+                            <details className="mt-2">
+                              <summary>Add observation photos</summary>
+                              <AttachmentUploader
+                                id={`nursery-observation-photos-${entry.pk}`}
+                                targetType="nursery_observation"
+                                targetId={entry.pk}
+                                onUploaded={() => void refreshPlant()}
+                              />
+                            </details>
                           </td>
                         </tr>
                       ))}
@@ -181,6 +195,16 @@ function PlantDetailView({ plantPk, workspace }: PlantDetailViewProps) {
             </Card>
           </Col>
         )}
+        <Col md={6}>
+          <Card>
+            <Card.Header>Photos</Card.Header>
+            <Card.Body>
+              <AttachmentGallery attachments={plant.attachments} />
+              {plant.attachments.length === 0 && <p className="text-muted">No photos attached yet.</p>}
+              <AttachmentUploader id="plant-photos" targetType="plant" targetId={plant.pk} onUploaded={() => void refreshPlant()} />
+            </Card.Body>
+          </Card>
+        </Col>
         <Col md={6}>
           <Card>
             <Card.Header>Lineage</Card.Header>

--- a/frontend/js/types/attachments.ts
+++ b/frontend/js/types/attachments.ts
@@ -1,0 +1,29 @@
+type AttachmentTargetType = 'plant' | 'nursery_observation' | 'health_observation' | 'harvest'
+
+interface ImageAttachment {
+  id: string
+  target_type: AttachmentTargetType
+  target_id: number
+  original_filename: string
+  content_type: 'image/jpeg' | 'image/png'
+  byte_size: number
+  width: number
+  height: number
+  sha256: string
+  captured_at: string | null
+  created: string
+  content_url: string
+  thumbnail_url: string
+}
+
+interface AttachmentUploadFailure {
+  file: File
+  message: string
+}
+
+interface AttachmentUploadResult {
+  uploaded: Array<ImageAttachment>
+  failures: Array<AttachmentUploadFailure>
+}
+
+export type { AttachmentTargetType, AttachmentUploadFailure, AttachmentUploadResult, ImageAttachment }

--- a/frontend/js/types/health.ts
+++ b/frontend/js/types/health.ts
@@ -1,3 +1,5 @@
+import { ImageAttachment } from './attachments'
+
 type HealthSeverity = 'low' | 'moderate' | 'high' | 'critical'
 type HealthScopeType = 'plant' | 'cohort' | 'tray' | 'generation' | 'batch' | 'location'
 
@@ -44,6 +46,7 @@ interface HealthObservation {
   affected_count: number
   diagnoses: Array<HealthDiagnosisAssessment>
   evidence: Array<{ url: string; label: string }>
+  attachments: Array<ImageAttachment>
   corrects: number | null
   correction_reason: string
   quarantine_cases: Array<{ pk: number; active: boolean; reason: string }>

--- a/frontend/js/types/plantings.ts
+++ b/frontend/js/types/plantings.ts
@@ -1,4 +1,5 @@
 import { GardenSquare } from './garden'
+import { ImageAttachment } from './attachments'
 
 type ProductionBatchStatus = 'planned' | 'active' | 'output_finalized' | 'completed' | 'cancelled'
 
@@ -387,6 +388,7 @@ interface SpecificPlantDetail extends SpecificPlant {
   availability_intervals: Array<AvailabilityInterval>
   growth: NurseryGrowth
   nursery_observations: Array<NurseryObservation>
+  attachments: Array<ImageAttachment>
 }
 
 interface GrowthCatalogValue {
@@ -422,6 +424,7 @@ interface NurseryObservation extends NurseryGrowth {
   notes: string
   corrects: number | null
   input_application: number | null
+  attachments: Array<ImageAttachment>
 }
 
 interface SpecificPlantCreate {
@@ -668,6 +671,7 @@ interface Harvest {
   created: string
   plants: Array<number>
   finished_plants: Array<number>
+  attachments: Array<ImageAttachment>
 }
 
 interface HarvestCreate {

--- a/frontend/js/utils.tsx
+++ b/frontend/js/utils.tsx
@@ -141,6 +141,19 @@ function csrfPost(url: string, data: object): Promise<Response> {
   return csrfRequest('POST', url, data)
 }
 
+async function csrfPostForm(url: string, data: FormData): Promise<Response> {
+  const method = 'POST'
+  const response = await fetchResponse(method, url, {
+    method,
+    headers: {
+      'X-CSRFToken': Cookies.get('csrftoken') || ''
+    },
+    body: data
+  })
+  await checkResponse(method, url, response)
+  return response
+}
+
 function csrfDelete(url: string): Promise<Response> {
   return csrfRequest('DELETE', url)
 }
@@ -303,6 +316,7 @@ export {
   errorsByField,
   csrfDelete,
   csrfPost,
+  csrfPostForm,
   csrfPatch,
   fetchAsJson,
   localDatetimeInputValue,

--- a/health/rest.py
+++ b/health/rest.py
@@ -10,6 +10,7 @@ from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from attachments.rest import AttachmentSerializer
 from workspaces.models import Workspace, get_current_workspace
 from workspaces.scoping import CurrentWorkspaceViewSetMixin, RequireWorkspaceModeMixin
 
@@ -163,6 +164,7 @@ class HealthObservationSerializer(serializers.ModelSerializer):
     quarantine_cases = serializers.SerializerMethodField()
     treatments = serializers.SerializerMethodField()
     follow_ups = serializers.SerializerMethodField()
+    attachments = AttachmentSerializer(source='image_attachments', many=True, read_only=True)
 
     class Meta:
         model = HealthObservation
@@ -172,6 +174,7 @@ class HealthObservationSerializer(serializers.ModelSerializer):
             'affected_count', 'diagnoses', 'evidence', 'corrects',
             'correction_reason', 'created_by', 'created',
             'quarantine_cases', 'treatments', 'follow_ups',
+            'attachments',
         ]
 
     def get_scopes(self, observation):
@@ -329,6 +332,7 @@ class HealthObservationViewSet(
         'diagnoses__diagnosis', 'evidence_links',
         'quarantine_cases__actions', 'quarantine_cases__members',
         'treatments__application', 'follow_ups',
+        'image_attachments',
     )
     serializer_class = HealthObservationSerializer
 

--- a/plantings/growth_rest.py
+++ b/plantings/growth_rest.py
@@ -9,6 +9,7 @@ from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from attachments.rest import AttachmentSerializer
 from workspaces.models import Workspace
 from workspaces.models import get_current_workspace
 from workspaces.scoping import CurrentWorkspaceViewSetMixin, RequireWorkspaceModeMixin
@@ -71,6 +72,7 @@ class NurseryObservationSerializer(serializers.ModelSerializer):
     cohort = serializers.SerializerMethodField()
     stage_name = serializers.CharField(source='stage.name', read_only=True, allow_null=True)
     grade_name = serializers.CharField(source='grade.name', read_only=True, allow_null=True)
+    attachments = AttachmentSerializer(source='image_attachments', many=True, read_only=True)
 
     class Meta:
         model = NurseryObservation
@@ -81,6 +83,7 @@ class NurseryObservationSerializer(serializers.ModelSerializer):
             'height_cm', 'spread_cm', 'root_condition', 'expected_ready',
             'photo_url', 'occurred_at', 'notes', 'corrects', 'created_by', 'created',
             'input_application',
+            'attachments',
         ]
 
     def get_plants(self, observation):
@@ -123,7 +126,7 @@ class NurseryObservationViewSet(
     RequireWorkspaceModeMixin, CurrentWorkspaceViewSetMixin, viewsets.ReadOnlyModelViewSet,
 ):
     required_workspace_modes = (Workspace.Mode.NURSERY,)
-    queryset = NurseryObservation.objects.select_related('stage', 'grade', 'container_item', 'created_by').prefetch_related('targets')
+    queryset = NurseryObservation.objects.select_related('stage', 'grade', 'container_item', 'created_by').prefetch_related('targets', 'image_attachments')
     serializer_class = NurseryObservationSerializer
 
     def get_queryset(self):

--- a/plantings/harvest_rest.py
+++ b/plantings/harvest_rest.py
@@ -15,6 +15,8 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from attachments.rest import AttachmentSerializer
+
 from garden.models import GardenRow, GardenSquare
 from inventory.models import (
     POSITIVE_DECIMAL,
@@ -84,6 +86,7 @@ class HarvestSerializer(serializers.ModelSerializer):
     location_label = serializers.SerializerMethodField()
     plants = serializers.SerializerMethodField()
     finished_plants = serializers.SerializerMethodField()
+    attachments = AttachmentSerializer(source='image_attachments', many=True, read_only=True)
 
     class Meta:
         model = Harvest
@@ -112,6 +115,7 @@ class HarvestSerializer(serializers.ModelSerializer):
             'created',
             'plants',
             'finished_plants',
+            'attachments',
         ]
         read_only_fields = fields
 
@@ -271,7 +275,7 @@ class HarvestViewSet(
         'batch__variety__plant',
         'garden_square',
         'garden_row',
-    ).prefetch_related('plant_allocations')
+    ).prefetch_related('plant_allocations', 'image_attachments')
     serializer_class = HarvestSerializer
     http_method_names = ['get', 'post', 'head', 'options']
     bind_workspace_on_create = False

--- a/plantings/rest.py
+++ b/plantings/rest.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from attachments.rest import AttachmentSerializer
 from locations.occupancy import check_capacity, plant_contribution
 from seeds.models import SeedPacket
 from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
@@ -554,10 +555,12 @@ class SpecificPlantDetailSerializer(SpecificPlantSerializer):
     availability_intervals = serializers.SerializerMethodField()
     growth = serializers.SerializerMethodField()
     nursery_observations = serializers.SerializerMethodField()
+    attachments = AttachmentSerializer(source='image_attachments', many=True, read_only=True)
 
     class Meta(SpecificPlantSerializer.Meta):
         fields = SpecificPlantSerializer.Meta.fields + [
-            'lifecycle_events', 'availability_intervals', 'growth', 'nursery_observations',
+            'lifecycle_events', 'availability_intervals', 'growth',
+            'nursery_observations', 'attachments',
         ]
 
     def get_growth(self, plant):
@@ -583,9 +586,11 @@ class SpecificPlantDetailSerializer(SpecificPlantSerializer):
         observations = (
             NurseryObservation.objects.filter(targets__plant=plant)
             .select_related('stage', 'grade', 'container_item', 'created_by')
-            .prefetch_related('targets')
+            .prefetch_related('targets', 'image_attachments')
         )
-        return NurseryObservationSerializer(observations, many=True).data
+        return NurseryObservationSerializer(
+            observations, many=True, context=self.context,
+        ).data
 
 
 class GardenSquareTransplantSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
@@ -967,7 +972,10 @@ class SpecificPlantViewSet(PlantOutcomeViewSetMixin, CurrentWorkspaceViewSetMixi
     """
     ViewSet of SpecificPlant
     """
-    queryset = SpecificPlant.objects.prefetch_related('locations', 'locations__seed_tray_cell', 'locations__garden_square', 'lifecycle_events')
+    queryset = SpecificPlant.objects.prefetch_related(
+        'locations', 'locations__seed_tray_cell', 'locations__garden_square',
+        'lifecycle_events', 'image_attachments',
+    )
     serializer_class = SpecificPlantSerializer
 
     def get_serializer_class(self):


### PR DESCRIPTION
Gardeners need one mobile-friendly control instead of URL-only evidence. Embed protected attachment metadata in existing records and reuse camera selection, previews, galleries, and retry behavior across plants, observations, corrections, and harvests.

## Summary by Sourcery

Add mobile-friendly photo evidence support across record workflows.

New Features:
- Enable gardeners to capture and attach photos directly to plants, nursery observations, health observations, corrections, and harvest records.
- Provide reusable attachment galleries and upload controls with mobile camera capture, previews, protected metadata, and retry handling for failed uploads.

Enhancements:
- Expose attachment metadata through record APIs while preserving workspace-scoped access and efficient related-object loading.

Tests:
- Add coverage verifying attachment metadata is embedded in plant, nursery observation, health observation, and harvest responses.