### PR TITLE
feat(purchasing): add payable workflows and API

### DIFF
--- a/gp/urls.py
+++ b/gp/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path("costing/", include('costing.urls')),
     path("sales/", include('sales.urls')),
     path("billing/", include('billing.urls')),
+    path("purchasing/", include('purchasing.urls')),
     path("labels/", include('labels.urls')),
     path("work/", include('work.urls')),
     path("health/", include('health.urls')),

--- a/purchasing/models.py
+++ b/purchasing/models.py
@@ -132,6 +132,13 @@ class PurchaseRequisition(WorkspaceOwnedModel, ValidatedModel):
         if errors:
             raise ValidationError(errors)
 
+    def save(self, *args, **kwargs):
+        if self.pk:
+            previous = type(self).objects.filter(pk=self.pk).only('status').first()
+            if previous and previous.status != self.Status.DRAFT:
+                raise ValidationError('Reviewed requisitions are immutable.')
+        super().save(*args, **kwargs)
+
 
 class PurchaseOrder(WorkspaceOwnedModel, ValidatedModel):
     """A supplier commitment editable as a draft and frozen on confirmation."""
@@ -280,10 +287,15 @@ class PurchaseOrderLine(ValidatedModel):
                 errors['requisition'] = 'The requisition belongs to another workspace.'
             elif self.requisition.item_id != self.item_id:
                 errors['requisition'] = 'The requisition is for another item.'
+            elif self.requisition.status != PurchaseRequisition.Status.REVIEWED:
+                errors['requisition'] = 'Only a reviewed requisition can be ordered.'
         if self.cancelled_quantity > self.base_quantity:
             errors['cancelled_quantity'] = 'Cancelled quantity cannot exceed ordered quantity.'
         if errors:
             raise ValidationError(errors)
+
+        if self.order_id and self.order.status != PurchaseOrder.Status.DRAFT:
+            raise ValidationError({'order': 'Lines can only be added to a draft order.'})
 
     def save(self, *args, **kwargs):
         if self.pk:
@@ -496,12 +508,20 @@ class SupplierInvoiceLine(ValidatedModel):
         workspace_id = self.invoice.workspace_id if self.invoice_id else None
         if self.purchase_order_line_id and self.purchase_order_line.order.workspace_id != workspace_id:
             errors['purchase_order_line'] = 'The order line belongs to another workspace.'
+        elif self.purchase_order_line_id and self.purchase_order_line.order.supplier_id != self.invoice.supplier_id:
+            errors['purchase_order_line'] = 'The order line belongs to another supplier.'
         if self.receipt_line_id and self.receipt_line.receipt.workspace_id != workspace_id:
             errors['receipt_line'] = 'The receipt line belongs to another workspace.'
+        elif self.receipt_line_id and self.receipt_line.receipt.supplier_id != self.invoice.supplier_id:
+            errors['receipt_line'] = 'The receipt line belongs to another supplier.'
+        elif self.receipt_line_id and self.receipt_line.receipt.status != 'posted':
+            errors['receipt_line'] = 'Only a posted receipt can be invoiced.'
         if self.expense_category_id and self.expense_category.workspace_id != workspace_id:
             errors['expense_category'] = 'The category belongs to another workspace.'
         if self.total_incl_tax != self.subtotal_ex_tax + self.tax_total:
             errors['total_incl_tax'] = 'The line total must equal subtotal plus tax.'
+        if self.invoice_id and self.invoice.status != SupplierInvoice.Status.DRAFT:
+            errors['invoice'] = 'Lines can only be added to a draft invoice.'
         if errors:
             raise ValidationError(errors)
 

--- a/purchasing/reports.py
+++ b/purchasing/reports.py
@@ -1,0 +1,107 @@
+"""Derived purchasing, due-payment, committed-spend, and expense reporting."""
+
+# pylint: disable=too-many-locals
+
+from django.db.models import Sum
+
+from inventory.models import StockReceiptLine
+
+from .models import BusinessExpense, PurchaseOrder, PurchaseRequisition, SupplierInvoice, SupplierPayment, ZERO
+from .services import invoice_state, money, order_line_state
+
+
+def purchasing_summary(workspace, as_of):
+    """Reconcile commitments, liabilities, cash, expenses, and quality findings."""
+    requisitions = PurchaseRequisition.objects.filter(workspace=workspace)
+    orders = PurchaseOrder.objects.filter(workspace=workspace).prefetch_related(
+        'lines__receipt_matches__receipt_line__receipt',
+    )
+    invoices = SupplierInvoice.objects.filter(
+        workspace=workspace, status=SupplierInvoice.Status.CONFIRMED,
+    ).select_related('supplier').prefetch_related(
+        'lines__receipt_line', 'corrections', 'payment_allocations__payment',
+    )
+    expenses = BusinessExpense.objects.filter(
+        workspace=workspace, status=BusinessExpense.Status.CONFIRMED,
+    )
+    committed = ZERO
+    overdue = []
+    invoice_rows = []
+    warnings = []
+    for order in orders.filter(status=PurchaseOrder.Status.CONFIRMED):
+        for line in order.lines.all():
+            state = order_line_state(line)
+            if line.base_quantity:
+                committed += money(
+                    line.total_incl_tax * state['outstanding'] / line.base_quantity,
+                )
+            if order.expected_on and order.expected_on < as_of and state['outstanding'] > 0:
+                warnings.append({
+                    'code': 'order_overdue',
+                    'source_type': 'purchase_order',
+                    'source_id': order.pk,
+                    'message': f'{order.order_number} has overdue outstanding stock.',
+                })
+    for invoice in invoices:
+        state = invoice_state(invoice)
+        row = {
+            'invoice': invoice.pk,
+            'reference': invoice.external_reference,
+            'supplier': invoice.supplier.name,
+            'invoice_date': invoice.invoice_date,
+            'due_date': invoice.due_date,
+            **state,
+        }
+        invoice_rows.append(row)
+        if invoice.due_date and invoice.due_date < as_of and state['balance_due'] > 0:
+            overdue.append(row)
+        for message in state['warnings']:
+            warnings.append({
+                'code': 'invoice_unmatched' if 'unmatched' in message.lower() else 'invoice_quality',
+                'source_type': 'supplier_invoice',
+                'source_id': invoice.pk,
+                'message': message,
+            })
+        for line in invoice.lines.all():
+            if line.receipt_line_id and line.total_incl_tax != line.receipt_line.supplier_cost_incl_tax:
+                warnings.append({
+                    'code': 'invoice_receipt_price_difference',
+                    'source_type': 'supplier_invoice',
+                    'source_id': invoice.pk,
+                    'message': 'Invoice line differs from the posted receipt cost; lot valuation was not changed.',
+                })
+    unmatched_receipts = StockReceiptLine.objects.filter(
+        receipt__workspace=workspace,
+        receipt__status='posted',
+        supplier_invoice_lines=None,
+    ).values_list('pk', flat=True)
+    for line_id in unmatched_receipts:
+        warnings.append({
+            'code': 'receipt_not_invoiced',
+            'source_type': 'stock_receipt_line',
+            'source_id': line_id,
+            'message': 'Posted receipt line is not matched to a supplier invoice.',
+        })
+    live_payments = SupplierPayment.objects.filter(
+        workspace=workspace, reversal_of=None, reversal__isnull=True,
+    )
+    expense_totals = expenses.aggregate(
+        subtotal=Sum('subtotal_ex_tax'), tax=Sum('tax_total'), total=Sum('total_incl_tax'),
+    )
+    return {
+        'as_of': as_of,
+        'requisitions': {
+            status: requisitions.filter(status=status).count()
+            for status in PurchaseRequisition.Status.values
+        },
+        'committed_spend': money(committed),
+        'invoices': invoice_rows,
+        'overdue_invoices': overdue,
+        'cash_paid': money(live_payments.aggregate(total=Sum('amount'))['total'] or ZERO),
+        'expenses': {
+            'subtotal_ex_tax': money(expense_totals['subtotal'] or ZERO),
+            'tax_total': money(expense_totals['tax'] or ZERO),
+            'total_incl_tax': money(expense_totals['total'] or ZERO),
+        },
+        'warnings': warnings,
+    }

