### PR TITLE
feat(bookkeeping): enforce retained tax schedules

### DIFF
--- a/bookkeeping/apps.py
+++ b/bookkeeping/apps.py
@@ -8,3 +8,7 @@ class BookkeepingConfig(AppConfig):
 
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'bookkeeping'
+
+    def ready(self):
+        """Register cross-app deletion protection after every model is loaded."""
+        from . import signals  # pylint: disable=import-outside-toplevel,unused-import

--- a/bookkeeping/services.py
+++ b/bookkeeping/services.py
@@ -15,10 +15,10 @@ from django.utils import timezone
 
 from billing.models import SupplyCorrection, SupplyDocument
 from costing.models import CostAllocation
-from inventory.models import InventoryItem, StockLot, StockMovement, StockReceiptLine
+from inventory.models import InputTaxAdjustment, InventoryItem, StockLot, StockMovement, StockReceiptLine
 from plantings.lifecycle import LifecycleState, derive_state
 from plantings.models import PlantCohort, PlantLifecycleEvent, SpecificPlant
-from purchasing.models import BusinessExpense, SupplierInvoice
+from purchasing.models import BusinessExpense, SupplierInvoice, SupplierPayment
 from sales.models import Payment, Refund
 
 from .models import (
@@ -286,6 +286,25 @@ def _expense_rows(income_year, start, end):
                     'reference': invoice.external_reference,
                     'amount': str(line.deductible_amount), 'currency_code': invoice.currency_code,
                 })
+    else:
+        payments = SupplierPayment.objects.filter(
+            workspace=workspace, paid_on__gte=start, paid_on__lte=end,
+            reversal_of=None, reversal__isnull=True,
+        ).prefetch_related('allocations__invoice__lines')
+        for payment in payments:
+            for allocation in payment.allocations.all():
+                invoice = allocation.invoice
+                if invoice.total_incl_tax <= ZERO:
+                    continue
+                paid_ratio = allocation.amount / invoice.total_incl_tax
+                for line in invoice.lines.exclude(expense_category=None):
+                    rows.append({
+                        'kind': 'paid_expense', 'date': payment.paid_on.isoformat(),
+                        'source_type': 'supplier_payment', 'source_id': payment.pk,
+                        'reference': payment.account_reference or payment.external_reference,
+                        'amount': str(money(line.deductible_amount * paid_ratio)),
+                        'currency_code': payment.currency_code,
+                    })
     return rows
 
 
@@ -327,9 +346,20 @@ def build_report(income_year):
     ).order_by('-revision').first()
     opening = Decimal(prior.frozen_report.get('totals', {}).get('closing_stock', '0')) if prior else ZERO
     purchases = money(_purchase_total(income_year.workspace, start, end))
-    depreciation = DepreciationSchedule.objects.filter(
+    schedules = list(DepreciationSchedule.objects.filter(
         workspace=income_year.workspace, income_year_end=end,
-    ).aggregate(total=Sum('depreciation_claimed'))['total'] or ZERO
+    ).select_related('asset'))
+    depreciation = sum((row.depreciation_claimed for row in schedules), ZERO)
+    depreciation_rows = [{
+        'kind': 'depreciation', 'date': end.isoformat(),
+        'source_type': 'depreciation_schedule', 'source_id': row.pk,
+        'reference': row.asset.code, 'amount': str(row.depreciation_claimed),
+        'currency_code': row.asset.currency_code, 'asset_id': row.asset_id,
+    } for row in schedules]
+    gst_adjustments = InputTaxAdjustment.objects.filter(
+        workspace=income_year.workspace,
+        adjustment_date__gte=start, adjustment_date__lte=end,
+    ).aggregate(total=Sum('tax_adjustment'))['total'] or ZERO
     sales_total = sum((Decimal(row['amount']) for row in sales), ZERO)
     income_total = sum((Decimal(row['amount']) for row in other_income), ZERO)
     expense_total = sum((Decimal(row['amount']) for row in expenses), ZERO)
@@ -356,9 +386,10 @@ def build_report(income_year):
             'opening_stock': str(money(opening)), 'stock_purchases': str(purchases),
             'closing_stock': str(money(closing)), 'cost_of_sales': str(money(cost_of_sales)),
             'deductible_expenses': str(money(expense_total)), 'depreciation': str(money(depreciation)),
