### PR TITLE
feat(attachments): export and restore photo archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Before setup:
 - Set `CSRF_TRUSTED_ORIGINS` to every public origin, including its scheme.
 - Fill in all four database values directly, or provide `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` in the deployment environment.
 - Leave `CURRENT_WORKSPACE_ID = 1` for an existing single-workspace installation. Selecting another ID does not move records between workspaces.
+- Set `ATTACHMENT_ROOT` to a private, persistent, backed-up directory writable by the application. Never expose that directory through the reverse proxy; authenticated Django views serve its files.
 - For HTTPS behind a trusted reverse proxy, review and enable the commented proxy and secure-cookie settings.
 
 Run `./setup-venv.sh`; it substitutes any provided database variables and applies migrations to the configured PostgreSQL database.
@@ -148,6 +149,8 @@ Development notes
   The `setup-venv.sh` already runs the build unless `NODE_DONE=yes` is set in the environment.
 
 - Do not commit secrets: `gp/local_settings.py` is produced from a selected template; keep secrets out of source control.
+
+- Uploaded photographs live under `ATTACHMENT_ROOT` (by default `var/attachments/` in development), outside static files. Back up this directory with the database. The Workspace settings screen can export a portable photo-only ZIP, but restoring that ZIP requires the referenced records to exist with matching IDs.
 
 - Secret-key management:
   - `setup-venv.sh` creates `gp/local_settings.py` and `gp/secretkey.txt` with mode `0600`. Rerunning setup preserves both files while repairing their permissions.