--- a/purchasing/rest.py
+++ b/purchasing/rest.py
@@ -1,0 +1,622 @@
+"""REST resources and explicit commands for the purchasing subledger."""
+
+# pylint: disable=abstract-method,missing-function-docstring,too-many-ancestors,too-many-lines,unused-argument
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils import timezone
+from rest_framework import serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from inventory.models import StockReceiptLine
+from supplies.models import Supplier
+from workspaces.models import get_current_workspace
+from workspaces.scoping import CurrentWorkspaceSerializerMixin, CurrentWorkspaceViewSetMixin
+
+from .models import (
+    BusinessExpense,
+    ExpenseCategory,
+    PurchaseOrder,
+    PurchaseOrderCancellation,
+    PurchaseOrderLine,
+    PurchaseRequisition,
+    ReceiptMatch,
+    SupplierInvoice,
+    SupplierInvoiceCorrection,
+    SupplierInvoiceLine,
+    SupplierPayment,
+    SupplierPaymentAllocation,
+)
+from .reports import purchasing_summary
+from .services import (
+    cancel_order,
+    cancel_order_quantity,
+    cancel_requisition,
+    close_order,
+    confirm_expense,
+    confirm_invoice,
+    confirm_order,
+    create_invoice,
+    create_order,
+    invoice_state,
+    issue_invoice_correction,
+    match_receipt,
+    order_line_state,
+    record_supplier_payment,
+    replace_invoice_draft,
+    replace_order_draft,
+    review_requisition,
+    reverse_supplier_payment,
+)
+
+
+def _errors(error):
+    return error.message_dict if hasattr(error, 'message_dict') else error.messages
+
+
+def _run(command, *args, **kwargs):
+    try:
+        return command(*args, **kwargs)
+    except DjangoValidationError as exc:
+        raise serializers.ValidationError(_errors(exc)) from exc
+
+
+class ActionSerializer(serializers.Serializer):
+    """A validation-only serializer for domain commands."""
+
+    def create(self, validated_data):
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError
+
+
+class PurchaseRequisitionSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Read and write an editable purchase need."""
+
+    workspace_field_lookups = {
+        'item': 'workspace',
+        'preferred_supplier': 'workspace',
+        'source_issue': 'plan__workspace',
+    }
+
+    class Meta:
+        model = PurchaseRequisition
+        fields = [
+            'pk', 'item', 'source_issue', 'required_on', 'quantity',
+            'unit_code', 'preferred_supplier', 'estimated_total_incl_tax',
+            'status', 'notes', 'created_by', 'reviewed_at', 'cancelled_at',
+            'created', 'updated',
+        ]
+        read_only_fields = [
+            'status', 'created_by', 'reviewed_at', 'cancelled_at', 'created', 'updated',
+        ]
+
+
+class RequisitionOrderSerializer(ActionSerializer):
+    """Commercial terms used to convert one reviewed need into an order."""
+
+    order_number = serializers.CharField()
+    supplier = serializers.PrimaryKeyRelatedField(queryset=Supplier.objects.all())
+    ordered_on = serializers.DateField()
+    expected_on = serializers.DateField(required=False, allow_null=True)
+    currency_code = serializers.CharField(max_length=3)
+    unit_price_ex_tax = serializers.DecimalField(max_digits=18, decimal_places=4)
+    tax_rate = serializers.DecimalField(max_digits=7, decimal_places=4)
+    freight_ex_tax = serializers.DecimalField(max_digits=18, decimal_places=4, required=False, default=0)
+    notes = serializers.CharField(required=False, allow_blank=True)
+
+    def validate_supplier(self, supplier):
+        if supplier.workspace_id != get_current_workspace().pk:
+            raise serializers.ValidationError('The supplier belongs to another workspace.')
+        return supplier
+
+
+class PurchaseOrderLineSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Entered order terms plus derived delivery state."""
+
+    state = serializers.SerializerMethodField()
+    workspace_field_lookups = {
+        'item': 'workspace',
+        'requisition': 'workspace',
+    }
+
+    class Meta:
+        model = PurchaseOrderLine
+        fields = [
+            'pk', 'item', 'requisition', 'description', 'quantity',
+            'unit_code', 'base_quantity', 'unit_price_ex_tax', 'tax_rate',
+            'freight_ex_tax', 'subtotal_ex_tax', 'tax_total',
+            'total_incl_tax', 'cancelled_quantity', 'state',
+        ]
+        read_only_fields = [
+            'pk', 'base_quantity', 'subtotal_ex_tax', 'tax_total',
+            'total_incl_tax', 'cancelled_quantity', 'state',
+        ]
+
+    def get_state(self, line):
+        return order_line_state(line)
+
+
+class PurchaseOrderSerializer(serializers.ModelSerializer):
+    """A purchase order with commercial and delivery reconciliation."""
+
+    lines = PurchaseOrderLineSerializer(many=True)
+    supplier_name = serializers.CharField(source='supplier.name', read_only=True)
+
+    class Meta:
+        model = PurchaseOrder
+        fields = [
+            'pk', 'order_number', 'supplier', 'supplier_name', 'status',
+            'ordered_on', 'expected_on', 'currency_code', 'subtotal_ex_tax',
+            'freight_ex_tax', 'tax_total', 'total_incl_tax', 'notes',
+            'created_by', 'confirmed_at', 'closed_at', 'cancelled_at',
+            'created', 'updated', 'lines',
+        ]
+        read_only_fields = [
+            'status', 'subtotal_ex_tax', 'freight_ex_tax', 'tax_total',
+            'total_incl_tax', 'created_by', 'confirmed_at', 'closed_at',
+            'cancelled_at', 'created', 'updated',
+        ]
+
+
+class PurchaseOrderWriteSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Nested draft purchase-order input."""
+
+    lines = PurchaseOrderLineSerializer(many=True, allow_empty=False)
+    workspace_field_lookups = {'supplier': 'workspace'}
+
+    class Meta:
+        model = PurchaseOrder
+        fields = [
+            'pk', 'status', 'order_number', 'supplier', 'ordered_on', 'expected_on',
+            'currency_code', 'notes', 'lines',
+        ]
+        read_only_fields = ['pk', 'status']
+
+    def create(self, validated_data):
+        lines = validated_data.pop('lines')
+        request = self.context['request']
+        return _run(
+            create_order, get_current_workspace(), request.user,
+            validated_data, lines,
+        )
+
+    def update(self, instance, validated_data):
+        lines = validated_data.pop('lines')
+        return _run(replace_order_draft, instance, validated_data, lines)
+
+
+class CancelQuantitySerializer(ActionSerializer):
+    """A partial or complete order cancellation."""
+
+    line = serializers.PrimaryKeyRelatedField(queryset=PurchaseOrderLine.objects.all())
+    base_quantity = serializers.DecimalField(max_digits=24, decimal_places=9)
+    reason = serializers.CharField()
+
+    def validate_line(self, line):
+        if line.order.workspace_id != get_current_workspace().pk:
+            raise serializers.ValidationError('The order line belongs to another workspace.')
+        return line
+
+
+class MatchReceiptSerializer(ActionSerializer):
+    """A posted receipt quantity matched to an ordered item."""
+
+    order_line = serializers.PrimaryKeyRelatedField(queryset=PurchaseOrderLine.objects.all())
+    receipt_line = serializers.PrimaryKeyRelatedField(queryset=StockReceiptLine.objects.all())
+    base_quantity = serializers.DecimalField(max_digits=24, decimal_places=9)
+
+    def validate(self, attrs):
+        workspace_id = get_current_workspace().pk
+        if attrs['order_line'].order.workspace_id != workspace_id:
+            raise serializers.ValidationError({'order_line': 'The order line belongs to another workspace.'})
+        if attrs['receipt_line'].receipt.workspace_id != workspace_id:
+            raise serializers.ValidationError({'receipt_line': 'The receipt line belongs to another workspace.'})
+        return attrs
+
+
+class ReceiptMatchSerializer(serializers.ModelSerializer):
+    """Read-only delivery reconciliation record."""
+
+    class Meta:
+        model = ReceiptMatch
+        fields = ['pk', 'order_line', 'receipt_line', 'base_quantity', 'created_by', 'created']
+        read_only_fields = fields
+
+
+class PurchaseOrderCancellationSerializer(serializers.ModelSerializer):
+    """Read-only quantity-cancellation history."""
+
+    class Meta:
+        model = PurchaseOrderCancellation
+        fields = ['pk', 'line', 'base_quantity', 'reason', 'created_by', 'created']
+        read_only_fields = fields
+
+
+class ExpenseCategorySerializer(serializers.ModelSerializer):
+    """A workspace expense category."""
+
+    class Meta:
+        model = ExpenseCategory
+        fields = ['pk', 'name', 'active', 'notes']
+
+
+class SupplierInvoiceLineSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Invoice money reconciled to stock, freight, or an expense category."""
+
+    workspace_field_lookups = {
+        'purchase_order_line': 'order__workspace',
+        'receipt_line': 'receipt__workspace',
+        'expense_category': 'workspace',
+    }
+
+    class Meta:
+        model = SupplierInvoiceLine
+        fields = [
+            'pk', 'description', 'purchase_order_line', 'receipt_line',
+            'expense_category', 'is_freight', 'subtotal_ex_tax', 'tax_rate',
+            'tax_total', 'total_incl_tax',
+        ]
+        read_only_fields = ['pk']
+
+
+class SupplierInvoiceCorrectionSerializer(serializers.ModelSerializer):
+    """Read-only append-only invoice correction."""
+
+    class Meta:
+        model = SupplierInvoiceCorrection
+        fields = [
+            'pk', 'invoice', 'kind', 'external_reference', 'corrected_on',
+            'subtotal_ex_tax', 'tax_total', 'total_incl_tax', 'reason',
+            'attachment_url', 'operation_key', 'created_by', 'created',
+        ]
+        read_only_fields = fields
+
+
+class SupplierInvoiceSerializer(serializers.ModelSerializer):
+    """A payable document with live correction and settlement state."""
+
+    lines = SupplierInvoiceLineSerializer(many=True)
+    corrections = SupplierInvoiceCorrectionSerializer(many=True, read_only=True)
+    supplier_name = serializers.CharField(source='supplier.name', read_only=True)
+    state = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SupplierInvoice
+        fields = [
+            'pk', 'supplier', 'supplier_name', 'purchase_order',
+            'external_reference', 'invoice_date', 'due_date', 'currency_code',
+            'status', 'supplier_name_snapshot', 'supplier_address_snapshot',
+            'supplier_gst_number_snapshot', 'subtotal_ex_tax', 'tax_total',
+            'total_incl_tax', 'attachment_url', 'notes', 'created_by',
+            'confirmed_at', 'cancelled_at', 'created', 'updated', 'lines',
+            'corrections', 'state',
+        ]
+        read_only_fields = [
+            'status', 'supplier_name_snapshot', 'supplier_address_snapshot',
+            'supplier_gst_number_snapshot', 'subtotal_ex_tax', 'tax_total',
+            'total_incl_tax', 'created_by', 'confirmed_at', 'cancelled_at',
+            'created', 'updated', 'corrections', 'state',
+        ]
+
+    def get_state(self, invoice):
+        return invoice_state(invoice)
+
+
+class SupplierInvoiceWriteSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Nested draft supplier-invoice input."""
+
+    lines = SupplierInvoiceLineSerializer(many=True, allow_empty=False)
+    workspace_field_lookups = {
+        'supplier': 'workspace',
+        'purchase_order': 'workspace',
+    }
+
+    class Meta:
+        model = SupplierInvoice
+        fields = [
+            'pk', 'status', 'supplier', 'purchase_order', 'external_reference', 'invoice_date',
+            'due_date', 'currency_code', 'attachment_url', 'notes', 'lines',
+        ]
+        read_only_fields = ['pk', 'status']
+
+    def create(self, validated_data):
+        lines = validated_data.pop('lines')
+        request = self.context['request']
+        return _run(
+            create_invoice, get_current_workspace(), request.user,
+            validated_data, lines,
+        )
+
+    def update(self, instance, validated_data):
+        lines = validated_data.pop('lines')
+        return _run(replace_invoice_draft, instance, validated_data, lines)
+
+
+class InvoiceCorrectionWriteSerializer(ActionSerializer):
+    """Input for a credit or debit against an invoice."""
+
+    kind = serializers.ChoiceField(choices=SupplierInvoiceCorrection.Kind.choices)
+    external_reference = serializers.CharField()
+    corrected_on = serializers.DateField()
+    subtotal_ex_tax = serializers.DecimalField(max_digits=18, decimal_places=4)
+    tax_total = serializers.DecimalField(max_digits=18, decimal_places=4)
+    total_incl_tax = serializers.DecimalField(max_digits=18, decimal_places=4)
+    reason = serializers.CharField()
+    attachment_url = serializers.URLField(required=False, allow_blank=True)
+
+
+class SupplierPaymentAllocationSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """Amount of a payment applied to one supplier invoice."""
+
+    workspace_field_lookups = {'invoice': 'workspace'}
+
+    class Meta:
+        model = SupplierPaymentAllocation
+        fields = ['pk', 'invoice', 'amount']
+        read_only_fields = ['pk']
+
+
+class SupplierPaymentSerializer(serializers.ModelSerializer):
+    """An immutable supplier payment or reversal."""
+
+    allocations = SupplierPaymentAllocationSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SupplierPayment
+        fields = [
+            'pk', 'supplier', 'paid_on', 'amount', 'currency_code', 'method',
+            'external_reference', 'notes', 'reversal_of', 'operation_key',
+            'created_by', 'created', 'allocations',
+        ]
+        read_only_fields = fields
+
+
+class SupplierPaymentWriteSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """One payment with zero or more explicit invoice allocations."""
+
+    allocations = SupplierPaymentAllocationSerializer(many=True, required=False)
+    workspace_field_lookups = {'supplier': 'workspace'}
+
+    class Meta:
+        model = SupplierPayment
+        fields = [
+            'pk', 'supplier', 'paid_on', 'amount', 'currency_code', 'method',
+            'external_reference', 'notes', 'allocations',
+        ]
+        read_only_fields = ['pk']
+
+    def create(self, validated_data):
+        allocations = validated_data.pop('allocations', [])
+        request = self.context['request']
+        return _run(
+            record_supplier_payment, get_current_workspace(), request.user,
+            validated_data, allocations,
+        )
+
+
+class ReversePaymentSerializer(ActionSerializer):
+    """Reason for an equal payment reversal."""
+
+    reason = serializers.CharField()
+
+
+class ReasonSerializer(ActionSerializer):
+    """Required explanation for an auditable cancellation."""
+
+    reason = serializers.CharField()
+
+
+class BusinessExpenseSerializer(CurrentWorkspaceSerializerMixin, serializers.ModelSerializer):
+    """A non-stock business cost with optional operational allocation."""
+
+    workspace_field_lookups = {
+        'category': 'workspace',
+        'supplier': 'workspace',
+        'supplier_invoice': 'workspace',
+        'garden_area': 'workspace',
+        'crop_plan': 'workspace',
+        'production_batch': 'workspace',
+    }
+
+    class Meta:
+        model = BusinessExpense
+        fields = [
+            'pk', 'category', 'supplier', 'payee', 'incurred_on',
+            'currency_code', 'subtotal_ex_tax', 'tax_total', 'total_incl_tax',
+            'supplier_invoice', 'garden_area', 'crop_plan', 'production_batch',
+            'allocation_type', 'allocation_reference', 'status',
+            'attachment_url', 'notes', 'created_by', 'confirmed_at',
+            'cancelled_at', 'created', 'updated',
+        ]
+        read_only_fields = [
+            'status', 'created_by', 'confirmed_at', 'cancelled_at', 'created', 'updated',
+        ]
+
+
+class PurchaseRequisitionViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Manage purchase needs and their review state."""
+
+    queryset = PurchaseRequisition.objects.select_related('item', 'preferred_supplier', 'source_issue__plan')
+    serializer_class = PurchaseRequisitionSerializer
+
+    def perform_create(self, serializer):
+        serializer.save(workspace=self.get_current_workspace(), created_by=self.request.user)
+
+    @action(detail=True, methods=['post'])
+    def review(self, request, pk=None):
+        requisition = _run(review_requisition, self.get_object(), request.user)
+        return Response(self.get_serializer(requisition).data)
+
+    @action(detail=True, methods=['post'])
+    def cancel(self, request, pk=None):
+        requisition = _run(cancel_requisition, self.get_object(), request.user)
+        return Response(self.get_serializer(requisition).data)
+
+    @action(detail=True, methods=['post'])
+    def order(self, request, pk=None):
+        requisition = self.get_object()
+        serializer = RequisitionOrderSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data.copy()
+        line = {
+            'item': requisition.item,
+            'requisition': requisition,
+            'description': requisition.item.name,
+            'quantity': requisition.quantity,
+            'unit_code': requisition.unit_code,
+            'unit_price_ex_tax': values.pop('unit_price_ex_tax'),
+            'tax_rate': values.pop('tax_rate'),
+            'freight_ex_tax': values.pop('freight_ex_tax'),
+        }
+        order = _run(
+            create_order, self.get_current_workspace(), request.user, values, [line],
+        )
+        return Response(PurchaseOrderSerializer(order, context={'request': request}).data, status=201)
+
+
+class PurchaseOrderViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Manage orders and explicit delivery reconciliation."""
+
+    queryset = PurchaseOrder.objects.select_related('supplier').prefetch_related(
+        'lines__receipt_matches__receipt_line__receipt',
+    )
+    bind_workspace_on_create = False
+    http_method_names = ['get', 'post', 'put', 'delete', 'head', 'options']
+
+    def get_serializer_class(self):
+        if self.action in {'create', 'update'}:
+            return PurchaseOrderWriteSerializer
+        return PurchaseOrderSerializer
+
+    @action(detail=True, methods=['post'])
+    def confirm(self, request, pk=None):
+        order = _run(confirm_order, self.get_object(), request.user)
+        return Response(PurchaseOrderSerializer(order, context={'request': request}).data)
+
+    @action(detail=True, methods=['post'])
+    def close(self, request, pk=None):
+        order = _run(close_order, self.get_object(), request.user)
+        return Response(PurchaseOrderSerializer(order, context={'request': request}).data)
+
+    @action(detail=True, methods=['post'])
+    def cancel(self, request, pk=None):
+        serializer = ReasonSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        order = _run(
+            cancel_order, self.get_object(), serializer.validated_data['reason'],
+            request.user,
+        )
+        return Response(PurchaseOrderSerializer(order, context={'request': request}).data)
+
+    @action(detail=True, methods=['post'], url_path='cancel-quantity')
+    def cancel_quantity(self, request, pk=None):
+        serializer = CancelQuantitySerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        line = serializer.validated_data['line']
+        if line.order_id != self.get_object().pk:
+            raise serializers.ValidationError({'line': 'The line is not on this order.'})
+        cancellation = _run(
+            cancel_order_quantity, line,
+            serializer.validated_data['base_quantity'],
+            serializer.validated_data['reason'], request.user,
+        )
+        return Response(PurchaseOrderCancellationSerializer(cancellation).data, status=201)
+
+    @action(detail=True, methods=['post'], url_path='match-receipt')
+    def match_receipt_line(self, request, pk=None):
+        serializer = MatchReceiptSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        line = serializer.validated_data['order_line']
+        if line.order_id != self.get_object().pk:
+            raise serializers.ValidationError({'order_line': 'The line is not on this order.'})
+        matched = _run(
+            match_receipt, line, serializer.validated_data['receipt_line'],
+            serializer.validated_data['base_quantity'], request.user,
+        )
+        return Response(ReceiptMatchSerializer(matched).data, status=201)
+
+
+class ExpenseCategoryViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Manage reusable non-stock expense categories."""
+
+    queryset = ExpenseCategory.objects.all()
+    serializer_class = ExpenseCategorySerializer
+
+
+class SupplierInvoiceViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Manage supplier invoices and append-only corrections."""
+
+    queryset = SupplierInvoice.objects.select_related('supplier', 'purchase_order').prefetch_related(
+        'lines', 'corrections', 'payment_allocations__payment',
+    )
+    bind_workspace_on_create = False
+    http_method_names = ['get', 'post', 'put', 'delete', 'head', 'options']
+
+    def get_serializer_class(self):
+        if self.action in {'create', 'update'}:
+            return SupplierInvoiceWriteSerializer
+        return SupplierInvoiceSerializer
+
+    @action(detail=True, methods=['post'])
+    def confirm(self, request, pk=None):
+        invoice = _run(confirm_invoice, self.get_object(), request.user)
+        return Response(SupplierInvoiceSerializer(invoice, context={'request': request}).data)
+
+    @action(detail=True, methods=['post'])
+    def correct(self, request, pk=None):
+        serializer = InvoiceCorrectionWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        correction = _run(
+            issue_invoice_correction, self.get_object(),
+            serializer.validated_data, request.user,
+        )
+        return Response(SupplierInvoiceCorrectionSerializer(correction).data, status=201)
+
+
+class SupplierPaymentViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Create and read append-only supplier payments."""
+
+    queryset = SupplierPayment.objects.select_related('supplier', 'reversal_of').prefetch_related('allocations')
+    bind_workspace_on_create = False
+    http_method_names = ['get', 'post', 'head', 'options']
+
+    def get_serializer_class(self):
+        return SupplierPaymentWriteSerializer if self.action == 'create' else SupplierPaymentSerializer
+
+    @action(detail=True, methods=['post'])
+    def reverse(self, request, pk=None):
+        serializer = ReversePaymentSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        reversal = _run(
+            reverse_supplier_payment, self.get_object(), request.user,
+            serializer.validated_data['reason'],
+        )
+        return Response(SupplierPaymentSerializer(reversal).data, status=201)
+
+
+class BusinessExpenseViewSet(CurrentWorkspaceViewSetMixin, viewsets.ModelViewSet):
+    """Manage and confirm non-stock business expenses."""
+
+    queryset = BusinessExpense.objects.select_related('category', 'supplier')
+    serializer_class = BusinessExpenseSerializer
+
+    def perform_create(self, serializer):
+        serializer.save(workspace=self.get_current_workspace(), created_by=self.request.user)
+
+    @action(detail=True, methods=['post'])
+    def confirm(self, request, pk=None):
+        expense = _run(confirm_expense, self.get_object(), request.user)
+        return Response(self.get_serializer(expense).data)
+
+
+class PurchasingSummaryView(APIView):
+    """Return reconciled purchasing and expense reporting as of one date."""
+
+    def get(self, request):
+        as_of = serializers.DateField().to_internal_value(
+            request.query_params.get('as_of', timezone.localdate().isoformat()),
+        )
+        return Response(purchasing_summary(get_current_workspace(), as_of))

