### PR TITLE
feat(tax): recognize supplier invoices and payments

### DIFF
--- a/inventory/ledger.py
+++ b/inventory/ledger.py
@@ -1026,6 +1026,11 @@ def settle_receipt(receipt, settled_on):
     ).get(pk=receipt.pk)
     if receipt.status != StockReceipt.Status.POSTED:
         raise ValidationError({'status': 'Only posted receipts can be settled.'})
+    from purchasing.models import SupplierInvoiceLine  # pylint: disable=import-outside-toplevel
+    if SupplierInvoiceLine.objects.filter(receipt_line__receipt=receipt).exists():
+        raise ValidationError({
+            'settled_on': 'Record payments against the linked supplier invoice.',
+        })
     if settled_on is not None:
         zone = ZoneInfo(receipt.workspace.timezone)
         if settled_on > timezone.now().astimezone(zone).date():

--- a/inventory/ledger_rest.py
+++ b/inventory/ledger_rest.py
@@ -198,6 +198,7 @@ class StockReceiptSerializer(
     movement_ids = serializers.SerializerMethodField()
     is_seed_packet_draft = serializers.SerializerMethodField()
     tax_warnings = serializers.SerializerMethodField()
+    settled_on = serializers.SerializerMethodField()
 
     class Meta:
         model = StockReceipt
@@ -263,6 +264,13 @@ class StockReceiptSerializer(
     def get_tax_warnings(self, receipt):
         """Expose unsupported claims without silently changing them."""
         return receipt_tax_warnings(receipt)
+
+    def get_settled_on(self, receipt):
+        """Expose invoice-allocation settlement, falling back for legacy receipts."""
+        from purchasing.services import receipt_paid_on  # pylint: disable=import-outside-toplevel
+
+        paid_on = receipt_paid_on(receipt)
+        return paid_on.isoformat() if paid_on else None
 
     def validate(self, attrs):
         """Apply workspace financial defaults to new draft documents."""

--- a/purchasing/services.py
+++ b/purchasing/services.py
@@ -311,6 +311,32 @@ def invoice_state(invoice):
     }
 
 
+def receipt_paid_on(receipt, prefetched_invoice_lines=None):
+    """Derive full settlement from live invoice allocations, with legacy fallback."""
+    if prefetched_invoice_lines is None:
+        invoices = list(SupplierInvoice.objects.filter(
+            lines__receipt_line__receipt=receipt,
+            status=SupplierInvoice.Status.CONFIRMED,
+        ).distinct().prefetch_related(
+            'corrections', 'payment_allocations__payment__reversal',
+        ))
+    else:
+        invoices = list({
+            line.invoice_id: line.invoice for line in prefetched_invoice_lines
+        }.values())
+    if not invoices:
+        return receipt.settled_on
+    if any(invoice_state(invoice)['balance_due'] > 0 for invoice in invoices):
+        return None
+    dates = [
+        allocation.payment.paid_on
+        for invoice in invoices
+        for allocation in invoice.payment_allocations.all()
+        if allocation.payment.reversal_of_id is None and not hasattr(allocation.payment, 'reversal')
+    ]
+    return max(dates) if dates else None
+
+
 def _refresh_invoice_totals(invoice):
     totals = invoice.lines.aggregate(
         subtotal=Sum('subtotal_ex_tax'), tax=Sum('tax_total'), total=Sum('total_incl_tax'),
@@ -359,6 +385,13 @@ def confirm_invoice(invoice, user):
         raise ValidationError({'status': 'Only a draft supplier invoice can be confirmed.'})
     if not invoice.lines.exists():
         raise ValidationError({'lines': 'Add at least one line before confirming.'})
+    receipt_ids = invoice.lines.exclude(receipt_line=None).values_list('receipt_line_id', flat=True)
+    already_invoiced = SupplierInvoiceLine.objects.filter(
+        receipt_line_id__in=receipt_ids,
+        invoice__status=SupplierInvoice.Status.CONFIRMED,
+    ).exclude(invoice=invoice)
+    if already_invoiced.exists():
+        raise ValidationError({'lines': 'A posted receipt line is already on a confirmed invoice.'})
     _refresh_invoice_totals(invoice)
     SupplierInvoice.objects.filter(pk=invoice.pk).update(
         status=SupplierInvoice.Status.CONFIRMED,

--- a/purchasing/tests/test_rest.py
+++ b/purchasing/tests/test_rest.py
@@ -1,5 +1,8 @@
 """End-to-end API contracts for purchasing and supplier payables."""
 
+# pylint: disable=duplicate-code
+
+from datetime import date
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
@@ -8,6 +11,9 @@ from rest_framework.test import APITestCase
 from inventory.models import StockReceipt
 from inventory.units import UnitCode
 from tests.factories import make_plant_variety, make_supplier
+from tax.entries import AWAITING_PAYMENT, PURCHASE, derive_entries
+from tax.models import GstRegistration
+from tax.services import record_registration
 from workspaces.models import get_current_workspace
 
 
@@ -32,7 +38,7 @@ class PurchasingRestTests(APITestCase):
         self.assertEqual(catalog.status_code, 201, catalog.data)
         self.seed_catalog = catalog.data
 
-    def receive_seed(self, quantity='40', reference='DEL-1'):
+    def receive_seed(self, quantity='40', reference='DEL-1', received_date='2026-08-20'):
         """Receive one exact packet and return its posted receipt line."""
         draft = self.client.post('/seeds/packet-receipts/', {
             'seeds': self.seed_catalog['pk'],
@@ -40,7 +46,14 @@ class PurchasingRestTests(APITestCase):
             'quantity_certainty': 'exact',
             'quantity': quantity,
             'line_price': '11.5000',
-            'received_date': '2026-08-20',
+            'supplier_cost_incl_tax': '11.5000',
+            'tax_treatment': 'standard',
+            'tax_rate': '15.0000',
+            'input_tax_source': 'supplier',
+            'input_tax_amount': '1.5000',
+            'claim_input_tax': True,
+            'claimable_percentage': '100.0000',
+            'received_date': received_date,
             'supplier_reference': reference,
         }, format='json')
         self.assertEqual(draft.status_code, 201, draft.data)
@@ -118,6 +131,52 @@ class PurchasingRestTests(APITestCase):
 
         lot.refresh_from_db()
         self.assertEqual(lot.acquisition_total, original_cost)
+
+    def test_payments_basis_claims_partial_invoice_payments_proportionally(self):
+        """A part-paid seed invoice claims only the discharged share of input tax."""
+        record_registration(
+            self.workspace, self.user,
+            registered=True,
+            gst_number='123456785',
+            basis=GstRegistration.Basis.PAYMENTS,
+            filing_frequency=GstRegistration.Frequency.MONTHLY,
+            period_anchor_month=1,
+            effective_from=date(2026, 1, 1),
+        )
+        invoice = self.create_invoice(self.receive_seed())
+        self.pay(invoice['pk'], '5.0000', 'PAY-PART')
+
+        entries = derive_entries(
+            self.workspace,
+            date(2026, 8, 1),
+            date(2026, 8, 31),
+        )
+        purchases = [entry for entry in entries if entry.kind == PURCHASE]
+        claimed = [entry for entry in purchases if not entry.exclusion]
+        awaiting = [entry for entry in purchases if entry.exclusion == AWAITING_PAYMENT]
+        self.assertEqual(sum(entry.tax for entry in claimed), Decimal('0.6522'))
+        self.assertEqual(sum(entry.tax for entry in awaiting), Decimal('0.8478'))
+        self.assertEqual({entry.source_type for entry in claimed}, {'supplier_payment'})
+
+    def test_invoice_basis_uses_confirmed_supplier_invoice_date(self):
+        """A later supplier invoice supersedes the receipt-date proxy."""
+        record_registration(
+            self.workspace, self.user,
+            registered=True,
+            gst_number='123456785',
+            basis=GstRegistration.Basis.INVOICE,
+            filing_frequency=GstRegistration.Frequency.MONTHLY,
+            period_anchor_month=1,
+            effective_from=date(2026, 1, 1),
+        )
+        self.create_invoice(self.receive_seed(received_date='2026-07-31'))
+
+        entries = derive_entries(self.workspace, date(2026, 7, 1), date(2026, 8, 31))
+        purchases = [entry for entry in entries if entry.kind == PURCHASE]
+        self.assertEqual(len(purchases), 1)
+        self.assertEqual(purchases[0].supply_date, date(2026, 8, 21))
+        self.assertEqual(purchases[0].source_type, 'supplier_invoice')
+        self.assertFalse(purchases[0].proxy)
 
     def test_partial_deliveries_and_over_delivery_remain_visible(self):
         """Receipt matching reports each commercial quantity independently."""

--- a/seeds/rest.py
+++ b/seeds/rest.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
+from django.db.models import Prefetch
 from rest_framework import routers, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -20,6 +21,8 @@ from workspaces.scoping import (
 from supplies.defaults import ensure_default_supplier
 from supplies.models import Supplier
 
+from purchasing.models import SupplierInvoice, SupplierInvoiceLine
+
 from .models import SeedPacket, SeedPacketReceiptDraft, Seeds
 from .services import (
     create_packet_receipt_draft,
@@ -31,6 +34,18 @@ from .services import (
     reconcile_packet_quantity,
     set_seed_inventory_unit,
     update_packet_receipt_draft,
+)
+
+
+PACKET_INVOICE_PREFETCH = Prefetch(
+    'stock_lot__receipt_line__supplier_invoice_lines',
+    queryset=SupplierInvoiceLine.objects.filter(
+        invoice__status=SupplierInvoice.Status.CONFIRMED,
+    ).select_related('invoice').prefetch_related(
+        'invoice__corrections',
+        'invoice__payment_allocations__payment__reversal',
+    ),
+    to_attr='confirmed_supplier_invoice_lines',
 )
 
 
@@ -386,7 +401,7 @@ class SeedPacketCurrentViewSet(
         'stock_lot__receipt_line__receipt__supplier',
         'seeds__supplier',
         'storage_location',
-    )
+    ).prefetch_related(PACKET_INVOICE_PREFETCH)
     serializer_class = SeedPacketSerializer
     http_method_names = ['get', 'patch', 'head', 'options', 'post']
 
@@ -445,7 +460,7 @@ class SeedPacketAllViewSet(
         'stock_lot__receipt_line__receipt__supplier',
         'seeds__supplier',
         'storage_location',
-    )
+    ).prefetch_related(PACKET_INVOICE_PREFETCH)
     serializer_class = SeedPacketSerializer
     http_method_names = ['get', 'patch', 'head', 'options']
 

--- a/seeds/services.py
+++ b/seeds/services.py
@@ -356,6 +356,8 @@ def packet_provenance(packet):
     figures do, so the payload reads the same whether it was rendered to JSON
     or read straight off the serializer.
     """
+    from purchasing.services import receipt_paid_on  # pylint: disable=import-outside-toplevel
+
     brand = packet.seeds.supplier
     lot = packet.stock_lot if packet.stock_lot_id else None
     line = lot.receipt_line if lot and lot.receipt_line_id else None
@@ -399,7 +401,9 @@ def packet_provenance(packet):
         'recoverable_input_tax': f'{line.recoverable_input_tax:.4f}',
         'non_recoverable_tax': f'{line.non_recoverable_tax:.4f}',
         'acquisition_amount': f'{line.acquisition_amount:.4f}',
-        'settled_on': _isoformat(receipt.settled_on),
+        'settled_on': _isoformat(receipt_paid_on(
+            receipt, getattr(line, 'confirmed_supplier_invoice_lines', None),
+        )),
     }
 
 

--- a/tax/entries.py
+++ b/tax/entries.py
@@ -20,6 +20,8 @@ Anything falling outside a registration produces an entry with no period and an
 exclusion reason. Nothing is silently dropped and nothing becomes a zero.
 """
 
+# pylint: disable=too-many-arguments,too-many-locals
+
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -29,6 +31,8 @@ from django.db import models
 
 from inventory.ledger import quantize_money
 from inventory.models import InputTaxAdjustment, StockReceipt, StockReceiptLine
+from purchasing.models import SupplierInvoice, SupplierInvoiceLine, SupplierPaymentAllocation
+from purchasing.services import invoice_net_total, invoice_paid_total
 
 from .facts import workspace_order_facts
 from .periods import (
@@ -218,25 +222,128 @@ def _period_purchase_entries(workspace, period, claimed):
     `claimed` carries the lines earlier periods already took, and is added to
     here. See `derive_entries` for why a period has to be told.
     """
+    entries = _supplier_invoice_purchase_entries(workspace, period)
+    linked_line_ids = SupplierInvoiceLine.objects.filter(
+        invoice__workspace=workspace,
+        receipt_line__isnull=False,
+    ).values_list('receipt_line_id', flat=True)
     if period.basis == INVOICE:
         lines = _invoiced_receipt_lines(workspace, period.start, period.end)
-        return [
+        entries.extend([
             _purchase_entry(line, period, period.basis)
-            for line in _take(lines, claimed)
-        ]
+            for line in _take(lines.exclude(pk__in=linked_line_ids), claimed)
+        ])
+        return entries
     settled = _settled_receipt_lines(workspace, period.start, period.end)
-    entries = [
+    entries.extend([
         _purchase_entry(line, period, period.basis)
-        for line in _take(settled, claimed)
-    ]
+        for line in _take(settled.exclude(pk__in=linked_line_ids), claimed)
+    ])
     unsettled = _unsettled_receipt_lines(workspace, period.start, period.end)
     entries.extend(
         _with(
             _purchase_entry(line, None, period.basis),
             exclusion=AWAITING_PAYMENT,
         )
-        for line in _take(unsettled, claimed)
+        for line in _take(unsettled.exclude(pk__in=linked_line_ids), claimed)
     )
+    return entries
+
+
+def _supplier_invoice_purchase_entries(workspace, period):
+    """Claim receipt evidence through confirmed invoices and allocated payments."""
+    if period.basis == INVOICE:
+        lines = SupplierInvoiceLine.objects.filter(
+            invoice__workspace=workspace,
+            invoice__status=SupplierInvoice.Status.CONFIRMED,
+            invoice__invoice_date__gte=period.start,
+            invoice__invoice_date__lte=period.end,
+            receipt_line__isnull=False,
+            receipt_line__receipt__status=StockReceipt.Status.POSTED,
+        ).select_related('invoice', 'receipt_line__receipt').prefetch_related(
+            'invoice__corrections',
+        )
+        return [
+            _purchase_entry(
+                line.receipt_line, period, period.basis,
+                claim_date=line.invoice.invoice_date,
+                source_type='supplier_invoice',
+                source_id=line.invoice_id,
+                document_id=line.invoice_id,
+                factor=_invoice_claim_factor(line.invoice),
+            )
+            for line in lines
+        ]
+    allocations = SupplierPaymentAllocation.objects.filter(
+        invoice__workspace=workspace,
+        invoice__status=SupplierInvoice.Status.CONFIRMED,
+        payment__paid_on__gte=period.start,
+        payment__paid_on__lte=period.end,
+        payment__reversal_of__isnull=True,
+        payment__reversal__isnull=True,
+    ).select_related('payment', 'invoice').prefetch_related(
+        'invoice__corrections', 'invoice__lines__receipt_line__receipt',
+    )
+    entries = []
+    for allocation in allocations:
+        factor = _payment_claim_factor(allocation)
+        for line in allocation.invoice.lines.all():
+            if line.receipt_line_id is None or line.receipt_line.receipt.status != StockReceipt.Status.POSTED:
+                continue
+            entries.append(_purchase_entry(
+                line.receipt_line, period, period.basis,
+                claim_date=allocation.payment.paid_on,
+                source_type='supplier_payment',
+                source_id=allocation.payment_id,
+                document_id=allocation.invoice_id,
+                factor=factor,
+            ))
+    entries.extend(_awaiting_invoice_payment_entries(workspace, period))
+    return entries
+
+
+def _invoice_claim_factor(invoice):
+    """Reduce a claim proportionally when credits reduce an invoice."""
+    if invoice.total_incl_tax <= 0:
+        return ZERO
+    return min(invoice_net_total(invoice) / invoice.total_incl_tax, Decimal('1'))
+
+
+def _payment_claim_factor(allocation):
+    """Return the fraction of an invoice discharged by one allocation."""
+    net = invoice_net_total(allocation.invoice)
+    if net <= 0:
+        return ZERO
+    return min(allocation.amount / net, Decimal('1')) * _invoice_claim_factor(allocation.invoice)
+
+
+def _awaiting_invoice_payment_entries(workspace, period):
+    """Expose the unclaimed share of invoices first seen in this period."""
+    lines = SupplierInvoiceLine.objects.filter(
+        invoice__workspace=workspace,
+        invoice__status=SupplierInvoice.Status.CONFIRMED,
+        invoice__invoice_date__gte=period.start,
+        invoice__invoice_date__lte=period.end,
+        receipt_line__isnull=False,
+        receipt_line__receipt__status=StockReceipt.Status.POSTED,
+    ).select_related('invoice', 'receipt_line__receipt').prefetch_related(
+        'invoice__corrections', 'invoice__payment_allocations__payment',
+    )
+    entries = []
+    for line in lines:
+        net = invoice_net_total(line.invoice)
+        paid = invoice_paid_total(line.invoice, through=period.end)
+        if net <= 0 or paid >= net:
+            continue
+        factor = _invoice_claim_factor(line.invoice) * (net - paid) / net
+        entries.append(_with(_purchase_entry(
+            line.receipt_line, None, period.basis,
+            claim_date=line.invoice.invoice_date,
+            source_type='supplier_invoice',
+            source_id=line.invoice_id,
+            document_id=line.invoice_id,
+            factor=factor,
+        ), exclusion=AWAITING_PAYMENT))
     return entries
 
 
@@ -264,6 +371,8 @@ def _unregistered_purchase_entries(context, accounted_line_ids):
     start, end = context.window
     entries = []
     for line in _invoiced_receipt_lines(context.workspace, start, end):
+        if line.supplier_invoice_lines.exists():
+            continue
         if line.pk in accounted_line_ids:
             continue
         day = _unaccounted_day(line, context)
@@ -302,7 +411,9 @@ def _unaccounted_day(line, context):
     return None
 
 
-def _purchase_entry(line, period, basis):
+def _purchase_entry(
+        line, period, basis, *, claim_date=None, source_type='stock_receipt',
+        source_id=None, document_id=None, factor=Decimal('1')):
     """Split one receipt line into its recoverable and non-recoverable tax.
 
     The claimable amount is recomputed rather than read: `_receipt_acquisition_cost`
@@ -315,23 +426,25 @@ def _purchase_entry(line, period, basis):
     owns moving it down to the line, and the report says so.
     """
     receipt = line.receipt
-    taxable = quantize_money(line.line_cost_ex_tax)
-    recoverable = quantize_money(line.recoverable_input_tax)
-    non_recoverable = quantize_money(line.non_recoverable_tax)
+    taxable = quantize_money(line.line_cost_ex_tax * factor)
+    recoverable = quantize_money(line.recoverable_input_tax * factor)
+    non_recoverable = quantize_money(line.non_recoverable_tax * factor)
     # A settlement date is a date somebody paid a supplier on, so under a basis
     # that claims on payment it is the real time of supply and not a stand-in.
     # Every other purchase is still dated by the receipt standing in for the
     # supplier invoice date this application does not hold, and stays a proxy.
-    paid = basis in PAYMENT_BASED and receipt.settled_on is not None
+    legacy_paid = source_type == 'stock_receipt' and basis in PAYMENT_BASED and receipt.settled_on is not None
+    paid = source_type == 'supplier_payment' or legacy_paid
     invoice_day = receipt.invoice_date or receipt.received_date
+    supply_date = claim_date or (receipt.settled_on if paid else invoice_day)
     return GstEntry(
         kind=PURCHASE,
-        supply_date=receipt.settled_on if paid else invoice_day,
+        supply_date=supply_date,
         period=period,
         basis=basis,
-        source_type='stock_receipt',
-        source_id=receipt.pk,
-        document_id=receipt.pk,
+        source_type=source_type,
+        source_id=source_id or receipt.pk,
+        document_id=document_id or receipt.pk,
         line_id=line.pk,
         tax_code=line.tax_treatment,
         tax_rate=Decimal(line.tax_rate),
@@ -341,11 +454,11 @@ def _purchase_entry(line, period, basis):
         currency_code=receipt.currency_code,
         time_of_supply_source=(
             SUPPLIER_PAYMENT if paid
-            else SUPPLIER_INVOICE if receipt.invoice_date
+            else SUPPLIER_INVOICE if source_type == 'supplier_invoice' or receipt.invoice_date
             else RECEIPT_PROXY
         ),
         input_tax_source=line.input_tax_source,
-        proxy=not paid and receipt.invoice_date is None,
+        proxy=source_type == 'stock_receipt' and not paid and receipt.invoice_date is None,
     )
 
 


### PR DESCRIPTION
The legacy receipt settlement date can only represent all-or-nothing payment and cannot drive correct input-tax timing once real payables exist. Derive invoice and payment recognition from confirmed supplier documents, apportion partial payments, expose remaining claims, and keep the old settlement field only for receipts without linked invoices.

## Summary by Sourcery

Base supplier input-tax recognition on confirmed invoices and payments while preserving legacy receipt handling for uninvoiced receipts.

New Features:
- Recognize confirmed supplier invoices and supplier payments as input-tax events, including proportional claims for partial payments and visibility into remaining unclaimed amounts.

Bug Fixes:
- Prevent legacy receipt settlement from being used when a receipt is linked to a confirmed supplier invoice.
- Avoid duplicate tax recognition when receipt lines have already been invoiced.

Enhancements:
- Derive receipt and seed-packet settlement dates from invoice payment allocations while retaining the legacy receipt settlement fallback.
- Use confirmed supplier invoice dates for invoice-basis tax timing and expose invoice or payment source metadata in tax entries.
- Prevent confirmed invoices from reusing receipt lines that are already attached to another confirmed invoice.

Tests:
- Add coverage for proportional input-tax claims on partial supplier payments and invoice-date-based recognition.