--- a/attachments/archive.py
+++ b/attachments/archive.py
@@ -1,0 +1,275 @@
+"""Versioned workspace photo export and validated restore."""
+
+import json
+import shutil
+import stat
+from hashlib import sha256
+from io import BytesIO
+from tempfile import SpooledTemporaryFile
+from uuid import UUID
+from zipfile import BadZipFile, ZIP_DEFLATED, ZipFile
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.db import transaction
+from django.utils.dateparse import parse_datetime
+from PIL import Image, UnidentifiedImageError
+
+from .models import ImageAttachment
+from .processing import _encode  # pylint: disable=protected-access
+from .storage import private_attachment_storage
+
+
+ARCHIVE_FORMAT = 'garden-tracker-photo-archive'
+ARCHIVE_VERSION = 1
+MANIFEST_PATH = 'manifest.json'
+FORMAT_CONTENT_TYPES = {'JPEG': 'image/jpeg', 'PNG': 'image/png'}
+
+
+def _manifest_row(attachment):
+    extension = 'png' if attachment.content_type == 'image/png' else 'jpg'
+    return {
+        'id': str(attachment.public_id),
+        'target_type': attachment.target_type,
+        'target_id': attachment.target_id,
+        'original_filename': attachment.original_filename,
+        'content_type': attachment.content_type,
+        'byte_size': attachment.byte_size,
+        'width': attachment.width,
+        'height': attachment.height,
+        'sha256': attachment.sha256,
+        'captured_at': (
+            attachment.captured_at.isoformat() if attachment.captured_at else None
+        ),
+        'created': attachment.created.isoformat(),
+        'path': f'photos/{attachment.public_id}.{extension}',
+    }
+
+
+def export_archive(workspace):
+    """Build a seeked ZIP containing this workspace's sanitized originals."""
+    attachments = list(
+        ImageAttachment.objects.filter(workspace=workspace).order_by('created', 'pk')
+    )
+    rows = [_manifest_row(attachment) for attachment in attachments]
+    # FileResponse owns and closes this returned stream after sending it.
+    output = SpooledTemporaryFile(  # pylint: disable=consider-using-with
+        max_size=16 * 1024 * 1024, mode='w+b',
+    )
+    with ZipFile(output, 'w', compression=ZIP_DEFLATED, compresslevel=6) as archive:
+        archive.writestr(MANIFEST_PATH, json.dumps({
+            'format': ARCHIVE_FORMAT,
+            'version': ARCHIVE_VERSION,
+            'workspace': {'id': workspace.pk, 'name': workspace.name},
+            'attachments': rows,
+        }, indent=2).encode('utf-8'))
+        for attachment, row in zip(attachments, rows, strict=True):
+            with attachment.original.open('rb') as source, archive.open(row['path'], 'w') as target:
+                shutil.copyfileobj(source, target)
+    output.seek(0)
+    return output
+
+
+def _parse_timestamp(value, field, errors, *, nullable=False):
+    if value is None and nullable:
+        return None
+    if not isinstance(value, str):
+        errors.append(f'{field} must be an ISO-8601 timestamp.')
+        return None
+    parsed = parse_datetime(value)
+    if parsed is None or parsed.tzinfo is None:
+        errors.append(f'{field} must include a timezone.')
+        return None
+    return parsed
+
+
+def _inspect_image(data, row, errors):
+    try:
+        image = Image.open(BytesIO(data))
+        image.load()
+    except (Image.DecompressionBombError, UnidentifiedImageError, OSError) as exc:
+        errors.append(f'{row.get("path", "photo")}: invalid image ({exc}).')
+        return None
+    content_type = FORMAT_CONTENT_TYPES.get(image.format)
+    if content_type is None or content_type != row.get('content_type'):
+        errors.append(f'{row.get("path", "photo")}: image format does not match its manifest.')
+    if getattr(image, 'n_frames', 1) != 1:
+        errors.append(f'{row.get("path", "photo")}: animated images are not supported.')
+    if image.width * image.height > settings.ATTACHMENT_MAX_PIXELS:
+        errors.append(f'{row.get("path", "photo")}: image exceeds the pixel limit.')
+    if image.getexif():
+        errors.append(f'{row.get("path", "photo")}: image still contains EXIF metadata.')
+    if [image.width, image.height] != [row.get('width'), row.get('height')]:
+        errors.append(f'{row.get("path", "photo")}: dimensions do not match its manifest.')
+    thumbnail = image.copy()
+    thumbnail.thumbnail((512, 512), Image.Resampling.LANCZOS)
+    output_format = 'PNG' if content_type == 'image/png' else 'JPEG'
+    return _encode(thumbnail, output_format, thumbnail=True)
+
+
+def _safe_zip(archive, errors):
+    infos = archive.infolist()
+    if len(infos) > settings.ATTACHMENT_ARCHIVE_MAX_ENTRIES + 1:
+        errors.append('The archive contains too many entries.')
+    names = [info.filename for info in infos]
+    if len(names) != len(set(names)):
+        errors.append('The archive contains duplicate paths.')
+    if sum(info.file_size for info in infos) > settings.ATTACHMENT_ARCHIVE_MAX_EXPANDED_BYTES:
+        errors.append('The expanded archive is too large.')
+    for info in infos:
+        if info.filename.startswith('/') or '..' in info.filename.split('/'):
+            errors.append(f'Unsafe archive path: {info.filename}.')
+        file_type = (info.external_attr >> 16) & 0o170000
+        if file_type == stat.S_IFLNK:
+            errors.append(f'Symbolic links are not permitted: {info.filename}.')
+    return set(names)
+
+
+def _target(workspace, target_type, target_id, target_mapping):
+    try:
+        mapped_type, mapped_id = target_mapping(target_type, target_id)
+    except (TypeError, ValueError):
+        return None, None, None, None
+    field = ImageAttachment.TARGET_FIELDS.get(mapped_type)
+    if field is None:
+        return None, None, None, None
+    model = ImageAttachment._meta.get_field(field).remote_field.model
+    try:
+        target = model.objects.filter(workspace=workspace, pk=mapped_id).first()
+    except (TypeError, ValueError):
+        target = None
+    return field, target, mapped_type, mapped_id
+
+
+def _inspect_archive(workspace, upload, target_mapping):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    errors = []
+    prepared = []
+    already_present = 0
+    if upload.size > settings.ATTACHMENT_ARCHIVE_MAX_BYTES:
+        return {'valid': False, 'would_create': 0, 'already_present': 0, 'errors': ['The archive is too large.']}, []
+    try:
+        upload.seek(0)
+        archive = ZipFile(upload)
+    except (BadZipFile, OSError):
+        return {'valid': False, 'would_create': 0, 'already_present': 0, 'errors': ['Upload a valid photo archive ZIP.']}, []
+    with archive:
+        names = _safe_zip(archive, errors)
+        if MANIFEST_PATH not in names:
+            errors.append('The archive has no manifest.json.')
+            return {'valid': False, 'would_create': 0, 'already_present': 0, 'errors': errors}, []
+        try:
+            manifest = json.loads(archive.read(MANIFEST_PATH))
+        except (UnicodeDecodeError, json.JSONDecodeError, KeyError):
+            errors.append('The archive manifest is not valid JSON.')
+            return {'valid': False, 'would_create': 0, 'already_present': 0, 'errors': errors}, []
+        if manifest.get('format') != ARCHIVE_FORMAT or manifest.get('version') != ARCHIVE_VERSION:
+            errors.append('The archive format or version is not supported.')
+        rows = manifest.get('attachments')
+        if not isinstance(rows, list):
+            errors.append('The manifest attachments value must be a list.')
+            rows = []
+        expected_paths = {MANIFEST_PATH}
+        seen_ids = set()
+        seen_paths = set()
+        for index, row in enumerate(rows):
+            label = f'attachments[{index}]'
+            if not isinstance(row, dict):
+                errors.append(f'{label} must be an object.')
+                continue
+            path = row.get('path')
+            if not isinstance(path, str) or not path.startswith('photos/'):
+                errors.append(f'{label}.path is invalid.')
+                continue
+            expected_paths.add(path)
+            if path in seen_paths:
+                errors.append(f'{label}.path is duplicated in the manifest.')
+                continue
+            seen_paths.add(path)
+            try:
+                public_id = UUID(str(row.get('id')))
+            except ValueError:
+                errors.append(f'{label}.id is not a UUID.')
+                continue
+            if public_id in seen_ids:
+                errors.append(f'{label}.id is duplicated.')
+                continue
+            seen_ids.add(public_id)
+            if path not in names:
+                errors.append(f'{path} is missing from the archive.')
+                continue
+            data = archive.read(path)
+            digest = sha256(data).hexdigest()
+            if digest != row.get('sha256') or len(data) != row.get('byte_size'):
+                errors.append(f'{path}: checksum or byte size does not match its manifest.')
+            thumbnail = _inspect_image(data, row, errors)
+            captured_at = _parse_timestamp(
+                row.get('captured_at'), f'{label}.captured_at', errors, nullable=True,
+            )
+            created = _parse_timestamp(row.get('created'), f'{label}.created', errors)
+            if not isinstance(row.get('original_filename'), str):
+                errors.append(f'{label}.original_filename must be text.')
+            field, target, mapped_type, mapped_id = _target(
+                workspace, row.get('target_type'), row.get('target_id'), target_mapping,
+            )
+            if field is None or target is None:
+                errors.append(f'{label} does not identify a target in this workspace.')
+            existing = ImageAttachment.objects.filter(public_id=public_id).first()
+            if existing is not None:
+                if all((
+                    existing.workspace_id == workspace.pk,
+                    existing.sha256 == digest,
+                    existing.target_type == mapped_type,
+                    existing.target_id == mapped_id,
+                )):
+                    already_present += 1
+                    continue
+                errors.append(f'{label}.id conflicts with an existing attachment.')
+            if thumbnail is not None and target is not None and created is not None:
+                prepared.append({
+                    'row': row, 'public_id': public_id, 'data': data,
+                    'thumbnail': thumbnail, 'captured_at': captured_at,
+                    'created': created, 'field': field, 'target': target,
+                })
+        extras = names - expected_paths
+        if extras:
+            errors.append(f'Unexpected archive entries: {sorted(extras)}.')
+    report = {
+        'valid': not errors,
+        'would_create': len(prepared) if not errors else 0,
+        'already_present': already_present,
+        'errors': errors,
+    }
+    return report, prepared
+
+
+def restore_archive(workspace, user, upload, *, dry_run=True, target_mapping=None):
+    """Validate, then optionally restore, one photo-only workspace archive."""
+    mapper = target_mapping or (lambda target_type, target_id: (target_type, target_id))
+    report, prepared = _inspect_archive(workspace, upload, mapper)
+    if dry_run or not report['valid']:
+        return report
+    stored_names = []
+    try:
+        with transaction.atomic():
+            for item in prepared:
+                row = item['row']
+                extension = 'png' if row['content_type'] == 'image/png' else 'jpg'
+                attachment = ImageAttachment(
+                    workspace=workspace, public_id=item['public_id'],
+                    uploaded_by=user if user and user.is_authenticated else None,
+                    original_filename=row['original_filename'][:255],
+                    content_type=row['content_type'], byte_size=row['byte_size'],
+                    width=row['width'], height=row['height'], sha256=row['sha256'],
+                    captured_at=item['captured_at'], **{item['field']: item['target']},
+                )
+                attachment.original = ContentFile(item['data'], name=f'photo.{extension}')
+                attachment.thumbnail = ContentFile(item['thumbnail'], name=f'thumbnail.{extension}')
+                attachment.save()
+                stored_names.extend([attachment.original.name, attachment.thumbnail.name])
+                ImageAttachment.objects.filter(pk=attachment.pk).update(created=item['created'])
+    except Exception:
+        for name in stored_names:
+            if private_attachment_storage.exists(name):
+                private_attachment_storage.delete(name)
+        raise
+    return {**report, 'created': len(prepared)}