--- a/purchasing/services.py
+++ b/purchasing/services.py
@@ -1,0 +1,442 @@
+"""Transactional commands for purchasing and accounts payable."""
+
+from decimal import Decimal, ROUND_HALF_UP
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Sum
+from django.utils import timezone
+
+from inventory.models import StockReceiptLine
+from inventory.units import convert_standard_quantity
+
+from .models import (
+    BusinessExpense,
+    PurchaseOrder,
+    PurchaseOrderCancellation,
+    PurchaseOrderLine,
+    PurchaseRequisition,
+    ReceiptMatch,
+    SupplierInvoice,
+    SupplierInvoiceCorrection,
+    SupplierInvoiceLine,
+    SupplierPayment,
+    SupplierPaymentAllocation,
+    ZERO,
+)
+
+
+MONEY_QUANTUM = Decimal('0.0001')
+
+
+def money(value):
+    """Canonicalize a financial input to ledger precision."""
+    return Decimal(value).quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def order_line_amounts(quantity, unit_price_ex_tax, tax_rate, freight_ex_tax=ZERO):
+    """Return stable exclusive, freight, tax, and inclusive line amounts."""
+    merchandise = money(Decimal(quantity) * Decimal(unit_price_ex_tax))
+    freight = money(freight_ex_tax)
+    subtotal = money(merchandise + freight)
+    tax = money(subtotal * Decimal(tax_rate) / Decimal('100'))
+    return subtotal, freight, tax, money(subtotal + tax)
+
+
+def normalize_order_quantity(item, quantity, unit_code):
+    """Convert an entered controlled quantity into the item's base unit."""
+    return convert_standard_quantity(Decimal(quantity), unit_code, item.base_unit)
+
+
+def _line_values(values):
+    item = values['item']
+    quantity = values['quantity']
+    unit_code = values['unit_code']
+    subtotal, freight, tax, total = order_line_amounts(
+        quantity,
+        values['unit_price_ex_tax'],
+        values.get('tax_rate', ZERO),
+        values.get('freight_ex_tax', ZERO),
+    )
+    return {
+        **values,
+        'base_quantity': normalize_order_quantity(item, quantity, unit_code),
+        'subtotal_ex_tax': subtotal,
+        'freight_ex_tax': freight,
+        'tax_total': tax,
+        'total_incl_tax': total,
+    }
+
+
+def _refresh_order_totals(order):
+    totals = order.lines.aggregate(
+        subtotal=Sum('subtotal_ex_tax'),
+        freight=Sum('freight_ex_tax'),
+        tax=Sum('tax_total'),
+        total=Sum('total_incl_tax'),
+    )
+    PurchaseOrder.objects.filter(pk=order.pk).update(
+        subtotal_ex_tax=money(totals['subtotal'] or ZERO),
+        freight_ex_tax=money(totals['freight'] or ZERO),
+        tax_total=money(totals['tax'] or ZERO),
+        total_incl_tax=money(totals['total'] or ZERO),
+    )
+    order.refresh_from_db()
+    return order
+
+
+@transaction.atomic
+def create_order(workspace, user, values, lines):
+    """Create a draft purchase order and normalize every commercial line."""
+    order = PurchaseOrder.objects.create(
+        workspace=workspace, created_by=user, **values,
+    )
+    for values_for_line in lines:
+        line = PurchaseOrderLine.objects.create(
+            order=order, **_line_values(values_for_line),
+        )
+        if line.requisition_id:
+            PurchaseRequisition.objects.filter(pk=line.requisition_id).update(
+                status=PurchaseRequisition.Status.ORDERED,
+            )
+    return _refresh_order_totals(order)
+
+
+@transaction.atomic
+def replace_order_draft(order, values, lines):
+    """Replace all editable terms on a locked draft order."""
+    order = PurchaseOrder.objects.select_for_update().get(pk=order.pk)
+    if order.status != PurchaseOrder.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft purchase order can be edited.'})
+    old_requisitions = list(order.lines.exclude(requisition=None).values_list('requisition_id', flat=True))
+    PurchaseRequisition.objects.filter(
+        pk__in=old_requisitions, status=PurchaseRequisition.Status.ORDERED,
+    ).update(status=PurchaseRequisition.Status.REVIEWED)
+    order.lines.all().delete()
+    for field, value in values.items():
+        setattr(order, field, value)
+    order.save()
+    for values_for_line in lines:
+        line = PurchaseOrderLine.objects.create(
+            order=order, **_line_values(values_for_line),
+        )
+        if line.requisition_id:
+            PurchaseRequisition.objects.filter(pk=line.requisition_id).update(
+                status=PurchaseRequisition.Status.ORDERED,
+            )
+    return _refresh_order_totals(order)
+
+
+@transaction.atomic
+def review_requisition(requisition, user):
+    """Approve one draft need for conversion into an order."""
+    del user
+    requisition = PurchaseRequisition.objects.select_for_update().get(pk=requisition.pk)
+    if requisition.status != PurchaseRequisition.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft requisition can be reviewed.'})
+    PurchaseRequisition.objects.filter(pk=requisition.pk).update(
+        status=PurchaseRequisition.Status.REVIEWED, reviewed_at=timezone.now(),
+    )
+    requisition.refresh_from_db()
+    return requisition
+
+
+@transaction.atomic
+def cancel_requisition(requisition, user):
+    """Cancel a need which has not yet become an order line."""
+    del user
+    requisition = PurchaseRequisition.objects.select_for_update().get(pk=requisition.pk)
+    if requisition.status not in {
+            PurchaseRequisition.Status.DRAFT,
+            PurchaseRequisition.Status.REVIEWED}:
+        raise ValidationError({'status': 'Only an unordered requisition can be cancelled.'})
+    PurchaseRequisition.objects.filter(pk=requisition.pk).update(
+        status=PurchaseRequisition.Status.CANCELLED, cancelled_at=timezone.now(),
+    )
+    requisition.refresh_from_db()
+    return requisition
+
+
+@transaction.atomic
+def confirm_order(order, user):
+    """Freeze a non-empty supplier order and its calculated totals."""
+    del user
+    order = PurchaseOrder.objects.select_for_update().get(pk=order.pk)
+    if order.status != PurchaseOrder.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft purchase order can be confirmed.'})
+    if not order.lines.exists():
+        raise ValidationError({'lines': 'Add at least one line before confirming.'})
+    _refresh_order_totals(order)
+    PurchaseOrder.objects.filter(pk=order.pk).update(
+        status=PurchaseOrder.Status.CONFIRMED, confirmed_at=timezone.now(),
+    )
+    order.refresh_from_db()
+    return order
+
+
+@transaction.atomic
+def close_order(order, user):
+    """Close a confirmed order whose lines have no outstanding quantity."""
+    del user
+    order = PurchaseOrder.objects.select_for_update().prefetch_related(
+        'lines__receipt_matches', 'lines__cancellations',
+    ).get(pk=order.pk)
+    if order.status != PurchaseOrder.Status.CONFIRMED:
+        raise ValidationError({'status': 'Only a confirmed purchase order can be closed.'})
+    if any(order_line_state(line)['outstanding'] > 0 for line in order.lines.all()):
+        raise ValidationError({'status': 'Receive or cancel every outstanding quantity first.'})
+    PurchaseOrder.objects.filter(pk=order.pk).update(
+        status=PurchaseOrder.Status.CLOSED, closed_at=timezone.now(),
+    )
+    order.refresh_from_db()
+    return order
+
+
+@transaction.atomic
+def cancel_order(order, reason, user):
+    """Cancel every unreceived quantity and retain line-level history."""
+    order = PurchaseOrder.objects.select_for_update().prefetch_related(
+        'lines__receipt_matches', 'lines__cancellations',
+    ).get(pk=order.pk)
+    if order.status != PurchaseOrder.Status.CONFIRMED:
+        raise ValidationError({'status': 'Only a confirmed purchase order can be cancelled.'})
+    for line in order.lines.all():
+        outstanding = order_line_state(line)['outstanding']
+        if outstanding > 0:
+            PurchaseOrderCancellation.objects.create(
+                line=line, base_quantity=outstanding, reason=reason, created_by=user,
+            )
+            PurchaseOrderLine.objects.filter(pk=line.pk).update(
+                cancelled_quantity=line.cancelled_quantity + outstanding,
+            )
+    PurchaseOrder.objects.filter(pk=order.pk).update(
+        status=PurchaseOrder.Status.CANCELLED, cancelled_at=timezone.now(),
+    )
+    order.refresh_from_db()
+    return order
+
+
+@transaction.atomic
+def cancel_order_quantity(line, base_quantity, reason, user):
+    """Append a quantity cancellation without rewriting confirmed terms."""
+    line = PurchaseOrderLine.objects.select_for_update().select_related('order').get(pk=line.pk)
+    if line.order.status != PurchaseOrder.Status.CONFIRMED:
+        raise ValidationError({'order': 'Only a confirmed order can be cancelled.'})
+    quantity = Decimal(base_quantity)
+    already = line.cancellations.aggregate(total=Sum('base_quantity'))['total'] or Decimal('0')
+    if quantity <= 0 or already + quantity > line.base_quantity:
+        raise ValidationError({'base_quantity': 'Cancellation exceeds the uncancelled ordered quantity.'})
+    cancellation = PurchaseOrderCancellation.objects.create(
+        line=line, base_quantity=quantity, reason=reason, created_by=user,
+    )
+    PurchaseOrderLine.objects.filter(pk=line.pk).update(cancelled_quantity=already + quantity)
+    return cancellation
+
+
+@transaction.atomic
+def match_receipt(order_line, receipt_line, base_quantity, user):
+    """Match a posted delivery quantity while allowing visible over-delivery."""
+    line = PurchaseOrderLine.objects.select_for_update().select_related('order').get(pk=order_line.pk)
+    receipt = StockReceiptLine.objects.select_for_update().select_related('receipt', 'item').get(pk=receipt_line.pk)
+    quantity = Decimal(base_quantity)
+    matched = receipt.purchase_order_matches.aggregate(total=Sum('base_quantity'))['total'] or Decimal('0')
+    if receipt.base_quantity is None:
+        raise ValidationError({'receipt_line': 'An unknown receipt quantity cannot be matched.'})
+    if quantity <= 0 or matched + quantity > receipt.base_quantity:
+        raise ValidationError({'base_quantity': 'Match exceeds the receipt line quantity.'})
+    return ReceiptMatch.objects.create(
+        order_line=line, receipt_line=receipt,
+        base_quantity=quantity, created_by=user,
+    )
+
+
+def order_line_state(line):
+    """Return ordered, received, cancelled, returned, and outstanding quantities."""
+    received = line.receipt_matches.aggregate(total=Sum('base_quantity'))['total'] or Decimal('0')
+    returned = line.receipt_matches.filter(
+        receipt_line__receipt__status='reversed',
+    ).aggregate(total=Sum('base_quantity'))['total'] or Decimal('0')
+    live_received = received - returned
+    outstanding = line.base_quantity - line.cancelled_quantity - live_received
+    return {
+        'ordered': line.base_quantity,
+        'received': live_received,
+        'cancelled': line.cancelled_quantity,
+        'returned': returned,
+        'outstanding': max(outstanding, Decimal('0')),
+        'over_received': max(-outstanding, Decimal('0')),
+    }
+
+
+def invoice_net_total(invoice):
+    """Return invoice value after append-only credits and debits."""
+    total = invoice.total_incl_tax
+    for correction in invoice.corrections.all():
+        direction = Decimal('-1') if correction.kind == SupplierInvoiceCorrection.Kind.CREDIT else Decimal('1')
+        total += direction * correction.total_incl_tax
+    return money(total)
+
+
+def invoice_paid_total(invoice, through=None):
+    """Return live allocated payments, optionally through a local date."""
+    allocations = invoice.payment_allocations.select_related('payment').filter(
+        payment__reversal_of=None,
+        payment__reversal__isnull=True,
+    )
+    if through is not None:
+        allocations = allocations.filter(payment__paid_on__lte=through)
+    return money(allocations.aggregate(total=Sum('amount'))['total'] or ZERO)
+
+
+def invoice_state(invoice):
+    """Return corrected liability, payment state, and reconciliation warnings."""
+    net = invoice_net_total(invoice)
+    paid = invoice_paid_total(invoice)
+    balance = money(max(net - paid, ZERO))
+    warnings = []
+    if invoice.status == SupplierInvoice.Status.CONFIRMED and not invoice.lines.exists():
+        warnings.append('Invoice has no lines.')
+    if invoice.lines.filter(
+            purchase_order_line=None, receipt_line=None,
+            expense_category=None, is_freight=False).exists():
+        warnings.append('Invoice has unmatched lines.')
+    if paid > net:
+        warnings.append('Payments exceed the corrected invoice total.')
+    return {
+        'net_total': net,
+        'paid_total': paid,
+        'balance_due': balance,
+        'payment_state': 'paid' if balance == 0 else ('part_paid' if paid > 0 else 'unpaid'),
+        'warnings': warnings,
+    }
+
+
+def _refresh_invoice_totals(invoice):
+    totals = invoice.lines.aggregate(
+        subtotal=Sum('subtotal_ex_tax'), tax=Sum('tax_total'), total=Sum('total_incl_tax'),
+    )
+    SupplierInvoice.objects.filter(pk=invoice.pk).update(
+        subtotal_ex_tax=money(totals['subtotal'] or ZERO),
+        tax_total=money(totals['tax'] or ZERO),
+        total_incl_tax=money(totals['total'] or ZERO),
+    )
+    invoice.refresh_from_db()
+    return invoice
+
+
+@transaction.atomic
+def create_invoice(workspace, user, values, lines):
+    """Create an editable payable and its explicit reconciliation lines."""
+    invoice = SupplierInvoice.objects.create(
+        workspace=workspace, created_by=user, **values,
+    )
+    for line in lines:
+        SupplierInvoiceLine.objects.create(invoice=invoice, **line)
+    return _refresh_invoice_totals(invoice)
+
+
+@transaction.atomic
+def replace_invoice_draft(invoice, values, lines):
+    """Replace all lines and editable header values on a locked draft invoice."""
+    invoice = SupplierInvoice.objects.select_for_update().get(pk=invoice.pk)
+    if invoice.status != SupplierInvoice.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft supplier invoice can be edited.'})
+    invoice.lines.all().delete()
+    for field, value in values.items():
+        setattr(invoice, field, value)
+    invoice.save()
+    for line in lines:
+        SupplierInvoiceLine.objects.create(invoice=invoice, **line)
+    return _refresh_invoice_totals(invoice)
+
+
+@transaction.atomic
+def confirm_invoice(invoice, user):
+    """Freeze a payable with supplier identity and calculated money snapshots."""
+    del user
+    invoice = SupplierInvoice.objects.select_for_update().select_related('supplier').get(pk=invoice.pk)
+    if invoice.status != SupplierInvoice.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft supplier invoice can be confirmed.'})
+    if not invoice.lines.exists():
+        raise ValidationError({'lines': 'Add at least one line before confirming.'})
+    _refresh_invoice_totals(invoice)
+    SupplierInvoice.objects.filter(pk=invoice.pk).update(
+        status=SupplierInvoice.Status.CONFIRMED,
+        supplier_name_snapshot=invoice.supplier.name,
+        supplier_address_snapshot=invoice.supplier.address,
+        supplier_gst_number_snapshot=invoice.supplier.gst_number,
+        confirmed_at=timezone.now(),
+    )
+    invoice.refresh_from_db()
+    return invoice
+
+
+@transaction.atomic
+def issue_invoice_correction(invoice, values, user):
+    """Append a bounded credit or a debit to a confirmed invoice."""
+    invoice = SupplierInvoice.objects.select_for_update().get(pk=invoice.pk)
+    if invoice.status != SupplierInvoice.Status.CONFIRMED:
+        raise ValidationError({'invoice': 'Only a confirmed invoice can be corrected.'})
+    if values['kind'] == SupplierInvoiceCorrection.Kind.CREDIT:
+        prior_credits = invoice.corrections.filter(
+            kind=SupplierInvoiceCorrection.Kind.CREDIT,
+        ).aggregate(total=Sum('total_incl_tax'))['total'] or ZERO
+        prior_debits = invoice.corrections.filter(
+            kind=SupplierInvoiceCorrection.Kind.DEBIT,
+        ).aggregate(total=Sum('total_incl_tax'))['total'] or ZERO
+        if prior_credits + values['total_incl_tax'] > invoice.total_incl_tax + prior_debits:
+            raise ValidationError({'total_incl_tax': 'Credit exceeds the remaining invoice value.'})
+    return SupplierInvoiceCorrection.objects.create(
+        workspace=invoice.workspace, invoice=invoice, created_by=user, **values,
+    )
+
+
+@transaction.atomic
+def record_supplier_payment(workspace, user, values, allocations):
+    """Record one payment and explicit invoice allocations atomically."""
+    amount = money(values['amount'])
+    allocated = money(sum((entry['amount'] for entry in allocations), ZERO))
+    if allocated > amount:
+        raise ValidationError({'allocations': 'Allocated amount exceeds the payment.'})
+    payment = SupplierPayment.objects.create(
+        workspace=workspace, created_by=user, **values,
+    )
+    for allocation in allocations:
+        SupplierPaymentAllocation.objects.create(payment=payment, **allocation)
+    return payment
+
+
+@transaction.atomic
+def reverse_supplier_payment(payment, user, reason):
+    """Append an equal compensating payment and leave the original readable."""
+    payment = SupplierPayment.objects.select_for_update().get(pk=payment.pk)
+    if payment.reversal_of_id:
+        raise ValidationError({'payment': 'A reversal cannot itself be reversed.'})
+    if hasattr(payment, 'reversal'):
+        raise ValidationError({'payment': 'This payment is already reversed.'})
+    return SupplierPayment.objects.create(
+        workspace=payment.workspace,
+        supplier=payment.supplier,
+        paid_on=timezone.localdate(),
+        amount=payment.amount,
+        currency_code=payment.currency_code,
+        method=payment.method,
+        external_reference=payment.external_reference,
+        notes=reason,
+        reversal_of=payment,
+        created_by=user,
+    )
+
+
+@transaction.atomic
+def confirm_expense(expense, user):
+    """Freeze a reviewed non-stock cost independently of inventory."""
+    del user
+    expense = BusinessExpense.objects.select_for_update().get(pk=expense.pk)
+    if expense.status != BusinessExpense.Status.DRAFT:
+        raise ValidationError({'status': 'Only a draft expense can be confirmed.'})
+    BusinessExpense.objects.filter(pk=expense.pk).update(
+        status=BusinessExpense.Status.CONFIRMED, confirmed_at=timezone.now(),
+    )
+    expense.refresh_from_db()
+    return expense