-            'working_result': str(money(sales_total + income_total - cost_of_sales - expense_total - depreciation)),
+            'gst_adjustments': str(money(gst_adjustments)),
+            'working_result': str(money(sales_total + income_total - cost_of_sales - expense_total - depreciation + gst_adjustments)),
         },
-        'rows': sales + other_income + expenses,
+        'rows': sales + other_income + expenses + depreciation_rows,
         'cash_reconciliation': cash_reconciliation,
         'stock_lines': [{
             'id': line.pk, 'category': line.category, 'description': line.description,
@@ -396,6 +427,9 @@ def finalize_income_year(income_year, user, confirm_zero_opening=False):
     source_rows.extend({
         'source_type': row['source_type'], 'source_id': row['source_id']
     } for row in report['stock_lines'])
+    for row in report['rows']:
+        if row.get('asset_id'):
+            source_rows.append({'source_type': 'tax_asset', 'source_id': row['asset_id']})
     source_rows.append({'source_type': 'income_tax_year', 'source_id': income_year.pk})
     for row in source_rows:
         TaxRetentionRecord.objects.get_or_create(

--- a/bookkeeping/signals.py
+++ b/bookkeeping/signals.py
@@ -1,0 +1,36 @@
+"""Deletion guard for source records retained by finalized tax working papers."""
+
+import re
+
+from django.core.exceptions import ValidationError
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+from django.utils import timezone
+
+from .models import TaxRetentionRecord
+
+
+def _source_type(instance):
+    """Translate a Django model name to the stable report source spelling."""
+    name = type(instance).__name__
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
+
+
+@receiver(pre_delete)
+def prevent_retained_source_deletion(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """Block deletion while a finalized tax source is retained or held."""
+    workspace_id = getattr(instance, 'workspace_id', None)
+    if workspace_id is None or isinstance(instance, TaxRetentionRecord):
+        return
+    retained = TaxRetentionRecord.objects.filter(
+        workspace_id=workspace_id,
+        source_type=_source_type(instance), source_id=str(instance.pk),
+    ).filter(legal_hold=True).exists()
+    if not retained:
+        retained = TaxRetentionRecord.objects.filter(
+            workspace_id=workspace_id,
+            source_type=_source_type(instance), source_id=str(instance.pk),
+            retain_until__gte=timezone.localdate(),
+        ).exists()
+    if retained:
+        raise ValidationError('This tax source is inside its retention period or under legal hold.')

--- a/bookkeeping/test_bookkeeping.py
+++ b/bookkeeping/test_bookkeeping.py
@@ -60,6 +60,19 @@ class BookkeepingTests(APITestCase):
             closing_tax_value='800.0000', created_by=self.user,
         )
         self.assertEqual(str(schedule.closing_tax_value), '800.0000')
+        retained_asset = TaxAsset.objects.create(
+            workspace=self.workspace, code='SPADE-1', name='Spade',
+            category='Tools', acquired_on=date(2026, 4, 1),
+            cost_incl_tax='100.0000', recoverable_tax='0.0000',
+            tax_cost='100.0000', currency_code='NZD', created_by=self.user,
+        )
+        TaxRetentionRecord.objects.create(
+            workspace=self.workspace, source_type='tax_asset',
+            source_id=str(retained_asset.pk), income_year_end=date(2027, 3, 31),
+            retain_until=date(2034, 3, 31), created_by=self.user,
+        )
+        with self.assertRaises(ValidationError):
+            retained_asset.delete()
 
     def test_income_year_can_capture_and_finalize_confirmed_zero_opening(self):
         entry = BookkeepingEntry.objects.create(


### PR DESCRIPTION
Include paid supplier expenses and input-tax adjustments in income-year working papers, block deletion of retained cross-app sources, and document the delivered workflow and its explicit English-only and evidence-storage boundaries.

## Summary by Sourcery

Enforce retention of tax working-paper sources while expanding income-year reports to capture additional expense, tax, and depreciation information.

Bug Fixes:
- Prevent deletion of finalized tax sources while they are within their retention period or subject to legal hold.

Enhancements:
- Include paid supplier expenses, input-tax adjustments, and depreciation schedules in income-year working papers and finalization source retention.

Tests:
- Add coverage confirming retained tax assets cannot be deleted.