--- a/attachments/rest.py
+++ b/attachments/rest.py
@@ -9,12 +9,14 @@ from django.utils.http import content_disposition_header
 from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.views import APIView
 from rest_framework.response import Response
 
 from workspaces.models import get_current_workspace
 from workspaces.scoping import CurrentWorkspaceViewSetMixin
 
 from .models import ImageAttachment
+from .archive import export_archive, restore_archive
 from .processing import create_attachment
 
 
@@ -131,3 +133,38 @@ class ImageAttachmentViewSet(
 
 router = routers.DefaultRouter()
 router.register('', ImageAttachmentViewSet)
+
+
+class AttachmentArchiveExportView(APIView):
+    """Download the current workspace's versioned photo archive."""
+
+    def get(self, request):  # pylint: disable=unused-argument
+        response = FileResponse(
+            export_archive(get_current_workspace()),
+            content_type='application/zip',
+        )
+        response['Content-Disposition'] = 'attachment; filename="garden-photos-v1.zip"'
+        response['Cache-Control'] = 'private, no-store'
+        return response
+
+
+class AttachmentArchiveRestoreView(APIView):
+    """Dry-run or apply a validated photo-only archive restore."""
+
+    parser_classes = [MultiPartParser, FormParser]
+
+    def post(self, request):
+        upload = request.FILES.get('archive')
+        if upload is None:
+            raise serializers.ValidationError({'archive': 'Choose a photo archive ZIP.'})
+        dry_run_value = str(request.data.get('dry_run', 'true')).lower()
+        if dry_run_value not in {'true', 'false'}:
+            raise serializers.ValidationError({'dry_run': 'Use true or false.'})
+        dry_run = dry_run_value == 'true'
+        report = restore_archive(
+            get_current_workspace(), request.user, upload, dry_run=dry_run,
+        )
+        response_status = status.HTTP_200_OK
+        if not report['valid'] and not dry_run:
+            response_status = status.HTTP_400_BAD_REQUEST
+        return Response(report, status=response_status)

--- a/attachments/test_attachments.py
+++ b/attachments/test_attachments.py
@@ -4,9 +4,11 @@
 # closed by each test's temporary-directory lifecycle.
 # pylint: disable=missing-function-docstring,consider-using-with
 
+import json
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -21,6 +23,7 @@ from workspaces.models import Workspace, get_current_workspace
 
 from .models import ImageAttachment
 from .processing import create_attachment
+from .storage import private_attachment_storage
 
 
 def image_upload(
@@ -229,3 +232,123 @@ class AttachmentContractTests(AttachmentTestCase):
                 payload = next(row for row in payload if row['pk'] == target.pk)
             with self.subTest(target_type=target_type):
                 self.assertEqual(payload['attachments'][0]['target_type'], target_type)
+
+
+class AttachmentArchiveTests(AttachmentTestCase):
+    """Photo archives are scoped, self-validating, and idempotent."""
+
+    def archive_bytes(self):
+        response = self.client.get('/attachments/archive/')
+        self.assertEqual(response.status_code, 200)
+        return b''.join(response.streaming_content)
+
+    def restore(self, data, *, dry_run):
+        return self.client.post('/attachments/archive/restore/', {
+            'archive': SimpleUploadedFile(
+                'photos.zip', data, content_type='application/zip',
+            ),
+            'dry_run': str(dry_run).lower(),
+        }, format='multipart')
+
+    def rewrite_manifest(self, data, change):
+        source = ZipFile(BytesIO(data))
+        output = BytesIO()
+        with source, ZipFile(output, 'w', compression=ZIP_DEFLATED) as target:
+            manifest = json.loads(source.read('manifest.json'))
+            change(manifest)
+            for info in source.infolist():
+                content = (
+                    json.dumps(manifest).encode() if info.filename == 'manifest.json'
+                    else source.read(info.filename)
+                )
+                target.writestr(info.filename, content)
+        return output.getvalue()
+
+    def test_export_contains_only_current_workspace_originals(self):
+        attachment = create_attachment(
+            self.workspace, self.user, 'plant', self.plant, image_upload(),
+        )
+        other_workspace = Workspace.objects.create(name='Other garden')
+        other_plant = make_specific_plant(workspace=other_workspace)
+        create_attachment(
+            other_workspace, self.user, 'plant', other_plant, image_upload(),
+        )
+
+        with ZipFile(BytesIO(self.archive_bytes())) as archive:
+            manifest = json.loads(archive.read('manifest.json'))
+            self.assertEqual(manifest['format'], 'garden-tracker-photo-archive')
+            self.assertEqual(manifest['version'], 1)
+            self.assertEqual(
+                [row['id'] for row in manifest['attachments']],
+                [str(attachment.public_id)],
+            )
+            self.assertEqual(
+                set(archive.namelist()),
+                {'manifest.json', manifest['attachments'][0]['path']},
+            )
+            self.assertFalse(any('thumbnail' in name for name in archive.namelist()))
+
+    def test_dry_run_then_apply_round_trips_and_is_idempotent(self):
+        attachment = create_attachment(
+            self.workspace, self.user, 'plant', self.plant, image_upload(),
+        )
+        attachment_id = attachment.public_id
+        original_names = [attachment.original.name, attachment.thumbnail.name]
+        archive = self.archive_bytes()
+        ImageAttachment.objects.filter(pk=attachment.pk)._raw_delete(  # pylint: disable=protected-access
+            ImageAttachment.objects.db,
+        )
+        for name in original_names:
+            private_attachment_storage.delete(name)
+
+        preview = self.restore(archive, dry_run=True)
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(preview.data['would_create'], 1)
+        self.assertFalse(ImageAttachment.objects.exists())
+
+        applied = self.restore(archive, dry_run=False)
+        self.assertEqual(applied.status_code, 200, applied.data)
+        self.assertEqual(applied.data['created'], 1)
+        restored = ImageAttachment.objects.get(public_id=attachment_id)
+        self.assertEqual(restored.plant, self.plant)
+        self.assertTrue(restored.original.storage.exists(restored.original.name))
+
+        repeated = self.restore(archive, dry_run=False)
+        self.assertEqual(repeated.status_code, 200, repeated.data)
+        self.assertEqual(repeated.data['already_present'], 1)
+        self.assertEqual(repeated.data['created'], 0)
+
+    def test_restore_rejects_missing_targets_and_checksum_changes(self):
+        create_attachment(
+            self.workspace, self.user, 'plant', self.plant, image_upload(),
+        )
+        archive = self.archive_bytes()
+        missing = self.rewrite_manifest(
+            archive,
+            lambda manifest: manifest['attachments'][0].update(target_id=999999),
+        )
+        preview = self.restore(missing, dry_run=True)
+        self.assertFalse(preview.data['valid'])
+        self.assertTrue(any('target' in error for error in preview.data['errors']))
+
+        checksum = self.rewrite_manifest(
+            archive,
+            lambda manifest: manifest['attachments'][0].update(sha256='0' * 64),
+        )
+        rejected = self.restore(checksum, dry_run=False)
+        self.assertEqual(rejected.status_code, 400)
+        self.assertTrue(any('checksum' in error for error in rejected.data['errors']))
+
+    def test_archive_routes_require_authentication_and_enforce_size_limit(self):
+        self.client.force_authenticate(user=None)
+        self.assertEqual(self.client.get('/attachments/archive/').status_code, 403)
+        self.assertEqual(
+            self.restore(b'not a zip', dry_run=True).status_code,
+            403,
+        )
+        self.client.force_authenticate(self.user)
+        with override_settings(ATTACHMENT_ARCHIVE_MAX_BYTES=1):
+            response = self.restore(b'larger than one byte', dry_run=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data['valid'])
+        self.assertIn('too large', response.data['errors'][0])

--- a/attachments/urls.py
+++ b/attachments/urls.py
@@ -2,7 +2,18 @@
 
 from django.urls import include, path
 
-from .rest import router
+from .rest import (
+    AttachmentArchiveExportView,
+    AttachmentArchiveRestoreView,
+    router,
+)
 
 
-urlpatterns = [path('', include(router.urls))]
+urlpatterns = [
+    path('archive/', AttachmentArchiveExportView.as_view(), name='attachment-archive'),
+    path(
+        'archive/restore/', AttachmentArchiveRestoreView.as_view(),
+        name='attachment-archive-restore',
+    ),
+    path('', include(router.urls)),
+]

--- a/frontend/js/api/attachments.ts
+++ b/frontend/js/api/attachments.ts
@@ -1,4 +1,4 @@
-import { AttachmentTargetType, AttachmentUploadResult, ImageAttachment } from '../types/attachments'
+import { AttachmentArchiveReport, AttachmentTargetType, AttachmentUploadResult, ImageAttachment } from '../types/attachments'
 import { csrfPostForm, fetchAsJson } from '../utils'
 
 function getAttachments(targetType: AttachmentTargetType, targetId: number, signal?: AbortSignal): Promise<Array<ImageAttachment>> {
@@ -24,4 +24,12 @@ async function uploadAttachments(targetType: AttachmentTargetType, targetId: num
   return { uploaded, failures }
 }
 
-export { getAttachments, uploadAttachments }
+async function restoreAttachmentArchive(archive: File, dryRun: boolean): Promise<AttachmentArchiveReport> {
+  const form = new FormData()
+  form.set('archive', archive)
+  form.set('dry_run', String(dryRun))
+  const response = await csrfPostForm('/attachments/archive/restore/', form)
+  return response.json() as Promise<AttachmentArchiveReport>
+}
+
+export { getAttachments, restoreAttachmentArchive, uploadAttachments }

--- a/frontend/js/types/attachments.ts
+++ b/frontend/js/types/attachments.ts
@@ -26,4 +26,12 @@ interface AttachmentUploadResult {
   failures: Array<AttachmentUploadFailure>
 }
 
-export type { AttachmentTargetType, AttachmentUploadFailure, AttachmentUploadResult, ImageAttachment }
+interface AttachmentArchiveReport {
+  valid: boolean
+  would_create: number
+  already_present: number
+  created?: number
+  errors: Array<string>
+}
+
+export type { AttachmentArchiveReport, AttachmentTargetType, AttachmentUploadFailure, AttachmentUploadResult, ImageAttachment }

--- a/frontend/js/workspace.tsx
+++ b/frontend/js/workspace.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Alert, Button, Form } from 'react-bootstrap'
 
+import { restoreAttachmentArchive } from './api/attachments'
 import { updateWorkspace } from './api/workspace'
 import { GstRegistrationSettings } from './tax/registration.js'
 import { queryKeys } from './query'
 import { GardenExperience, Workspace, WorkspaceMode, WorkspaceUpdate } from './types/workspace'
+import { AttachmentArchiveReport } from './types/attachments'
 
 // The guided setup owns garden_setup_state; this screen edits everything else,
 // and must not send that field back and undo a gardener's answer.
@@ -50,6 +52,12 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
   const mutation = useMutation({
     mutationFn: updateWorkspace,
     onSuccess: (updated) => queryClient.setQueryData(queryKeys.workspace.current, updated)
+  })
+  const [archive, setArchive] = React.useState<File | null>(null)
+  const [archiveReport, setArchiveReport] = React.useState<AttachmentArchiveReport | null>(null)
+  const restoreMutation = useMutation({
+    mutationFn: ({ file, dryRun }: { file: File; dryRun: boolean }) => restoreAttachmentArchive(file, dryRun),
+    onSuccess: setArchiveReport
   })
 
   React.useEffect(() => {
@@ -241,6 +249,69 @@ function WorkspaceSettings({ workspace }: WorkspaceSettingsProps) {
         </Button>
         {mutation.isSuccess && <span className="ms-3 text-success">Settings saved.</span>}
       </Form>
+      <section className="mt-5" aria-labelledby="photo-archive-heading">
+        <h2 className="h4" id="photo-archive-heading">
+          Photo archive
+        </h2>
+        <p>Download sanitized full-size photos and their attachment metadata. Restore reconnects photos only when the matching record IDs already exist in this workspace.</p>
+        <Button as="a" href="/attachments/archive/" variant="outline-primary">
+          Download photo archive
+        </Button>
+        <Form.Group className="mt-3" controlId="photo-archive-file">
+          <Form.Label>Restore a photo archive</Form.Label>
+          <Form.Control
+            type="file"
+            accept="application/zip,.zip"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setArchive(event.target.files?.[0] ?? null)
+              setArchiveReport(null)
+            }}
+          />
+          <Form.Text>Run the dry check first. It makes no changes.</Form.Text>
+        </Form.Group>
+        <Button
+          className="mt-2"
+          variant="outline-secondary"
+          disabled={archive === null || restoreMutation.isPending}
+          onClick={() => {
+            if (archive !== null) restoreMutation.mutate({ file: archive, dryRun: true })
+          }}
+        >
+          {restoreMutation.isPending ? 'Checking…' : 'Check archive'}
+        </Button>
+        {archiveReport !== null && (
+          <Alert className="mt-3" variant={archiveReport.valid ? 'info' : 'danger'}>
+            {archiveReport.valid ? (
+              <>
+                Ready to restore {archiveReport.would_create} photos; {archiveReport.already_present} are already present.
+                {archive !== null && archiveReport.would_create > 0 && (
+                  <div>
+                    <Button
+                      className="mt-2"
+                      variant="warning"
+                      disabled={restoreMutation.isPending}
+                      onClick={() => {
+                        if (window.confirm('Restore the checked photos into this workspace?')) {
+                          restoreMutation.mutate({ file: archive, dryRun: false })
+                        }
+                      }}
+                    >
+                      Restore checked photos
+                    </Button>
+                  </div>
+                )}
+                {archiveReport.created !== undefined && <div className="mt-2 text-success">Restored {archiveReport.created} photos.</div>}
+              </>
+            ) : (
+              <ul className="mb-0">
+                {archiveReport.errors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            )}
+          </Alert>
+        )}
+      </section>
       {workspace.mode === 'nursery' && <GstRegistrationSettings />}
     </main>
   )

--- a/gp/settings.py
+++ b/gp/settings.py
@@ -161,6 +161,15 @@ ATTACHMENT_ROOT = Path(globals().get(
 ))
 ATTACHMENT_MAX_BYTES = globals().get("ATTACHMENT_MAX_BYTES", 15 * 1024 * 1024)
 ATTACHMENT_MAX_PIXELS = globals().get("ATTACHMENT_MAX_PIXELS", 40_000_000)
+ATTACHMENT_ARCHIVE_MAX_BYTES = globals().get(
+    "ATTACHMENT_ARCHIVE_MAX_BYTES", 1024 * 1024 * 1024,
+)
+ATTACHMENT_ARCHIVE_MAX_EXPANDED_BYTES = globals().get(
+    "ATTACHMENT_ARCHIVE_MAX_EXPANDED_BYTES", 2 * 1024 * 1024 * 1024,
+)
+ATTACHMENT_ARCHIVE_MAX_ENTRIES = globals().get(
+    "ATTACHMENT_ARCHIVE_MAX_ENTRIES", 10_000,
+)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field


### PR DESCRIPTION
Household photos need a durable path beyond the live filesystem. Add a versioned workspace ZIP with checksums, strict dry-run restore validation, idempotent import, settings controls, deployment guidance, and completion records for task 111.

## Summary by Sourcery

Add durable, validated workspace photo archiving with safe export, dry-run restore, and idempotent recovery controls.

New Features:
- Add authenticated workspace photo archive export and restore through the API and workspace settings UI.
- Provide versioned ZIP archives containing workspace photo originals, metadata, and checksums.

Bug Fixes:
- Prevent unsafe, corrupt, oversized, metadata-bearing, or mismatched archive contents from being restored.
- Make archive restoration idempotent and reject conflicting attachment identifiers.

Enhancements:
- Add dry-run validation and restore reporting before applying archive changes.
- Add configurable archive size, expansion, and entry limits.

Deployment:
- Document persistent private attachment storage and backup requirements for deployments.

Documentation:
- Document attachment storage, backup, archive export, and restore behavior.

Tests:
- Add coverage for workspace scoping, archive round trips, idempotent restores, validation failures, authentication, and size limits.