--- a/purchasing/tests/test_rest.py
+++ b/purchasing/tests/test_rest.py
@@ -1,0 +1,258 @@
+"""End-to-end API contracts for purchasing and supplier payables."""
+
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from inventory.models import StockReceipt
+from inventory.units import UnitCode
+from tests.factories import make_plant_variety, make_supplier
+from workspaces.models import get_current_workspace
+
+
+class PurchasingRestTests(APITestCase):
+    """Purchases reconcile commitments, received seed, liabilities, and cash."""
+
+    def setUp(self):
+        super().setUp()
+        self.workspace = get_current_workspace()
+        self.workspace.currency_code = 'NZD'
+        self.workspace.save()
+        self.user = get_user_model().objects.create_user(username='purchasing-api-user')
+        self.client.force_authenticate(self.user)
+        self.supplier = make_supplier(workspace=self.workspace, name='Seed merchant')
+        variety = make_plant_variety(workspace=self.workspace)
+        catalog = self.client.post('/seeds/seeds/', {
+            'supplier': self.supplier.pk,
+            'plant_variety': variety.pk,
+            'supplier_code': 'CARROT-1',
+            'base_unit': UnitCode.SEED,
+        }, format='json')
+        self.assertEqual(catalog.status_code, 201, catalog.data)
+        self.seed_catalog = catalog.data
+
+    def receive_seed(self, quantity='40', reference='DEL-1'):
+        """Receive one exact packet and return its posted receipt line."""
+        draft = self.client.post('/seeds/packet-receipts/', {
+            'seeds': self.seed_catalog['pk'],
+            'supplier': self.supplier.pk,
+            'quantity_certainty': 'exact',
+            'quantity': quantity,
+            'line_price': '11.5000',
+            'received_date': '2026-08-20',
+            'supplier_reference': reference,
+        }, format='json')
+        self.assertEqual(draft.status_code, 201, draft.data)
+        posted = self.client.post(
+            f"/seeds/packet-receipts/{draft.data['pk']}/post/", {}, format='json',
+        )
+        self.assertEqual(posted.status_code, 201, posted.data)
+        receipt = StockReceipt.objects.get(seed_packet_draft__pk=draft.data['pk'])
+        return receipt.lines.get()
+
+    def create_invoice(self, receipt_line, reference='INV-100'):
+        """Create and confirm an invoice for a received packet."""
+        created = self.client.post('/purchasing/invoices/', {
+            'supplier': self.supplier.pk,
+            'external_reference': reference,
+            'invoice_date': '2026-08-21',
+            'due_date': '2026-09-20',
+            'currency_code': 'NZD',
+            'lines': [{
+                'description': 'Received carrot seed',
+                'receipt_line': receipt_line.pk,
+                'is_freight': False,
+                'subtotal_ex_tax': '10.0000',
+                'tax_rate': '15.0000',
+                'tax_total': '1.5000',
+                'total_incl_tax': '11.5000',
+            }],
+        }, format='json')
+        self.assertEqual(created.status_code, 201, created.data)
+        confirmed = self.client.post(
+            f"/purchasing/invoices/{created.data['pk']}/confirm/", {}, format='json',
+        )
+        self.assertEqual(confirmed.status_code, 200, confirmed.data)
+        return confirmed.data
+
+    def pay(self, invoice, amount, reference):
+        """Create one allocated supplier payment."""
+        response = self.client.post('/purchasing/payments/', {
+            'supplier': self.supplier.pk,
+            'paid_on': '2026-08-25',
+            'amount': amount,
+            'currency_code': 'NZD',
+            'method': 'bank_transfer',
+            'external_reference': reference,
+            'allocations': [{'invoice': invoice, 'amount': amount}],
+        }, format='json')
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data
+
+    def test_existing_received_seed_can_be_invoiced_and_part_paid(self):
+        """The requested after-the-fact seed-invoice pathway is supported."""
+        receipt_line = self.receive_seed()
+        lot = receipt_line.stock_lot
+        original_cost = lot.acquisition_total
+
+        invoice = self.create_invoice(receipt_line)
+
+        self.assertEqual(invoice['supplier_name_snapshot'], self.supplier.name)
+        self.assertEqual(invoice['state']['payment_state'], 'unpaid')
+        self.assertEqual(invoice['state']['balance_due'], Decimal('11.5000'))
+        self.pay(invoice['pk'], '5.0000', 'PAY-1')
+        part_paid = self.client.get(f"/purchasing/invoices/{invoice['pk']}/")
+        self.assertEqual(part_paid.data['state']['payment_state'], 'part_paid')
+        self.assertEqual(part_paid.data['state']['balance_due'], Decimal('6.5000'))
+        self.pay(invoice['pk'], '6.5000', 'PAY-2')
+        paid = self.client.get(f"/purchasing/invoices/{invoice['pk']}/")
+        self.assertEqual(paid.data['state']['payment_state'], 'paid')
+        summary = self.client.get('/purchasing/summary/', {'as_of': '2026-09-21'})
+        self.assertEqual(summary.status_code, 200, summary.data)
+        self.assertEqual(summary.data['cash_paid'], Decimal('11.5000'))
+        self.assertFalse(any(
+            warning['source_id'] == receipt_line.pk and warning['code'] == 'receipt_not_invoiced'
+            for warning in summary.data['warnings']
+        ))
+
+        lot.refresh_from_db()
+        self.assertEqual(lot.acquisition_total, original_cost)
+
+    def test_partial_deliveries_and_over_delivery_remain_visible(self):
+        """Receipt matching reports each commercial quantity independently."""
+        first = self.receive_seed('40', 'DEL-40')
+        second = self.receive_seed('80', 'DEL-80')
+        order = self.client.post('/purchasing/orders/', {
+            'order_number': 'PO-100',
+            'supplier': self.supplier.pk,
+            'ordered_on': '2026-08-15',
+            'expected_on': '2026-08-20',
+            'currency_code': 'NZD',
+            'lines': [{
+                'item': first.item_id,
+                'description': 'Carrot seed',
+                'quantity': '100.000000000',
+                'unit_code': UnitCode.SEED,
+                'unit_price_ex_tax': '0.1000',
+                'tax_rate': '15.0000',
+                'freight_ex_tax': '2.0000',
+            }],
+        }, format='json')
+        self.assertEqual(order.status_code, 201, order.data)
+        confirmed = self.client.post(
+            f"/purchasing/orders/{order.data['pk']}/confirm/", {}, format='json',
+        )
+        line = confirmed.data['lines'][0]
+        for receipt_line, quantity in ((first, '40'), (second, '80')):
+            matched = self.client.post(
+                f"/purchasing/orders/{order.data['pk']}/match-receipt/",
+                {
+                    'order_line': line['pk'],
+                    'receipt_line': receipt_line.pk,
+                    'base_quantity': quantity,
+                },
+                format='json',
+            )
+            self.assertEqual(matched.status_code, 201, matched.data)
+        refreshed = self.client.get(f"/purchasing/orders/{order.data['pk']}/")
+        state = refreshed.data['lines'][0]['state']
+        self.assertEqual(state['received'], Decimal('120'))
+        self.assertEqual(state['outstanding'], Decimal('0'))
+        self.assertEqual(state['over_received'], Decimal('20'))
+
+    def test_reviewed_requisition_converts_to_a_supplier_order(self):
+        """A reviewed material need becomes a traceable commercial line."""
+        item = self.receive_seed().item
+        requisition = self.client.post('/purchasing/requisitions/', {
+            'item': item.pk,
+            'required_on': '2026-09-10',
+            'quantity': '200.000000000',
+            'unit_code': UnitCode.SEED,
+            'preferred_supplier': self.supplier.pk,
+            'estimated_total_incl_tax': '23.0000',
+            'notes': 'Reviewed shortage',
+        }, format='json')
+        self.assertEqual(requisition.status_code, 201, requisition.data)
+        reviewed = self.client.post(
+            f"/purchasing/requisitions/{requisition.data['pk']}/review/", {}, format='json',
+        )
+        self.assertEqual(reviewed.data['status'], 'reviewed')
+        order = self.client.post(
+            f"/purchasing/requisitions/{requisition.data['pk']}/order/",
+            {
+                'order_number': 'PO-REQ-1',
+                'supplier': self.supplier.pk,
+                'ordered_on': '2026-08-26',
+                'expected_on': '2026-09-10',
+                'currency_code': 'NZD',
+                'unit_price_ex_tax': '0.1000',
+                'tax_rate': '15.0000',
+                'freight_ex_tax': '0.0000',
+                'notes': '',
+            },
+            format='json',
+        )
+        self.assertEqual(order.status_code, 201, order.data)
+        self.assertEqual(order.data['lines'][0]['requisition'], requisition.data['pk'])
+        refreshed = self.client.get(f"/purchasing/requisitions/{requisition.data['pk']}/")
+        self.assertEqual(refreshed.data['status'], 'ordered')
+
+    def test_credit_and_payment_reversal_preserve_original_records(self):
+        """Corrections are linked acts, never destructive edits."""
+        invoice = self.create_invoice(self.receive_seed())
+        credit = self.client.post(f"/purchasing/invoices/{invoice['pk']}/correct/", {
+            'kind': 'credit',
+            'external_reference': 'CR-100',
+            'corrected_on': '2026-08-22',
+            'subtotal_ex_tax': '2.0000',
+            'tax_total': '0.3000',
+            'total_incl_tax': '2.3000',
+            'reason': 'Damaged seed packet',
+        }, format='json')
+        self.assertEqual(credit.status_code, 201, credit.data)
+        payment = self.pay(invoice['pk'], '9.2000', 'PAY-CORRECTED')
+        reversal = self.client.post(
+            f"/purchasing/payments/{payment['pk']}/reverse/",
+            {'reason': 'Wrong bank transaction'}, format='json',
+        )
+        self.assertEqual(reversal.status_code, 201, reversal.data)
+        state = self.client.get(f"/purchasing/invoices/{invoice['pk']}/").data['state']
+        self.assertEqual(state['net_total'], Decimal('9.2000'))
+        self.assertEqual(state['payment_state'], 'unpaid')
+
+    def test_non_stock_expense_is_confirmed_without_inventory(self):
+        """Business costs retain category, payee, tax, and payment context."""
+        category = self.client.post('/purchasing/expense-categories/', {
+            'name': 'Market fees', 'notes': '', 'active': True,
+        }, format='json')
+        self.assertEqual(category.status_code, 201, category.data)
+        expense = self.client.post('/purchasing/expenses/', {
+            'category': category.data['pk'],
+            'payee': 'Saturday market',
+            'incurred_on': '2026-08-22',
+            'currency_code': 'NZD',
+            'subtotal_ex_tax': '20.0000',
+            'tax_total': '3.0000',
+            'total_incl_tax': '23.0000',
+            'allocation_type': 'market',
+            'allocation_reference': 'Riverside 2026-08-22',
+        }, format='json')
+        self.assertEqual(expense.status_code, 201, expense.data)
+        confirmed = self.client.post(
+            f"/purchasing/expenses/{expense.data['pk']}/confirm/", {}, format='json',
+        )
+        self.assertEqual(confirmed.status_code, 200, confirmed.data)
+        self.assertEqual(confirmed.data['status'], 'confirmed')
+        summary = self.client.get('/purchasing/summary/', {'as_of': '2026-08-26'})
+        self.assertEqual(summary.data['expenses']['total_incl_tax'], Decimal('23.0000'))
+
+    def test_collections_require_authentication(self):
+        """Purchasing data is not exposed anonymously."""
+        self.client.force_authenticate(user=None)
+        for path in (
+                '/purchasing/requisitions/', '/purchasing/orders/',
+                '/purchasing/invoices/', '/purchasing/payments/',
+                '/purchasing/expenses/'):
+            with self.subTest(path=path):
+                self.assertEqual(self.client.get(path).status_code, 403)

--- a/purchasing/urls.py
+++ b/purchasing/urls.py
@@ -1,0 +1,28 @@
+"""URL routing for purchasing and accounts payable."""
+
+from django.urls import include, path
+from rest_framework import routers
+
+from .rest import (
+    BusinessExpenseViewSet,
+    ExpenseCategoryViewSet,
+    PurchaseOrderViewSet,
+    PurchaseRequisitionViewSet,
+    PurchasingSummaryView,
+    SupplierInvoiceViewSet,
+    SupplierPaymentViewSet,
+)
+
+
+router = routers.DefaultRouter()
+router.register('requisitions', PurchaseRequisitionViewSet)
+router.register('orders', PurchaseOrderViewSet)
+router.register('expense-categories', ExpenseCategoryViewSet)
+router.register('invoices', SupplierInvoiceViewSet)
+router.register('payments', SupplierPaymentViewSet)
+router.register('expenses', BusinessExpenseViewSet)
+
+urlpatterns = [
+    path('summary/', PurchasingSummaryView.as_view(), name='purchasing-summary'),
+    path('', include(router.urls)),
+]


### PR DESCRIPTION
Operators need to turn reviewed needs into orders, reconcile partial deliveries, attach supplier invoices to already posted receipt lines, and record corrections and partial payments without rewriting inventory. Add transactional commands, workspace-scoped REST resources, derived purchasing reports, and end-to-end coverage of received seed invoicing.

## Summary by Sourcery

Add transactional purchasing and accounts-payable workflows with workspace-scoped APIs, reconciliation reporting, and immutable financial corrections.

New Features:
- Expose workspace-scoped purchasing and accounts-payable REST resources for requisitions, orders, invoices, payments, expenses, and expense categories.
- Support converting reviewed requisitions into orders and reconciling orders with partial, returned, cancelled, and over-delivered receipts.
- Support supplier invoice creation, receipt-line matching, append-only corrections, payment allocations, and payment reversals.
- Provide derived purchasing summaries covering commitments, invoice liabilities, overdue balances, cash paid, expenses, and reconciliation warnings.

Bug Fixes:
- Prevent reviewed requisitions and confirmed purchasing records from being destructively edited.
- Prevent invoice lines from referencing mismatched suppliers or unposted receipts, and preserve posted receipt valuation when invoice prices differ.

Enhancements:
- Enforce transactional purchasing workflows with explicit review, confirmation, closure, cancellation, correction, payment, reversal, and expense-confirmation commands.
- Add immutable state transitions and audit-friendly history for requisitions, order cancellations, invoice corrections, and supplier payments.

Tests:
- Add end-to-end API coverage for received-seed invoicing, partial payments, delivery reconciliation, requisition ordering, invoice corrections, payment reversals, non-stock expenses, and authentication.